### PR TITLE
Add http.response.* fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
-Adds cloud.account.id for top level organizational level.
+* Adds cloud.account.id for top level organizational level. #11
+* Add `http.response.status_code` and `http.response.body` fields. #4
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of available ECS fields.
  * [File fields](#file)
  * [Geoip fields](#geoip)
  * [Host fields](#host)
+ * [HTTP fields](#http)
  * [Kubernetes fields](#kubernetes)
  * [Log fields](#log)
  * [Network fields](#network)
@@ -236,6 +237,17 @@ Normally the host information is related to the machine on which the event was g
 | <a name="host.os.family"></a>`host.os.family`  | OS family (e.g. redhat, debian, freebsd, windows).  | keyword  |   | `debian`  |
 | <a name="host.os.version"></a>`host.os.version`  | Operating system version.  | keyword  |   | `10.12.6`  |
 | <a name="host.architecture"></a>`host.architecture`  | Operating system architecture.  | keyword  |   | `x86_64`  |
+
+
+## <a name="http"></a> HTTP fields
+
+Fields related to HTTP requests and responses.
+
+
+| Field  | Description  | Type  | Multi Field  | Example  |
+|---|---|---|---|---|
+| <a name="http.response.status_code"></a>`http.response.status_code`  | Http response status code.  | long  |   | `404`  |
+| <a name="http.response.body"></a>`http.response.body`  | The full http response body.  | text  |   | `Hello world`  |
 
 
 ## <a name="kubernetes"></a> Kubernetes fields

--- a/schema.csv
+++ b/schema.csv
@@ -79,6 +79,8 @@ host.os.platform,keyword,0,darwin
 host.os.version,keyword,0,10.12.6
 host.timezone.offset.sec,long,1,-5400
 host.type,keyword,1,
+http.response.body,text,0,Hello world
+http.response.status_code,long,0,404
 kubernetes.annotations,object,0,
 kubernetes.container.name,keyword,0,
 kubernetes.labels,object,0,

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -1,0 +1,17 @@
+---
+- name: http
+  title: HTTP
+  group: 2
+  description: >
+    Fields related to HTTP requests and responses.
+  fields:
+    - name: response.status_code
+      type: long
+      description: >
+        Http response status code.
+      example: 404
+    - name: response.body
+      type: text
+      description: >
+        The full http response body.
+      example: Hello world

--- a/template.json
+++ b/template.json
@@ -400,6 +400,21 @@
             }
           }
         },
+        "http": {
+          "properties": {
+            "response": {
+              "properties": {
+                "body": {
+                  "norms": false,
+                  "type": "text"
+                },
+                "status_code": {
+                  "type": "long"
+                }
+              }
+            }
+          }
+        },
         "kubernetes": {
           "properties": {
             "annotations": {


### PR DESCRIPTION
HTTP response status code and body show up in different Beats as packetbeat, heartbeat, filebeat, apm-server and also in web server logs. They are so common that it makes sense to standardise on the naming which is not the case yet.

I initially thought of creating `response` object outside as it also exists for other protocols but came to the conclusion that it's not really useful to correlate for example response codes across different protocols.