### PR TITLE
Follow-up to #81 on network layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,5 +41,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `host.os.kernel` containing the OS kernel version. #60
 * Add `agent.type` field.
 * Add `http.request.referrer` field. #164
+* Add `network.type`, `network.iana_number`, `network.transport` and
+  `network.application`. #81 and #170
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ Fields related to network data.
 |---|---|---|---|---|
 | <a name="network.name"></a>network.name | Name given by operators to sections of their network. | extended | keyword | `Guest Wifi` |
 | <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. IPv4, IPv6, IPSec, PIM, etc | core | keyword | `IPv4` |
-| <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which log using the IANA Protocol Number. | extended | keyword | `6` |
-| <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name. | core | keyword | `IPv6-ICMP` |
+| <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | extended | keyword | `6` |
+| <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name of the transport layer (UDP, TCP, IPv6-ICMP, etc.) | core | keyword | `TCP` |
 | <a name="network.application"></a>network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format. | extended | keyword | `AIM` |
 | <a name="network.protocol"></a>network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol | core | keyword | `http` |
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown | core | keyword | `inbound` |

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Fields related to network data.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="network.name"></a>network.name | Name given by operators to sections of their network. | extended | keyword | `Guest Wifi` |
-| <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc | core | keyword | `IPV4` |
+| <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. IPv4, IPv6, IPSec, PIM, etc | core | keyword | `IPv4` |
 | <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which log using the IANA Protocol Number. | extended | keyword | `6` |
 | <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name. | core | keyword | `IPv6-ICMP` |
 | <a name="network.application"></a>network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format. | extended | keyword | `AIM` |

--- a/fields.yml
+++ b/fields.yml
@@ -839,15 +839,16 @@
           description: >
               IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
               Standardized list of protocols. This aligns well with NetFlow and
-              sFlow related logs which log using the IANA Protocol Number.
+              sFlow related logs which use the IANA Protocol Number.
           example: 6
     
         - name: transport
           level: core
           type: keyword
           description: >
-            Same as network.iana_number, but instead using the Keyword name.
-          example: IPv6-ICMP
+            Same as network.iana_number, but instead using the Keyword name of the
+            transport layer (UDP, TCP, IPv6-ICMP, etc.)
+          example: TCP
     
         - name: application
           level: extended

--- a/fields.yml
+++ b/fields.yml
@@ -830,8 +830,8 @@
           level: core
           type: keyword
           description: >
-            In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc
-          example: IPV4
+            In the OSI Model this would be the Network Layer. IPv4, IPv6, IPSec, PIM, etc
+          example: IPv4
     
         - name: iana_number
           level: extended

--- a/schema.csv
+++ b/schema.csv
@@ -98,7 +98,7 @@ network.outbound.packets,long,core,12
 network.protocol,keyword,core,http
 network.total.bytes,long,core,368
 network.total.packets,long,core,24
-network.transport,keyword,core,IPv6-ICMP
+network.transport,keyword,core,TCP
 network.type,keyword,core,IPv4
 organization.id,keyword,extended,
 organization.name,keyword,extended,

--- a/schema.csv
+++ b/schema.csv
@@ -99,7 +99,7 @@ network.protocol,keyword,core,http
 network.total.bytes,long,core,368
 network.total.packets,long,core,24
 network.transport,keyword,core,IPv6-ICMP
-network.type,keyword,core,IPV4
+network.type,keyword,core,IPv4
 organization.id,keyword,extended,
 organization.name,keyword,extended,
 os.family,keyword,extended,debian

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -27,15 +27,16 @@
       description: >
           IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
           Standardized list of protocols. This aligns well with NetFlow and
-          sFlow related logs which log using the IANA Protocol Number.
+          sFlow related logs which use the IANA Protocol Number.
       example: 6
 
     - name: transport
       level: core
       type: keyword
       description: >
-        Same as network.iana_number, but instead using the Keyword name.
-      example: IPv6-ICMP
+        Same as network.iana_number, but instead using the Keyword name of the
+        transport layer (UDP, TCP, IPv6-ICMP, etc.)
+      example: TCP
 
     - name: application
       level: extended

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -18,8 +18,8 @@
       level: core
       type: keyword
       description: >
-        In the OSI Model this would be the Network Layer. IPv4, IPV6, IPSec, PIM, etc
-      example: IPV4
+        In the OSI Model this would be the Network Layer. IPv4, IPv6, IPSec, PIM, etc
+      example: IPv4
 
     - name: iana_number
       level: extended


### PR DESCRIPTION
- Make the capitalization of `IPv` consistent
- Missing changelog
- Tweak the wording of the examples

This is a quick follow-up to #81