### PR TITLE
Fix autopep8 version

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
 pip
-PyYAML
-autopep8
+PyYAML==3.13
+autopep8==1.4.2

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -74,11 +74,13 @@ def filtered_fields(fields, groups):
 
     return new_fields
 
+
 def check_fields(fields):
     for f in fields:
         for field in list(f["fields"]):
             if field["level"] not in ["core", "extended"]:
                 raise Exception('Field {} does not have an allowed level'.format(field["name"]))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
A new release of autopep8 causes a small diff in all PRs. This should fix it by setting a predefined autopep8 version.