### PR TITLE
Revises network.* to cover more use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,11 @@ Fields related to network data.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="network.name"></a>network.name | Name given by operators to sections of their network. | extended | keyword | `Guest Wifi` |
-| <a name="network.protocol"></a>network.protocol | Network protocol name. | core | keyword | `http` |
+| <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. | core | keyword | `IPV4` |
+| <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which log using the IANA Protocol Number. | extended | keyword | `6` |
+| <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name. | core | keyword | `IPv6-ICMP` |
+| <a name="network.application"></a>network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format. | extended | keyword | `AIM` |
+| <a name="network.protocol"></a>network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol | core | keyword | `http` |
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown | core | keyword | `inbound` |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` |
 | <a name="network.inbound.bytes"></a>network.inbound.bytes | Network inbound bytes. | core | long | `184` |

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Fields related to network data.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="network.name"></a>network.name | Name given by operators to sections of their network. | extended | keyword | `Guest Wifi` |
-| <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. | core | keyword | `IPV4` |
+| <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc | core | keyword | `IPV4` |
 | <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which log using the IANA Protocol Number. | extended | keyword | `6` |
 | <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name. | core | keyword | `IPv6-ICMP` |
 | <a name="network.application"></a>network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format. | extended | keyword | `AIM` |

--- a/fields.yml
+++ b/fields.yml
@@ -830,7 +830,7 @@
           level: core
           type: keyword
           description: >
-            In the OSI Model this would be the Network Layer.
+            In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc
           example: IPV4
     
         - name: iana_number

--- a/fields.yml
+++ b/fields.yml
@@ -826,11 +826,45 @@
             Name given by operators to sections of their network.
           example: Guest Wifi
     
+        - name: type
+          level: core
+          type: keyword
+          description: >
+            In the OSI Model this would be the Network Layer.
+          example: IPV4
+    
+        - name: iana_number
+          level: extended
+          type: keyword
+          description: >
+              IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+              Standardized list of protocols. This aligns well with NetFlow and
+              sFlow related logs which log using the IANA Protocol Number.
+          example: 6
+    
+        - name: transport
+          level: core
+          type: keyword
+          description: >
+            Same as network.iana_number, but instead using the Keyword name.
+          example: IPv6-ICMP
+    
+        - name: application
+          level: extended
+          type: keyword
+          description: >
+            A name given to an application. This can be arbitrarily assigned for
+            things like microservices, but also apply to things like skype, icq,
+            facebook, twitter. This would be used in situations where the vendor
+            or service can be decoded such as from the source/dest IP owners,
+            ports, or wire format.
+          example: AIM
+    
         - name: protocol
           level: core
           type: keyword
           description: >
-            Network protocol name.
+            L7 Network protocol name. ex. http, lumberjack, transport protocol
           example: http
     
         - name: direction

--- a/schema.csv
+++ b/schema.csv
@@ -86,8 +86,10 @@ http.response.status_code,long,extended,404
 http.version,keyword,extended,1.1
 log.level,keyword,core,ERR
 log.original,keyword,core,Sep 19 08:26:10 localhost My log
+network.application,keyword,extended,AIM
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
+network.iana_number,keyword,extended,6
 network.inbound.bytes,long,core,184
 network.inbound.packets,long,core,12
 network.name,keyword,extended,Guest Wifi
@@ -96,6 +98,8 @@ network.outbound.packets,long,core,12
 network.protocol,keyword,core,http
 network.total.bytes,long,core,368
 network.total.packets,long,core,24
+network.transport,keyword,core,IPv6-ICMP
+network.type,keyword,core,IPV4
 organization.id,keyword,extended,
 organization.name,keyword,extended,
 os.family,keyword,extended,debian

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -18,7 +18,7 @@
       level: core
       type: keyword
       description: >
-        In the OSI Model this would be the Network Layer.
+        In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc
       example: IPV4
 
     - name: iana_number

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -14,11 +14,45 @@
         Name given by operators to sections of their network.
       example: Guest Wifi
 
+    - name: type
+      level: core
+      type: keyword
+      description: >
+        In the OSI Model this would be the Network Layer.
+      example: IPV4
+
+    - name: iana_number
+      level: extended
+      type: keyword
+      description: >
+          IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
+          Standardized list of protocols. This aligns well with NetFlow and
+          sFlow related logs which log using the IANA Protocol Number.
+      example: 6
+
+    - name: transport
+      level: core
+      type: keyword
+      description: >
+        Same as network.iana_number, but instead using the Keyword name.
+      example: IPv6-ICMP
+
+    - name: application
+      level: extended
+      type: keyword
+      description: >
+        A name given to an application. This can be arbitrarily assigned for
+        things like microservices, but also apply to things like skype, icq,
+        facebook, twitter. This would be used in situations where the vendor
+        or service can be decoded such as from the source/dest IP owners,
+        ports, or wire format.
+      example: AIM
+
     - name: protocol
       level: core
       type: keyword
       description: >
-        Network protocol name.
+        L7 Network protocol name. ex. http, lumberjack, transport protocol
       example: http
 
     - name: direction

--- a/template.json
+++ b/template.json
@@ -429,12 +429,20 @@
         },
         "network": {
           "properties": {
+            "application": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "direction": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "forwarded_ip": {
               "type": "ip"
+            },
+            "iana_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "inbound": {
               "properties": {
@@ -473,6 +481,14 @@
                   "type": "long"
                 }
               }
+            },
+            "transport": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },


### PR DESCRIPTION
This is to help delineate between `network.protocol` like `tcp` and an
`network.application.protocol` such as `http`.