### PR TITLE
Add log.message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,6 @@ All notable changes to this project will be documented in this file based on the
 * Adds cloud.account.id for top level organizational level. #11
 * Add `http.response.status_code` and `http.response.body` fields. #4
 * Add fields for Operating System data. #5
+* Add `log.message`. #3
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Fields which are specific to log events.
 | <a name="log.level"></a>`log.level`  | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`.  | keyword  |   | `ERR`  |
 | <a name="log.line"></a>`log.line`  | Line number the log event was collected from.  | long  |   | `18`  |
 | <a name="log.offset"></a>`log.offset`  | Offset of the beginning of the log event.  | long  |   | `12`  |
+| <a name="log.message"></a>`log.message`  | This is the log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
 
 
 ## <a name="network"></a> Network fields

--- a/schema.csv
+++ b/schema.csv
@@ -88,6 +88,7 @@ kubernetes.namespace,keyword,0,
 kubernetes.pod.name,keyword,0,
 log.level,keyword,0,ERR
 log.line,long,0,18
+log.message,keyword,1,Sep 19 08:26:10 localhost My log
 log.offset,long,0,12
 network.direction,keyword,0,inbound
 network.forwarded_ip,ip,0,192.1.1.2

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -21,3 +21,20 @@
       description: >
         Offset of the beginning of the log event.
       example: 12
+    - name: message
+      type: keyword
+      phase: 1
+      example: "Sep 19 08:26:10 localhost My log"
+      index: false
+      doc_values: false
+      description: >
+        This is the log message and contains the full log message before
+        splitting it up in multiple parts.
+
+        In contrast to the `message` field which can contain an extracted part
+        of the log message, this field contains the original, full log message.
+        It can have already some modifications applied like encoding or new
+        lines removed to clean up the log message.
+
+        This field is not indexed and doc_values are disabled so it can't be
+        queried but the value can be retrieved from `_source`.

--- a/template.json
+++ b/template.json
@@ -459,6 +459,12 @@
             "line": {
               "type": "long"
             },
+            "message": {
+              "doc_values": false,
+              "ignore_above": 1024,
+              "index": false,
+              "type": "keyword"
+            },
             "offset": {
               "type": "long"
             }


### PR DESCRIPTION
The field `log.message` contains the full log message before splitting it up in multiple parts.

In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.

This field is not indexed and doc_values are disabled so it can't be
queried but the value can be retrieved from `_source`.