### PR TITLE
Add fields for Operating System data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 * Adds cloud.account.id for top level organizational level. #11
 * Add `http.response.status_code` and `http.response.body` fields. #4
+* Add fields for Operating System data. #5
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ List of available ECS fields.
  * [Log fields](#log)
  * [Network fields](#network)
  * [Organization fields](#organization)
+ * [Operating System fields](#os)
  * [Process fields](#process)
  * [Service fields](#service)
  * [Source fields](#source)
@@ -303,6 +304,21 @@ This can be useful if data should stored in the same index should be sometimes f
 |---|---|---|---|---|
 | <a name="organization.name"></a>`organization.name`  | Organization name.  | text  |   |   |
 | <a name="organization.id"></a>`organization.id`  | Unique identifier for the organization.  | keyword  |   |   |
+
+
+## <a name="os"></a> Operating System fields
+
+The OS fields contain information about the operating system and contains.
+
+The os fields are often used inside other prefixes like `host.os.*` or `user_agent.os.*`.
+
+
+| Field  | Description  | Type  | Multi Field  | Example  |
+|---|---|---|---|---|
+| <a name="os.platform"></a>`os.platform`  | Operating system platform (e.g. centos, ubuntu, windows).  | keyword  |   | `darwin`  |
+| <a name="os.name"></a>`os.name`  | Operating system name.  | keyword  |   | `Mac OS X`  |
+| <a name="os.family"></a>`os.family`  | OS family (e.g. redhat, debian, freebsd, windows).  | keyword  |   | `debian`  |
+| <a name="os.version"></a>`os.version`  | Operating system version as a raw string.  | keyword  |   | `10.12.6-rc2`  |
 
 
 ## <a name="process"></a> Process fields

--- a/schema.csv
+++ b/schema.csv
@@ -98,6 +98,10 @@ network.outbound.packets,long,0,12
 network.protocol,keyword,0,http
 organization.id,keyword,0,
 organization.name,text,0,
+os.family,keyword,0,debian
+os.name,keyword,0,Mac OS X
+os.platform,keyword,0,darwin
+os.version,keyword,0,10.12.6-rc2
 process.args,keyword,0,"['-l', 'user', '10.0.0.16']"
 process.name,keyword,0,ssh
 process.pid,long,0,

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -1,0 +1,28 @@
+- name: os
+  title: Operating System
+  group: 2
+  description: >
+    The OS fields contain information about the operating system and contains.
+
+    The os fields are often used inside other prefixes like `host.os.*` or `user_agent.os.*`.
+  fields:
+    - name: platform
+      type: keyword
+      description: >
+        Operating system platform (e.g. centos, ubuntu, windows).
+      example: darwin
+    - name: name
+      type: keyword
+      example: "Mac OS X"
+      description: >
+        Operating system name.
+    - name: family
+      type: keyword
+      example: "debian"
+      description: >
+        OS family (e.g. redhat, debian, freebsd, windows).
+    - name: version
+      type: keyword
+      example: "10.12.6-rc2"
+      description: >
+        Operating system version as a raw string.

--- a/template.json
+++ b/template.json
@@ -513,6 +513,26 @@
             }
           }
         },
+        "os": {
+          "properties": {
+            "family": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "process": {
           "properties": {
             "args": {


### PR DESCRIPTION
There were some previous discussions around the version field and if it should split up into major, minor, bugfix, patch. I chose to only go with `version` based on the assumption that if someone searches for a specific minor version he will know the major version. So searching for it can be done with a prefix query based on version keyword.