### PR TITLE
Use domain and registered_domain for the domain breakdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,7 @@ All notable changes to this project will be documented in this file based on the
 * Update definition of `service.type` and `service.name`.
 * Redefine purpose of `agent.name` field to be user defined field.
 * Rename `url.href` to `url.original`.
-* Remove `source.subdomain` and `destination.subdomain` fields.
-* Remove `source.hostname`, `destination.hostname`, `source.subdomain`,
-  `destination.subdomain` and `url.hostname`. #163
-* Remove `source.hostname`, `destination.hostname`, `source.subdomain` and
-  `destination.subdomain`. #163
-* Remove `source.subdomain` and `destination.subdomain`. #163
+* Remove `source.subdomain` and `destination.subdomain` fields. #165
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file based on the
 * Redefine purpose of `agent.name` field to be user defined field.
 * Rename `url.href` to `url.original`.
 * Remove `source.subdomain` and `destination.subdomain` fields.
+* Remove `source.hostname`, `destination.hostname`, `source.subdomain`,
+  `destination.subdomain` and `url.hostname`.
 
 ### Bugfixes
 
@@ -41,5 +43,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `host.os.kernel` containing the OS kernel version. #60
 * Add `agent.type` field.
 * Add `http.request.referrer` field. #164
+* Add `source.registered_domain`, `destination.registered_domain`,
+  `url.domain` and `url.registered_domain`.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ All notable changes to this project will be documented in this file based on the
 * Remove `source.subdomain` and `destination.subdomain` fields.
 * Remove `source.hostname`, `destination.hostname`, `source.subdomain`,
   `destination.subdomain` and `url.hostname`. #163
+* Remove `source.hostname`, `destination.hostname`, `source.subdomain` and
+  `destination.subdomain`. #163
 
 ### Bugfixes
 
@@ -45,5 +47,6 @@ All notable changes to this project will be documented in this file based on the
 * Add `http.request.referrer` field. #164
 * Add `source.registered_domain`, `destination.registered_domain`,
   `url.domain` and `url.registered_domain`. #163
+* Add `source.registered_domain`, `destination.registered_domain`. #163
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ All notable changes to this project will be documented in this file based on the
 * Add `host.os.kernel` containing the OS kernel version. #60
 * Add `agent.type` field.
 * Add `http.request.referrer` field. #164
-* Add `source.registered_domain`, `destination.registered_domain`,
-  `url.domain` and `url.registered_domain`. #163
+* Add `source.registered_domain` and `destination.registered_domain`. #163
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to this project will be documented in this file based on the
 * Rename `url.href` to `url.original`.
 * Remove `source.subdomain` and `destination.subdomain` fields.
 * Remove `source.hostname`, `destination.hostname`, `source.subdomain`,
-  `destination.subdomain` and `url.hostname`.
+  `destination.subdomain` and `url.hostname`. #163
 
 ### Bugfixes
 
@@ -44,6 +44,6 @@ All notable changes to this project will be documented in this file based on the
 * Add `agent.type` field.
 * Add `http.request.referrer` field. #164
 * Add `source.registered_domain`, `destination.registered_domain`,
-  `url.domain` and `url.registered_domain`.
+  `url.domain` and `url.registered_domain`. #163
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file based on the
   `destination.subdomain` and `url.hostname`. #163
 * Remove `source.hostname`, `destination.hostname`, `source.subdomain` and
   `destination.subdomain`. #163
+* Remove `source.subdomain` and `destination.subdomain`. #163
 
 ### Bugfixes
 
@@ -47,6 +48,5 @@ All notable changes to this project will be documented in this file based on the
 * Add `http.request.referrer` field. #164
 * Add `source.registered_domain`, `destination.registered_domain`,
   `url.domain` and `url.registered_domain`. #163
-* Add `source.registered_domain`, `destination.registered_domain`. #163
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -372,9 +372,10 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
+| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.hostname"></a>url.hostname | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
+| <a name="url.domain"></a>url.domain | URL's domain in full. | core | keyword | `www.elastic.co` |
+| <a name="url.registered_domain"></a>url.registered_domain | URL's domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `elastic.co`, whether the activity was on `www.elastic.co`, `assets.elastic.co` or `api.elastic.co`. | extended | keyword | `elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |

--- a/README.md
+++ b/README.md
@@ -372,10 +372,9 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` |
+| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.domain"></a>url.domain | URL's domain in full. | core | keyword | `www.elastic.co` |
-| <a name="url.registered_domain"></a>url.registered_domain | URL's domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `elastic.co`, whether the activity was on `www.elastic.co`, `assets.elastic.co` or `api.elastic.co`. | extended | keyword | `elastic.co` |
+| <a name="url.hostname"></a>url.hostname | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Destination fields describe details about the destination of a packet/event.
 | <a name="destination.ip"></a>destination.ip | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
+| <a name="destination.hostname"></a>destination.hostname | Hostname of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain in full. | core | keyword | `www.example.com` |
 | <a name="destination.registered_domain"></a>destination.registered_domain | Destination domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
@@ -361,6 +362,7 @@ Source fields describe details about the destination of a packet/event.
 | <a name="source.ip"></a>source.ip | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
+| <a name="source.hostname"></a>source.hostname | Hostname of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain in full. | core | keyword | `www.example.com` |
 | <a name="source.registered_domain"></a>source.registered_domain | Source domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ Destination fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="destination.ip"></a>destination.ip | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
-| <a name="destination.hostname"></a>destination.hostname | Hostname of the destination. | core | keyword |  |
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
-| <a name="destination.domain"></a>destination.domain | Destination domain. | core | keyword |  |
+| <a name="destination.domain"></a>destination.domain | Destination domain in full. | core | keyword | `www.example.com` |
+| <a name="destination.registered_domain"></a>destination.registered_domain | Destination domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
 
 ## <a name="device"></a> Device fields
@@ -359,10 +359,10 @@ Source fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="source.ip"></a>source.ip | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
-| <a name="source.hostname"></a>source.hostname | Hostname of the source. | core | keyword |  |
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
-| <a name="source.domain"></a>source.domain | Source domain. | core | keyword |  |
+| <a name="source.domain"></a>source.domain | Source domain in full. | core | keyword | `www.example.com` |
+| <a name="source.registered_domain"></a>source.registered_domain | Source domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
 
 ## <a name="url"></a> URL fields

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ Destination fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="destination.ip"></a>destination.ip | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
+| <a name="destination.hostname"></a>destination.hostname | Hostname of the destination. | core | keyword |  |
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
-| <a name="destination.hostname"></a>destination.hostname | Hostname of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain in full. | core | keyword | `www.example.com` |
 | <a name="destination.registered_domain"></a>destination.registered_domain | Destination domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
@@ -360,9 +360,9 @@ Source fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="source.ip"></a>source.ip | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
+| <a name="source.hostname"></a>source.hostname | Hostname of the source. | core | keyword |  |
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
-| <a name="source.hostname"></a>source.hostname | Hostname of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain in full. | core | keyword | `www.example.com` |
 | <a name="source.registered_domain"></a>source.registered_domain | Source domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ The service fields describe the service for or from which the data was collected
 
 ## <a name="source"></a> Source fields
 
-Source fields describe details about the source of the event.
+Source fields describe details about the destination of a packet/event.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Destination fields describe details about the destination of a packet/event.
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain in full. | core | keyword | `www.example.com` |
-| <a name="destination.registered_domain"></a>destination.registered_domain | Destination domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
+| <a name="destination.registered_domain"></a>destination.registered_domain | Destination domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
 
 ## <a name="device"></a> Device fields
@@ -362,7 +362,7 @@ Source fields describe details about the destination of a packet/event.
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain in full. | core | keyword | `www.example.com` |
-| <a name="source.registered_domain"></a>source.registered_domain | Source domain, with the subdomain stripped out.<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
+| <a name="source.registered_domain"></a>source.registered_domain | Source domain, with the subdomain stripped out. In other words, the effective TLD (.com) plus one level (example.com).<br/>This is useful to aggregate activity on multiple subdomains more broadly.<br/>This field enables aggregating/visualizing all activity on `example.com`, whether the activity was on `www.example.com`, `assets.example.com` or `api.example.com`. | extended | keyword | `example.com` |
 
 
 ## <a name="url"></a> URL fields

--- a/fields.yml
+++ b/fields.yml
@@ -276,7 +276,8 @@
           type: keyword
           example: example.com
           description: >
-            Destination domain, with the subdomain stripped out.
+            Destination domain, with the subdomain stripped out. In other words,
+            the effective TLD (.com) plus one level (example.com).
     
             This is useful to aggregate activity on multiple subdomains more broadly.
     
@@ -1145,7 +1146,8 @@
           type: keyword
           example: example.com
           description: >
-            Source domain, with the subdomain stripped out.
+            Source domain, with the subdomain stripped out. In other words,
+            the effective TLD (.com) plus one level (example.com).
     
             This is useful to aggregate activity on multiple subdomains more broadly.
     

--- a/fields.yml
+++ b/fields.yml
@@ -252,6 +252,12 @@
     
             Can be one or multiple IPv4 or IPv6 addresses.
     
+        - name: hostname
+          level: core
+          type: keyword
+          description: >
+            Hostname of the destination.
+    
         - name: port
           level: core
           type: long
@@ -263,12 +269,6 @@
           type: keyword
           description: >
             MAC address of the destination.
-    
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the destination.
     
         - name: domain
           level: core
@@ -1128,6 +1128,12 @@
     
             Can be one or multiple IPv4 or IPv6 addresses.
     
+        - name: hostname
+          level: core
+          type: keyword
+          description: >
+            Hostname of the source.
+    
         - name: port
           level: core
           type: long
@@ -1139,12 +1145,6 @@
           type: keyword
           description: >
             MAC address of the source.
-    
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the source.
     
         - name: domain
           level: core

--- a/fields.yml
+++ b/fields.yml
@@ -252,12 +252,6 @@
     
             Can be one or multiple IPv4 or IPv6 addresses.
     
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the destination.
-    
         - name: port
           level: core
           type: long
@@ -273,8 +267,22 @@
         - name: domain
           level: core
           type: keyword
+          example: www.example.com
           description: >
-            Destination domain.
+            Destination domain in full.
+    
+        - name: registered_domain
+          level: extended
+          type: keyword
+          example: example.com
+          description: >
+            Destination domain, with the subdomain stripped out.
+    
+            This is useful to aggregate activity on multiple subdomains more broadly.
+    
+            This field enables aggregating/visualizing all activity on `example.com`,
+            whether the activity was on `www.example.com`, `assets.example.com` or
+            `api.example.com`.
     
     - name: device
       title: Device
@@ -1113,12 +1121,6 @@
     
             Can be one or multiple IPv4 or IPv6 addresses.
     
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the source.
-    
         - name: port
           level: core
           type: long
@@ -1134,8 +1136,22 @@
         - name: domain
           level: core
           type: keyword
+          example: www.example.com
           description: >
-            Source domain.
+            Source domain in full.
+    
+        - name: registered_domain
+          level: extended
+          type: keyword
+          example: example.com
+          description: >
+            Source domain, with the subdomain stripped out.
+    
+            This is useful to aggregate activity on multiple subdomains more broadly.
+    
+            This field enables aggregating/visualizing all activity on `example.com`,
+            whether the activity was on `www.example.com`, `assets.example.com` or
+            `api.example.com`.
     
     - name: url
       title: URL

--- a/fields.yml
+++ b/fields.yml
@@ -1167,7 +1167,7 @@
           type: keyword
           description: >
             Full original url. The field is stored as keyword.
-          example: https://www.elastic.co:443/search?q=elasticsearch#top
+          example: https://elastic.co:443/search?q=elasticsearch#top
     
         - name: scheme
           level: extended
@@ -1178,25 +1178,15 @@
             Note: The `:` is not part of the scheme.
           example: https
     
-        - name: domain
-          level: core
-          type: keyword
-          example: www.elastic.co
-          description: >
-            URL's domain in full.
-    
-        - name: registered_domain
+        - name: hostname
           level: extended
           type: keyword
-          example: elastic.co
           description: >
-            URL's domain, with the subdomain stripped out.
+            Hostname of the request, such as "elastic.co".
     
-            This is useful to aggregate activity on multiple subdomains more broadly.
-    
-            This field enables aggregating/visualizing all activity on `elastic.co`,
-            whether the activity was on `www.elastic.co`, `assets.elastic.co` or
-            `api.elastic.co`.
+            In some cases a URL may refer to an IP and/or port directly, without a
+            domain name. In this case, the IP address would go to the `hostname` field.
+          example: elastic.co
     
         - name: port
           level: extended

--- a/fields.yml
+++ b/fields.yml
@@ -264,6 +264,12 @@
           description: >
             MAC address of the destination.
     
+        - name: hostname
+          level: core
+          type: keyword
+          description: >
+            Hostname of the destination.
+    
         - name: domain
           level: core
           type: keyword
@@ -1133,6 +1139,12 @@
           type: keyword
           description: >
             MAC address of the source.
+    
+        - name: hostname
+          level: core
+          type: keyword
+          description: >
+            Hostname of the source.
     
         - name: domain
           level: core

--- a/fields.yml
+++ b/fields.yml
@@ -1167,7 +1167,7 @@
           type: keyword
           description: >
             Full original url. The field is stored as keyword.
-          example: https://elastic.co:443/search?q=elasticsearch#top
+          example: https://www.elastic.co:443/search?q=elasticsearch#top
     
         - name: scheme
           level: extended
@@ -1178,15 +1178,25 @@
             Note: The `:` is not part of the scheme.
           example: https
     
-        - name: hostname
+        - name: domain
+          level: core
+          type: keyword
+          example: www.elastic.co
+          description: >
+            URL's domain in full.
+    
+        - name: registered_domain
           level: extended
           type: keyword
-          description: >
-            Hostname of the request, such as "elastic.co".
-    
-            In some cases a URL may refer to an IP and/or port directly, without a
-            domain name. In this case, the IP address would go to the `hostname` field.
           example: elastic.co
+          description: >
+            URL's domain, with the subdomain stripped out.
+    
+            This is useful to aggregate activity on multiple subdomains more broadly.
+    
+            This field enables aggregating/visualizing all activity on `elastic.co`,
+            whether the activity was on `www.elastic.co`, `assets.elastic.co` or
+            `api.elastic.co`.
     
         - name: port
           level: extended

--- a/fields.yml
+++ b/fields.yml
@@ -1100,7 +1100,8 @@
       title: Source
       group: 2
       description: >
-        Source fields describe details about the source of the event.
+        Source fields describe details about the destination of a
+        packet/event.
       type: group
       fields:
     

--- a/schema.csv
+++ b/schema.csv
@@ -21,11 +21,11 @@ container.image.tag,keyword,extended,
 container.labels,object,extended,
 container.name,keyword,extended,
 container.runtime,keyword,extended,docker
-destination.domain,keyword,core,
-destination.hostname,keyword,core,
+destination.domain,keyword,core,www.example.com
 destination.ip,ip,core,
 destination.mac,keyword,core,
 destination.port,long,core,
+destination.registered_domain,keyword,extended,example.com
 device.hostname,keyword,core,
 device.ip,ip,core,
 device.mac,keyword,core,
@@ -114,11 +114,11 @@ service.name,keyword,core,elasticsearch-metrics
 service.state,keyword,core,
 service.type,keyword,core,elasticsearch
 service.version,keyword,core,3.2.4
-source.domain,keyword,core,
-source.hostname,keyword,core,
+source.domain,keyword,core,www.example.com
 source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,
+source.registered_domain,keyword,extended,example.com
 url.fragment,keyword,extended,
 url.hostname,keyword,extended,elastic.co
 url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top

--- a/schema.csv
+++ b/schema.csv
@@ -119,14 +119,13 @@ source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,
 source.registered_domain,keyword,extended,example.com
-url.domain,keyword,core,www.elastic.co
 url.fragment,keyword,extended,
-url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top
+url.hostname,keyword,extended,elastic.co
+url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,extended,
 url.path,keyword,extended,
 url.port,integer,extended,443
 url.query,keyword,extended,
-url.registered_domain,keyword,extended,elastic.co
 url.scheme,keyword,extended,https
 url.username,keyword,extended,
 user.email,keyword,extended,

--- a/schema.csv
+++ b/schema.csv
@@ -22,6 +22,7 @@ container.labels,object,extended,
 container.name,keyword,extended,
 container.runtime,keyword,extended,docker
 destination.domain,keyword,core,www.example.com
+destination.hostname,keyword,core,
 destination.ip,ip,core,
 destination.mac,keyword,core,
 destination.port,long,core,
@@ -115,6 +116,7 @@ service.state,keyword,core,
 service.type,keyword,core,elasticsearch
 service.version,keyword,core,3.2.4
 source.domain,keyword,core,www.example.com
+source.hostname,keyword,core,
 source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,

--- a/schema.csv
+++ b/schema.csv
@@ -119,13 +119,14 @@ source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,
 source.registered_domain,keyword,extended,example.com
+url.domain,keyword,core,www.elastic.co
 url.fragment,keyword,extended,
-url.hostname,keyword,extended,elastic.co
-url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
+url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,extended,
 url.path,keyword,extended,
 url.port,integer,extended,443
 url.query,keyword,extended,
+url.registered_domain,keyword,extended,elastic.co
 url.scheme,keyword,extended,https
 url.username,keyword,extended,
 user.email,keyword,extended,

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -16,6 +16,12 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: hostname
+      level: core
+      type: keyword
+      description: >
+        Hostname of the destination.
+
     - name: port
       level: core
       type: long
@@ -27,12 +33,6 @@
       type: keyword
       description: >
         MAC address of the destination.
-
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the destination.
 
     - name: domain
       level: core

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -28,6 +28,12 @@
       description: >
         MAC address of the destination.
 
+    - name: hostname
+      level: core
+      type: keyword
+      description: >
+        Hostname of the destination.
+
     - name: domain
       level: core
       type: keyword

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -16,12 +16,6 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the destination.
-
     - name: port
       level: core
       type: long
@@ -37,5 +31,19 @@
     - name: domain
       level: core
       type: keyword
+      example: www.example.com
       description: >
-        Destination domain.
+        Destination domain in full.
+
+    - name: registered_domain
+      level: extended
+      type: keyword
+      example: example.com
+      description: >
+        Destination domain, with the subdomain stripped out.
+
+        This is useful to aggregate activity on multiple subdomains more broadly.
+
+        This field enables aggregating/visualizing all activity on `example.com`,
+        whether the activity was on `www.example.com`, `assets.example.com` or
+        `api.example.com`.

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -40,7 +40,8 @@
       type: keyword
       example: example.com
       description: >
-        Destination domain, with the subdomain stripped out.
+        Destination domain, with the subdomain stripped out. In other words,
+        the effective TLD (.com) plus one level (example.com).
 
         This is useful to aggregate activity on multiple subdomains more broadly.
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -16,6 +16,12 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: hostname
+      level: core
+      type: keyword
+      description: >
+        Hostname of the source.
+
     - name: port
       level: core
       type: long
@@ -27,12 +33,6 @@
       type: keyword
       description: >
         MAC address of the source.
-
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the source.
 
     - name: domain
       level: core

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -16,12 +16,6 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the source.
-
     - name: port
       level: core
       type: long
@@ -37,5 +31,19 @@
     - name: domain
       level: core
       type: keyword
+      example: www.example.com
       description: >
-        Source domain.
+        Source domain in full.
+
+    - name: registered_domain
+      level: extended
+      type: keyword
+      example: example.com
+      description: >
+        Source domain, with the subdomain stripped out.
+
+        This is useful to aggregate activity on multiple subdomains more broadly.
+
+        This field enables aggregating/visualizing all activity on `example.com`,
+        whether the activity was on `www.example.com`, `assets.example.com` or
+        `api.example.com`.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -28,6 +28,12 @@
       description: >
         MAC address of the source.
 
+    - name: hostname
+      level: core
+      type: keyword
+      description: >
+        Hostname of the source.
+
     - name: domain
       level: core
       type: keyword

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -40,7 +40,8 @@
       type: keyword
       example: example.com
       description: >
-        Source domain, with the subdomain stripped out.
+        Source domain, with the subdomain stripped out. In other words,
+        the effective TLD (.com) plus one level (example.com).
 
         This is useful to aggregate activity on multiple subdomains more broadly.
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -3,7 +3,8 @@
   title: Source
   group: 2
   description: >
-    Source fields describe details about the source of the event.
+    Source fields describe details about the destination of a
+    packet/event.
   type: group
   fields:
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -13,7 +13,7 @@
       type: keyword
       description: >
         Full original url. The field is stored as keyword.
-      example: https://www.elastic.co:443/search?q=elasticsearch#top
+      example: https://elastic.co:443/search?q=elasticsearch#top
 
     - name: scheme
       level: extended
@@ -24,25 +24,15 @@
         Note: The `:` is not part of the scheme.
       example: https
 
-    - name: domain
-      level: core
-      type: keyword
-      example: www.elastic.co
-      description: >
-        URL's domain in full.
-
-    - name: registered_domain
+    - name: hostname
       level: extended
       type: keyword
-      example: elastic.co
       description: >
-        URL's domain, with the subdomain stripped out.
+        Hostname of the request, such as "elastic.co".
 
-        This is useful to aggregate activity on multiple subdomains more broadly.
-
-        This field enables aggregating/visualizing all activity on `elastic.co`,
-        whether the activity was on `www.elastic.co`, `assets.elastic.co` or
-        `api.elastic.co`.
+        In some cases a URL may refer to an IP and/or port directly, without a
+        domain name. In this case, the IP address would go to the `hostname` field.
+      example: elastic.co
 
     - name: port
       level: extended

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -13,7 +13,7 @@
       type: keyword
       description: >
         Full original url. The field is stored as keyword.
-      example: https://elastic.co:443/search?q=elasticsearch#top
+      example: https://www.elastic.co:443/search?q=elasticsearch#top
 
     - name: scheme
       level: extended
@@ -24,15 +24,25 @@
         Note: The `:` is not part of the scheme.
       example: https
 
-    - name: hostname
+    - name: domain
+      level: core
+      type: keyword
+      example: www.elastic.co
+      description: >
+        URL's domain in full.
+
+    - name: registered_domain
       level: extended
       type: keyword
-      description: >
-        Hostname of the request, such as "elastic.co".
-
-        In some cases a URL may refer to an IP and/or port directly, without a
-        domain name. In this case, the IP address would go to the `hostname` field.
       example: elastic.co
+      description: >
+        URL's domain, with the subdomain stripped out.
+
+        This is useful to aggregate activity on multiple subdomains more broadly.
+
+        This field enables aggregating/visualizing all activity on `elastic.co`,
+        whether the activity was on `www.elastic.co`, `assets.elastic.co` or
+        `api.elastic.co`.
 
     - name: port
       level: extended

--- a/template.json
+++ b/template.json
@@ -128,10 +128,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "ip": {
               "type": "ip"
             },
@@ -141,6 +137,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -568,10 +568,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "ip": {
               "type": "ip"
             },
@@ -581,6 +577,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "registered_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },

--- a/template.json
+++ b/template.json
@@ -590,11 +590,11 @@
         },
         "url": {
           "properties": {
-            "fragment": {
+            "domain": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "hostname": {
+            "fragment": {
               "ignore_above": 1024,
               "type": "keyword"
             },
@@ -614,6 +614,10 @@
               "type": "long"
             },
             "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "registered_domain": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/template.json
+++ b/template.json
@@ -590,11 +590,11 @@
         },
         "url": {
           "properties": {
-            "domain": {
+            "fragment": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "fragment": {
+            "hostname": {
               "ignore_above": 1024,
               "type": "keyword"
             },
@@ -614,10 +614,6 @@
               "type": "long"
             },
             "query": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "registered_domain": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/template.json
+++ b/template.json
@@ -128,6 +128,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "hostname": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ip": {
               "type": "ip"
             },
@@ -565,6 +569,10 @@
         "source": {
           "properties": {
             "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hostname": {
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
This PR removes fields `subdomain` and `hostname` from `destination` and `source`.

View the readme [on my branch](https://github.com/webmat/ecs/tree/domain_breakdown)

Closes #84 