### PR TITLE
Add blake2b and xxhash to Auditbeat use-case fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-generate:
+generate: schemas readme template
+
+schemas:
 	python scripts/schemas.py
-	$(MAKE) readme
-	$(MAKE) template
 
 fmt:
 	find . -name *.py -exec autopep8 --in-place --max-line-length 120 {} \;
@@ -40,3 +40,5 @@ template:
 	go get github.com/elastic/go-ucfg/yaml
 	go get github.com/elastic/beats/libbeat/template
 	go run scripts/template.go > ./template.json
+
+.PHONY: generate schemas fmt check setup clean readme template

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,11 +1,10 @@
 # Use cases
 
-The use cases directory is used to define the fields for some more specific use cases. All the fields used here are inherited from ECS but are referenced here to have more details on it.
+The use cases directory is used to define the fields for some more specific use
+cases. All the fields used here are inherited from ECS but are referenced here
+to have more details on it.
 
 ## Generate
 
-To generate the markdown from the use-cases run
-
-```
-python use-cases.py
-```
+Execute `make` in the project's root directory after modifying any of the `.yml`
+files in this directory to rebuild the `.md` Markdown files.

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -24,6 +24,9 @@ ECS usage in Auditbeat.
 | [file.mtime](https://github.com/elastic/ecs#file.mtime)  | The last modified time of the file (time when content was modified).  | date  |   |   |
 | [file.ctime](https://github.com/elastic/ecs#file.ctime)  | The last change time of the file (time when metadata was changed).  | date  |   |   |
 | <a name="hash.&ast;"></a>*hash.&ast;*  | *Hash fields used in Auditbeat.<br/>The hash field contains cryptographic hashes of data associated with the event (such as a file). The keys are names of cryptographic algorithms. The values are encoded as hexidecimal (lower-case).<br/>All fields in user can have one or multiple entries.<br/>*  |   |   |   |
+| <a name="hash.blake2b_256"></a>*hash.blake2b_256*  | *BLAKE2b-256 hash of the file.*  | keyword  |   |   |
+| <a name="hash.blake2b_384"></a>*hash.blake2b_384*  | *BLAKE2b-384 hash of the file.*  | keyword  |   |   |
+| <a name="hash.blake2b_512"></a>*hash.blake2b_512*  | *BLAKE2b-512 hash of the file.*  | keyword  |   |   |
 | <a name="hash.md5"></a>*hash.md5*  | *MD5 hash.*  | keyword  |   |   |
 | <a name="hash.sha1"></a>*hash.sha1*  | *SHA-1 hash.*  | keyword  |   |   |
 | <a name="hash.sha224"></a>*hash.sha224*  | *SHA-224 hash (SHA-2 family).*  | keyword  |   |   |
@@ -36,6 +39,7 @@ ECS usage in Auditbeat.
 | <a name="hash.sha3_256"></a>*hash.sha3_256*  | *SHA3-256 hash (SHA-3 family).*  | keyword  |   |   |
 | <a name="hash.sha3_384"></a>*hash.sha3_384*  | *SHA3-384 hash (SHA-3 family).*  | keyword  |   |   |
 | <a name="hash.sha3_512"></a>*hash.sha3_512*  | *SHA3-512 hash (SHA-3 family).*  | keyword  |   |   |
+| <a name="hash.xxh64"></a>*hash.xxh64*  | *XX64 hash of the file.*  | keyword  |   |   |
 
 
 

--- a/use-cases/auditbeat.yml
+++ b/use-cases/auditbeat.yml
@@ -85,6 +85,18 @@ fields:
 
     All fields in user can have one or multiple entries.
   fields:
+    - name: blake2b_256
+      type: keyword
+      description: BLAKE2b-256 hash of the file.
+
+    - name: blake2b_384
+      type: keyword
+      description: BLAKE2b-384 hash of the file.
+
+    - name: blake2b_512
+      type: keyword
+      description: BLAKE2b-512 hash of the file.
+
     - name: md5
       type: keyword
       description: >
@@ -144,3 +156,7 @@ fields:
       type: keyword
       description: >
         SHA3-512 hash (SHA-3 family).
+
+    - name: xxh64
+      type: keyword
+      description: XX64 hash of the file.


### PR DESCRIPTION
There are a few new hash algorithms under the `hash` namespace used by Auditbeat.

- blake2b_256
- blake2b_384
- blake2b_512
- xxh64