### PR TITLE
Disable indexing for user_agent.original

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file based on the
 * Remove `log.offset` and `log.line` as too specific for ECS. #131
 * Remove top level objects `kubernetes` and `tls`. #132
 * Remove `*.timezone.offset.sec` fields as too specific for ECS at the moment. #134
+* Set indexing to false for `user_agent.original`.
 
 ### Bugfixes
 

--- a/fields.yml
+++ b/fields.yml
@@ -1274,6 +1274,7 @@
           type: text
           description: >
             Unparsed version of the user_agent.
+          index: false
     
         - name: device
           level: extended

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -13,6 +13,7 @@
       type: text
       description: >
         Unparsed version of the user_agent.
+      index: false
 
     - name: device
       level: extended

--- a/template.json
+++ b/template.json
@@ -704,6 +704,7 @@
               "type": "keyword"
             },
             "original": {
+              "index": false,
               "norms": false,
               "type": "text"
             },


### PR DESCRIPTION
All the original fields are not indexed. For consistency the same should be true for user_agent.original.