### PR TITLE
 Adds network.protocol.name and network.protocol.id 

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,9 @@ Fields related to network data.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="network.protocol"></a>network.protocol  | Network protocol name.  | keyword  |   | `http`  |
+| <a name="network.protocol"></a>network.protocol  | Network protocol name.  | keyword  |   | `tcp`  |
+| <a name="network.protocol.name"></a>network.protocol.name  | Network protocol name.  | keyword  |   | `TCP`  |
+| <a name="network.protocol.id"></a>network.protocol.id  | Network protocol id https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml  | keyword  |   | `6`  |
 | <a name="network.direction"></a>network.direction  | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip  | Host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |
 | <a name="network.inbound.bytes"></a>network.inbound.bytes  | Network inbound bytes.  | long  |   | `184`  |

--- a/schema.csv
+++ b/schema.csv
@@ -99,7 +99,9 @@ network.inbound.bytes,long,0,184
 network.inbound.packets,long,0,12
 network.outbound.bytes,long,0,184
 network.outbound.packets,long,0,12
-network.protocol,keyword,0,http
+network.protocol,keyword,0,tcp
+network.protocol.id,keyword,0,6
+network.protocol.name,keyword,0,TCP
 network.total.bytes,long,0,368
 network.total.packets,long,0,24
 organization.id,keyword,0,

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -9,7 +9,7 @@
       type: keyword
       description: >
         Network protocol name.
-      example: http
+      example: tcp
     - name: direction
       type: keyword
       description: >

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -10,6 +10,16 @@
       description: >
         Network protocol name.
       example: tcp
+    - name: protocol.name
+      type: keyword
+      description: >
+        Network protocol name.
+      example: TCP
+    - name: protocol.id
+      type: keyword
+      description: >
+        Network protocol id https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+      example: 6 
     - name: direction
       type: keyword
       description: >

--- a/template.json
+++ b/template.json
@@ -521,6 +521,16 @@
             },
             "protocol": {
               "ignore_above": 1024,
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "type": "keyword"
             },
             "total": {
@@ -655,6 +665,7 @@
           "properties": {
             "certificates": {
               "doc_values": false,
+              "ignore_above": 1024,
               "type": "keyword"
             },
             "ciphersuite": {


### PR DESCRIPTION
With most logs coming in, the protocol names are not resolved to their respective full name and instead rely on the IDs from [IANA](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). This adds names and ids. The regular `network.protocol` would use name, but if you're not planning to use resolution, `network.protocol.id` would be available.