### PR TITLE
Rename url.href multi_field for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file based on the
 
 ### Breaking changes
 * Change structure of URL. #7
+* Rename `url.href` `multi_field`. #18
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -380,8 +380,8 @@ The URL object can be reused in other prefixes like `host.url.*` for example. It
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="url.href"></a>`url.href`  | href contains the full url. The field is stored as keyword.<br/>`href` is an analyzed field so the parsed information can be accessed through `href.analyzed` in quries.  | keyword  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
-| <a name="url.href.analyzed"></a>`url.href.analyzed`  |   | text  | 1  |   |
+| <a name="url.href"></a>`url.href`  | The full URL.  | text  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
+| <a name="url.href.raw"></a>`url.href.raw`  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="url.scheme"></a>`url.scheme`  | The scheme of the request, e.g. "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
 | <a name="url.host.name"></a>`url.host.name`  | The hostname of the request, e.g. "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
 | <a name="url.port"></a>`url.port`  | The port of the request, e.g. 443.  | integer  |   | `443`  |

--- a/schema.csv
+++ b/schema.csv
@@ -121,7 +121,7 @@ source.port,long,1,
 source.subdomain,keyword,1,
 url.fragment,keyword,0,
 url.host.name,keyword,0,elastic.co
-url.href,keyword,0,https://elastic.co:443/search?q=elasticsearch#top
+url.href,text,0,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,0,
 url.path,text,0,
 url.port,integer,0,443

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -17,15 +17,15 @@
     URL in all its part on ingest time.
   fields:
     - name: href
-      type: keyword
+      type: text
       description: >
-        href contains the full url. The field is stored as keyword.
-
-        `href` is an analyzed field so the parsed information can be accessed
-        through `href.analyzed` in quries.
+        The full URL.
       multi_fields:
-        - name: analyzed
-          type: text
+        - name: raw
+          type: keyword
+          description: >
+            The full URL. This is a non-analyzed field that is useful
+            for aggregations.
       example: https://elastic.co:443/search?q=elasticsearch#top
     - name: scheme
       type: keyword

--- a/template.json
+++ b/template.json
@@ -631,13 +631,13 @@
             },
             "href": {
               "fields": {
-                "analyzed": {
-                  "norms": false,
-                  "type": "text"
+                "raw": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "norms": false,
+              "type": "text"
             },
             "password": {
               "ignore_above": 1024,


### PR DESCRIPTION
Non-analyzed `keyword` fields are currently in `.raw`, except for `url.href` where there is a `url.href.analyzed` field. This PR fixes that.