### PR TITLE
Remove log.offset and log.line from ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `file.path.raw` to `file.path.keyword`, `file.target_path.raw` to `file.target_path.keyword`,
   `url.href.raw` to `url.href.keyword`, `url.path.raw` to `url.path.keyword`,
   `url.query.raw` to `url.query.keyword`, and `network.name.raw` to `network.name.keyword`.
+* Remove `log.offset` and `log.line` as to specific for ECS.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -286,8 +286,6 @@ Fields which are specific to log events.
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
 | <a name="log.level"></a>log.level  | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`.  | keyword  |   | `ERR`  |
-| <a name="log.line"></a>log.line  | Line number the log event was collected from.  | long  |   | `18`  |
-| <a name="log.offset"></a>log.offset  | Offset of the beginning of the log event.  | long  |   | `12`  |
 | <a name="log.original"></a>log.original  | This is the original log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.  | keyword  |   | `Sep 19 08:26:10 localhost My log`  |
 
 

--- a/fields.yml
+++ b/fields.yml
@@ -722,16 +722,6 @@
     
             Some examples are `WARN`, `ERR`, `INFO`.
           example: ERR
-        - name: line
-          type: long
-          description: >
-            Line number the log event was collected from.
-          example: 18
-        - name: offset
-          type: long
-          description: >
-            Offset of the beginning of the log event.
-          example: 12
         - name: original
           type: keyword
           phase: 1

--- a/schema.csv
+++ b/schema.csv
@@ -91,8 +91,6 @@ kubernetes.labels,object,0,
 kubernetes.namespace,keyword,0,
 kubernetes.pod.name,keyword,0,
 log.level,keyword,0,ERR
-log.line,long,0,18
-log.offset,long,0,12
 log.original,keyword,1,Sep 19 08:26:10 localhost My log
 network.direction,keyword,0,inbound
 network.forwarded_ip,ip,0,192.1.1.2

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -12,16 +12,6 @@
 
         Some examples are `WARN`, `ERR`, `INFO`.
       example: ERR
-    - name: line
-      type: long
-      description: >
-        Line number the log event was collected from.
-      example: 18
-    - name: offset
-      type: long
-      description: >
-        Offset of the beginning of the log event.
-      example: 12
     - name: original
       type: keyword
       phase: 1

--- a/template.json
+++ b/template.json
@@ -475,12 +475,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "line": {
-              "type": "long"
-            },
-            "offset": {
-              "type": "long"
-            },
             "original": {
               "doc_values": false,
               "ignore_above": 1024,

--- a/use-cases/logging.md
+++ b/use-cases/logging.md
@@ -13,8 +13,8 @@ ECS fields used in logging use cases.
 | <a name="hostname"></a>*hostname*  | *Hostname extracted from the log line.*  | keyword  |   | `www.example.com`  |
 | <a name="ip"></a>*ip*  | *IP Address extracted from the log line. Can be IPv4 or IPv6.*  | ip  |   | `192.168.1.12`  |
 | [log.level](https://github.com/elastic/ecs#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc.  | keyword  |   | `ERR`  |
-| [log.line](https://github.com/elastic/ecs#log.line)  | Line number the log event was collected from.  | long  |   | `18`  |
-| [log.offset](https://github.com/elastic/ecs#log.offset)  | Offset of the log event.  | long  |   | `12`  |
+| <a name="log.line"></a>*log.line*  | *Line number the log event was collected from.*  | long  |   | `18`  |
+| <a name="log.offset"></a>*log.offset*  | *Offset of the log event.*  | long  |   | `12`  |
 | <a name="source.&ast;"></a>*source.&ast;*  | *Describes from where the log entries come from.<br/>*  |   |   |   |
 | <a name="source.path"></a>*source.path*  | *File path of the file the data is harvested from.*  | keyword  |   | `/var/log/test.log`  |
 


### PR DESCRIPTION
These fields were too specific and does not fit ECS well. It is still fields tthat are used by filebeat and other logging tools but this does not mean they have to be in ECS.