### PR TITLE
Make 4 more text fields multi-field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file based on the
 * Rename `file.path.raw` to `file.path.keyword`, `file.target_path.raw` to `file.target_path.keyword`,
   `url.href.raw` to `url.href.keyword`, `url.path.raw` to `url.path.keyword`,
   `url.query.raw` to `url.query.keyword`, and `network.name.raw` to `network.name.keyword`.
+* Make `host.name` multi-fields. This is a breaking change because the top
+  field went from datatype `keyword` to `text`.
 
 ### Bugfixes
 
@@ -27,5 +29,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `log.message`. #3
 * Add http.request.method and http.version
 * Add `host.os.kernel` containing the OS kernel version. #60
+* Made the following `text` fields multi-field by adding the `.keyword` nested
+  field: `device.vendor`, `error.message` and `user_agent.original`.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file based on the
 * Rename log.message to log.original. #106
 * Rename `event.raw` to `event.original`.
 * Rename `user_agent.raw` to `user_agent.original` and make it a keyword.
+* Rename `file.path.raw` to `file.path.keyword`, `file.target_path.raw` to `file.target_path.keyword`,
+  `url.href.raw` to `url.href.keyword`, `url.path.raw` to `url.path.keyword`,
+  and `url.query.raw` to `url.query.keyword`
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `user_agent.raw` to `user_agent.original` and make it a keyword.
 * Rename `file.path.raw` to `file.path.keyword`, `file.target_path.raw` to `file.target_path.keyword`,
   `url.href.raw` to `url.href.keyword`, `url.path.raw` to `url.path.keyword`,
-  and `url.query.raw` to `url.query.keyword`
+  `url.query.raw` to `url.query.keyword`, and `network.name.raw` to `network.name.keyword`.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ File fields provide details about each file.
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="file.path"></a>file.path  | Path to the file.  | text  |   |   |
-| <a name="file.path.raw"></a>file.path.raw  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="file.path.keyword"></a>file.path.keyword  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="file.target_path"></a>file.target_path  | Target path for symlinks.  | text  |   |   |
-| <a name="file.target_path.raw"></a>file.target_path.raw  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="file.target_path.keyword"></a>file.target_path.keyword  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="file.extension"></a>file.extension  | File extension.<br/>This should allow easy filtering by file extensions.  | keyword  |   | `png`  |
 | <a name="file.type"></a>file.type  | File type (file, dir, or symlink).  | keyword  |   |   |
 | <a name="file.device"></a>file.device  | Device that is the source of the file.  | keyword  |   |   |
@@ -392,14 +392,14 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="url.href"></a>url.href  | Full url. The field is stored as keyword.<br/>`url.href` is a [multi field](https://www.elastic.co/guide/en/ elasticsearch/reference/6.2/ multi-fields.html#_multi_fields_with_multiple_analyzers). The data is stored as keyword `url.href` and test `url.href.analyzed`. These fields enable you to run a query against part of the url still works splitting up the URL at ingest time.<br/>`href` is an analyzed field so the parsed information can be accessed through `href.analyzed` in queries.  | text  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
-| <a name="url.href.raw"></a>url.href.raw  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.href.keyword"></a>url.href.keyword  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="url.scheme"></a>url.scheme  | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
 | <a name="url.host.name"></a>url.host.name  | Hostname of the request, such as "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
 | <a name="url.port"></a>url.port  | Port of the request, such as 443.  | integer  |   | `443`  |
 | <a name="url.path"></a>url.path  | Path of the request, such as "/search".  | text  |   |   |
-| <a name="url.path.raw"></a>url.path.raw  | URL path. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.path.keyword"></a>url.path.keyword  | URL path. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="url.query"></a>url.query  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | text  |   |   |
-| <a name="url.query.raw"></a>url.query.raw  | URL query part. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.query.keyword"></a>url.query.keyword  | URL query part. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
 | <a name="url.fragment"></a>url.fragment  | Portion of the url after the `#`, such as "top".<br/>The `#` is not part of the fragment.  | keyword  |   |   |
 | <a name="url.username"></a>url.username  | Username of the request.  | keyword  |   |   |
 | <a name="url.password"></a>url.password  | Password of the request.  | keyword  |   |   |

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Device fields are used to provide additional information about the device that i
 | <a name="device.ip"></a>device.ip  | IP address of the device.  | ip  |   |   |
 | <a name="device.hostname"></a>device.hostname  | Hostname of the device.  | keyword  |   |   |
 | <a name="device.vendor"></a>device.vendor  | Device vendor information.  | text  |   |   |
+| <a name="device.vendor.keyword"></a>device.vendor.keyword  |   | keyword  | 1  |   |
 | <a name="device.version"></a>device.version  | Device version.  | keyword  |   |   |
 | <a name="device.serial_number"></a>device.serial_number  | Device serial number.  | keyword  |   |   |
 | <a name="device.timezone.offset.sec"></a>device.timezone.offset.sec  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
@@ -152,6 +153,7 @@ These fields can represent errors of any kind. Use them for errors that happen w
 |---|---|---|---|---|
 | <a name="error.id"></a>error.id  | Unique identifier for the error.  | keyword  |   |   |
 | <a name="error.message"></a>error.message  | Error message.  | text  |   |   |
+| <a name="error.message.keyword"></a>error.message.keyword  |   | keyword  | 1  |   |
 | <a name="error.code"></a>error.code  | Error code describing the error.  | keyword  |   |   |
 
 
@@ -227,7 +229,8 @@ Normally the host information is related to the machine on which the event was g
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="host.timezone.offset.sec"></a>host.timezone.offset.sec  | Timezone offset of the host in seconds.<br/>Number of seconds relative to UTC. If the offset is -01:30 the value will be -5400.  | long  |   | `-5400`  |
-| <a name="host.name"></a>host.name  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   |   |
+| <a name="host.name"></a>host.name  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | text  |   |   |
+| <a name="host.name.keyword"></a>host.name.keyword  |   | keyword  | 1  |   |
 | <a name="host.id"></a>host.id  | Unique host id.<br/>As hostname is not always unique, use values that are meaningful in your environment.<br/>Example: The current usage of `beat.name`.  | keyword  |   |   |
 | <a name="host.ip"></a>host.ip  | Host ip address.  | ip  |   |   |
 | <a name="host.mac"></a>host.mac  | Host mac address.  | keyword  |   |   |
@@ -426,6 +429,7 @@ The user_agent fields normally come from a browser request. They often show up i
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | text  |   |   |
+| <a name="user_agent.original.keyword"></a>user_agent.original.keyword  |   | keyword  | 1  |   |
 | <a name="user_agent.device"></a>user_agent.device  | Name of the physical device.  | keyword  |   |   |
 | <a name="user_agent.version"></a>user_agent.version  | Version of the physical device.  | keyword  |   |   |
 | <a name="user_agent.major"></a>user_agent.major  | Major version of the user agent.  | long  |   |   |

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Fields related to network data.
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="network.name"></a>network.name  | Name given by operators to sections of their network.  | text  |   | `Guest Wifi`  |
-| <a name="network.name.raw"></a>network.name.raw  | Name given by operators to sections of their network.  | keyword  | 1  |   |
+| <a name="network.name.keyword"></a>network.name.keyword  | Name given by operators to sections of their network.  | keyword  | 1  |   |
 | <a name="network.protocol"></a>network.protocol  | Network protocol name.  | keyword  |   | `http`  |
 | <a name="network.direction"></a>network.direction  | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip  | Host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |

--- a/README.md
+++ b/README.md
@@ -513,23 +513,24 @@ convention used is the following:
 
 * `foo`: `text` indexing.
   The top level of the field (its plain name) is used for full text search.
-* `foo.raw`: `keyword` indexing.
-  The nested field has suffix `.raw` and is what you will use for aggregations.
+* `foo.keyword`: `keyword` indexing.
+  The nested field has suffix `.keyword` and is what you will use for aggregations.
   * Performance tip: when filtering your stream in Kibana (or elsewhere), if you
     are filtering for an exact match or doing a prefix search,
     both `text` and `keyword` field can be used, but doing so on the `keyword`
-    field (named `.raw`) will be much faster and less memory intensive.
+    field will be much faster and less memory intensive.
 
 **Keyword only fields**
 
-The fields that only make sense as type `keyword` are not named `foo.raw`, the
+The fields that only make sense as type `keyword` are not named `foo.keyword`, the
 plain field (`foo`) will be of type `keyword`, with no nested field.
 
-### IDs are keywords not integers
+### IDs are keywords, not integers
 
 Despite the fact that IDs are often integers in various systems, this is not
 always the case. Since we want to make it possible to map as many data sources
 to ECS as possible, we default to using the `keyword` type for IDs.
+
 
 # <a name="about-ecs"></a>FAQ
 

--- a/docs/implementing.md
+++ b/docs/implementing.md
@@ -49,20 +49,21 @@ convention used is the following:
 
 * `foo`: `text` indexing.
   The top level of the field (its plain name) is used for full text search.
-* `foo.raw`: `keyword` indexing.
-  The nested field has suffix `.raw` and is what you will use for aggregations.
+* `foo.keyword`: `keyword` indexing.
+  The nested field has suffix `.keyword` and is what you will use for aggregations.
   * Performance tip: when filtering your stream in Kibana (or elsewhere), if you
     are filtering for an exact match or doing a prefix search,
     both `text` and `keyword` field can be used, but doing so on the `keyword`
-    field (named `.raw`) will be much faster and less memory intensive.
+    field will be much faster and less memory intensive.
 
 **Keyword only fields**
 
-The fields that only make sense as type `keyword` are not named `foo.raw`, the
+The fields that only make sense as type `keyword` are not named `foo.keyword`, the
 plain field (`foo`) will be of type `keyword`, with no nested field.
 
-### IDs are keywords not integers
+### IDs are keywords, not integers
 
 Despite the fact that IDs are often integers in various systems, this is not
 always the case. Since we want to make it possible to map as many data sources
 to ECS as possible, we default to using the `keyword` type for IDs.
+

--- a/fields.yml
+++ b/fields.yml
@@ -764,7 +764,7 @@
             Name given by operators to sections of their network.
           example: Guest Wifi
           multi_fields:
-            - name: raw
+            - name: keyword
               type: keyword
               description: >
                 Name given by operators to sections of their network.

--- a/fields.yml
+++ b/fields.yml
@@ -250,6 +250,9 @@
           type: text
           description: >
             Device vendor information.
+          multi_fields:
+            - name: keyword
+              type: keyword
         - name: version
           type: keyword
           description: >
@@ -293,6 +296,9 @@
           type: text
           description: >
             Error message.
+          multi_fields:
+            - name: keyword
+              type: keyword
     
         - name: code
           type: keyword
@@ -576,7 +582,7 @@
           example: -5400
     
         - name: name
-          type: keyword
+          type: text
           description: >
             host.name is the hostname of the host.
     
@@ -584,6 +590,9 @@
             qualified domain name, or a name specified by the user. The sender
             decides which value to use.
           phase: 1
+          multi_fields:
+            - name: keyword
+              type: keyword
     
         - name: id
           type: keyword
@@ -1196,6 +1205,9 @@
           type: text
           description: >
             Unparsed version of the user_agent.
+          multi_fields:
+            - name: keyword
+              type: keyword
         - name: device
           type: keyword
           description: >

--- a/fields.yml
+++ b/fields.yml
@@ -454,7 +454,7 @@
         type: text
         description: Path to the file.
         multi_fields:
-        - name: raw
+        - name: keyword
           type: keyword
           description: >
             Path to the file. This is a non-analyzed field that is useful
@@ -464,7 +464,7 @@
         type: text
         description: Target path for symlinks.
         multi_fields:
-          - name: raw
+          - name: keyword
             type: keyword
             description: >
               Path to the file. This is a non-analyzed field that is useful
@@ -1083,7 +1083,7 @@
             through `href.analyzed` in queries.
     
           multi_fields:
-            - name: raw
+            - name: keyword
               type: keyword
               description: >
                 The full URL. This is a non-analyzed field that is useful
@@ -1114,7 +1114,7 @@
           description: >
             Path of the request, such as "/search".
           multi_fields:
-            - name: raw
+            - name: keyword
               type: keyword
               description: >
                 URL path. A non-analyzed field that is useful
@@ -1130,7 +1130,7 @@
             the query field exists with an empty string. The `exists`
             query can be used to differentiate between the two cases.
           multi_fields:
-            - name: raw
+            - name: keyword
               type: keyword
               description: >
                 URL query part. A non-analyzed field that is useful

--- a/schema.csv
+++ b/schema.csv
@@ -74,7 +74,7 @@ host.architecture,keyword,0,x86_64
 host.id,keyword,1,
 host.ip,ip,0,
 host.mac,keyword,0,
-host.name,keyword,1,
+host.name,text,1,
 host.os.family,keyword,0,debian
 host.os.name,keyword,0,Mac OS X
 host.os.platform,keyword,0,darwin

--- a/schemas/device.yml
+++ b/schemas/device.yml
@@ -23,6 +23,9 @@
       type: text
       description: >
         Device vendor information.
+      multi_fields:
+        - name: keyword
+          type: keyword
     - name: version
       type: keyword
       description: >

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -17,6 +17,9 @@
       type: text
       description: >
         Error message.
+      multi_fields:
+        - name: keyword
+          type: keyword
 
     - name: code
       type: keyword

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -10,7 +10,7 @@
     type: text
     description: Path to the file.
     multi_fields:
-    - name: raw
+    - name: keyword
       type: keyword
       description: >
         Path to the file. This is a non-analyzed field that is useful
@@ -20,7 +20,7 @@
     type: text
     description: Target path for symlinks.
     multi_fields:
-      - name: raw
+      - name: keyword
         type: keyword
         description: >
           Path to the file. This is a non-analyzed field that is useful

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -21,7 +21,7 @@
       example: -5400
 
     - name: name
-      type: keyword
+      type: text
       description: >
         host.name is the hostname of the host.
 
@@ -29,6 +29,9 @@
         qualified domain name, or a name specified by the user. The sender
         decides which value to use.
       phase: 1
+      multi_fields:
+        - name: keyword
+          type: keyword
 
     - name: id
       type: keyword

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -12,7 +12,7 @@
         Name given by operators to sections of their network.
       example: Guest Wifi
       multi_fields:
-        - name: raw
+        - name: keyword
           type: keyword
           description: >
             Name given by operators to sections of their network.

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -24,7 +24,7 @@
         through `href.analyzed` in queries.
 
       multi_fields:
-        - name: raw
+        - name: keyword
           type: keyword
           description: >
             The full URL. This is a non-analyzed field that is useful
@@ -55,7 +55,7 @@
       description: >
         Path of the request, such as "/search".
       multi_fields:
-        - name: raw
+        - name: keyword
           type: keyword
           description: >
             URL path. A non-analyzed field that is useful
@@ -71,7 +71,7 @@
         the query field exists with an empty string. The `exists`
         query can be used to differentiate between the two cases.
       multi_fields:
-        - name: raw
+        - name: keyword
           type: keyword
           description: >
             URL query part. A non-analyzed field that is useful

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -11,6 +11,9 @@
       type: text
       description: >
         Unparsed version of the user_agent.
+      multi_fields:
+        - name: keyword
+          type: keyword
     - name: device
       type: keyword
       description: >

--- a/template.json
+++ b/template.json
@@ -177,6 +177,12 @@
               "type": "keyword"
             },
             "vendor": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "norms": false,
               "type": "text"
             },
@@ -197,6 +203,12 @@
               "type": "keyword"
             },
             "message": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "norms": false,
               "type": "text"
             }
@@ -369,8 +381,14 @@
               "type": "keyword"
             },
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "fields": {
+                "keyword": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "norms": false,
+              "type": "text"
             },
             "os": {
               "properties": {
@@ -782,6 +800,12 @@
               "type": "keyword"
             },
             "original": {
+              "fields": {
+                "keyword": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "norms": false,
               "type": "text"
             },

--- a/template.json
+++ b/template.json
@@ -514,7 +514,7 @@
             },
             "name": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/template.json
+++ b/template.json
@@ -297,7 +297,7 @@
             },
             "path": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -310,7 +310,7 @@
             },
             "target_path": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -700,7 +700,7 @@
             },
             "href": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -714,7 +714,7 @@
             },
             "path": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -727,7 +727,7 @@
             },
             "query": {
               "fields": {
-                "raw": {
+                "keyword": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -21,7 +21,7 @@ ECS fields used Metricbeat.
 | <a name="error.&ast;"></a>*error.&ast;*  | *Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>*  |   |   |   |
 | [error.message](https://github.com/elastic/ecs#error.message)  | Error message returned by the service during fetching metrics.  | text  |   |   |
 | [error.code](https://github.com/elastic/ecs#error.code)  | Error code returned by the service during fetching metrics.  | keyword  |   |   |
-| [host.name](https://github.com/elastic/ecs#host.name)  | Hostname of the system metricbeat is running on or user defined name.  | keyword  |   |   |
+| [host.name](https://github.com/elastic/ecs#host.name)  | Hostname of the system metricbeat is running on or user defined name.  | text  |   |   |
 | [host.timezone.offset.sec](https://github.com/elastic/ecs#host.timezone.offset.sec)  | Timezone offset of the host in seconds.  | long  |   | `-5400`  |
 | [host.id](https://github.com/elastic/ecs#host.id)  | Unique host id.  | keyword  |   |   |
 | [event.module](https://github.com/elastic/ecs#event.module)  | Name of the module this data is coming from.  | keyword  |   | `mysql`  |


### PR DESCRIPTION
For issue #104, I identified 6 fields I think should be made multi-field.

This PR addresses 4 of them:

* `device.vendor`
* `error.message`
* `file.path`
* `file.target_path`

The other two are `cloud.instance.name` and `kubernetes.container.name`. However I was hitting problems with the automation, so I'm submitting the 4 straightforward ones now and will look into the other ones in #119.

Note that this PR was added on top of #118 (commits from Sept 19th).