### PR TITLE
Rename log.message to log.original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file based on the
 * Change structure of URL. #7
 * Rename `url.href` `multi_field`. #18
 * Rename `geoip.*` to `geo`.
+* Rename log.message to log.original. #106
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Fields which are specific to log events.
 | <a name="log.level"></a>log.level  | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`.  | keyword  |   | `ERR`  |
 | <a name="log.line"></a>log.line  | Line number the log event was collected from.  | long  |   | `18`  |
 | <a name="log.offset"></a>log.offset  | Offset of the beginning of the log event.  | long  |   | `12`  |
-| <a name="log.message"></a>log.message  | This is the log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
+| <a name="log.original"></a>log.original  | This is the original log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
 
 
 ## <a name="network"></a> Network fields

--- a/schema.csv
+++ b/schema.csv
@@ -92,8 +92,8 @@ kubernetes.namespace,keyword,0,
 kubernetes.pod.name,keyword,0,
 log.level,keyword,0,ERR
 log.line,long,0,18
-log.message,keyword,1,Sep 19 08:26:10 localhost My log
 log.offset,long,0,12
+log.original,keyword,1,Sep 19 08:26:10 localhost My log
 network.direction,keyword,0,inbound
 network.forwarded_ip,ip,0,192.1.1.2
 network.inbound.bytes,long,0,184

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -26,8 +26,6 @@
       phase: 1
       example: "Sep 19 08:26:10 localhost My log"
       index: false
-      # TODO: Best would be to disable ignore_above completely
-      ignore_above: 32766
       doc_values: false
       description: >
 

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -21,15 +21,18 @@
       description: >
         Offset of the beginning of the log event.
       example: 12
-    - name: message
+    - name: original
       type: keyword
       phase: 1
       example: "Sep 19 08:26:10 localhost My log"
       index: false
+      # TODO: Best would be to disable ignore_above completely
+      ignore_above: 32766
       doc_values: false
       description: >
-        This is the log message and contains the full log message before
-        splitting it up in multiple parts.
+
+        This is the original log message and contains the full log message
+        before splitting it up in multiple parts.
 
         In contrast to the `message` field which can contain an extracted part
         of the log message, this field contains the original, full log message.

--- a/template.json
+++ b/template.json
@@ -478,14 +478,14 @@
             "line": {
               "type": "long"
             },
-            "message": {
-              "doc_values": false,
-              "ignore_above": 1024,
-              "index": false,
-              "type": "keyword"
-            },
             "offset": {
               "type": "long"
+            },
+            "original": {
+              "doc_values": false,
+              "ignore_above": 32766,
+              "index": false,
+              "type": "keyword"
             }
           }
         },

--- a/template.json
+++ b/template.json
@@ -483,7 +483,7 @@
             },
             "original": {
               "doc_values": false,
-              "ignore_above": 32766,
+              "ignore_above": 1024,
               "index": false,
               "type": "keyword"
             }


### PR DESCRIPTION
log.message was confused with message. To bring it in line with https://github.com/elastic/ecs/issues/102 the field log.message was renamed to log.original.