### PR TITLE
Adds cloud.account.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
+Adds cloud.account.id for top level organizational level.
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ In case Metricbeat is running on an EC2 host and fetches data from its host, the
 | <a name="cloud.instance.id"></a>`cloud.instance.id`  | Instance ID of the host machine.  | keyword  |   | `i-1234567890abcdef0`  |
 | <a name="cloud.instance.name"></a>`cloud.instance.name`  | Instance name of the host machine.  | keyword  |   |   |
 | <a name="cloud.machine.type"></a>`cloud.machine.type`  | Machine type of the host machine.  | keyword  |   | `t2.medium`  |
-| <a name="cloud.account.id"></a>`cloud.account.id`  | The cloud account or organization id<br/>This could be the AWS account id or Google Cloud ORG Id. This should be organizational. Other things like GCP project id should be in an extended schema for the specific cloud provider.  | keyword  |   | `666777888999`  |
+| <a name="cloud.account.id"></a>`cloud.account.id`  | The cloud account or organization id<br/>This could be the AWS account id or Google Cloud ORG Id. This should be organizational.  | keyword  |   | `666777888999`  |
 
 
 ## <a name="container"></a> Container fields

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ In case Metricbeat is running on an EC2 host and fetches data from its host, the
 | <a name="cloud.instance.id"></a>`cloud.instance.id`  | Instance ID of the host machine.  | keyword  |   | `i-1234567890abcdef0`  |
 | <a name="cloud.instance.name"></a>`cloud.instance.name`  | Instance name of the host machine.  | keyword  |   |   |
 | <a name="cloud.machine.type"></a>`cloud.machine.type`  | Machine type of the host machine.  | keyword  |   | `t2.medium`  |
+| <a name="cloud.account.id"></a>`cloud.account.id`  | The cloud account or organization id<br/>This could be the AWS account id or Google Cloud ORG Id. This should be organizational. Other things like GCP project id should be in an extended schema for the specific cloud provider.  | keyword  |   | `666777888999`  |
 
 
 ## <a name="container"></a> Container fields

--- a/schema.csv
+++ b/schema.csv
@@ -7,6 +7,7 @@ agent.ephemeral_id,keyword,0,8a4f500f
 agent.id,keyword,0,8a4f500d
 agent.name,keyword,0,filebeat
 agent.version,keyword,0,6.0.0-rc2
+cloud.account.id,keyword,0,666777888999
 cloud.availability_zone,keyword,0,us-east-1c
 cloud.instance.id,keyword,0,i-1234567890abcdef0
 cloud.instance.name,keyword,0,

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -55,5 +55,4 @@
         The cloud account or organization id
 
         This could be the AWS account id or Google Cloud ORG Id. This should be
-        organizational. Other things like GCP project id should be in an
-        extended schema for the specific cloud provider.
+        organizational. 

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -47,3 +47,13 @@
       example: t2.medium
       description: >
         Machine type of the host machine.
+
+    - name: account.id
+      type: keyword
+      example: 666777888999
+      description: >
+        The cloud account or organization id
+
+        This could be the AWS account id or Google Cloud ORG Id. This should be
+        organizational. Other things like GCP project id should be in an
+        extended schema for the specific cloud provider.

--- a/template.json
+++ b/template.json
@@ -45,6 +45,14 @@
         },
         "cloud": {
           "properties": {
+            "account": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "availability_zone": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
The cloud.account.id can be a common field. All cloud providers have a
high level account id, org id, or subscription id that can be used in
this field. Anything more specific such as GCP's project id should go in
an extended schema for the specific cloud provider. Its important to put
GCP's project id in to a separate extended schema, because it does not
overlap conceptually with other cloud providers' structure.

For example. In GCP, you'll have an `organization id`. Under that
`organization id`, you can have multiple projects. This diverges quite
substantially from the flat AWS structure which is just a bunch of
linked accounts. For AWS, there is no subtree like GCP has for projects
or folders.

Azure has a top level organization as well. Under that there are
[subscriptions](https://docs.microsoft.com/en-us/office365/enterprise/subscriptions-licenses-accounts-and-tenants-for-microsoft-cloud-offerings).

For security analytics use cases it will be difficult to normalize
across all cloud providers, but account id could be the most basic
start. Since high level orgs are pretty much consistent across all cloud
providers, this could be in the common schema.

_I'm open to calling this organization.id also_