### PR TITLE
Add union merge for CHANGELOG to reduce merge conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md  merge=union


### PR DESCRIPTION
As the CHANELOG is updated in each PR this often leads to merge conflicts. As the CHANGELOG normally can be merged with a union merge this should reduce conflicts.