### PR TITLE
Rename `url.host.name` to `url.hostname`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ All notable changes to this project will be documented in this file based on the
 * Remove `log.offset` and `log.line` as too specific for ECS. #131
 * Remove top level objects `kubernetes` and `tls`. #132
 * Remove `*.timezone.offset.sec` fields as too specific for ECS at the moment. #134
-* Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original 
+* Make the following fields keyword: device.vendor, file.path, file.target_path, http.response.body, network.name, organization.name, url.href, url.path, url.query, user_agent.original
+* Rename `url.host.name` to `url.hostname` to better align with industry convention.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 |---|---|---|---|---|
 | <a name="url.href"></a>url.href  | Full url. The field is stored as keyword.  | keyword  |   | `https://elastic.co:443/search?q=elasticsearch#top`  |
 | <a name="url.scheme"></a>url.scheme  | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme.  | keyword  |   | `https`  |
-| <a name="url.host.name"></a>url.host.name  | Hostname of the request, such as "example.com".<br/>For correlation the this field can be copied into the `host.name` field.  | keyword  |   | `elastic.co`  |
+| <a name="url.hostname"></a>url.hostname  | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field.  | keyword  |   | `elastic.co`  |
 | <a name="url.port"></a>url.port  | Port of the request, such as 443.  | integer  |   | `443`  |
 | <a name="url.path"></a>url.path  | Path of the request, such as "/search".  | keyword  |   |   |
 | <a name="url.query"></a>url.query  | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.  | keyword  |   |   |

--- a/fields.yml
+++ b/fields.yml
@@ -1120,14 +1120,14 @@
             Note: The `:` is not part of the scheme.
           example: https
     
-        - name: host.name
+        - name: hostname
           level: extended
           type: keyword
           description: >
-            Hostname of the request, such as "example.com".
+            Hostname of the request, such as "elastic.co".
     
-            For correlation the this field can be copied into the `host.name`
-            field.
+            In some cases a URL may refer to an IP and/or port directly, without a
+            domain name. In this case, the IP address would go to the `hostname` field.
           example: elastic.co
     
         - name: port

--- a/schema.csv
+++ b/schema.csv
@@ -120,7 +120,7 @@ source.mac,keyword,0,
 source.port,long,0,
 source.subdomain,keyword,0,
 url.fragment,keyword,0,
-url.host.name,keyword,0,elastic.co
+url.hostname,keyword,0,elastic.co
 url.href,keyword,0,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,0,
 url.path,keyword,0,

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -24,14 +24,14 @@
         Note: The `:` is not part of the scheme.
       example: https
 
-    - name: host.name
+    - name: hostname
       level: extended
       type: keyword
       description: >
-        Hostname of the request, such as "example.com".
+        Hostname of the request, such as "elastic.co".
 
-        For correlation the this field can be copied into the `host.name`
-        field.
+        In some cases a URL may refer to an IP and/or port directly, without a
+        domain name. In this case, the IP address would go to the `hostname` field.
       example: elastic.co
 
     - name: port

--- a/template.json
+++ b/template.json
@@ -594,13 +594,9 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "host": {
-              "properties": {
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "href": {
               "ignore_above": 1024,


### PR DESCRIPTION
Also in there:
- Replace example.com to continue using the elastic.co example we're breaking down everywhere in this TLO's documentation.
- Removed discussion about correlation via copying to `host.name`, as the correlation will instead happen via `related.*` soon, instead.
- Added changelog