### PR TITLE
Rename .raw to .original fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file based on the
 * Rename `url.href` `multi_field`. #18
 * Rename `geoip.*` to `geo`.
 * Rename log.message to log.original. #106
+* Rename `event.raw` to `event.original`.
+* Rename `user_agent.raw` to `user_agent.original` and make it a keyword.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | keyword  |   |   |
+| <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | text  |   |   |
 | <a name="user_agent.device"></a>user_agent.device  | Name of the physical device.  | keyword  |   |   |
 | <a name="user_agent.version"></a>user_agent.version  | Version of the physical device.  | keyword  |   |   |
 | <a name="user_agent.major"></a>user_agent.major  | Major version of the user agent.  | long  |   |   |

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The event fields are used for context information about the data itself.
 | <a name="event.module"></a>event.module  | Name of the module this data is coming from.<br/>This information is coming from the modules used in Beats or Logstash.  | keyword  |   | `mysql`  |
 | <a name="event.dataset"></a>event.dataset  | Name of the dataset.<br/>The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name.  | keyword  |   | `stats`  |
 | <a name="event.severity"></a>event.severity  | Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.  | long  |   | `7`  |
-| <a name="event.raw"></a>event.raw  | Raw text message of entire event. Used to demonstrate log integrity.<br/>This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232`  |
+| <a name="event.original"></a>event.original  | Raw text message of entire event. Used to demonstrate log integrity.<br/>This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232`  |
 | <a name="event.hash"></a>event.hash  | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.  | keyword  |   | `123456789012345678901234567890ABCD`  |
 | <a name="event.version"></a>event.version  | The version field contains the version an event for ECS adheres to.<br/>This field should be provided as part of each event to make it possible to detect to which ECS version an event belongs.<br/>event.version is a required field and must exist in all events. It describes which ECS version the event adheres to.<br/>The current version is 0.1.0.  | keyword  |   | `0.1.0`  |
 | <a name="event.duration"></a>event.duration  | Duration of the event in nanoseconds.  | long  |   |   |
@@ -425,7 +425,7 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.raw"></a>user_agent.raw  | Unparsed version of the user_agent.  | text  |   |   |
+| <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | keyword  |   |   |
 | <a name="user_agent.device"></a>user_agent.device  | Name of the physical device.  | keyword  |   |   |
 | <a name="user_agent.version"></a>user_agent.version  | Version of the physical device.  | keyword  |   |   |
 | <a name="user_agent.major"></a>user_agent.major  | Major version of the user agent.  | long  |   |   |

--- a/schema.csv
+++ b/schema.csv
@@ -149,7 +149,7 @@ user_agent.device,keyword,0,
 user_agent.major,long,0,
 user_agent.minor,long,0,
 user_agent.name,keyword,0,Chrome
-user_agent.original,keyword,0,
+user_agent.original,text,0,
 user_agent.os.major,long,0,
 user_agent.os.minor,long,0,
 user_agent.os.name,keyword,0,

--- a/schema.csv
+++ b/schema.csv
@@ -45,7 +45,7 @@ event.duration,long,0,
 event.hash,keyword,1,123456789012345678901234567890ABCD
 event.id,keyword,1,8a4f500d
 event.module,keyword,0,mysql
-event.raw,keyword,1,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
+event.original,keyword,1,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
 event.risk_score,float,0,
 event.risk_score_norm,float,0,
 event.severity,long,1,7
@@ -149,10 +149,10 @@ user_agent.device,keyword,0,
 user_agent.major,long,0,
 user_agent.minor,long,0,
 user_agent.name,keyword,0,Chrome
+user_agent.original,keyword,0,
 user_agent.os.major,long,0,
 user_agent.os.minor,long,0,
 user_agent.os.name,keyword,0,
 user_agent.os.version,keyword,0,
 user_agent.patch,keyword,0,
-user_agent.raw,text,0,
 user_agent.version,keyword,0,

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -65,7 +65,7 @@
         severity values mean can very different between use cases. It's up to
         the implementer to make sure severities are consistent across events.
 
-    - name: raw
+    - name: original
       type: keyword
       phase: 1
       # Unfortunately this example is not shown correctly yet as | do not work

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -7,7 +7,7 @@
     show up in web service logs coming from the parsed user agent string.
   fields:
     - name: original
-      type: keyword
+      type: text
       description: >
         Unparsed version of the user_agent.
     - name: device

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -6,8 +6,8 @@
     The user_agent fields normally come from a browser request. They often
     show up in web service logs coming from the parsed user agent string.
   fields:
-    - name: raw
-      type: text
+    - name: original
+      type: keyword
       description: >
         Unparsed version of the user_agent.
     - name: device

--- a/template.json
+++ b/template.json
@@ -234,7 +234,7 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "raw": {
+            "original": {
               "doc_values": false,
               "ignore_above": 1024,
               "index": false,
@@ -781,6 +781,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "original": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "os": {
               "properties": {
                 "major": {
@@ -802,10 +806,6 @@
             "patch": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "raw": {
-              "norms": false,
-              "type": "text"
             },
             "version": {
               "ignore_above": 1024,

--- a/template.json
+++ b/template.json
@@ -782,8 +782,8 @@
               "type": "keyword"
             },
             "original": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "norms": false,
+              "type": "text"
             },
             "os": {
               "properties": {

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -21,7 +21,7 @@ ECS fields used in Filebeat for the apache module.
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes*  | *Http response body bytes sent, currently apache.access.body_sent.bytes*  | long  |   | `117`  |
 | <a name="http.referer"></a>*http.referer*  | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard*  | keyword  |   | `http://elastic.co/`  |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;*  | *User agent fields as in schema. Currently under apache.access.user_agent.*<br/>*  |   |   |   |
-| [user_agent.raw](https://github.com/elastic/ecs#user_agent.raw)  | Raw user agent. Currently apache.access.agent  | text  |   | `http://elastic.co/`  |
+| <a name="user_agent.raw"></a>*user_agent.raw*  | *Raw user agent. Currently apache.access.agent*  | text  |   | `http://elastic.co/`  |
 | <a name="geoip.&ast;"></a>*geoip.&ast;*  | *User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>*  |   |   |   |
 | <a name="geoip...."></a>*geoip....*  | *All geoip fields.*  | text  |   |   |
 

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -21,7 +21,7 @@ ECS fields used in Filebeat for the apache module.
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes*  | *Http response body bytes sent, currently apache.access.body_sent.bytes*  | long  |   | `117`  |
 | <a name="http.referer"></a>*http.referer*  | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard*  | keyword  |   | `http://elastic.co/`  |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;*  | *User agent fields as in schema. Currently under apache.access.user_agent.*<br/>*  |   |   |   |
-| <a name="user_agent.raw"></a>*user_agent.raw*  | *Raw user agent. Currently apache.access.agent*  | text  |   | `http://elastic.co/`  |
+| [user_agent.original](https://github.com/elastic/ecs#user_agent.original)  | Original user agent. Currently apache.access.agent  | text  |   | `http://elastic.co/`  |
 | <a name="geoip.&ast;"></a>*geoip.&ast;*  | *User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>*  |   |   |   |
 | <a name="geoip...."></a>*geoip....*  | *All geoip fields.*  | text  |   |   |
 

--- a/use-cases/filebeat-apache-access.yml
+++ b/use-cases/filebeat-apache-access.yml
@@ -90,10 +90,10 @@ fields:
   description: >
     User agent fields as in schema. Currently under apache.access.user_agent.*
   fields:
-    - name: raw
+    - name: original
       type: text
       description: >
-        Raw user agent. Currently apache.access.agent
+        Original user agent. Currently apache.access.agent
       example: http://elastic.co/
 
 - name: geoip


### PR DESCRIPTION
* Rename `user_agent.raw` to `user_agent.original` and make it a keyword. I think this always should have been a keyword.
* Rename `event.raw` to `event.original`.

Closes https://github.com/elastic/ecs/issues/102