### PR TITLE
Rename `host.name` to `host.hostname`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,10 @@ All notable changes to this project will be documented in this file based on the
 * Remove top level objects `kubernetes` and `tls`. #132
 * Remove `*.timezone.offset.sec` fields as too specific for ECS at the moment. #134
 * Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original
-* Rename `url.host.name` to `url.hostname` to better align with industry convention.
+* Rename `url.host.name` to `url.hostname` to better align with industry convention. #147
 * Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original. #137
   * Only two fields using `text` indexing at this time are `message` and `error.message`.
-* Rename `host.name` to `host.hostname` to better align with industry convention.
+* Rename `host.name` to `host.hostname` to better align with industry convention. #144
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `url.host.name` to `url.hostname` to better align with industry convention.
 * Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original. #137
   * Only two fields using `text` indexing at this time are `message` and `error.message`.
+* Rename `host.name` to `host.hostname` to better align with industry convention.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Normally the host information is related to the machine on which the event was g
 
 | Field  | Description  | Type  | Multi Field  | Example  |
 |---|---|---|---|---|
-| <a name="host.name"></a>host.name  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   |   |
+| <a name="host.hostname"></a>host.hostname  | Hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   |   |
 | <a name="host.id"></a>host.id  | Unique host id.<br/>As hostname is not always unique, use values that are meaningful in your environment.<br/>Example: The current usage of `beat.name`.  | keyword  |   |   |
 | <a name="host.ip"></a>host.ip  | Host ip address.  | ip  |   |   |
 | <a name="host.mac"></a>host.mac  | Host mac address.  | keyword  |   |   |

--- a/fields.yml
+++ b/fields.yml
@@ -632,11 +632,11 @@
       type: group
       fields:
     
-        - name: name
+        - name: hostname
           level: core
           type: keyword
           description: >
-            host.name is the hostname of the host.
+            Hostname of the host.
     
             It can contain what `hostname` returns on Unix systems, the fully
             qualified domain name, or a name specified by the user. The sender

--- a/schema.csv
+++ b/schema.csv
@@ -70,10 +70,10 @@ geo.country_iso_code,keyword,0,
 geo.location,geo_point,0,
 geo.region_name,keyword,0,
 host.architecture,keyword,0,x86_64
+host.hostname,keyword,0,
 host.id,keyword,0,
 host.ip,ip,0,
 host.mac,keyword,0,
-host.name,keyword,0,
 host.os.family,keyword,0,debian
 host.os.name,keyword,0,Mac OS X
 host.os.platform,keyword,0,darwin

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -11,11 +11,11 @@
   type: group
   fields:
 
-    - name: name
+    - name: hostname
       level: core
       type: keyword
       description: >
-        host.name is the hostname of the host.
+        Hostname of the host.
 
         It can contain what `hostname` returns on Unix systems, the fully
         qualified domain name, or a name specified by the user. The sender

--- a/template.json
+++ b/template.json
@@ -334,6 +334,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -342,10 +346,6 @@
               "type": "ip"
             },
             "mac": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/use-cases/kubernetes.md
+++ b/use-cases/kubernetes.md
@@ -10,7 +10,7 @@ You can monitor containers running in a Kubernetes cluster by adding Kubernetes-
 |---|---|---|---|---|
 | [container.id](https://github.com/elastic/ecs#container.id)  | Unique container id.  | keyword  |   | `fdbef803fa2b`  |
 | [container.name](https://github.com/elastic/ecs#container.name)  | Container name.  | keyword  |   |   |
-| [host.name](https://github.com/elastic/ecs#host.name)  | host.name is the hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   | `kube-high-cpu-42`  |
+| [host.hostname](https://github.com/elastic/ecs#host.hostname)  | Hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.  | keyword  |   | `kube-high-cpu-42`  |
 | <a name="kubernetes.pod.name"></a>*kubernetes.pod.name*  | *Kubernetes pod name*  | keyword  |   | `foo-webserver`  |
 | <a name="kubernetes.namespace"></a>*kubernetes.namespace*  | *Kubernetes namespace*  | keyword  |   | `foo-team`  |
 | <a name="kubernetes.labels"></a>*kubernetes.labels*  | *Kubernetes labels map*  | object  |   |   |

--- a/use-cases/kubernetes.yml
+++ b/use-cases/kubernetes.yml
@@ -16,7 +16,7 @@ fields:
 - name: host
   fields:
 
-  - name: name
+  - name: hostname
     example: kube-high-cpu-42
 
 - name: kubernetes

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -21,7 +21,7 @@ ECS fields used Metricbeat.
 | <a name="error.&ast;"></a>*error.&ast;*  | *Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>*  |   |   |   |
 | [error.message](https://github.com/elastic/ecs#error.message)  | Error message returned by the service during fetching metrics.  | text  |   |   |
 | [error.code](https://github.com/elastic/ecs#error.code)  | Error code returned by the service during fetching metrics.  | keyword  |   |   |
-| [host.name](https://github.com/elastic/ecs#host.name)  | Hostname of the system metricbeat is running on or user defined name.  | keyword  |   |   |
+| [host.hostname](https://github.com/elastic/ecs#host.hostname)  | Hostname of the system metricbeat is running on or user defined name.  | keyword  |   |   |
 | <a name="host.timezone.offset.sec"></a>*host.timezone.offset.sec*  | *Timezone offset of the host in seconds.*  | long  |   |   |
 | [host.id](https://github.com/elastic/ecs#host.id)  | Unique host id.  | keyword  |   |   |
 | [event.module](https://github.com/elastic/ecs#event.module)  | Name of the module this data is coming from.  | keyword  |   | `mysql`  |

--- a/use-cases/metricbeat.yml
+++ b/use-cases/metricbeat.yml
@@ -113,7 +113,7 @@ fields:
 
 - name: host
   fields:
-    - name: name
+    - name: hostname
       type: text
       description: >
         Hostname of the system metricbeat is running on or user defined name.


### PR DESCRIPTION
This is to align with the industry's convention of using the word "hostname".