### PR TITLE
Make cloud.instance.name and kubernetes.instance.name multi-fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `file.path.raw` to `file.path.keyword`, `file.target_path.raw` to `file.target_path.keyword`,
   `url.href.raw` to `url.href.keyword`, `url.path.raw` to `url.path.keyword`,
   `url.query.raw` to `url.query.keyword`, and `network.name.raw` to `network.name.keyword`.
+* Make `cloud.container.name` and `kubernetes.container.name` multi-fields.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ Fields related to the cloud or infrastructure the events are coming from.
 | <a name="cloud.availability_zone"></a>cloud.availability_zone  | Availability zone in which this host is running.  | keyword  |   | `us-east-1c`  |
 | <a name="cloud.region"></a>cloud.region  | Region in which this host is running.  | keyword  |   | `us-east-1`  |
 | <a name="cloud.instance.id"></a>cloud.instance.id  | Instance ID of the host machine.  | keyword  |   | `i-1234567890abcdef0`  |
-| <a name="cloud.instance.name"></a>cloud.instance.name  | Instance name of the host machine.  | keyword  |   |   |
+| <a name="cloud.instance.name"></a>cloud.instance.name  | Instance name of the host machine.  | text  |   |   |
+| <a name="cloud.instance.name.keyword"></a>cloud.instance.name.keyword  |   | keyword  | 1  |   |
 | <a name="cloud.machine.type"></a>cloud.machine.type  | Machine type of the host machine.  | keyword  |   | `t2.medium`  |
 | <a name="cloud.account.id"></a>cloud.account.id  | The cloud account or organization id used to identify different entities in a multi-tenant environment.<br/>Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.  | keyword  |   | `666777888999`  |
 
@@ -275,7 +276,8 @@ Kubernetes fields are used for Kubernetes meta information. This information hel
 | <a name="kubernetes.namespace"></a>kubernetes.namespace  | Kubernetes namespace  | keyword  |   |   |
 | <a name="kubernetes.labels"></a>kubernetes.labels  | Kubernetes labels map  | object  |   |   |
 | <a name="kubernetes.annotations"></a>kubernetes.annotations  | Kubernetes annotations map  | object  |   |   |
-| <a name="kubernetes.container.name"></a>kubernetes.container.name  | Kubernetes container name. This name is unique within the pod only. It is different from the underlying `container.name` field.  | keyword  |   |   |
+| <a name="kubernetes.container.name"></a>kubernetes.container.name  | Kubernetes container name. This name is unique within the pod only. It is different from the underlying `container.name` field.  | text  |   |   |
+| <a name="kubernetes.container.name.keyword"></a>kubernetes.container.name.keyword  |   | keyword  | 1  |   |
 
 
 ## <a name="log"></a> Log fields

--- a/fields.yml
+++ b/fields.yml
@@ -133,9 +133,12 @@
             Instance ID of the host machine.
     
         - name: instance.name
-          type: keyword
+          type: text
           description: >
             Instance name of the host machine.
+          multi_fields:
+            - name: keyword
+              type: keyword
     
         - name: machine.type
           type: keyword
@@ -704,10 +707,13 @@
             Kubernetes annotations map
     
         - name: container.name
-          type: keyword
+          type: text
           description: >
             Kubernetes container name. This name is unique within the pod only.
             It is different from the underlying `container.name` field.
+          multi_fields:
+            - name: keyword
+              type: keyword
     
     - name: log
       title: Log

--- a/schema.csv
+++ b/schema.csv
@@ -10,7 +10,7 @@ agent.version,keyword,0,6.0.0-rc2
 cloud.account.id,keyword,0,666777888999
 cloud.availability_zone,keyword,0,us-east-1c
 cloud.instance.id,keyword,0,i-1234567890abcdef0
-cloud.instance.name,keyword,0,
+cloud.instance.name,text,0,
 cloud.machine.type,keyword,0,t2.medium
 cloud.provider,keyword,0,ec2
 cloud.region,keyword,0,us-east-1
@@ -86,7 +86,7 @@ http.response.body,text,0,Hello world
 http.response.status_code,long,0,404
 http.version,keyword,0,1.1
 kubernetes.annotations,object,0,
-kubernetes.container.name,keyword,0,
+kubernetes.container.name,text,0,
 kubernetes.labels,object,0,
 kubernetes.namespace,keyword,0,
 kubernetes.pod.name,keyword,0,

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -39,9 +39,12 @@
         Instance ID of the host machine.
 
     - name: instance.name
-      type: keyword
+      type: text
       description: >
         Instance name of the host machine.
+      multi_fields:
+        - name: keyword
+          type: keyword
 
     - name: machine.type
       type: keyword

--- a/schemas/kubernetes.yml
+++ b/schemas/kubernetes.yml
@@ -29,7 +29,10 @@
         Kubernetes annotations map
 
     - name: container.name
-      type: keyword
+      type: text
       description: >
         Kubernetes container name. This name is unique within the pod only.
         It is different from the underlying `container.name` field.
+      multi_fields:
+        - name: keyword
+          type: keyword

--- a/template.json
+++ b/template.json
@@ -64,8 +64,14 @@
                   "type": "keyword"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "fields": {
+                    "keyword": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "norms": false,
+                  "type": "text"
                 }
               }
             },
@@ -444,8 +450,14 @@
             "container": {
               "properties": {
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "fields": {
+                    "keyword": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "norms": false,
+                  "type": "text"
                 }
               }
             },


### PR DESCRIPTION
Not ready for review. I want to discuss this with @ruflin after his vacation.

In order to make `cloud.instance.name` multi-fields, we need to make
`instance` into an object explicitly. But the automation doesn't seem to pick up
the multi-fields I'm adding below `name`.

I've done a pass at all text fields for #104. `kubernetes.container.name` will
also likely have the same problem.