### PR TITLE
Remove duplicate definitions of `os` from `host.os` and `user_agent.os`...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@ All notable changes to this project will be documented in this file based on the
 * Redefine purpose of `agent.name` field to be user defined field.
 * Rename `url.href` to `url.original`.
 * Remove `source.subdomain` and `destination.subdomain` fields.
-* Remove duplicate definitions of the `os` field set from `host.os` and
-  `user_agent.os`. #168
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,4 +44,9 @@ All notable changes to this project will be documented in this file based on the
 * Add `network.type`, `network.iana_number`, `network.transport` and
   `network.application`. #81 and #170
 
+### Improvements
+
+* Remove duplicate definitions of the reuseable `os` field set from `host.os` and
+  `user_agent.os`.  #168
+
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ All notable changes to this project will be documented in this file based on the
 * Redefine purpose of `agent.name` field to be user defined field.
 * Rename `url.href` to `url.original`.
 * Remove `source.subdomain` and `destination.subdomain` fields.
+* Remove duplicate definitions of the `os` field set from `host.os` and
+  `user_agent.os`. #168
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -242,10 +242,6 @@ Normally the host information is related to the machine on which the event was g
 | <a name="host.ip"></a>host.ip | Host ip address. | core | ip |  |
 | <a name="host.mac"></a>host.mac | Host mac address. | core | keyword |  |
 | <a name="host.type"></a>host.type | Type of host.<br/>For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | core | keyword |  |
-| <a name="host.os.platform"></a>host.os.platform | Operating system platform (centos, ubuntu, windows, etc.) | extended | keyword | `darwin` |
-| <a name="host.os.name"></a>host.os.name | Operating system name. | extended | keyword | `Mac OS X` |
-| <a name="host.os.family"></a>host.os.family | OS family (redhat, debian, freebsd, windows, etc.) | extended | keyword | `debian` |
-| <a name="host.os.version"></a>host.os.version | Operating system version. | extended | keyword | `10.12.6` |
 | <a name="host.architecture"></a>host.architecture | Operating system architecture. | core | keyword | `x86_64` |
 
 
@@ -418,10 +414,6 @@ The user_agent fields normally come from a browser request. They often show up i
 | <a name="user_agent.minor"></a>user_agent.minor | Minor version of the user agent. | extended | long |  |
 | <a name="user_agent.patch"></a>user_agent.patch | Patch version of the user agent. | extended | keyword |  |
 | <a name="user_agent.name"></a>user_agent.name | Name of the user agent. | extended | keyword | `Chrome` |
-| <a name="user_agent.os.name"></a>user_agent.os.name | Name of the operating system. | extended | keyword |  |
-| <a name="user_agent.os.version"></a>user_agent.os.version | Version of the operating system. | extended | keyword |  |
-| <a name="user_agent.os.major"></a>user_agent.os.major | Major version of the operating system. | extended | long |  |
-| <a name="user_agent.os.minor"></a>user_agent.os.minor | Minor version of the operating system. | extended | long |  |
 
 
 

--- a/fields.yml
+++ b/fields.yml
@@ -697,35 +697,6 @@
             If vm, this could be the container, for example, or other information
             meaningful in your environment.
     
-        # Operating System information
-        - name: os.platform
-          level: extended
-          type: keyword
-          description: >
-            Operating system platform (centos, ubuntu, windows, etc.)
-          example: darwin
-    
-        - name: os.name
-          level: extended
-          type: keyword
-          example: "Mac OS X"
-          description: >
-            Operating system name.
-    
-        - name: os.family
-          level: extended
-          type: keyword
-          example: "debian"
-          description: >
-            OS family (redhat, debian, freebsd, windows, etc.)
-    
-        - name: os.version
-          level: extended
-          type: keyword
-          example: "10.12.6"
-          description: >
-            Operating system version.
-    
         - name: architecture
           level: core
           type: keyword
@@ -1348,27 +1319,3 @@
           example: Chrome
           description: >
             Name of the user agent.
-    
-        - name: os.name
-          level: extended
-          type: keyword
-          description: >
-            Name of the operating system.
-    
-        - name: os.version
-          level: extended
-          type: keyword
-          description: >
-            Version of the operating system.
-    
-        - name: os.major
-          level: extended
-          type: long
-          description: >
-            Major version of the operating system.
-    
-        - name: os.minor
-          level: extended
-          type: long
-          description: >
-            Minor version of the operating system.

--- a/schema.csv
+++ b/schema.csv
@@ -74,10 +74,6 @@ host.hostname,keyword,core,
 host.id,keyword,core,
 host.ip,ip,core,
 host.mac,keyword,core,
-host.os.family,keyword,extended,debian
-host.os.name,keyword,extended,Mac OS X
-host.os.platform,keyword,extended,darwin
-host.os.version,keyword,extended,10.12.6
 host.type,keyword,core,
 http.request.method,keyword,extended,"GET, POST, PUT"
 http.request.referrer,keyword,extended,https://blog.example.com/
@@ -141,9 +137,5 @@ user_agent.major,long,extended,
 user_agent.minor,long,extended,
 user_agent.name,keyword,extended,Chrome
 user_agent.original,keyword,extended,
-user_agent.os.major,long,extended,
-user_agent.os.minor,long,extended,
-user_agent.os.name,keyword,extended,
-user_agent.os.version,keyword,extended,
 user_agent.patch,keyword,extended,
 user_agent.version,keyword,extended,

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -53,35 +53,6 @@
         If vm, this could be the container, for example, or other information
         meaningful in your environment.
 
-    # Operating System information
-    - name: os.platform
-      level: extended
-      type: keyword
-      description: >
-        Operating system platform (centos, ubuntu, windows, etc.)
-      example: darwin
-
-    - name: os.name
-      level: extended
-      type: keyword
-      example: "Mac OS X"
-      description: >
-        Operating system name.
-
-    - name: os.family
-      level: extended
-      type: keyword
-      example: "debian"
-      description: >
-        OS family (redhat, debian, freebsd, windows, etc.)
-
-    - name: os.version
-      level: extended
-      type: keyword
-      example: "10.12.6"
-      description: >
-        Operating system version.
-
     - name: architecture
       level: core
       type: keyword

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -50,27 +50,3 @@
       example: Chrome
       description: >
         Name of the user agent.
-
-    - name: os.name
-      level: extended
-      type: keyword
-      description: >
-        Name of the operating system.
-
-    - name: os.version
-      level: extended
-      type: keyword
-      description: >
-        Version of the operating system.
-
-    - name: os.major
-      level: extended
-      type: long
-      description: >
-        Major version of the operating system.
-
-    - name: os.minor
-      level: extended
-      type: long
-      description: >
-        Minor version of the operating system.

--- a/template.json
+++ b/template.json
@@ -349,26 +349,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "os": {
-              "properties": {
-                "family": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "platform": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
             "type": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -682,24 +662,6 @@
             "original": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "os": {
-              "properties": {
-                "major": {
-                  "type": "long"
-                },
-                "minor": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "version": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
             },
             "patch": {
               "ignore_above": 1024,


### PR DESCRIPTION
With `os` now a reuseable field set, it's now expected in these locations. The field set should only be defined once.

Having it (and other reuseable field sets) appear correctly in `template.json` is still work to be done.