### PR TITLE
Fix example when processed as asciidoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The base set contains all fields which are on the top level. These fields are co
 |---|---|---|---|---|
 | <a name="@timestamp"></a>@timestamp  | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events.  | date  |   | `2016-05-23T08:05:34.853Z`  |
 | <a name="tags"></a>tags  | List of keywords used to tag each event.  | keyword  |   | `["production", "env2"]`  |
-| <a name="labels"></a>labels  | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels.  | object  |   | `{key1: value1, key2: value2}`  |
+| <a name="labels"></a>labels  | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels.  | object  |   | `{'key2': 'value2', 'key1': 'value1'}`  |
 | <a name="message"></a>message  | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message.  | text  |   | `Hello World`  |
 
 

--- a/fields.yml
+++ b/fields.yml
@@ -73,7 +73,7 @@
     
         - name: labels
           type: object
-          example: "{key1: value1, key2: value2}"
+          example: {key1: value1, key2: value2}
           description: >
             Key/value pairs.
     

--- a/schema.csv
+++ b/schema.csv
@@ -1,6 +1,6 @@
 Field,Type,Phase,Example
 @timestamp,date,3,2016-05-23T08:05:34.853Z
-labels,object,0,"{key1: value1, key2: value2}"
+labels,object,0,"{'key2': 'value2', 'key1': 'value1'}"
 message,text,1,Hello World
 tags,keyword,0,"[""production"", ""env2""]"
 agent.ephemeral_id,keyword,0,8a4f500f

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -27,7 +27,7 @@
 
     - name: labels
       type: object
-      example: "{key1: value1, key2: value2}"
+      example: {key1: value1, key2: value2}
       description: >
         Key/value pairs.
 


### PR DESCRIPTION
The `fields` entry example consists of a dictionary surrounded by quotes. This causes problems when the example is used for documentation in asciidoc format, as it is interpreted as an escaped attribute, and the docs generation fails because it cannot find a "key1" attribute.

Fixed by removing the quotes around the example, which isn't perfect because it looks a bit ugly in the generated README.md and CSV formats.

Suggestions welcome.