### PR TITLE
Switch most fields to keyword as the type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file based on the
 * Remove `log.offset` and `log.line` as too specific for ECS. #131
 * Remove top level objects `kubernetes` and `tls`. #132
 * Remove `*.timezone.offset.sec` fields as too specific for ECS at the moment. #134
+* Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original 
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Device fields are used to provide additional information about the device that i
 | <a name="device.mac"></a>device.mac  | MAC address of the device  | keyword  |   |   |
 | <a name="device.ip"></a>device.ip  | IP address of the device.  | ip  |   |   |
 | <a name="device.hostname"></a>device.hostname  | Hostname of the device.  | keyword  |   |   |
-| <a name="device.vendor"></a>device.vendor  | Device vendor information.  | text  |   |   |
+| <a name="device.vendor"></a>device.vendor  | Device vendor information.  | keyword  |   |   |
 | <a name="device.version"></a>device.version  | Device version.  | keyword  |   |   |
 | <a name="device.serial_number"></a>device.serial_number  | Device serial number.  | keyword  |   |   |
 | <a name="device.type"></a>device.type  | The type of the device the data is coming from.<br/>There is no predefined list of device types. Some examples are `endpoint`, `firewall`, `ids`, `ips`, `proxy`.  | keyword  |   | `firewall`  |
@@ -194,10 +194,8 @@ File fields provide details about each file.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="file.path"></a>file.path  | Path to the file.  | text  |   |   |
-| <a name="file.path.keyword"></a>file.path.keyword  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="file.target_path"></a>file.target_path  | Target path for symlinks.  | text  |   |   |
-| <a name="file.target_path.keyword"></a>file.target_path.keyword  | Path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="file.path"></a>file.path  | Path to the file.  | keyword  |   |   |
+| <a name="file.target_path"></a>file.target_path  | Target path for symlinks.  | keyword  |   |   |
 | <a name="file.extension"></a>file.extension  | File extension.<br/>This should allow easy filtering by file extensions.  | keyword  |   | `png`  |
 | <a name="file.type"></a>file.type  | File type (file, dir, or symlink).  | keyword  |   |   |
 | <a name="file.device"></a>file.device  | Device that is the source of the file.  | keyword  |   |   |
@@ -256,7 +254,7 @@ Fields related to HTTP requests and responses.
 |---|---|---|---|---|
 | <a name="http.request.method"></a>http.request.method  | Http request method.  | keyword  |   | `GET, POST, PUT`  |
 | <a name="http.response.status_code"></a>http.response.status_code  | Http response status code.  | long  |   | `404`  |
-| <a name="http.response.body"></a>http.response.body  | The full http response body.  | text  |   | `Hello world`  |
+| <a name="http.response.body"></a>http.response.body  | The full http response body.  | keyword  |   | `Hello world`  |
 | <a name="http.version"></a>http.version  | Http version.  | keyword  |   | `1.1`  |
 
 
@@ -278,8 +276,7 @@ Fields related to network data.
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="network.name"></a>network.name  | Name given by operators to sections of their network.  | text  |   | `Guest Wifi`  |
-| <a name="network.name.keyword"></a>network.name.keyword  | Name given by operators to sections of their network.  | keyword  | 1  |   |
+| <a name="network.name"></a>network.name  | Name given by operators to sections of their network.  | keyword  |   | `Guest Wifi`  |
 | <a name="network.protocol"></a>network.protocol  | Network protocol name.  | keyword  |   | `http`  |
 | <a name="network.direction"></a>network.direction  | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown  | keyword  |   | `inbound`  |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip  | Host IP address when the source IP address is the proxy.  | ip  |   | `192.1.1.2`  |
@@ -298,7 +295,7 @@ The organization fields enrich data with information about the company or entity
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="organization.name"></a>organization.name  | Organization name.  | text  |   |   |
+| <a name="organization.name"></a>organization.name  | Organization name.  | keyword  |   |   |
 | <a name="organization.id"></a>organization.id  | Unique identifier for the organization.  | keyword  |   |   |
 
 
@@ -367,15 +364,12 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="url.href"></a>url.href  | Full url. The field is stored as keyword.<br/>`url.href` is a [multi field](https://www.elastic.co/guide/en/ elasticsearch/reference/6.2/ multi-fields.html#_multi_fields_with_multiple_analyzers). The data is stored as keyword `url.href` and test `url.href.analyzed`. These fields enable you to run a query against part of the url still works splitting up the URL at ingest time.<br/>`href` is an analyzed field so the parsed information can be accessed through `href.analyzed` in queries.  | text  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
-| <a name="url.href.keyword"></a>url.href.keyword  | The full URL. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.href"></a>url.href  | Full url. The field is stored as keyword.  | keyword  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
 | <a name="url.scheme"></a>url.scheme  | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
 | <a name="url.host.name"></a>url.host.name  | Hostname of the request, such as "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
 | <a name="url.port"></a>url.port  | Port of the request, such as 443.  | integer  |   | `443`  |
-| <a name="url.path"></a>url.path  | Path of the request, such as "/search".  | text  |   |   |
-| <a name="url.path.keyword"></a>url.path.keyword  | URL path. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| <a name="url.query"></a>url.query  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | text  |   |   |
-| <a name="url.query.keyword"></a>url.query.keyword  | URL query part. A non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
+| <a name="url.path"></a>url.path  | Path of the request, such as "/search".  | keyword  |   |   |
+| <a name="url.query"></a>url.query  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | keyword  |   |   |
 | <a name="url.fragment"></a>url.fragment  | Portion of the url after the `#`, such as "top".<br/>The `#` is not part of the fragment.  | keyword  |   |   |
 | <a name="url.username"></a>url.username  | Username of the request.  | keyword  |   |   |
 | <a name="url.password"></a>url.password  | Password of the request.  | keyword  |   |   |
@@ -401,7 +395,7 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | text  |   |   |
+| <a name="user_agent.original"></a>user_agent.original  | Unparsed version of the user_agent.  | keyword  |   |   |
 | <a name="user_agent.device"></a>user_agent.device  | Name of the physical device.  | keyword  |   |   |
 | <a name="user_agent.version"></a>user_agent.version  | Version of the physical device.  | keyword  |   |   |
 | <a name="user_agent.major"></a>user_agent.major  | Major version of the user agent.  | long  |   |   |

--- a/fields.yml
+++ b/fields.yml
@@ -290,7 +290,7 @@
             Hostname of the device.
         - name: vendor
           level: core
-          type: text
+          type: keyword
           description: >
             Device vendor information.
         - name: version
@@ -506,25 +506,13 @@
     
       - name: path
         level: extended
-        type: text
+        type: keyword
         description: Path to the file.
-        multi_fields:
-        - name: keyword
-          type: keyword
-          description: >
-            Path to the file. This is a non-analyzed field that is useful
-            for aggregations.
     
       - name: target_path
         level: extended
-        type: text
+        type: keyword
         description: Target path for symlinks.
-        multi_fields:
-          - name: keyword
-            type: keyword
-            description: >
-              Path to the file. This is a non-analyzed field that is useful
-              for aggregations.
     
       - name: extension
         level: extended
@@ -746,7 +734,7 @@
     
         - name: response.body
           level: extended
-          type: text
+          type: keyword
           description: >
             The full http response body.
           example: Hello world
@@ -803,15 +791,10 @@
     
         - name: name
           level: extended
-          type: text
+          type: keyword
           description: >
             Name given by operators to sections of their network.
           example: Guest Wifi
-          multi_fields:
-            - name: keyword
-              type: keyword
-              description: >
-                Name given by operators to sections of their network.
     
         - name: protocol
           level: core
@@ -894,7 +877,7 @@
     
         - name: name
           level: extended
-          type: text
+          type: keyword
           description: >
             Organization name.
     
@@ -1123,25 +1106,9 @@
     
         - name: href
           level: extended
-          type: text
+          type: keyword
           description: >
             Full url. The field is stored as keyword.
-    
-            `url.href` is a [multi field](https://www.elastic.co/guide/en/
-            elasticsearch/reference/6.2/
-            multi-fields.html#_multi_fields_with_multiple_analyzers). The data is
-            stored as keyword `url.href` and test
-            `url.href.analyzed`. These fields enable you to run a query against part
-            of the url still works splitting up the URL at ingest time.
-    
-            `href` is an analyzed field so the parsed information can be accessed
-            through `href.analyzed` in queries.
-          multi_fields:
-            - name: keyword
-              type: keyword
-              description: >
-                The full URL. This is a non-analyzed field that is useful
-                for aggregations.
           example: https://elastic.co:443/search?q=elasticsearch#top
     
         - name: scheme
@@ -1172,19 +1139,13 @@
     
         - name: path
           level: extended
-          type: text
+          type: keyword
           description: >
             Path of the request, such as "/search".
-          multi_fields:
-            - name: keyword
-              type: keyword
-              description: >
-                URL path. A non-analyzed field that is useful
-                for aggregations.
     
         - name: query
           level: extended
-          type: text
+          type: keyword
           description: >
             The query field describes the query string of the request,
             such as "q=elasticsearch".
@@ -1193,12 +1154,6 @@
             no `?`, there is no query field. If there is a `?` but no query,
             the query field exists with an empty string. The `exists`
             query can be used to differentiate between the two cases.
-          multi_fields:
-            - name: keyword
-              type: keyword
-              description: >
-                URL query part. A non-analyzed field that is useful
-                for aggregations.
     
         - name: fragment
           level: extended
@@ -1271,7 +1226,7 @@
     
         - name: original
           level: extended
-          type: text
+          type: keyword
           description: >
             Unparsed version of the user_agent.
     

--- a/schema.csv
+++ b/schema.csv
@@ -31,7 +31,7 @@ device.ip,ip,0,
 device.mac,keyword,0,
 device.serial_number,keyword,0,
 device.type,keyword,0,firewall
-device.vendor,text,0,
+device.vendor,keyword,0,
 device.version,keyword,0,
 error.code,keyword,0,
 error.id,keyword,0,
@@ -59,9 +59,9 @@ file.inode,keyword,0,
 file.mode,keyword,0,416
 file.mtime,date,0,
 file.owner,keyword,0,
-file.path,text,0,
+file.path,keyword,0,
 file.size,long,0,
-file.target_path,text,0,
+file.target_path,keyword,0,
 file.type,keyword,0,
 file.uid,keyword,0,
 geo.city_name,keyword,0,
@@ -80,7 +80,7 @@ host.os.platform,keyword,0,darwin
 host.os.version,keyword,0,10.12.6
 host.type,keyword,0,
 http.request.method,keyword,0,"GET, POST, PUT"
-http.response.body,text,0,Hello world
+http.response.body,keyword,0,Hello world
 http.response.status_code,long,0,404
 http.version,keyword,0,1.1
 log.level,keyword,0,ERR
@@ -89,14 +89,14 @@ network.direction,keyword,0,inbound
 network.forwarded_ip,ip,0,192.1.1.2
 network.inbound.bytes,long,0,184
 network.inbound.packets,long,0,12
-network.name,text,0,Guest Wifi
+network.name,keyword,0,Guest Wifi
 network.outbound.bytes,long,0,184
 network.outbound.packets,long,0,12
 network.protocol,keyword,0,http
 network.total.bytes,long,0,368
 network.total.packets,long,0,24
 organization.id,keyword,0,
-organization.name,text,0,
+organization.name,keyword,0,
 os.family,keyword,0,debian
 os.kernel,keyword,0,4.4.0-112-generic
 os.name,keyword,0,Mac OS X
@@ -121,11 +121,11 @@ source.port,long,0,
 source.subdomain,keyword,0,
 url.fragment,keyword,0,
 url.host.name,keyword,0,elastic.co
-url.href,text,0,https://elastic.co:443/search?q=elasticsearch#top
+url.href,keyword,0,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,0,
-url.path,text,0,
+url.path,keyword,0,
 url.port,integer,0,443
-url.query,text,0,
+url.query,keyword,0,
 url.scheme,keyword,0,https
 url.username,keyword,0,
 user.email,keyword,0,
@@ -136,7 +136,7 @@ user_agent.device,keyword,0,
 user_agent.major,long,0,
 user_agent.minor,long,0,
 user_agent.name,keyword,0,Chrome
-user_agent.original,text,0,
+user_agent.original,keyword,0,
 user_agent.os.major,long,0,
 user_agent.os.minor,long,0,
 user_agent.os.name,keyword,0,

--- a/schemas/device.yml
+++ b/schemas/device.yml
@@ -24,7 +24,7 @@
         Hostname of the device.
     - name: vendor
       level: core
-      type: text
+      type: keyword
       description: >
         Device vendor information.
     - name: version

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -9,25 +9,13 @@
 
   - name: path
     level: extended
-    type: text
+    type: keyword
     description: Path to the file.
-    multi_fields:
-    - name: keyword
-      type: keyword
-      description: >
-        Path to the file. This is a non-analyzed field that is useful
-        for aggregations.
 
   - name: target_path
     level: extended
-    type: text
+    type: keyword
     description: Target path for symlinks.
-    multi_fields:
-      - name: keyword
-        type: keyword
-        description: >
-          Path to the file. This is a non-analyzed field that is useful
-          for aggregations.
 
   - name: extension
     level: extended

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -23,7 +23,7 @@
 
     - name: response.body
       level: extended
-      type: text
+      type: keyword
       description: >
         The full http response body.
       example: Hello world

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -9,15 +9,10 @@
 
     - name: name
       level: extended
-      type: text
+      type: keyword
       description: >
         Name given by operators to sections of their network.
       example: Guest Wifi
-      multi_fields:
-        - name: keyword
-          type: keyword
-          description: >
-            Name given by operators to sections of their network.
 
     - name: protocol
       level: core

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -11,7 +11,7 @@
 
     - name: name
       level: extended
-      type: text
+      type: keyword
       description: >
         Organization name.
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -10,25 +10,9 @@
 
     - name: href
       level: extended
-      type: text
+      type: keyword
       description: >
         Full url. The field is stored as keyword.
-
-        `url.href` is a [multi field](https://www.elastic.co/guide/en/
-        elasticsearch/reference/6.2/
-        multi-fields.html#_multi_fields_with_multiple_analyzers). The data is
-        stored as keyword `url.href` and test
-        `url.href.analyzed`. These fields enable you to run a query against part
-        of the url still works splitting up the URL at ingest time.
-
-        `href` is an analyzed field so the parsed information can be accessed
-        through `href.analyzed` in queries.
-      multi_fields:
-        - name: keyword
-          type: keyword
-          description: >
-            The full URL. This is a non-analyzed field that is useful
-            for aggregations.
       example: https://elastic.co:443/search?q=elasticsearch#top
 
     - name: scheme
@@ -59,19 +43,13 @@
 
     - name: path
       level: extended
-      type: text
+      type: keyword
       description: >
         Path of the request, such as "/search".
-      multi_fields:
-        - name: keyword
-          type: keyword
-          description: >
-            URL path. A non-analyzed field that is useful
-            for aggregations.
 
     - name: query
       level: extended
-      type: text
+      type: keyword
       description: >
         The query field describes the query string of the request,
         such as "q=elasticsearch".
@@ -80,12 +58,6 @@
         no `?`, there is no query field. If there is a `?` but no query,
         the query field exists with an empty string. The `exists`
         query can be used to differentiate between the two cases.
-      multi_fields:
-        - name: keyword
-          type: keyword
-          description: >
-            URL query part. A non-analyzed field that is useful
-            for aggregations.
 
     - name: fragment
       level: extended

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -10,7 +10,7 @@
 
     - name: original
       level: extended
-      type: text
+      type: keyword
       description: >
         Unparsed version of the user_agent.
 

--- a/template.json
+++ b/template.json
@@ -166,8 +166,8 @@
               "type": "keyword"
             },
             "vendor": {
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "version": {
               "ignore_above": 1024,
@@ -285,27 +285,15 @@
               "type": "keyword"
             },
             "path": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "size": {
               "type": "long"
             },
             "target_path": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "type": {
               "ignore_above": 1024,
@@ -400,8 +388,8 @@
             "response": {
               "properties": {
                 "body": {
-                  "norms": false,
-                  "type": "text"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "status_code": {
                   "type": "long"
@@ -455,14 +443,8 @@
               }
             },
             "name": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "outbound": {
               "properties": {
@@ -497,8 +479,8 @@
               "type": "keyword"
             },
             "name": {
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -621,41 +603,23 @@
               }
             },
             "href": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "password": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "path": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "port": {
               "type": "long"
             },
             "query": {
-              "fields": {
-                "keyword": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              },
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "scheme": {
               "ignore_above": 1024,
@@ -704,8 +668,8 @@
               "type": "keyword"
             },
             "original": {
-              "norms": false,
-              "type": "text"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "os": {
               "properties": {

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -9,9 +9,9 @@ ECS usage in Auditbeat.
 |---|---|---|---|---|
 | [event.module](https://github.com/elastic/ecs#event.module)  | Auditbeat module name.  | keyword  |   | `mysql`  |
 | <a name="file.&ast;"></a>*file.&ast;*  | *File attributes.<br/>*  |   |   |   |
-| [file.path](https://github.com/elastic/ecs#file.path)  | The path to the file.  | text  |   |   |
+| [file.path](https://github.com/elastic/ecs#file.path)  | The path to the file.  | keyword  |   |   |
 | [file.path.raw](https://github.com/elastic/ecs#file.path.raw)  | The path to the file. This is a non-analyzed field that is useful for aggregations.  | keyword  | 1  |   |
-| [file.target_path](https://github.com/elastic/ecs#file.target_path)  | The target path for symlinks.  | text  |   |   |
+| [file.target_path](https://github.com/elastic/ecs#file.target_path)  | The target path for symlinks.  | keyword  |   |   |
 | [file.type](https://github.com/elastic/ecs#file.type)  | The file type (file, dir, or symlink).  | keyword  |   |   |
 | [file.device](https://github.com/elastic/ecs#file.device)  | The device.  | keyword  |   |   |
 | [file.inode](https://github.com/elastic/ecs#file.inode)  | The inode representing the file in the filesystem.  | keyword  |   |   |

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -21,7 +21,7 @@ ECS fields used in Filebeat for the apache module.
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes*  | *Http response body bytes sent, currently apache.access.body_sent.bytes*  | long  |   | `117`  |
 | <a name="http.referer"></a>*http.referer*  | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard*  | keyword  |   | `http://elastic.co/`  |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;*  | *User agent fields as in schema. Currently under apache.access.user_agent.*<br/>*  |   |   |   |
-| [user_agent.original](https://github.com/elastic/ecs#user_agent.original)  | Original user agent. Currently apache.access.agent  | text  |   | `http://elastic.co/`  |
+| [user_agent.original](https://github.com/elastic/ecs#user_agent.original)  | Original user agent. Currently apache.access.agent  | keyword  |   | `http://elastic.co/`  |
 | <a name="geoip.&ast;"></a>*geoip.&ast;*  | *User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>*  |   |   |   |
 | <a name="geoip...."></a>*geoip....*  | *All geoip fields.*  | text  |   |   |
 


### PR DESCRIPTION
We started to use multi fields in ECS and if we used a multi field, the base field was text as is the default in Elasticsearch. The problem with this is we decide in the future to make a field multi field, it would be breaking change as what was before a keyword now becomes text. To prevent this all fields except `message` are by default a keyword. Making a multifield out of a field is then a non breaking change.

On the ECS side we still need to figure out what our recommendation is for naming multiple fields like `.analyzed, .text` or others.

This change has also an affect on Beats as in ttps://github.com/elastic/beats/pull/8313 the fields.yml from ECS was added to Beats. There was even a breaking change I think we missed when switch to ECS there as the `http.response.body` in packetbeat was text and in Metricbeat keyword.

The following fields were changed to keyword and multifield removed for now. We can add it later again when we figure out the convention:

* device.vendor
* file.path
* file.target_path
* http.response.body
* network.name
* organization.name
* url.href
* url.path
* url.query
* user_agent.original