### PR TITLE
Rename url.href to url.original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `host.name` to `host.hostname` to better align with industry convention. #144
 * Update definition of `service.type` and `service.name`.
 * Redefine purpose of `agent.name` field to be user defined field.
+* Rename `url.href` to `url.original`.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="url.href"></a>url.href | Full url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
+| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
 | <a name="url.hostname"></a>url.hostname | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |

--- a/fields.yml
+++ b/fields.yml
@@ -1150,11 +1150,11 @@
       type: group
       fields:
     
-        - name: href
+        - name: original
           level: extended
           type: keyword
           description: >
-            Full url. The field is stored as keyword.
+            Full original url. The field is stored as keyword.
           example: https://elastic.co:443/search?q=elasticsearch#top
     
         - name: scheme

--- a/schema.csv
+++ b/schema.csv
@@ -122,7 +122,7 @@ source.port,long,core,
 source.subdomain,keyword,core,
 url.fragment,keyword,extended,
 url.hostname,keyword,extended,elastic.co
-url.href,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
+url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,extended,
 url.path,keyword,extended,
 url.port,integer,extended,443

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -8,11 +8,11 @@
   type: group
   fields:
 
-    - name: href
+    - name: original
       level: extended
       type: keyword
       description: >
-        Full url. The field is stored as keyword.
+        Full original url. The field is stored as keyword.
       example: https://elastic.co:443/search?q=elasticsearch#top
 
     - name: scheme

--- a/template.json
+++ b/template.json
@@ -602,7 +602,7 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "href": {
+            "original": {
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
Recently we changed several fields which contain the initial original value to .original. `href` now follows the same example.

There is an issue with original in the description as it is text by default and we have .raw. What is our recommended approach here?