### PR TITLE
Revised Network Metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file based on the
 ## [Unreleased](https://github.com/elastic/ecs/compare/0.1.0...master)
 
 ### Breaking changes
+- Replaced network.inbound/outbound with less ambigious network.transfer.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -271,12 +271,9 @@ All fields related to network data.
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="network.protocol"></a>`network.protocol`  | Network protocol name.  | keyword  |   | `http`  |
-| <a name="network.direction"></a>`network.direction`  | Direction of the network traffic.<br/>The recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
 | <a name="network.forwarded_ip"></a>`network.forwarded_ip`  | forwarded_ip indicates the host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |
-| <a name="network.inbound.bytes"></a>`network.inbound.bytes`  | Network inbound bytes.  | long  |   | `184`  |
-| <a name="network.inbound.packets"></a>`network.inbound.packets`  | Network inbound packets.  | long  |   | `12`  |
-| <a name="network.outbound.bytes"></a>`network.outbound.bytes`  | Network outbound bytes.  | long  |   | `184`  |
-| <a name="network.outbound.packets"></a>`network.outbound.packets`  | Network outbound packets.  | long  |   | `12`  |
+| <a name="network.transfer.bytes"></a>`network.transfer.bytes`  | Network bytes transferred.<br/>Typically used with netflow, sflow, or cloud provider flow logs  | long  |   | `184`  |
+| <a name="network.transfer.packets"></a>`network.transfer.packets`  | Network packets transferred.<br/>Typically used with netflow, sflow, or cloud provider flow logs  | long  |   | `12`  |
 
 
 ## <a name="organization"></a> Organization fields

--- a/schema.csv
+++ b/schema.csv
@@ -86,13 +86,10 @@ kubernetes.pod.name,keyword,0,
 log.level,keyword,0,ERR
 log.line,long,0,18
 log.offset,long,0,12
-network.direction,keyword,0,inbound
 network.forwarded_ip,ip,0,192.1.1.2
-network.inbound.bytes,long,0,184
-network.inbound.packets,long,0,12
-network.outbound.bytes,long,0,184
-network.outbound.packets,long,0,12
 network.protocol,keyword,0,http
+network.transfer.bytes,long,0,184
+network.transfer.packets,long,0,12
 organization.id,keyword,0,
 organization.name,text,0,
 process.args,keyword,0,"['-l', 'user', '10.0.0.16']"

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -10,16 +10,6 @@
       description: >
         Network protocol name.
       example: http
-    - name: direction
-      type: keyword
-      description: >
-        Direction of the network traffic.
-
-        The recommended values are:
-          * inbound
-          * outbound
-          * unknown
-      example: inbound
 
     - name: forwarded_ip
       type: ip
@@ -29,23 +19,17 @@
       example: 192.1.1.2
 
     # Metrics
-    - name: inbound.bytes
+    - name: transfer.bytes
       type: long
       description: >
-        Network inbound bytes.
+        Network bytes transferred.
+        
+        Typically used with netflow, sflow, or cloud provider flow logs
       example: 184
-    - name: inbound.packets
+    - name: transfer.packets
       type: long
       description: >
-        Network inbound packets.
-      example: 12
-    - name: outbound.bytes
-      type: long
-      description: >
-        Network outbound bytes.
-      example: 184
-    - name: outbound.packets
-      type: long
-      description: >
-        Network outbound packets.
+        Network packets transferred.
+        
+        Typically used with netflow, sflow, or cloud provider flow logs
       example: 12

--- a/template.json
+++ b/template.json
@@ -445,36 +445,22 @@
         },
         "network": {
           "properties": {
-            "direction": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "forwarded_ip": {
               "type": "ip"
-            },
-            "inbound": {
-              "properties": {
-                "bytes": {
-                  "type": "long"
-                },
-                "packets": {
-                  "type": "long"
-                }
-              }
-            },
-            "outbound": {
-              "properties": {
-                "bytes": {
-                  "type": "long"
-                },
-                "packets": {
-                  "type": "long"
-                }
-              }
             },
             "protocol": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "transfer": {
+              "properties": {
+                "bytes": {
+                  "type": "long"
+                },
+                "packets": {
+                  "type": "long"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
Inbound and outbound are ambiguous with regard to netflow data. When
using src and destination, the direction is explicit. `inbound` and
`outbound` don't map back to `src` and `dest` and becomes ambiguous. I don't
see a use case for `inbound` and `outbound` as this is already
defined by `src` and `dest`. This removes the `inbound` and `outbound`
sections and replaces them with a single transfer field which lines up with
netflow, gcp flow logs, aws flowlogs, and so on.