### PR TITLE
Add host.os.kernel field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,6 @@ All notable changes to this project will be documented in this file based on the
 * Add fields for Operating System data. #5
 * Add `log.message`. #3
 * Add http.request.method and http.version
+* Add `host.os.kernel` containing the OS kernel version. #60
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ The OS fields contain information about the operating system. These fields are o
 | <a name="os.name"></a>os.name  | Operating system name.  | keyword  |   | `Mac OS X`  |
 | <a name="os.family"></a>os.family  | OS family (such as redhat, debian, freebsd, windows).  | keyword  |   | `debian`  |
 | <a name="os.version"></a>os.version  | Operating system version as a raw string.  | keyword  |   | `10.12.6-rc2`  |
+| <a name="os.kernel"></a>os.kernel  | Operating system kernel version as a raw string.  | keyword  |   | `4.4.0-112-generic`  |
 
 
 ## <a name="process"></a> Process fields

--- a/schema.csv
+++ b/schema.csv
@@ -105,6 +105,7 @@ network.total.packets,long,0,24
 organization.id,keyword,0,
 organization.name,text,0,
 os.family,keyword,0,debian
+os.kernel,keyword,0,4.4.0-112-generic
 os.name,keyword,0,Mac OS X
 os.platform,keyword,0,darwin
 os.version,keyword,0,10.12.6-rc2

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -25,3 +25,8 @@
       example: "10.12.6-rc2"
       description: >
         Operating system version as a raw string.
+    - name: kernel
+      type: keyword
+      example: "4.4.0-112-generic"
+      description: >
+        Operating system kernel version as a raw string.

--- a/template.json
+++ b/template.json
@@ -553,6 +553,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "kernel": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "name": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
host.os.kernel contains the raw kernel version.

Example values:
- linux: `4.4.0-112-generic`
- windows: `6.3.9600.19000 (winblue_ltsb.180410-0600)` (taken from the FileVersion value on ntoskrnl.exe)
- darwin: `16.7.0`

Closes #60