### PR TITLE
Make fields in uses cases which are not in ECS italic

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ The base set contains all fields which are on the top level. These fields are co
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="@timestamp"></a>`@timestamp`  | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| <a name="tags"></a>`tags`  | List of keywords used to tag each event.  | keyword  |   | `["production", "env2"]`  |
-| <a name="labels"></a>`labels`  | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels.  | object  |   | `{key1: value1, key2: value2}`  |
-| <a name="message"></a>`message`  | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message.  | text  |   | `Hello World`  |
+| <a name="@timestamp"></a>@timestamp  | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events.  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| <a name="tags"></a>tags  | List of keywords used to tag each event.  | keyword  |   | `["production", "env2"]`  |
+| <a name="labels"></a>labels  | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels.  | object  |   | `{key1: value1, key2: value2}`  |
+| <a name="message"></a>message  | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message.  | text  |   | `Hello World`  |
 
 
 ## <a name="agent"></a> Agent fields
@@ -68,10 +68,10 @@ The agent fields contain the data about the agent/client/shipper that created th
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="agent.version"></a>`agent.version`  | Version of the agent.  | keyword  |   | `6.0.0-rc2`  |
-| <a name="agent.name"></a>`agent.name`  | Name of the agent.  | keyword  |   | `filebeat`  |
-| <a name="agent.id"></a>`agent.id`  | Unique identifier of this agent (if one exists).<br/>Example: For Beats this would be beat.id.  | keyword  |   | `8a4f500d`  |
-| <a name="agent.ephemeral_id"></a>`agent.ephemeral_id`  | Ephemeral identifier of this agent (if one exists).<br/>This id normally changes across restarts, but `agent.id` does not.  | keyword  |   | `8a4f500f`  |
+| <a name="agent.version"></a>agent.version  | Version of the agent.  | keyword  |   | `6.0.0-rc2`  |
+| <a name="agent.name"></a>agent.name  | Name of the agent.  | keyword  |   | `filebeat`  |
+| <a name="agent.id"></a>agent.id  | Unique identifier of this agent (if one exists).<br/>Example: For Beats this would be beat.id.  | keyword  |   | `8a4f500d`  |
+| <a name="agent.ephemeral_id"></a>agent.ephemeral_id  | Ephemeral identifier of this agent (if one exists).<br/>This id normally changes across restarts, but `agent.id` does not.  | keyword  |   | `8a4f500f`  |
 
 
 Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the agent running in the app/service. The agent information does not change if data is sent through queuing systems like Kafka, Redis, or processing systems such as Logstash or APM Server.
@@ -84,13 +84,13 @@ Fields related to the cloud or infrastructure the events are coming from.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="cloud.provider"></a>`cloud.provider`  | Name of the cloud provider. Example values are ec2, gce, or digitalocean.  | keyword  |   | `ec2`  |
-| <a name="cloud.availability_zone"></a>`cloud.availability_zone`  | Availability zone in which this host is running.  | keyword  |   | `us-east-1c`  |
-| <a name="cloud.region"></a>`cloud.region`  | Region in which this host is running.  | keyword  |   | `us-east-1`  |
-| <a name="cloud.instance.id"></a>`cloud.instance.id`  | Instance ID of the host machine.  | keyword  |   | `i-1234567890abcdef0`  |
-| <a name="cloud.instance.name"></a>`cloud.instance.name`  | Instance name of the host machine.  | keyword  |   |   |
-| <a name="cloud.machine.type"></a>`cloud.machine.type`  | Machine type of the host machine.  | keyword  |   | `t2.medium`  |
-| <a name="cloud.account.id"></a>`cloud.account.id`  | The cloud account or organization id used to identify different entities in a multi-tenant environment.<br/>Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.  | keyword  |   | `666777888999`  |
+| <a name="cloud.provider"></a>cloud.provider  | Name of the cloud provider. Example values are ec2, gce, or digitalocean.  | keyword  |   | `ec2`  |
+| <a name="cloud.availability_zone"></a>cloud.availability_zone  | Availability zone in which this host is running.  | keyword  |   | `us-east-1c`  |
+| <a name="cloud.region"></a>cloud.region  | Region in which this host is running.  | keyword  |   | `us-east-1`  |
+| <a name="cloud.instance.id"></a>cloud.instance.id  | Instance ID of the host machine.  | keyword  |   | `i-1234567890abcdef0`  |
+| <a name="cloud.instance.name"></a>cloud.instance.name  | Instance name of the host machine.  | keyword  |   |   |
+| <a name="cloud.machine.type"></a>cloud.machine.type  | Machine type of the host machine.  | keyword  |   | `t2.medium`  |
+| <a name="cloud.account.id"></a>cloud.account.id  | The cloud account or organization id used to identify different entities in a multi-tenant environment.<br/>Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.  | keyword  |   | `666777888999`  |
 
 
 Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the  service is running on.
@@ -103,12 +103,12 @@ Container fields are used for meta information about the specific container that
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="container.runtime"></a>`container.runtime`  | Runtime managing this container.  | keyword  |   | `docker`  |
-| <a name="container.id"></a>`container.id`  | Unique container id.  | keyword  |   |   |
-| <a name="container.image.name"></a>`container.image.name`  | Name of the image the container was built on.  | keyword  |   |   |
-| <a name="container.image.tag"></a>`container.image.tag`  | Container image tag.  | keyword  |   |   |
-| <a name="container.name"></a>`container.name`  | Container name.  | keyword  |   |   |
-| <a name="container.labels"></a>`container.labels`  | Image labels.  | object  |   |   |
+| <a name="container.runtime"></a>container.runtime  | Runtime managing this container.  | keyword  |   | `docker`  |
+| <a name="container.id"></a>container.id  | Unique container id.  | keyword  |   |   |
+| <a name="container.image.name"></a>container.image.name  | Name of the image the container was built on.  | keyword  |   |   |
+| <a name="container.image.tag"></a>container.image.tag  | Container image tag.  | keyword  |   |   |
+| <a name="container.name"></a>container.name  | Container name.  | keyword  |   |   |
+| <a name="container.labels"></a>container.labels  | Image labels.  | object  |   |   |
 
 
 ## <a name="destination"></a> Destination fields
@@ -118,12 +118,12 @@ Destination fields describe details about the destination of a packet/event.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="destination.ip"></a>`destination.ip`  | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses.  | ip  |   |   |
-| <a name="destination.hostname"></a>`destination.hostname`  | Hostname of the destination.  | keyword  |   |   |
-| <a name="destination.port"></a>`destination.port`  | Port of the destination.  | long  |   |   |
-| <a name="destination.mac"></a>`destination.mac`  | MAC address of the destination.  | keyword  |   |   |
-| <a name="destination.domain"></a>`destination.domain`  | Destination domain.  | keyword  |   |   |
-| <a name="destination.subdomain"></a>`destination.subdomain`  | Destination subdomain.  | keyword  |   |   |
+| <a name="destination.ip"></a>destination.ip  | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses.  | ip  |   |   |
+| <a name="destination.hostname"></a>destination.hostname  | Hostname of the destination.  | keyword  |   |   |
+| <a name="destination.port"></a>destination.port  | Port of the destination.  | long  |   |   |
+| <a name="destination.mac"></a>destination.mac  | MAC address of the destination.  | keyword  |   |   |
+| <a name="destination.domain"></a>destination.domain  | Destination domain.  | keyword  |   |   |
+| <a name="destination.subdomain"></a>destination.subdomain  | Destination subdomain.  | keyword  |   |   |
 
 
 ## <a name="device"></a> Device fields
@@ -133,14 +133,14 @@ Device fields are used to provide additional information about the device that i
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="device.mac"></a>`device.mac`  | MAC address of the device  | keyword  |   |   |
-| <a name="device.ip"></a>`device.ip`  | IP address of the device.  | ip  |   |   |
-| <a name="device.hostname"></a>`device.hostname`  | Hostname of the device.  | keyword  |   |   |
-| <a name="device.vendor"></a>`device.vendor`  | Device vendor information.  | text  |   |   |
-| <a name="device.version"></a>`device.version`  | Device version.  | keyword  |   |   |
-| <a name="device.serial_number"></a>`device.serial_number`  | Device serial number.  | keyword  |   |   |
-| <a name="device.timezone.offset.sec"></a>`device.timezone.offset.sec`  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
-| <a name="device.type"></a>`device.type`  | The type of the device the data is coming from.<br/>There is no predefined list of device types. Some examples are `endpoint`, `firewall`, `ids`, `ips`, `proxy`.  | keyword  |   | `firewall`  |
+| <a name="device.mac"></a>device.mac  | MAC address of the device  | keyword  |   |   |
+| <a name="device.ip"></a>device.ip  | IP address of the device.  | ip  |   |   |
+| <a name="device.hostname"></a>device.hostname  | Hostname of the device.  | keyword  |   |   |
+| <a name="device.vendor"></a>device.vendor  | Device vendor information.  | text  |   |   |
+| <a name="device.version"></a>device.version  | Device version.  | keyword  |   |   |
+| <a name="device.serial_number"></a>device.serial_number  | Device serial number.  | keyword  |   |   |
+| <a name="device.timezone.offset.sec"></a>device.timezone.offset.sec  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
+| <a name="device.type"></a>device.type  | The type of the device the data is coming from.<br/>There is no predefined list of device types. Some examples are `endpoint`, `firewall`, `ids`, `ips`, `proxy`.  | keyword  |   | `firewall`  |
 
 
 ## <a name="error"></a> Error fields
@@ -150,9 +150,9 @@ These fields can represent errors of any kind. Use them for errors that happen w
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="error.id"></a>`error.id`  | Unique identifier for the error.  | keyword  |   |   |
-| <a name="error.message"></a>`error.message`  | Error message.  | text  |   |   |
-| <a name="error.code"></a>`error.code`  | Error code describing the error.  | keyword  |   |   |
+| <a name="error.id"></a>error.id  | Unique identifier for the error.  | keyword  |   |   |
+| <a name="error.message"></a>error.message  | Error message.  | text  |   |   |
+| <a name="error.code"></a>error.code  | Error code describing the error.  | keyword  |   |   |
 
 
 ## <a name="event"></a> Event fields
@@ -162,19 +162,19 @@ The event fields are used for context information about the data itself.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="event.id"></a>`event.id`  | Unique ID to describe the event.  | keyword  |   | `8a4f500d`  |
-| <a name="event.category"></a>`event.category`  | Event category.<br/>This can be a user defined category.  | keyword  |   | `metrics`  |
-| <a name="event.type"></a>`event.type`  | A type given to this kind of event which can be used for grouping.<br/>This is normally defined by the user.  | keyword  |   | `nginx-stats-metrics`  |
-| <a name="event.action"></a>`event.action`  | The action captured by the event. The type of action will vary from system to system but is likely to include actions by security services, such as blocking or quarantining; as well as more generic actions such as login events, file i/o or proxy forwarding events.<br/>The value is normally defined by the user.  | keyword  |   | `reject`  |
-| <a name="event.module"></a>`event.module`  | Name of the module this data is coming from.<br/>This information is coming from the modules used in Beats or Logstash.  | keyword  |   | `mysql`  |
-| <a name="event.dataset"></a>`event.dataset`  | Name of the dataset.<br/>The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name.  | keyword  |   | `stats`  |
-| <a name="event.severity"></a>`event.severity`  | Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.  | long  |   | `7`  |
-| <a name="event.raw"></a>`event.raw`  | Raw text message of entire event. Used to demonstrate log integrity.<br/>This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232`  |
-| <a name="event.hash"></a>`event.hash`  | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.  | keyword  |   | `123456789012345678901234567890ABCD`  |
-| <a name="event.version"></a>`event.version`  | The version field contains the version an event for ECS adheres to.<br/>This field should be provided as part of each event to make it possible to detect to which ECS version an event belongs.<br/>event.version is a required field and must exist in all events. It describes which ECS version the event adheres to.<br/>The current version is 0.1.0.  | keyword  |   | `0.1.0`  |
-| <a name="event.duration"></a>`event.duration`  | Duration of the event in nanoseconds.  | long  |   |   |
-| <a name="event.created"></a>`event.created`  | event.created contains the date when the event was created.<br/>This timestamp is distinct from @timestamp in that @timestamp contains the processed timestamp. For logs these two timestamps can be different as the timestamp in the log line and when the event is read for example by Filebeat are not identical. `@timestamp` must contain the timestamp extracted from the log line, event.created when the log line is read. The same could apply to package capturing where @timestamp contains the timestamp extracted from the network package and event.created when the event was created.<br/>In case the two timestamps are identical, @timestamp should be used.  | date  |   |   |
-| <a name="event.risk_score"></a>`event.risk_score`  | Risk score value of the event.  | float  |   |   |
+| <a name="event.id"></a>event.id  | Unique ID to describe the event.  | keyword  |   | `8a4f500d`  |
+| <a name="event.category"></a>event.category  | Event category.<br/>This can be a user defined category.  | keyword  |   | `metrics`  |
+| <a name="event.type"></a>event.type  | A type given to this kind of event which can be used for grouping.<br/>This is normally defined by the user.  | keyword  |   | `nginx-stats-metrics`  |
+| <a name="event.action"></a>event.action  | The action captured by the event. The type of action will vary from system to system but is likely to include actions by security services, such as blocking or quarantining; as well as more generic actions such as login events, file i/o or proxy forwarding events.<br/>The value is normally defined by the user.  | keyword  |   | `reject`  |
+| <a name="event.module"></a>event.module  | Name of the module this data is coming from.<br/>This information is coming from the modules used in Beats or Logstash.  | keyword  |   | `mysql`  |
+| <a name="event.dataset"></a>event.dataset  | Name of the dataset.<br/>The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name.  | keyword  |   | `stats`  |
+| <a name="event.severity"></a>event.severity  | Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.  | long  |   | `7`  |
+| <a name="event.raw"></a>event.raw  | Raw text message of entire event. Used to demonstrate log integrity.<br/>This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232`  |
+| <a name="event.hash"></a>event.hash  | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.  | keyword  |   | `123456789012345678901234567890ABCD`  |
+| <a name="event.version"></a>event.version  | The version field contains the version an event for ECS adheres to.<br/>This field should be provided as part of each event to make it possible to detect to which ECS version an event belongs.<br/>event.version is a required field and must exist in all events. It describes which ECS version the event adheres to.<br/>The current version is 0.1.0.  | keyword  |   | `0.1.0`  |
+| <a name="event.duration"></a>event.duration  | Duration of the event in nanoseconds.  | long  |   |   |
+| <a name="event.created"></a>event.created  | event.created contains the date when the event was created.<br/>This timestamp is distinct from @timestamp in that @timestamp contains the processed timestamp. For logs these two timestamps can be different as the timestamp in the log line and when the event is read for example by Filebeat are not identical. `@timestamp` must contain the timestamp extracted from the log line, event.created when the log line is read. The same could apply to package capturing where @timestamp contains the timestamp extracted from the network package and event.created when the event was created.<br/>In case the two timestamps are identical, @timestamp should be used.  | date  |   |   |
+| <a name="event.risk_score"></a>event.risk_score  | Risk score value of the event.  | float  |   |   |
 
 
 ## <a name="file"></a> File fields
@@ -184,22 +184,22 @@ File fields provide details about each file.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="file.path"></a>`file.path`  | Path to the file.  | text  |   |   |
-| <a name="file.path.raw"></a>`file.path.raw`  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="file.target_path"></a>`file.target_path`  | Target path for symlinks.  | text  |   |   |
-| <a name="file.target_path.raw"></a>`file.target_path.raw`  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="file.extension"></a>`file.extension`  | File extension.<br/>This should allow easy filtering by file extensions.  | keyword  |   | `png`  |
-| <a name="file.type"></a>`file.type`  | File type (file, dir, or symlink).  | keyword  |   |   |
-| <a name="file.device"></a>`file.device`  | Device that is the source of the file.  | keyword  |   |   |
-| <a name="file.inode"></a>`file.inode`  | Inode representing the file in the filesystem.  | keyword  |   |   |
-| <a name="file.uid"></a>`file.uid`  | The user ID (UID) or security identifier (SID) of the file owner.  | keyword  |   |   |
-| <a name="file.owner"></a>`file.owner`  | File owner's username.  | keyword  |   |   |
-| <a name="file.gid"></a>`file.gid`  | Primary group ID (GID) of the file.  | keyword  |   |   |
-| <a name="file.group"></a>`file.group`  | Primary group name of the file.  | keyword  |   |   |
-| <a name="file.mode"></a>`file.mode`  | Mode of the file in octal representation.  | keyword  |   | `416`  |
-| <a name="file.size"></a>`file.size`  | File size in bytes (field is only added when `type` is `file`).  | long  |   |   |
-| <a name="file.mtime"></a>`file.mtime`  | Last time file content was modified.  | date  |   |   |
-| <a name="file.ctime"></a>`file.ctime`  | Last time file metadata changed.  | date  |   |   |
+| <a name="file.path"></a>file.path  | Path to the file.  | text  |   |   |
+| <a name="file.path.raw"></a>file.path.raw  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="file.target_path"></a>file.target_path  | Target path for symlinks.  | text  |   |   |
+| <a name="file.target_path.raw"></a>file.target_path.raw  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="file.extension"></a>file.extension  | File extension.<br/>This should allow easy filtering by file extensions.  | keyword  |   | `png`  |
+| <a name="file.type"></a>file.type  | File type (file, dir, or symlink).  | keyword  |   |   |
+| <a name="file.device"></a>file.device  | Device that is the source of the file.  | keyword  |   |   |
+| <a name="file.inode"></a>file.inode  | Inode representing the file in the filesystem.  | keyword  |   |   |
+| <a name="file.uid"></a>file.uid  | The user ID (UID) or security identifier (SID) of the file owner.  | keyword  |   |   |
+| <a name="file.owner"></a>file.owner  | File owner's username.  | keyword  |   |   |
+| <a name="file.gid"></a>file.gid  | Primary group ID (GID) of the file.  | keyword  |   |   |
+| <a name="file.group"></a>file.group  | Primary group name of the file.  | keyword  |   |   |
+| <a name="file.mode"></a>file.mode  | Mode of the file in octal representation.  | keyword  |   | `416`  |
+| <a name="file.size"></a>file.size  | File size in bytes (field is only added when `type` is `file`).  | long  |   |   |
+| <a name="file.mtime"></a>file.mtime  | Last time file content was modified.  | date  |   |   |
+| <a name="file.ctime"></a>file.ctime  | Last time file metadata changed.  | date  |   |   |
 
 
 ## <a name="geoip"></a> Geoip fields
@@ -209,11 +209,11 @@ Geoip fields carry geo information for an ip address.  The Elasticsearch geoip p
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="geoip.continent_name"></a>`geoip.continent_name`  | Name of the continent.  | keyword  |   |   |
-| <a name="geoip.country_iso_code"></a>`geoip.country_iso_code`  | Country ISO code.  | keyword  |   |   |
-| <a name="geoip.location"></a>`geoip.location`  | Longitude and latitude.  | geo_point  |   |   |
-| <a name="geoip.region_name"></a>`geoip.region_name`  | Region name.  | keyword  |   |   |
-| <a name="geoip.city_name"></a>`geoip.city_name`  | City name.  | keyword  |   |   |
+| <a name="geoip.continent_name"></a>geoip.continent_name  | Name of the continent.  | keyword  |   |   |
+| <a name="geoip.country_iso_code"></a>geoip.country_iso_code  | Country ISO code.  | keyword  |   |   |
+| <a name="geoip.location"></a>geoip.location  | Longitude and latitude.  | geo_point  |   |   |
+| <a name="geoip.region_name"></a>geoip.region_name  | Region name.  | keyword  |   |   |
+| <a name="geoip.city_name"></a>geoip.city_name  | City name.  | keyword  |   |   |
 
 
 ## <a name="host"></a> Host fields
@@ -225,17 +225,17 @@ Normally the host information is related to the machine on which the event was g
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="host.timezone.offset.sec"></a>`host.timezone.offset.sec`  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
-| <a name="host.name"></a>`host.name`  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   |   |
-| <a name="host.id"></a>`host.id`  | Unique host id.<br/>As hostname is not always unique, use values that are meaningful in your environment. <br/>Example: The current usage of `beat.name`.  | keyword  |   |   |
-| <a name="host.ip"></a>`host.ip`  | Host ip address.  | ip  |   |   |
-| <a name="host.mac"></a>`host.mac`  | Host mac address.  | keyword  |   |   |
-| <a name="host.type"></a>`host.type`  | Type of host.<br/>For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.  | keyword  |   |   |
-| <a name="host.os.platform"></a>`host.os.platform`  | Operating system platform (centos, ubuntu, windows, etc.)  | keyword  |   | `darwin`  |
-| <a name="host.os.name"></a>`host.os.name`  | Operating system name.  | keyword  |   | `Mac OS X`  |
-| <a name="host.os.family"></a>`host.os.family`  | OS family (redhat, debian, freebsd, windows, etc.)  | keyword  |   | `debian`  |
-| <a name="host.os.version"></a>`host.os.version`  | Operating system version.  | keyword  |   | `10.12.6`  |
-| <a name="host.architecture"></a>`host.architecture`  | Operating system architecture.  | keyword  |   | `x86_64`  |
+| <a name="host.timezone.offset.sec"></a>host.timezone.offset.sec  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
+| <a name="host.name"></a>host.name  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   |   |
+| <a name="host.id"></a>host.id  | Unique host id.<br/>As hostname is not always unique, use values that are meaningful in your environment. <br/>Example: The current usage of `beat.name`.  | keyword  |   |   |
+| <a name="host.ip"></a>host.ip  | Host ip address.  | ip  |   |   |
+| <a name="host.mac"></a>host.mac  | Host mac address.  | keyword  |   |   |
+| <a name="host.type"></a>host.type  | Type of host.<br/>For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.  | keyword  |   |   |
+| <a name="host.os.platform"></a>host.os.platform  | Operating system platform (centos, ubuntu, windows, etc.)  | keyword  |   | `darwin`  |
+| <a name="host.os.name"></a>host.os.name  | Operating system name.  | keyword  |   | `Mac OS X`  |
+| <a name="host.os.family"></a>host.os.family  | OS family (redhat, debian, freebsd, windows, etc.)  | keyword  |   | `debian`  |
+| <a name="host.os.version"></a>host.os.version  | Operating system version.  | keyword  |   | `10.12.6`  |
+| <a name="host.architecture"></a>host.architecture  | Operating system architecture.  | keyword  |   | `x86_64`  |
 
 
 ## <a name="http"></a> HTTP fields
@@ -245,10 +245,10 @@ Fields related to HTTP requests and responses.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="http.request.method"></a>`http.request.method`  | Http request method.  | keyword  |   | `GET, POST, PUT`  |
-| <a name="http.response.status_code"></a>`http.response.status_code`  | Http response status code.  | long  |   | `404`  |
-| <a name="http.response.body"></a>`http.response.body`  | The full http response body.  | text  |   | `Hello world`  |
-| <a name="http.version"></a>`http.version`  | Http version.  | keyword  |   | `1.1`  |
+| <a name="http.request.method"></a>http.request.method  | Http request method.  | keyword  |   | `GET, POST, PUT`  |
+| <a name="http.response.status_code"></a>http.response.status_code  | Http response status code.  | long  |   | `404`  |
+| <a name="http.response.body"></a>http.response.body  | The full http response body.  | text  |   | `Hello world`  |
+| <a name="http.version"></a>http.version  | Http version.  | keyword  |   | `1.1`  |
 
 
 ## <a name="kubernetes"></a> Kubernetes fields
@@ -258,11 +258,11 @@ Kubernetes fields are used for Kubernetes meta information. This information hel
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="kubernetes.pod.name"></a>`kubernetes.pod.name`  | Kubernetes pod name  | keyword  |   |   |
-| <a name="kubernetes.namespace"></a>`kubernetes.namespace`  | Kubernetes namespace  | keyword  |   |   |
-| <a name="kubernetes.labels"></a>`kubernetes.labels`  | Kubernetes labels map  | object  |   |   |
-| <a name="kubernetes.annotations"></a>`kubernetes.annotations`  | Kubernetes annotations map  | object  |   |   |
-| <a name="kubernetes.container.name"></a>`kubernetes.container.name`  | Kubernetes container name. This name is unique within the pod only. It is different from the underlying `container.name` field.  | keyword  |   |   |
+| <a name="kubernetes.pod.name"></a>kubernetes.pod.name  | Kubernetes pod name  | keyword  |   |   |
+| <a name="kubernetes.namespace"></a>kubernetes.namespace  | Kubernetes namespace  | keyword  |   |   |
+| <a name="kubernetes.labels"></a>kubernetes.labels  | Kubernetes labels map  | object  |   |   |
+| <a name="kubernetes.annotations"></a>kubernetes.annotations  | Kubernetes annotations map  | object  |   |   |
+| <a name="kubernetes.container.name"></a>kubernetes.container.name  | Kubernetes container name. This name is unique within the pod only. It is different from the underlying `container.name` field.  | keyword  |   |   |
 
 
 ## <a name="log"></a> Log fields
@@ -272,10 +272,10 @@ Fields which are specific to log events.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="log.level"></a>`log.level`  | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`.  | keyword  |   | `ERR`  |
-| <a name="log.line"></a>`log.line`  | Line number the log event was collected from.  | long  |   | `18`  |
-| <a name="log.offset"></a>`log.offset`  | Offset of the beginning of the log event.  | long  |   | `12`  |
-| <a name="log.message"></a>`log.message`  | This is the log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
+| <a name="log.level"></a>log.level  | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`.  | keyword  |   | `ERR`  |
+| <a name="log.line"></a>log.line  | Line number the log event was collected from.  | long  |   | `18`  |
+| <a name="log.offset"></a>log.offset  | Offset of the beginning of the log event.  | long  |   | `12`  |
+| <a name="log.message"></a>log.message  | This is the log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
 
 
 ## <a name="network"></a> Network fields
@@ -285,15 +285,15 @@ Fields related to network data.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="network.protocol"></a>`network.protocol`  | Network protocol name.  | keyword  |   | `http`  |
-| <a name="network.direction"></a>`network.direction`  | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
-| <a name="network.forwarded_ip"></a>`network.forwarded_ip`  | Host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |
-| <a name="network.inbound.bytes"></a>`network.inbound.bytes`  | Network inbound bytes.  | long  |   | `184`  |
-| <a name="network.inbound.packets"></a>`network.inbound.packets`  | Network inbound packets.  | long  |   | `12`  |
-| <a name="network.outbound.bytes"></a>`network.outbound.bytes`  | Network outbound bytes.  | long  |   | `184`  |
-| <a name="network.outbound.packets"></a>`network.outbound.packets`  | Network outbound packets.  | long  |   | `12`  |
-| <a name="network.total.bytes"></a>`network.total.bytes`  | Network total bytes. The sum of inbound.bytes + outbound.bytes.  | long  |   | `368`  |
-| <a name="network.total.packets"></a>`network.total.packets`  | Network outbound packets. The sum of inbound.packets + outbound.packets  | long  |   | `24`  |
+| <a name="network.protocol"></a>network.protocol  | Network protocol name.  | keyword  |   | `http`  |
+| <a name="network.direction"></a>network.direction  | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
+| <a name="network.forwarded_ip"></a>network.forwarded_ip  | Host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |
+| <a name="network.inbound.bytes"></a>network.inbound.bytes  | Network inbound bytes.  | long  |   | `184`  |
+| <a name="network.inbound.packets"></a>network.inbound.packets  | Network inbound packets.  | long  |   | `12`  |
+| <a name="network.outbound.bytes"></a>network.outbound.bytes  | Network outbound bytes.  | long  |   | `184`  |
+| <a name="network.outbound.packets"></a>network.outbound.packets  | Network outbound packets.  | long  |   | `12`  |
+| <a name="network.total.bytes"></a>network.total.bytes  | Network total bytes. The sum of inbound.bytes + outbound.bytes.  | long  |   | `368`  |
+| <a name="network.total.packets"></a>network.total.packets  | Network outbound packets. The sum of inbound.packets + outbound.packets  | long  |   | `24`  |
 
 
 ## <a name="organization"></a> Organization fields
@@ -303,8 +303,8 @@ The organization fields enrich data with information about the company or entity
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="organization.name"></a>`organization.name`  | Organization name.  | text  |   |   |
-| <a name="organization.id"></a>`organization.id`  | Unique identifier for the organization.  | keyword  |   |   |
+| <a name="organization.name"></a>organization.name  | Organization name.  | text  |   |   |
+| <a name="organization.id"></a>organization.id  | Unique identifier for the organization.  | keyword  |   |   |
 
 
 ## <a name="os"></a> Operating System fields
@@ -314,10 +314,10 @@ The OS fields contain information about the operating system. These fields are o
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="os.platform"></a>`os.platform`  | Operating system platform (such centos, ubuntu, windows).  | keyword  |   | `darwin`  |
-| <a name="os.name"></a>`os.name`  | Operating system name.  | keyword  |   | `Mac OS X`  |
-| <a name="os.family"></a>`os.family`  | OS family (such as redhat, debian, freebsd, windows).  | keyword  |   | `debian`  |
-| <a name="os.version"></a>`os.version`  | Operating system version as a raw string.  | keyword  |   | `10.12.6-rc2`  |
+| <a name="os.platform"></a>os.platform  | Operating system platform (such centos, ubuntu, windows).  | keyword  |   | `darwin`  |
+| <a name="os.name"></a>os.name  | Operating system name.  | keyword  |   | `Mac OS X`  |
+| <a name="os.family"></a>os.family  | OS family (such as redhat, debian, freebsd, windows).  | keyword  |   | `debian`  |
+| <a name="os.version"></a>os.version  | Operating system version as a raw string.  | keyword  |   | `10.12.6-rc2`  |
 
 
 ## <a name="process"></a> Process fields
@@ -327,11 +327,11 @@ These fields contain information about a process. These fields can help you corr
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="process.args"></a>`process.args`  | Process arguments.<br/>May be filtered to protect sensitive information.  | keyword  |   | `['-l', 'user', '10.0.0.16']`  |
-| <a name="process.name"></a>`process.name`  | Process name.<br/>Sometimes called program name or similar.  | keyword  |   | `ssh`  |
-| <a name="process.pid"></a>`process.pid`  | Process id.  | long  |   |   |
-| <a name="process.ppid"></a>`process.ppid`  | Process parent id.  | long  |   |   |
-| <a name="process.title"></a>`process.title`  | Process title.<br/>The proctitle, often the same as process name.  | keyword  |   |   |
+| <a name="process.args"></a>process.args  | Process arguments.<br/>May be filtered to protect sensitive information.  | keyword  |   | `['-l', 'user', '10.0.0.16']`  |
+| <a name="process.name"></a>process.name  | Process name.<br/>Sometimes called program name or similar.  | keyword  |   | `ssh`  |
+| <a name="process.pid"></a>process.pid  | Process id.  | long  |   |   |
+| <a name="process.ppid"></a>process.ppid  | Process parent id.  | long  |   |   |
+| <a name="process.title"></a>process.title  | Process title.<br/>The proctitle, often the same as process name.  | keyword  |   |   |
 
 
 ## <a name="service"></a> Service fields
@@ -341,12 +341,12 @@ The service fields describe the service for or from which the data was collected
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="service.id"></a>`service.id`  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. <br/>Example: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
-| <a name="service.name"></a>`service.name`  | Name of the service data is collected from.<br/>The name can be used to group and correlate logs and metrics from one service.<br/>Example: If logs or metrics are collected from Redis, `service.name` would be `redis`.  | keyword  |   | `elasticsearch`  |
-| <a name="service.type"></a>`service.type`  | Service type.  | keyword  |   |   |
-| <a name="service.state"></a>`service.state`  | Current state of the service.  | keyword  |   |   |
-| <a name="service.version"></a>`service.version`  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service.  | keyword  |   | `3.2.4`  |
-| <a name="service.ephemeral_id"></a>`service.ephemeral_id`  | Ephemeral identifier of this service (if one exists).<br/>This id normally changes across restarts, but `service.id` does not.  | keyword  |   | `8a4f500f`  |
+| <a name="service.id"></a>service.id  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. <br/>Example: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
+| <a name="service.name"></a>service.name  | Name of the service data is collected from.<br/>The name can be used to group and correlate logs and metrics from one service.<br/>Example: If logs or metrics are collected from Redis, `service.name` would be `redis`.  | keyword  |   | `elasticsearch`  |
+| <a name="service.type"></a>service.type  | Service type.  | keyword  |   |   |
+| <a name="service.state"></a>service.state  | Current state of the service.  | keyword  |   |   |
+| <a name="service.version"></a>service.version  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service.  | keyword  |   | `3.2.4`  |
+| <a name="service.ephemeral_id"></a>service.ephemeral_id  | Ephemeral identifier of this service (if one exists).<br/>This id normally changes across restarts, but `service.id` does not.  | keyword  |   | `8a4f500f`  |
 
 
 ## <a name="source"></a> Source fields
@@ -356,12 +356,12 @@ Source fields describe details about the source of the event.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="source.ip"></a>`source.ip`  | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses.  | ip  |   |   |
-| <a name="source.hostname"></a>`source.hostname`  | Hostname of the source.  | keyword  |   |   |
-| <a name="source.port"></a>`source.port`  | Port of the source.  | long  |   |   |
-| <a name="source.mac"></a>`source.mac`  | MAC address of the source.  | keyword  |   |   |
-| <a name="source.domain"></a>`source.domain`  | Source domain.  | keyword  |   |   |
-| <a name="source.subdomain"></a>`source.subdomain`  | Source subdomain.  | keyword  |   |   |
+| <a name="source.ip"></a>source.ip  | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses.  | ip  |   |   |
+| <a name="source.hostname"></a>source.hostname  | Hostname of the source.  | keyword  |   |   |
+| <a name="source.port"></a>source.port  | Port of the source.  | long  |   |   |
+| <a name="source.mac"></a>source.mac  | MAC address of the source.  | keyword  |   |   |
+| <a name="source.domain"></a>source.domain  | Source domain.  | keyword  |   |   |
+| <a name="source.subdomain"></a>source.subdomain  | Source subdomain.  | keyword  |   |   |
 
 
 ## <a name="tls"></a> TLS fields
@@ -371,10 +371,10 @@ The tls fields contain the TLS related data about a specific connection.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="tls.version"></a>`tls.version`  | TLS version.  | keyword  |   | `TLSv1.2`  |
-| <a name="tls.certificates"></a>`tls.certificates`  | An array of certificates.  | keyword  |   |   |
-| <a name="tls.servername"></a>`tls.servername`  | Server name requested by the client.  | keyword  |   | `localhost`  |
-| <a name="tls.ciphersuite"></a>`tls.ciphersuite`  | Name of the cipher used for the communication.  | keyword  |   | `ECDHE-ECDSA-AES-128-CBC-SHA`  |
+| <a name="tls.version"></a>tls.version  | TLS version.  | keyword  |   | `TLSv1.2`  |
+| <a name="tls.certificates"></a>tls.certificates  | An array of certificates.  | keyword  |   |   |
+| <a name="tls.servername"></a>tls.servername  | Server name requested by the client.  | keyword  |   | `localhost`  |
+| <a name="tls.ciphersuite"></a>tls.ciphersuite  | Name of the cipher used for the communication.  | keyword  |   | `ECDHE-ECDSA-AES-128-CBC-SHA`  |
 
 
 As an example in the case of Filebeat and the TCP input, the `version` field would be the version of the TLS protocol in use, the `certificates` would be the chain of certificates provided by the client and the `ciphersuite` is the encryption algorithm used for the communication.
@@ -387,18 +387,18 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="url.href"></a>`url.href`  | Full url. The field is stored as keyword.<br/>`url.href` is a [multi field](https://www.elastic.co/guide/en/ elasticsearch/reference/6.2/ multi-fields.html#_multi_fields_with_multiple_analyzers). The data is stored as keyword `url.href` and test `url.href.analyzed`. These fields enable you to run a query against part of the url still works splitting up the URL at ingest time.  <br/>`href` is an analyzed field so the parsed information can be accessed through `href.analyzed` in queries.  | text  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
-| <a name="url.href.raw"></a>`url.href.raw`  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="url.scheme"></a>`url.scheme`  | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
-| <a name="url.host.name"></a>`url.host.name`  | Hostname of the request, such as "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
-| <a name="url.port"></a>`url.port`  | Port of the request, such as 443.  | integer  |   | `443`  |
-| <a name="url.path"></a>`url.path`  | Path of the request, such as "/search".  | text  |   |   |
-| <a name="url.path.raw"></a>`url.path.raw`  | URL path. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="url.query"></a>`url.query`  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | text  |   |   |
-| <a name="url.query.raw"></a>`url.query.raw`  | URL query part. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="url.fragment"></a>`url.fragment`  | Portion of the url after the `#`, such as "top".<br/>The `#` is not part of the fragment.  | keyword  |   |   |
-| <a name="url.username"></a>`url.username`  | Username of the request.  | keyword  |   |   |
-| <a name="url.password"></a>`url.password`  | Password of the request.  | keyword  |   |   |
+| <a name="url.href"></a>url.href  | Full url. The field is stored as keyword.<br/>`url.href` is a [multi field](https://www.elastic.co/guide/en/ elasticsearch/reference/6.2/ multi-fields.html#_multi_fields_with_multiple_analyzers). The data is stored as keyword `url.href` and test `url.href.analyzed`. These fields enable you to run a query against part of the url still works splitting up the URL at ingest time.  <br/>`href` is an analyzed field so the parsed information can be accessed through `href.analyzed` in queries.  | text  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
+| <a name="url.href.raw"></a>url.href.raw  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.scheme"></a>url.scheme  | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
+| <a name="url.host.name"></a>url.host.name  | Hostname of the request, such as "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
+| <a name="url.port"></a>url.port  | Port of the request, such as 443.  | integer  |   | `443`  |
+| <a name="url.path"></a>url.path  | Path of the request, such as "/search".  | text  |   |   |
+| <a name="url.path.raw"></a>url.path.raw  | URL path. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.query"></a>url.query  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | text  |   |   |
+| <a name="url.query.raw"></a>url.query.raw  | URL query part. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.fragment"></a>url.fragment  | Portion of the url after the `#`, such as "top".<br/>The `#` is not part of the fragment.  | keyword  |   |   |
+| <a name="url.username"></a>url.username  | Username of the request.  | keyword  |   |   |
+| <a name="url.password"></a>url.password  | Password of the request.  | keyword  |   |   |
 
 
 ## <a name="user"></a> User fields
@@ -408,10 +408,10 @@ The user fields describe information about the user that is relevant to  the eve
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="user.id"></a>`user.id`  | One or multiple unique identifiers of the user.  | keyword  |   |   |
-| <a name="user.name"></a>`user.name`  | Name of the user.<br/>The field is a keyword, and will not be tokenized.  | keyword  |   |   |
-| <a name="user.email"></a>`user.email`  | User email address.  | keyword  |   |   |
-| <a name="user.hash"></a>`user.hash`  | Unique user hash to correlate information for a user in anonymized form.<br/>Useful if `user.id` or `user.name` contain confidential information and cannot be used.  | keyword  |   |   |
+| <a name="user.id"></a>user.id  | One or multiple unique identifiers of the user.  | keyword  |   |   |
+| <a name="user.name"></a>user.name  | Name of the user.<br/>The field is a keyword, and will not be tokenized.  | keyword  |   |   |
+| <a name="user.email"></a>user.email  | User email address.  | keyword  |   |   |
+| <a name="user.hash"></a>user.hash  | Unique user hash to correlate information for a user in anonymized form.<br/>Useful if `user.id` or `user.name` contain confidential information and cannot be used.  | keyword  |   |   |
 
 
 ## <a name="user_agent"></a> User agent fields
@@ -421,17 +421,17 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.raw"></a>`user_agent.raw`  | Unparsed version of the user_agent.  | text  |   |   |
-| <a name="user_agent.device"></a>`user_agent.device`  | Name of the physical device.  | keyword  |   |   |
-| <a name="user_agent.version"></a>`user_agent.version`  | Version of the physical device.  | keyword  |   |   |
-| <a name="user_agent.major"></a>`user_agent.major`  | Major version of the user agent.  | long  |   |   |
-| <a name="user_agent.minor"></a>`user_agent.minor`  | Minor version of the user agent.  | long  |   |   |
-| <a name="user_agent.patch"></a>`user_agent.patch`  | Patch version of the user agent.  | keyword  |   |   |
-| <a name="user_agent.name"></a>`user_agent.name`  | Name of the user agent.  | keyword  |   | `Chrome`  |
-| <a name="user_agent.os.name"></a>`user_agent.os.name`  | Name of the operating system.  | keyword  |   |   |
-| <a name="user_agent.os.version"></a>`user_agent.os.version`  | Version of the operating system.  | keyword  |   |   |
-| <a name="user_agent.os.major"></a>`user_agent.os.major`  | Major version of the operating system.  | long  |   |   |
-| <a name="user_agent.os.minor"></a>`user_agent.os.minor`  | Minor version of the operating system.  | long  |   |   |
+| <a name="user_agent.raw"></a>user_agent.raw  | Unparsed version of the user_agent.  | text  |   |   |
+| <a name="user_agent.device"></a>user_agent.device  | Name of the physical device.  | keyword  |   |   |
+| <a name="user_agent.version"></a>user_agent.version  | Version of the physical device.  | keyword  |   |   |
+| <a name="user_agent.major"></a>user_agent.major  | Major version of the user agent.  | long  |   |   |
+| <a name="user_agent.minor"></a>user_agent.minor  | Minor version of the user agent.  | long  |   |   |
+| <a name="user_agent.patch"></a>user_agent.patch  | Patch version of the user agent.  | keyword  |   |   |
+| <a name="user_agent.name"></a>user_agent.name  | Name of the user agent.  | keyword  |   | `Chrome`  |
+| <a name="user_agent.os.name"></a>user_agent.os.name  | Name of the operating system.  | keyword  |   |   |
+| <a name="user_agent.os.version"></a>user_agent.os.version  | Version of the operating system.  | keyword  |   |   |
+| <a name="user_agent.os.major"></a>user_agent.os.major  | Major version of the operating system.  | long  |   |   |
+| <a name="user_agent.os.minor"></a>user_agent.os.minor  | Minor version of the operating system.  | long  |   |   |
 
 
 

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -1,4 +1,5 @@
 import yaml
+import os
 
 
 def read_schema_file(path):
@@ -85,10 +86,12 @@ def get_markdown_row(field, link, multi_field):
     # Replace newlines with HTML representation as otherwise newlines don't work in Markdown
     description = field["description"].replace("\n", "<br/>")
 
-    # Verified and accepted fields are bold
-    verified = False
-    if 'verified' in field.keys() and field["verified"]:
-        field["name"] = "**" + field["name"] + "**"
+    show_name = field["name"]
+    non_ecs = 'ecs' in field.keys() and not field["ecs"]
+    # non ecs fields are italic
+    if non_ecs:
+        show_name = "*" + field["name"] + "*"
+        description = "*" + description + "*"
 
     example = ""
     if field["example"] != "":
@@ -101,11 +104,18 @@ def get_markdown_row(field, link, multi_field):
         multi_field = ""
 
     # If link is true, it link to the anchor is provided. This is used for the use-cases
-    if link:
-        return '| [`{}`]({}#{})  | {}  | {}  | {}  | {}  |\n'.format(field["name"], link, field["name"], description, field["type"], multi_field, example)
+    if link and not non_ecs:
+        return '| [{}]({}#{})  | {}  | {}  | {}  | {}  |\n'.format(show_name, link, field["name"], description, field["type"], multi_field, example)
 
     # By default a anchor is attached to the name
-    return '| <a name="{}"></a>`{}`  | {}  | {}  | {}  | {}  |\n'.format(field["name"], field["name"], description, field["type"], multi_field, example)
+    return '| <a name="{}"></a>{}  | {}  | {}  | {}  | {}  |\n'.format(field["name"], show_name, description, field["type"], multi_field, example)
+
+
+def get_schema():
+    fields = []
+    for file in sorted(os.listdir("schemas")):
+        fields = fields + read_schema_file("schemas/" + file)
+    return fields
 
 
 def get_markdown_table(namespace, title_prefix="##", link=False):

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -80,9 +80,7 @@ if __name__ == "__main__":
     # Load schema files into yaml
     files = os.listdir("./schemas")
 
-    fields = []
-    for file in sorted(os.listdir("schemas")):
-        fields = fields + read_schema_file("schemas/" + file)
+    fields = get_schema()
 
     # Load all fields into object
     sortedNamespaces = sorted(fields, key=lambda field: field["group"])

--- a/scripts/use-cases.py
+++ b/scripts/use-cases.py
@@ -8,6 +8,8 @@ import os.path
 def write_stdout():
 
     link_prefix = "https://github.com/elastic/ecs"
+    schema = get_schema()
+    flat_schema = create_flat_schema(schema)
 
     links = ""
     for file in sorted(os.listdir("./use-cases")):
@@ -39,6 +41,7 @@ def write_stdout():
                 })
 
             for f2 in f["fields"]:
+                f2["ecs"] = f2["name"] in flat_schema
                 fields.append(f2)
 
         global_fields = {"name": use_case["name"], "title": use_case["title"], "description": "", "fields": fields}
@@ -51,6 +54,19 @@ def write_stdout():
             f.write(output)
 
     print("\n" + links + "\n\n")
+
+
+def create_flat_schema(schema):
+    fields = {}
+
+    for namespace in schema:
+        if len(namespace["fields"]) == 0:
+            continue
+
+        for f in namespace["fields"]:
+            fields[f["name"]] = f
+
+    return fields
 
 
 if __name__ == "__main__":

--- a/use-cases/apm.md
+++ b/use-cases/apm.md
@@ -7,15 +7,15 @@ ECS usage for the APM data.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`id`](https://github.com/elastic/ecs#id)  | Unique id to describe the event.  | keyword  |   | `8a4f500d`  |
-| [`timestamp`](https://github.com/elastic/ecs#timestamp)  | Timestamp when the event was created in the app / service.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| [`agent.*`](https://github.com/elastic/ecs#agent.*)  | The agent fields are used to describe which agent did send the information.<br/>  |   |   |   |
-| [`agent.version`](https://github.com/elastic/ecs#agent.version)  | APM Agent version.  | keyword  |   | `3.14.0`  |
-| [`agent.name`](https://github.com/elastic/ecs#agent.name)  | APM agent name.  | keyword  |   | `elastic-node`  |
-| [`service.*`](https://github.com/elastic/ecs#service.*)  | The service fields describe the service inside which the APM agent is running.<br/>  |   |   |   |
-| [`service.id`](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
-| [`service.name`](https://github.com/elastic/ecs#service.name)  | Name of the service the agent is running in. This is normally a user defined name.  | keyword  |   | `user-service`  |
-| [`service.version`](https://github.com/elastic/ecs#service.version)  | Version of the service the agent is running in. This depends on if the service is given a version.  | keyword  |   | `3.2.4`  |
+| <a name="id"></a>*id*  | *Unique id to describe the event.*  | keyword  |   | `8a4f500d`  |
+| <a name="timestamp"></a>*timestamp*  | *Timestamp when the event was created in the app / service.*  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| [agent.*](https://github.com/elastic/ecs#agent.*)  | The agent fields are used to describe which agent did send the information.<br/>  |   |   |   |
+| [agent.version](https://github.com/elastic/ecs#agent.version)  | APM Agent version.  | keyword  |   | `3.14.0`  |
+| [agent.name](https://github.com/elastic/ecs#agent.name)  | APM agent name.  | keyword  |   | `elastic-node`  |
+| [service.*](https://github.com/elastic/ecs#service.*)  | The service fields describe the service inside which the APM agent is running.<br/>  |   |   |   |
+| [service.id](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
+| [service.name](https://github.com/elastic/ecs#service.name)  | Name of the service the agent is running in. This is normally a user defined name.  | keyword  |   | `user-service`  |
+| [service.version](https://github.com/elastic/ecs#service.version)  | Version of the service the agent is running in. This depends on if the service is given a version.  | keyword  |   | `3.2.4`  |
 
 
 

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -7,22 +7,35 @@ ECS usage in Auditbeat.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`event.module`](https://github.com/elastic/ecs#event.module)  | Auditbeat module name.  |   |   |   |
-| [`file.*`](https://github.com/elastic/ecs#file.*)  | File attributes.<br/>  |   |   |   |
-| [`file.path`](https://github.com/elastic/ecs#file.path)  | The path to the file.  | text  |   |   |
-| [`file.path.raw`](https://github.com/elastic/ecs#file.path.raw)  | The path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| [`file.target_path`](https://github.com/elastic/ecs#file.target_path)  | The target path for symlinks.  | keyword  |   |   |
-| [`file.type`](https://github.com/elastic/ecs#file.type)  | The file type (file, dir, or symlink).  | keyword  |   |   |
-| [`file.device`](https://github.com/elastic/ecs#file.device)  | The device.  | keyword  |   |   |
-| [`file.inode`](https://github.com/elastic/ecs#file.inode)  | The inode representing the file in the filesystem.  | keyword  |   |   |
-| [`file.uid`](https://github.com/elastic/ecs#file.uid)  | The user ID (UID) or security identifier (SID) of the file owner.  | keyword  |   |   |
-| [`file.owner`](https://github.com/elastic/ecs#file.owner)  | The file owner's username.  | keyword  |   |   |
-| [`file.gid`](https://github.com/elastic/ecs#file.gid)  | The primary group ID (GID) of the file.  | keyword  |   |   |
-| [`file.group`](https://github.com/elastic/ecs#file.group)  | The primary group name of the file.  | keyword  |   |   |
-| [`file.mode`](https://github.com/elastic/ecs#file.mode)  | The mode of the file in octal representation.  | keyword  |   | `416`  |
-| [`file.size`](https://github.com/elastic/ecs#file.size)  | The file size in bytes (field is only added when `type` is `file`).  | long  |   |   |
-| [`file.mtime`](https://github.com/elastic/ecs#file.mtime)  | The last modified time of the file (time when content was modified).  | date  |   |   |
-| [`file.ctime`](https://github.com/elastic/ecs#file.ctime)  | The last change time of the file (time when metadata was changed).  | date  |   |   |
+| [event.module](https://github.com/elastic/ecs#event.module)  | Auditbeat module name.  |   |   |   |
+| [file.*](https://github.com/elastic/ecs#file.*)  | File attributes.<br/>  |   |   |   |
+| [file.path](https://github.com/elastic/ecs#file.path)  | The path to the file.  | text  |   |   |
+| [file.path.raw](https://github.com/elastic/ecs#file.path.raw)  | The path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| [file.target_path](https://github.com/elastic/ecs#file.target_path)  | The target path for symlinks.  | keyword  |   |   |
+| [file.type](https://github.com/elastic/ecs#file.type)  | The file type (file, dir, or symlink).  | keyword  |   |   |
+| [file.device](https://github.com/elastic/ecs#file.device)  | The device.  | keyword  |   |   |
+| [file.inode](https://github.com/elastic/ecs#file.inode)  | The inode representing the file in the filesystem.  | keyword  |   |   |
+| [file.uid](https://github.com/elastic/ecs#file.uid)  | The user ID (UID) or security identifier (SID) of the file owner.  | keyword  |   |   |
+| [file.owner](https://github.com/elastic/ecs#file.owner)  | The file owner's username.  | keyword  |   |   |
+| [file.gid](https://github.com/elastic/ecs#file.gid)  | The primary group ID (GID) of the file.  | keyword  |   |   |
+| [file.group](https://github.com/elastic/ecs#file.group)  | The primary group name of the file.  | keyword  |   |   |
+| [file.mode](https://github.com/elastic/ecs#file.mode)  | The mode of the file in octal representation.  | keyword  |   | `416`  |
+| [file.size](https://github.com/elastic/ecs#file.size)  | The file size in bytes (field is only added when `type` is `file`).  | long  |   |   |
+| [file.mtime](https://github.com/elastic/ecs#file.mtime)  | The last modified time of the file (time when content was modified).  | date  |   |   |
+| [file.ctime](https://github.com/elastic/ecs#file.ctime)  | The last change time of the file (time when metadata was changed).  | date  |   |   |
+| [hash.*](https://github.com/elastic/ecs#hash.*)  | Hash fields used in Auditbeat.<br/>The hash field contains cryptographic hashes of data associated with the event (such as a file). The keys are names of cryptographic algorithms. The values are encoded as hexidecimal (lower-case).<br/>All fields in user can have one or multiple entries.<br/>  |   |   |   |
+| <a name="hash.md5"></a>*hash.md5*  | *MD5 hash.*  | keyword  |   |   |
+| <a name="hash.sha1"></a>*hash.sha1*  | *SHA-1 hash.*  | keyword  |   |   |
+| <a name="hash.sha224"></a>*hash.sha224*  | *SHA-224 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha256"></a>*hash.sha256*  | *SHA-256 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha384"></a>*hash.sha384*  | *SHA-384 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha512"></a>*hash.sha512*  | *SHA-512 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha512_224"></a>*hash.sha512_224*  | *SHA-512/224 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha512_256"></a>*hash.sha512_256*  | *SHA-512/256 hash (SHA-2 family).*  | keyword  |   |   |
+| <a name="hash.sha3_224"></a>*hash.sha3_224*  | *SHA3-224 hash (SHA-3 family).*  | keyword  |   |   |
+| <a name="hash.sha3_256"></a>*hash.sha3_256*  | *SHA3-256 hash (SHA-3 family).*  | keyword  |   |   |
+| <a name="hash.sha3_384"></a>*hash.sha3_384*  | *SHA3-384 hash (SHA-3 family).*  | keyword  |   |   |
+| <a name="hash.sha3_512"></a>*hash.sha3_512*  | *SHA3-512 hash (SHA-3 family).*  | keyword  |   |   |
 
 
 

--- a/use-cases/auditbeat.yml
+++ b/use-cases/auditbeat.yml
@@ -73,75 +73,74 @@ fields:
     type: date
     description: The last change time of the file (time when metadata was changed).
 
-# TODO (@ruflin 2018-05-01): These fields are not in ECS. Needs decision or removal.
-#
-#- name: hash
-#  group: 3
-#  description: >
-#    Hash fields used in Auditbeat.
-#
-#    The hash field contains cryptographic hashes of data associated with the event
-#    (such as a file). The keys are names of cryptographic algorithms. The values
-#    are encoded as hexidecimal (lower-case).
-#
-#    All fields in user can have one or multiple entries.
-#  fields:
-#    - name: md5
-#      type: keyword
-#      description: >
-#        MD5 hash.
-#
-#    - name: sha1
-#      type: keyword
-#      description: >
-#        SHA-1 hash.
-#
-#    - name: sha224
-#      type: keyword
-#      description: >
-#        SHA-224 hash (SHA-2 family).
-#
-#    - name: sha256
-#      type: keyword
-#      description: >
-#        SHA-256 hash (SHA-2 family).
-#
-#    - name: sha384
-#      type: keyword
-#      description: >
-#        SHA-384 hash (SHA-2 family).
-#
-#    - name: sha512
-#      type: keyword
-#      description: >
-#        SHA-512 hash (SHA-2 family).
-#
-#    - name: sha512_224
-#      type: keyword
-#      description: >
-#        SHA-512/224 hash (SHA-2 family).
-#
-#    - name: sha512_256
-#      type: keyword
-#      description: >
-#        SHA-512/256 hash (SHA-2 family).
-#
-#    - name: sha3_224
-#      type: keyword
-#      description: >
-#        SHA3-224 hash (SHA-3 family).
-#
-#    - name: sha3_256
-#      type: keyword
-#      description: >
-#        SHA3-256 hash (SHA-3 family).
-#
-#    - name: sha3_384
-#      type: keyword
-#      description: >
-#        SHA3-384 hash (SHA-3 family).
-#
-#    - name: sha3_512
-#      type: keyword
-#      description: >
-#        SHA3-512 hash (SHA-3 family).
+
+- name: hash
+  group: 3
+  description: >
+    Hash fields used in Auditbeat.
+
+    The hash field contains cryptographic hashes of data associated with the event
+    (such as a file). The keys are names of cryptographic algorithms. The values
+    are encoded as hexidecimal (lower-case).
+
+    All fields in user can have one or multiple entries.
+  fields:
+    - name: md5
+      type: keyword
+      description: >
+        MD5 hash.
+
+    - name: sha1
+      type: keyword
+      description: >
+        SHA-1 hash.
+
+    - name: sha224
+      type: keyword
+      description: >
+        SHA-224 hash (SHA-2 family).
+
+    - name: sha256
+      type: keyword
+      description: >
+        SHA-256 hash (SHA-2 family).
+
+    - name: sha384
+      type: keyword
+      description: >
+        SHA-384 hash (SHA-2 family).
+
+    - name: sha512
+      type: keyword
+      description: >
+        SHA-512 hash (SHA-2 family).
+
+    - name: sha512_224
+      type: keyword
+      description: >
+        SHA-512/224 hash (SHA-2 family).
+
+    - name: sha512_256
+      type: keyword
+      description: >
+        SHA-512/256 hash (SHA-2 family).
+
+    - name: sha3_224
+      type: keyword
+      description: >
+        SHA3-224 hash (SHA-3 family).
+
+    - name: sha3_256
+      type: keyword
+      description: >
+        SHA3-256 hash (SHA-3 family).
+
+    - name: sha3_384
+      type: keyword
+      description: >
+        SHA3-384 hash (SHA-3 family).
+
+    - name: sha3_512
+      type: keyword
+      description: >
+        SHA3-512 hash (SHA-3 family).

--- a/use-cases/beats.md
+++ b/use-cases/beats.md
@@ -7,12 +7,12 @@ ECS fields used in Beats.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`id`](https://github.com/elastic/ecs#id)  | Unique id to describe the event.  | keyword  |   | `8a4f500d`  |
-| [`timestamp`](https://github.com/elastic/ecs#timestamp)  | Timestamp when the event was created.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| [`agent.*`](https://github.com/elastic/ecs#agent.*)  | The agent fields are used to describe by which beat the information was collected.<br/>  |   |   |   |
-| [`agent.version`](https://github.com/elastic/ecs#agent.version)  | Beat version.  | keyword  |   | `6.0.0-rc2`  |
-| [`agent.name`](https://github.com/elastic/ecs#agent.name)  | Beat name.  | keyword  |   | `filebeat`  |
-| [`agent.id`](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier.  | keyword  |   | `8a4f500d`  |
+| <a name="id"></a>*id*  | *Unique id to describe the event.*  | keyword  |   | `8a4f500d`  |
+| <a name="timestamp"></a>*timestamp*  | *Timestamp when the event was created.*  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| [agent.*](https://github.com/elastic/ecs#agent.*)  | The agent fields are used to describe by which beat the information was collected.<br/>  |   |   |   |
+| [agent.version](https://github.com/elastic/ecs#agent.version)  | Beat version.  | keyword  |   | `6.0.0-rc2`  |
+| [agent.name](https://github.com/elastic/ecs#agent.name)  | Beat name.  | keyword  |   | `filebeat`  |
+| [agent.id](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier.  | keyword  |   | `8a4f500d`  |
 
 
 

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -7,17 +7,23 @@ ECS fields used in Filebeat for the apache module.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`id`](https://github.com/elastic/ecs#id)  | Unique id to describe the event.  | keyword  |   | `8a4f500d`  |
-| [`@timestamp`](https://github.com/elastic/ecs#@timestamp)  | Timestamp of the log line after processing.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| [`message`](https://github.com/elastic/ecs#message)  | Log message of the event  | date  |   | `Hello World`  |
-| [`event.module`](https://github.com/elastic/ecs#event.module)  | Currently fileset.module  | keyword  |   | `apache`  |
-| [`event.dataset`](https://github.com/elastic/ecs#event.dataset)  | Currenly fileset.name  | keyword  |   | `access`  |
-| [`source.ip`](https://github.com/elastic/ecs#source.ip)  | Source ip of the request. Currently apache.access.remote_ip  | ip  |   | `192.168.1.1`  |
-| [`user.name`](https://github.com/elastic/ecs#user.name)  | User name in the request. Currently apache.access.user_name  | keyword  |   | `ruflin`  |
-| [`user_agent.*`](https://github.com/elastic/ecs#user_agent.*)  | User agent fields as in schema. Currently under apache.access.user_agent.*<br/>  |   |   |   |
-| [`user_agent.raw`](https://github.com/elastic/ecs#user_agent.raw)  | Raw user agent. Currently apache.access.agent  | text  |   | `http://elastic.co/`  |
-| [`geoip.*`](https://github.com/elastic/ecs#geoip.*)  | User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>  |   |   |   |
-| [`geoip....`](https://github.com/elastic/ecs#geoip....)  | All geoip fields.  | text  |   |   |
+| <a name="id"></a>*id*  | *Unique id to describe the event.*  | keyword  |   | `8a4f500d`  |
+| [@timestamp](https://github.com/elastic/ecs#@timestamp)  | Timestamp of the log line after processing.  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| [message](https://github.com/elastic/ecs#message)  | Log message of the event  | date  |   | `Hello World`  |
+| [event.module](https://github.com/elastic/ecs#event.module)  | Currently fileset.module  | keyword  |   | `apache`  |
+| [event.dataset](https://github.com/elastic/ecs#event.dataset)  | Currenly fileset.name  | keyword  |   | `access`  |
+| [source.ip](https://github.com/elastic/ecs#source.ip)  | Source ip of the request. Currently apache.access.remote_ip  | ip  |   | `192.168.1.1`  |
+| [user.name](https://github.com/elastic/ecs#user.name)  | User name in the request. Currently apache.access.user_name  | keyword  |   | `ruflin`  |
+| <a name="http.method"></a>*http.method*  | *Http method, currently apache.access.method*  | keyword  |   | `GET`  |
+| <a name="http.url"></a>*http.url*  | *Http url, currently apache.access.url*  | keyword  |   | `http://elastic.co/`  |
+| [http.version](https://github.com/elastic/ecs#http.version)  | Http version, currently apache.access.http_version  | keyword  |   | `1.1`  |
+| <a name="http.response.code"></a>*http.response.code*  | *Http response code, currently apache.access.response_code*  | keyword  |   | `404`  |
+| <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes*  | *Http response body bytes sent, currently apache.access.body_sent.bytes*  | long  |   | `117`  |
+| <a name="http.referer"></a>*http.referer*  | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard*  | keyword  |   | `http://elastic.co/`  |
+| [user_agent.*](https://github.com/elastic/ecs#user_agent.*)  | User agent fields as in schema. Currently under apache.access.user_agent.*<br/>  |   |   |   |
+| [user_agent.raw](https://github.com/elastic/ecs#user_agent.raw)  | Raw user agent. Currently apache.access.agent  | text  |   | `http://elastic.co/`  |
+| [geoip.*](https://github.com/elastic/ecs#geoip.*)  | User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>  |   |   |   |
+| <a name="geoip...."></a>*geoip....*  | *All geoip fields.*  | text  |   |   |
 
 
 

--- a/use-cases/filebeat-apache-access.yml
+++ b/use-cases/filebeat-apache-access.yml
@@ -50,42 +50,40 @@ fields:
         User name in the request. Currently apache.access.user_name
       example: ruflin
 
-# TODO (@ruflin 2018-05-01): These fields are not in ECS. Needs decision or removal.
-#
-#- name: http
-#  fields:
-#    - name: method
-#      type: keyword
-#      description: >
-#        Http method, currently apache.access.method
-#      example: GET
-#    - name: url
-#      type: keyword
-#      description: >
-#        Http url, currently apache.access.url
-#      example: "http://elastic.co/"
-#    - name: version
-#      type: keyword
-#      description: >
-#        Http version, currently apache.access.http_version
-#      example: 1.1
-#    - name: response.code
-#      type: keyword
-#      description: >
-#        Http response code, currently apache.access.response_code
-#      example: 404
-#    - name: response.body_sent.bytes
-#      type: long
-#      description: >
-#        Http response body bytes sent, currently apache.access.body_sent.bytes
-#      example: 117
-#    - name: referer
-#      type: keyword
-#      description: >
-#        Http referrer code, currently apache.access.referrer
-#
-#        NOTE: In the RFC its misspell as referer and has become accepted standard
-#      example: http://elastic.co/
+- name: http
+  fields:
+    - name: method
+      type: keyword
+      description: >
+        Http method, currently apache.access.method
+      example: GET
+    - name: url
+      type: keyword
+      description: >
+        Http url, currently apache.access.url
+      example: "http://elastic.co/"
+    - name: version
+      type: keyword
+      description: >
+        Http version, currently apache.access.http_version
+      example: 1.1
+    - name: response.code
+      type: keyword
+      description: >
+        Http response code, currently apache.access.response_code
+      example: 404
+    - name: response.body_sent.bytes
+      type: long
+      description: >
+        Http response body bytes sent, currently apache.access.body_sent.bytes
+      example: 117
+    - name: referer
+      type: keyword
+      description: >
+        Http referrer code, currently apache.access.referrer
+
+        NOTE: In the RFC its misspell as referer and has become accepted standard
+      example: http://elastic.co/
 
 - name: user_agent
   title: User Agent

--- a/use-cases/logging.md
+++ b/use-cases/logging.md
@@ -7,14 +7,16 @@ ECS fields used in logging use cases.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`id`](https://github.com/elastic/ecs#id)  | Unique id of the log entry.  | keyword  |   | `8a4f500d`  |
-| [`timestamp`](https://github.com/elastic/ecs#timestamp)  | Timestamp of the log line.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| [`message`](https://github.com/elastic/ecs#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable.  | text  |   | `Hello World`  |
-| [`hostname`](https://github.com/elastic/ecs#hostname)  | Hostname extracted from the log line.  | keyword  |   | `www.example.com`  |
-| [`ip`](https://github.com/elastic/ecs#ip)  | IP Address extracted from the log line. Can be IPv4 or IPv6.  | ip  |   | `192.168.1.12`  |
-| [`log.level`](https://github.com/elastic/ecs#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc.  | keyword  |   | `ERR`  |
-| [`log.line`](https://github.com/elastic/ecs#log.line)  | Line number the log event was collected from.  | long  |   | `18`  |
-| [`log.offset`](https://github.com/elastic/ecs#log.offset)  | Offset of the log event.  | long  |   | `12`  |
+| <a name="id"></a>*id*  | *Unique id of the log entry.*  | keyword  |   | `8a4f500d`  |
+| <a name="timestamp"></a>*timestamp*  | *Timestamp of the log line.*  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| [message](https://github.com/elastic/ecs#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable.  | text  |   | `Hello World`  |
+| <a name="hostname"></a>*hostname*  | *Hostname extracted from the log line.*  | keyword  |   | `www.example.com`  |
+| <a name="ip"></a>*ip*  | *IP Address extracted from the log line. Can be IPv4 or IPv6.*  | ip  |   | `192.168.1.12`  |
+| [log.level](https://github.com/elastic/ecs#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc.  | keyword  |   | `ERR`  |
+| [log.line](https://github.com/elastic/ecs#log.line)  | Line number the log event was collected from.  | long  |   | `18`  |
+| [log.offset](https://github.com/elastic/ecs#log.offset)  | Offset of the log event.  | long  |   | `12`  |
+| [source.*](https://github.com/elastic/ecs#source.*)  | Describes from where the log entries come from.<br/>  |   |   |   |
+| <a name="source.path"></a>*source.path*  | *File path of the file the data is harvested from.*  | keyword  |   | `/var/log/test.log`  |
 
 
 

--- a/use-cases/logging.yml
+++ b/use-cases/logging.yml
@@ -55,15 +55,13 @@ fields:
         Offset of the log event.
       example: 12
 
-# TODO (@ruflin 2018-05-01): These fields are not in ECS. Needs decision or removal.
-# Should this be file.path?
-#
-#- name: source
-#  description: >
-#    Describes from where the log entries come from.
-#  fields:
-#    - name: path
-#      type: keyword
-#      description: >
-#        File path of the file the data is harvested from.
-#      example: /var/log/test.log
+
+- name: source
+  description: >
+    Describes from where the log entries come from.
+  fields:
+    - name: path
+      type: keyword
+      description: >
+        File path of the file the data is harvested from.
+      example: /var/log/test.log

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -7,24 +7,25 @@ ECS fields used Metricbeat.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| [`id`](https://github.com/elastic/ecs#id)  | Unique id to describe the event.  | keyword  |   | `8a4f500d`  |
-| [`timestamp`](https://github.com/elastic/ecs#timestamp)  | Timestamp when the event was created.  | date  |   | `2016-05-23T08:05:34.853Z`  |
-| [`agent.version`](https://github.com/elastic/ecs#agent.version)  | Beat version.  | keyword  |   | `6.0.0-rc2`  |
-| [`agent.name`](https://github.com/elastic/ecs#agent.name)  | Beat name.  | keyword  |   | `filebeat`  |
-| [`agent.id`](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier.  | keyword  |   | `8a4f500d`  |
-| [`service.*`](https://github.com/elastic/ecs#service.*)  | The service fields describe the service for / from which the data was collected.<br/>If logs or metrics are collected from Redis, `service.name` would be `redis`. This allows to find and correlate logs for a specicic service or even version with `service.version`.<br/>  |   |   |   |
-| [`service.id`](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. For example in case of issues with one redis instance, it's possible to filter on the id to see metrics and logs for this single instance.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
-| [`service.name`](https://github.com/elastic/ecs#service.name)  | Name of the service data is collected from.<br/>The name is normally the same as the module name.  | keyword  |   | `elasticsearch`  |
-| [`service.version`](https://github.com/elastic/ecs#service.version)  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service.  | keyword  |   | `3.2.4`  |
-| [`service.host`](https://github.com/elastic/ecs#service.host)  | Host address that is used to connect to the service.<br/>This normally contains hostname + port.<br/>REVIEW: Should this be service.uri instead, sometimes it's more then just the host? It could also include a path or the protocol.  | keyword  |   | `elasticsearch:9200`  |
-| [`error.*`](https://github.com/elastic/ecs#error.*)  | Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>  |   |   |   |
-| [`error.message`](https://github.com/elastic/ecs#error.message)  | Error message returned by the service during fetching metrics.  | text  |   |   |
-| [`error.code`](https://github.com/elastic/ecs#error.code)  | Error code returned by the service during fetching metrics.  | long  |   |   |
-| [`host.name`](https://github.com/elastic/ecs#host.name)  | Hostname of the system metricbeat is running on or user defined name.  | text  |   |   |
-| [`host.timezone.offset.sec`](https://github.com/elastic/ecs#host.timezone.offset.sec)  | Timezone offset of the host in seconds.  | long  |   |   |
-| [`host.id`](https://github.com/elastic/ecs#host.id)  | Unique host id.  | keyword  |   |   |
-| [`event.module`](https://github.com/elastic/ecs#event.module)  | Name of the module this data is coming from.  | keyword  |   | `mysql`  |
-| [`event.dataset`](https://github.com/elastic/ecs#event.dataset)  | Name of the dataset.<br/>This contains the information which is currently stored in metricset.name and metricset.module.  | keyword  |   | `stats`  |
+| <a name="id"></a>*id*  | *Unique id to describe the event.*  | keyword  |   | `8a4f500d`  |
+| <a name="timestamp"></a>*timestamp*  | *Timestamp when the event was created.*  | date  |   | `2016-05-23T08:05:34.853Z`  |
+| [agent.version](https://github.com/elastic/ecs#agent.version)  | Beat version.  | keyword  |   | `6.0.0-rc2`  |
+| [agent.name](https://github.com/elastic/ecs#agent.name)  | Beat name.  | keyword  |   | `filebeat`  |
+| [agent.id](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier.  | keyword  |   | `8a4f500d`  |
+| [service.*](https://github.com/elastic/ecs#service.*)  | The service fields describe the service for / from which the data was collected.<br/>If logs or metrics are collected from Redis, `service.name` would be `redis`. This allows to find and correlate logs for a specicic service or even version with `service.version`.<br/>  |   |   |   |
+| [service.id](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. For example in case of issues with one redis instance, it's possible to filter on the id to see metrics and logs for this single instance.  | keyword  |   | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6`  |
+| [service.name](https://github.com/elastic/ecs#service.name)  | Name of the service data is collected from.<br/>The name is normally the same as the module name.  | keyword  |   | `elasticsearch`  |
+| [service.version](https://github.com/elastic/ecs#service.version)  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service.  | keyword  |   | `3.2.4`  |
+| <a name="service.host"></a>*service.host*  | *Host address that is used to connect to the service.<br/>This normally contains hostname + port.<br/>REVIEW: Should this be service.uri instead, sometimes it's more then just the host? It could also include a path or the protocol.*  | keyword  |   | `elasticsearch:9200`  |
+| <a name="request.rtt"></a>*request.rtt*  | *Request round trip time.<br/>How long did the request take to fetch metrics from the service.<br/>REVIEW: THIS DOES NOT EXIST YET IN ECS.*  | long  |   | `115`  |
+| [error.*](https://github.com/elastic/ecs#error.*)  | Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>  |   |   |   |
+| [error.message](https://github.com/elastic/ecs#error.message)  | Error message returned by the service during fetching metrics.  | text  |   |   |
+| [error.code](https://github.com/elastic/ecs#error.code)  | Error code returned by the service during fetching metrics.  | long  |   |   |
+| [host.name](https://github.com/elastic/ecs#host.name)  | Hostname of the system metricbeat is running on or user defined name.  | text  |   |   |
+| [host.timezone.offset.sec](https://github.com/elastic/ecs#host.timezone.offset.sec)  | Timezone offset of the host in seconds.  | long  |   |   |
+| [host.id](https://github.com/elastic/ecs#host.id)  | Unique host id.  | keyword  |   |   |
+| [event.module](https://github.com/elastic/ecs#event.module)  | Name of the module this data is coming from.  | keyword  |   | `mysql`  |
+| [event.dataset](https://github.com/elastic/ecs#event.dataset)  | Name of the dataset.<br/>This contains the information which is currently stored in metricset.name and metricset.module.  | keyword  |   | `stats`  |
 
 
 

--- a/use-cases/metricbeat.yml
+++ b/use-cases/metricbeat.yml
@@ -82,19 +82,18 @@ fields:
         REVIEW: Should this be service.uri instead, sometimes it's more then just the host?
         It could also include a path or the protocol.
 
-# TODO (@ruflin 2018-05-01): These fields are not in ECS. Needs decision or removal.
-#- name: request
-#  fields:
-#    - name: rtt
-#      type: long
-#      description: >
-#        Request round trip time.
-#
-#        How long did the request take to fetch metrics from the service.
-#
-#        REVIEW: THIS DOES NOT EXIST YET IN ECS.
-#
-#      example: 115
+- name: request
+  fields:
+    - name: rtt
+      type: long
+      description: >
+        Request round trip time.
+
+        How long did the request take to fetch metrics from the service.
+
+        REVIEW: THIS DOES NOT EXIST YET IN ECS.
+
+      example: 115
 
 - name: error
   description: >


### PR DESCRIPTION
Some of the existing use cases contain fields which are not in ECS. Also we had several fields commented to make it clear they are not in ECS. In recent discussions it popped up that it could be useful for others to share their schema they use for specific use cases + the fields which are not in ECS. As we now show the fields different this is possible.

I plan to do follow up PR's to also clean up the use cases. Some are outdated and should be updated to use ECS fields, others can be useful for inspiration on new fields. Reviewing use cases is now much easier as it is directly visible which fields come from ECS and which ones not.

Additional changes

* Remove links for non ecs fields.
* Remove ticks from name to make it nicer and support italic
* Add fields to uses cases which were commented out previously