### PR TITLE
Proposal: TLS related fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ECS defines these fields.
  * [Process fields](#process)
  * [Service fields](#service)
  * [Source fields](#source)
+ * [TLS fields](#tls)
  * [URL fields](#url)
  * [User fields](#user)
  * [User agent fields](#user_agent)
@@ -356,6 +357,21 @@ Source fields describe details about the source of the event.
 | <a name="source.mac"></a>`source.mac`  | MAC address of the source.  | keyword  |   |   |
 | <a name="source.domain"></a>`source.domain`  | Source domain.  | keyword  |   |   |
 | <a name="source.subdomain"></a>`source.subdomain`  | Source subdomain.  | keyword  |   |   |
+
+
+## <a name="tls"></a> TLS fields
+
+The tls fields contains the TLS related data about a specific connection.
+
+As an example in the case of Filebeat and the TCP input, the `version` field would be the version of the TLS protocol in use, the `certificates` would be the chain of certificates provided by the client and the `ciphersuite` is the encryption algorithm used for the communication.
+
+
+| Field  | Description  | Type  | Multi Field  | Example  |
+|---|---|---|---|---|
+| <a name="tls.version"></a>`tls.version`  | TLS version  | keyword  |   | `TLSv1.2`  |
+| <a name="tls.certificates"></a>`tls.certificates`  | An array of certificates.  | keyword  |   |   |
+| <a name="tls.servername"></a>`tls.servername`  | Server name requested by the client.  | keyword  |   | `localhost`  |
+| <a name="tls.ciphersuite"></a>`tls.ciphersuite`  | Name of the cipher used for the communication.  | keyword  |   | `ECDHE-ECDSA-AES-128-CBC-SHA`  |
 
 
 ## <a name="url"></a> URL fields

--- a/README.md
+++ b/README.md
@@ -361,17 +361,18 @@ Source fields describe details about the source of the event.
 
 ## <a name="tls"></a> TLS fields
 
-The tls fields contains the TLS related data about a specific connection.
-
-As an example in the case of Filebeat and the TCP input, the `version` field would be the version of the TLS protocol in use, the `certificates` would be the chain of certificates provided by the client and the `ciphersuite` is the encryption algorithm used for the communication.
+The tls fields contain the TLS related data about a specific connection.
 
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="tls.version"></a>`tls.version`  | TLS version  | keyword  |   | `TLSv1.2`  |
+| <a name="tls.version"></a>`tls.version`  | TLS version.  | keyword  |   | `TLSv1.2`  |
 | <a name="tls.certificates"></a>`tls.certificates`  | An array of certificates.  | keyword  |   |   |
 | <a name="tls.servername"></a>`tls.servername`  | Server name requested by the client.  | keyword  |   | `localhost`  |
 | <a name="tls.ciphersuite"></a>`tls.ciphersuite`  | Name of the cipher used for the communication.  | keyword  |   | `ECDHE-ECDSA-AES-128-CBC-SHA`  |
+
+
+As an example in the case of Filebeat and the TCP input, the `version` field would be the version of the TLS protocol in use, the `certificates` would be the chain of certificates provided by the client and the `ciphersuite` is the encryption algorithm used for the communication.
 
 
 ## <a name="url"></a> URL fields

--- a/schema.csv
+++ b/schema.csv
@@ -120,6 +120,10 @@ source.ip,ip,0,
 source.mac,keyword,1,
 source.port,long,1,
 source.subdomain,keyword,1,
+tls.certificates,keyword,0,
+tls.ciphersuite,keyword,0,ECDHE-ECDSA-AES-128-CBC-SHA
+tls.servername,keyword,0,localhost
+tls.version,keyword,0,TLSv1.2
 url.fragment,keyword,0,
 url.host.name,keyword,0,elastic.co
 url.href,text,0,https://elastic.co:443/search?q=elasticsearch#top

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -1,0 +1,35 @@
+---
+- name: tls
+  title: TLS
+  group: 2
+  description: >
+    The tls fields contains the TLS related data about a specific connection.
+
+    As an example in the case of Filebeat and the TCP input, the `version` field would be the
+    version of the TLS protocol in use, the `certificates` would be the chain of certificates
+    provided by the client and the `ciphersuite` is the encryption algorithm used for the
+    communication.
+  fields:
+    - name: version
+      type: keyword
+      description: >
+        TLS version
+
+      example: TLSv1.2
+    - name: certificates
+      type: keyword
+      description: >
+        An array of certificates.
+      ignore_above: 4096
+    - name: servername
+      type: keyword
+      description: >
+        Server name requested by the client.
+
+      example: localhost
+    - name: ciphersuite
+      type: keyword
+      description: >
+        Name of the cipher used for the communication.
+
+      example: ECDHE-ECDSA-AES-128-CBC-SHA

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -20,7 +20,8 @@
       type: keyword
       description: >
         An array of certificates.
-      ignore_above: 4096
+      ignore_above: -1
+      doc_values: false
     - name: servername
       type: keyword
       description: >

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -3,7 +3,7 @@
   title: TLS
   group: 2
   description: >
-    The tls fields contains the TLS related data about a specific connection.
+    The tls fields contain the TLS related data about a specific connection.
 
     As an example in the case of Filebeat and the TCP input, the `version` field would be the
     version of the TLS protocol in use, the `certificates` would be the chain of certificates
@@ -13,7 +13,7 @@
     - name: version
       type: keyword
       description: >
-        TLS version
+        TLS version.
 
       example: TLSv1.2
     - name: certificates

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -5,6 +5,7 @@
   description: >
     The tls fields contain the TLS related data about a specific connection.
 
+  footnote: >
     As an example in the case of Filebeat and the TCP input, the `version` field would be the
     version of the TLS protocol in use, the `certificates` would be the chain of certificates
     provided by the client and the `ciphersuite` is the encryption algorithm used for the

--- a/template.json
+++ b/template.json
@@ -624,7 +624,7 @@
         "tls": {
           "properties": {
             "certificates": {
-              "ignore_above": 4096,
+              "doc_values": false,
               "type": "keyword"
             },
             "ciphersuite": {

--- a/template.json
+++ b/template.json
@@ -621,6 +621,26 @@
           "ignore_above": 1024,
           "type": "keyword"
         },
+        "tls": {
+          "properties": {
+            "certificates": {
+              "ignore_above": 4096,
+              "type": "keyword"
+            },
+            "ciphersuite": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "servername": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "url": {
           "properties": {
             "fragment": {


### PR DESCRIPTION
While working on the TCP inputs for beats I am able to extract information about the TLS envelope,
this might be useful information for post-mortems or audit. Also, this was a feature requested on
the beats input on the Logstash side.

We are also extracting some information in [packetbeat](https://github.com/elastic/beats/blob/master/packetbeat/protos/tls/_meta/fields.yml) from the work of @adriansr.

Concerning the TCP or the beats input, I think we can extract the following field and provide some
useful information.

- TLS version
- Remote Certificates (mutual auth)
- ServerName
- Cipher used.

Where OR should this information be in the ECS schema? Maybe we could add a `transport` top level
key and have something like this.

| Field  | Description  | Type  | Example  |
|---|---|---|---|
tls.version| string representation of the tls version| keyword|	TLSv1.1 |
tls.certificates| array of certificates used by the client.|text| raw certificate|
tls.servername| server name requested by client|keyword| localhost[1]
tls.ciphersuite| Name of the cipher used| keyword|  ECDHE-ECDSA-AES-128-CBC-SHA

[1]:https://en.wikipedia.org/wiki/Server_Name_Indication