### PR TITLE
Add travis file to run checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: false
+
+language: go
+
+os:
+- linux
+
+go:
+- 1.10.x
+
+before_install:
+- make setup
+
+script:
+- make check

--- a/Makefile
+++ b/Makefile
@@ -3,34 +3,25 @@ generate:
 	$(MAKE) readme
 	$(MAKE) template
 
-generate3:
-	python3 scripts/schemas.py
-	python3 scripts/use-cases.py
-
 fmt:
 	find . -name *.py -exec autopep8 --in-place --max-line-length 120 {} \;
 
 check:
-	#
 	# Validate that all generated changes are commited
 	$(MAKE) generate
+	$(MAKE) fmt
+
+	# Check if diff is empty
 	git diff | cat
 	git update-index --refresh
 	git diff-index --exit-code HEAD --
 
-	# Check python code
-	find . -name *.py -exec autopep8 --in-place --max-line-length 120  {} \; | \
-		(! grep . -q) || (echo "Code differs from autopep8's style" && false)
-	
 	# Basic spell checking
-	go get github.com/client9/misspell
+	go get github.com/client9/misspell/cmd/misspell
 	misspell README.md CONTRIBUTING.md
 
 setup:
-	pip install -Ur ./scripts/requirements.txt
-
-setup3:
-	pip3 install -Ur ./scripts/requirements.txt
+	pip install --user --upgrade --requirement ./scripts/requirements.txt
 
 clean:
 	rm schema.csv schema.md
@@ -47,4 +38,5 @@ readme:
 
 template:
 	go get github.com/elastic/go-ucfg/yaml
+	go get github.com/elastic/beats/libbeat/template
 	go run scripts/template.go > ./template.json

--- a/README.md
+++ b/README.md
@@ -414,11 +414,11 @@ These are common to show up in web service logs coming from the parsed user agen
 Below are some examples that demonstrate how ECS fields can be applied to
 specific use cases.
 
- * [Logging](https://github.com/elastic/ecs/blob/master/use-cases/logging.md)
  * [APM](https://github.com/elastic/ecs/blob/master/use-cases/apm.md)
- * [Filebeat Apache](https://github.com/elastic/ecs/blob/master/use-cases/filebeat-apache-access.md)
- * [Beats](https://github.com/elastic/ecs/blob/master/use-cases/beats.md)
  * [Auditbeat](https://github.com/elastic/ecs/blob/master/use-cases/auditbeat.md)
+ * [Beats](https://github.com/elastic/ecs/blob/master/use-cases/beats.md)
+ * [Filebeat Apache](https://github.com/elastic/ecs/blob/master/use-cases/filebeat-apache-access.md)
+ * [Logging](https://github.com/elastic/ecs/blob/master/use-cases/logging.md)
  * [Metricbeat](https://github.com/elastic/ecs/blob/master/use-cases/metricbeat.md)
 
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,3 @@
+pip
 PyYAML
+autopep8

--- a/scripts/use-cases.py
+++ b/scripts/use-cases.py
@@ -10,7 +10,7 @@ def write_stdout():
     link_prefix = "https://github.com/elastic/ecs"
 
     links = ""
-    for file in os.listdir("./use-cases"):
+    for file in sorted(os.listdir("./use-cases")):
 
         output = ""
 


### PR DESCRIPTION
These checks ensures that all generated files are always up-to-date and follow formatting rules.

Further changes:
* Add dependencies in travis file
* Reorganize check to first run fmt and then check for the diff
* Fix reading directories to be sorted as otherwise not same order on all OS.
* Remove old commands used for python 3.
* Update `make setup` command