### PR TITLE
Make Markdown links relative, so browsing a git ref stays in the same git ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,15 +403,15 @@ describe the full use case. The fields which are not in ECS are in italic.
 
 Contributions of additional uses cases on top of ECS are welcome.
 
- * [APM](https://github.com/elastic/ecs/blob/master/use-cases/apm.md)
- * [Auditbeat](https://github.com/elastic/ecs/blob/master/use-cases/auditbeat.md)
- * [Beats](https://github.com/elastic/ecs/blob/master/use-cases/beats.md)
- * [Filebeat Apache](https://github.com/elastic/ecs/blob/master/use-cases/filebeat-apache-access.md)
- * [Kubernetes](https://github.com/elastic/ecs/blob/master/use-cases/kubernetes.md)
- * [Logging](https://github.com/elastic/ecs/blob/master/use-cases/logging.md)
- * [Metricbeat](https://github.com/elastic/ecs/blob/master/use-cases/metricbeat.md)
- * [TLS](https://github.com/elastic/ecs/blob/master/use-cases/tls.md)
- * [Parsing web server logs](https://github.com/elastic/ecs/blob/master/use-cases/web-logs.md)
+ * [APM](use-cases/apm.md)
+ * [Auditbeat](use-cases/auditbeat.md)
+ * [Beats](use-cases/beats.md)
+ * [Filebeat Apache](use-cases/filebeat-apache-access.md)
+ * [Kubernetes](use-cases/kubernetes.md)
+ * [Logging](use-cases/logging.md)
+ * [Metricbeat](use-cases/metricbeat.md)
+ * [TLS](use-cases/tls.md)
+ * [Parsing web server logs](use-cases/web-logs.md)
 
 
 

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ The benefits to a user adopting these fields and names in their clusters are:
 
 ## What if I have fields that conflict with ECS?
 
-The [rename processor](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/rename-processor.html) can help you resolve field conflicts. For example, imagine that you already have a field called "user," but ECS employs `user` as an object. You can use the rename processor on ingest time to rename your field to the matching ECS field. If your field does not match ECS, you can rename your field to `user.value` instead.
+The [rename processor](https://www.elastic.co/guide/en/elasticsearch/reference/current/rename-processor.html) can help you resolve field conflicts. For example, imagine that you already have a field called "user," but ECS employs `user` as an object. You can use the rename processor on ingest time to rename your field to the matching ECS field. If your field does not match ECS, you can rename your field to `user.value` instead.
 
 ## What if my events have additional fields?
 
@@ -544,7 +544,7 @@ Ingesting `user.firstname: Nicolas` and `user.lastname: Ruflin` is identical to 
 }
 ```
 
-In Elasticsearch, `user` is represented as an [object datatype](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/object.html). In the case of the underline notation, both are just [string datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html).
+In Elasticsearch, `user` is represented as an [object datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html). In the case of the underline notation, both are just [string datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html).
 
 NOTE: ECS does not use [nested datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html), which are arrays of objects.
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -16,7 +16,7 @@ The benefits to a user adopting these fields and names in their clusters are:
 
 ## What if I have fields that conflict with ECS?
 
-The [rename processor](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/rename-processor.html) can help you resolve field conflicts. For example, imagine that you already have a field called "user," but ECS employs `user` as an object. You can use the rename processor on ingest time to rename your field to the matching ECS field. If your field does not match ECS, you can rename your field to `user.value` instead.
+The [rename processor](https://www.elastic.co/guide/en/elasticsearch/reference/current/rename-processor.html) can help you resolve field conflicts. For example, imagine that you already have a field called "user," but ECS employs `user` as an object. You can use the rename processor on ingest time to rename your field to the matching ECS field. If your field does not match ECS, you can rename your field to `user.value` instead.
 
 ## What if my events have additional fields?
 
@@ -42,7 +42,7 @@ Ingesting `user.firstname: Nicolas` and `user.lastname: Ruflin` is identical to 
 }
 ```
 
-In Elasticsearch, `user` is represented as an [object datatype](https://www.elastic.co/guide/en/elasticsearch/reference/6.2/object.html). In the case of the underline notation, both are just [string datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html).
+In Elasticsearch, `user` is represented as an [object datatype](https://www.elastic.co/guide/en/elasticsearch/reference/current/object.html). In the case of the underline notation, both are just [string datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html).
 
 NOTE: ECS does not use [nested datatypes](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html), which are arrays of objects.
 

--- a/scripts/use-cases.py
+++ b/scripts/use-cases.py
@@ -21,7 +21,8 @@ def write_stdout():
 
         use_case = read_use_case_file("./use-cases/" + file)
 
-        schema_link = "https://github.com/elastic/ecs/blob/master/use-cases/"
+        # Intentionally a relative link, to avoid leaving forked repo or branch
+        schema_link = "use-cases/"
         # Link list to field prefixes
         links += " * [{}]({}{}.md)\n".format(use_case["title"], schema_link, use_case["name"])
 

--- a/scripts/use-cases.py
+++ b/scripts/use-cases.py
@@ -7,7 +7,6 @@ import os.path
 
 def write_stdout():
 
-    link_prefix = "https://github.com/elastic/ecs"
     schema = get_schema()
     flat_schema = create_flat_schema(schema)
 
@@ -59,7 +58,8 @@ def write_stdout():
                 fields.append(section_fields)
 
         global_fields = {"name": use_case["name"], "title": use_case["title"], "description": "", "fields": fields}
-        output += get_markdown_section(global_fields, "###", link_prefix) + "\n"
+        # Generate use cases with a relative link to access field definitions
+        output += get_markdown_section(global_fields, "###", "../README.md") + "\n"
 
         # Write output to /use-cases/use_case["name"].md file
         # Adjust links

--- a/use-cases/apm.md
+++ b/use-cases/apm.md
@@ -8,14 +8,14 @@ ECS usage for the APM data.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id to describe the event.* | (use case) | keyword | `8a4f500d` |
-| [@timestamp](https://github.com/elastic/ecs#@timestamp)  | Timestamp when the event was created in the app / service. | core | date | `2016-05-23T08:05:34.853Z` |
+| [@timestamp](../README.md#@timestamp)  | Timestamp when the event was created in the app / service. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="agent.&ast;"></a>*agent.&ast;* | *The agent fields are used to describe which agent did send the information.<br/>* |  |  |  |
-| [agent.version](https://github.com/elastic/ecs#agent.version)  | APM Agent version. | core | keyword | `3.14.0` |
-| [agent.name](https://github.com/elastic/ecs#agent.name)  | APM agent name. | core | keyword | `elastic-node` |
+| [agent.version](../README.md#agent.version)  | APM Agent version. | core | keyword | `3.14.0` |
+| [agent.name](../README.md#agent.name)  | APM agent name. | core | keyword | `elastic-node` |
 | <a name="service.&ast;"></a>*service.&ast;* | *The service fields describe the service inside which the APM agent is running.<br/>* |  |  |  |
-| [service.id](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service. | core | keyword | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6` |
-| [service.name](https://github.com/elastic/ecs#service.name)  | Name of the service the agent is running in. This is normally a user defined name. | core | keyword | `user-service` |
-| [service.version](https://github.com/elastic/ecs#service.version)  | Version of the service the agent is running in. This depends on if the service is given a version. | core | keyword | `3.2.4` |
+| [service.id](../README.md#service.id)  | Unique identifier of the running service. | core | keyword | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6` |
+| [service.name](../README.md#service.name)  | Name of the service the agent is running in. This is normally a user defined name. | core | keyword | `user-service` |
+| [service.version](../README.md#service.version)  | Version of the service the agent is running in. This depends on if the service is given a version. | core | keyword | `3.2.4` |
 
 
 

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -7,21 +7,21 @@ ECS usage in Auditbeat.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| [event.module](https://github.com/elastic/ecs#event.module)  | Auditbeat module name. | core | keyword | `mysql` |
+| [event.module](../README.md#event.module)  | Auditbeat module name. | core | keyword | `mysql` |
 | <a name="file.&ast;"></a>*file.&ast;* | *File attributes.<br/>* |  |  |  |
-| [file.path](https://github.com/elastic/ecs#file.path)  | The path to the file. | extended | keyword |  |
-| [file.target_path](https://github.com/elastic/ecs#file.target_path)  | The target path for symlinks. | extended | keyword |  |
-| [file.type](https://github.com/elastic/ecs#file.type)  | The file type (file, dir, or symlink). | extended | keyword |  |
-| [file.device](https://github.com/elastic/ecs#file.device)  | The device. | extended | keyword |  |
-| [file.inode](https://github.com/elastic/ecs#file.inode)  | The inode representing the file in the filesystem. | extended | keyword |  |
-| [file.uid](https://github.com/elastic/ecs#file.uid)  | The user ID (UID) or security identifier (SID) of the file owner. | extended | keyword |  |
-| [file.owner](https://github.com/elastic/ecs#file.owner)  | The file owner's username. | extended | keyword |  |
-| [file.gid](https://github.com/elastic/ecs#file.gid)  | The primary group ID (GID) of the file. | extended | keyword |  |
-| [file.group](https://github.com/elastic/ecs#file.group)  | The primary group name of the file. | extended | keyword |  |
-| [file.mode](https://github.com/elastic/ecs#file.mode)  | The mode of the file in octal representation. | extended | keyword | `416` |
-| [file.size](https://github.com/elastic/ecs#file.size)  | The file size in bytes (field is only added when `type` is `file`). | extended | long |  |
-| [file.mtime](https://github.com/elastic/ecs#file.mtime)  | The last modified time of the file (time when content was modified). | extended | date |  |
-| [file.ctime](https://github.com/elastic/ecs#file.ctime)  | The last change time of the file (time when metadata was changed). | extended | date |  |
+| [file.path](../README.md#file.path)  | The path to the file. | extended | keyword |  |
+| [file.target_path](../README.md#file.target_path)  | The target path for symlinks. | extended | keyword |  |
+| [file.type](../README.md#file.type)  | The file type (file, dir, or symlink). | extended | keyword |  |
+| [file.device](../README.md#file.device)  | The device. | extended | keyword |  |
+| [file.inode](../README.md#file.inode)  | The inode representing the file in the filesystem. | extended | keyword |  |
+| [file.uid](../README.md#file.uid)  | The user ID (UID) or security identifier (SID) of the file owner. | extended | keyword |  |
+| [file.owner](../README.md#file.owner)  | The file owner's username. | extended | keyword |  |
+| [file.gid](../README.md#file.gid)  | The primary group ID (GID) of the file. | extended | keyword |  |
+| [file.group](../README.md#file.group)  | The primary group name of the file. | extended | keyword |  |
+| [file.mode](../README.md#file.mode)  | The mode of the file in octal representation. | extended | keyword | `416` |
+| [file.size](../README.md#file.size)  | The file size in bytes (field is only added when `type` is `file`). | extended | long |  |
+| [file.mtime](../README.md#file.mtime)  | The last modified time of the file (time when content was modified). | extended | date |  |
+| [file.ctime](../README.md#file.ctime)  | The last change time of the file (time when metadata was changed). | extended | date |  |
 | <a name="hash.&ast;"></a>*hash.&ast;* | *Hash fields used in Auditbeat.<br/>The hash field contains cryptographic hashes of data associated with the event (such as a file). The keys are names of cryptographic algorithms. The values are encoded as hexidecimal (lower-case).<br/>All fields in user can have one or multiple entries.<br/>* |  |  |  |
 | <a name="hash.blake2b_256"></a>*hash.blake2b_256* | *BLAKE2b-256 hash of the file.* | (use case) | keyword |  |
 | <a name="hash.blake2b_384"></a>*hash.blake2b_384* | *BLAKE2b-384 hash of the file.* | (use case) | keyword |  |

--- a/use-cases/beats.md
+++ b/use-cases/beats.md
@@ -10,9 +10,9 @@ ECS fields used in Beats.
 | <a name="id"></a>*id* | *Unique id to describe the event.* | (use case) | keyword | `8a4f500d` |
 | <a name="timestamp"></a>*timestamp* | *Timestamp when the event was created.* | (use case) | date | `2016-05-23T08:05:34.853Z` |
 | <a name="agent.&ast;"></a>*agent.&ast;* | *The agent fields are used to describe by which beat the information was collected.<br/>* |  |  |  |
-| [agent.version](https://github.com/elastic/ecs#agent.version)  | Beat version. | core | keyword | `6.0.0-rc2` |
-| [agent.name](https://github.com/elastic/ecs#agent.name)  | Beat name. | core | keyword | `filebeat` |
-| [agent.id](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier. | core | keyword | `8a4f500d` |
+| [agent.version](../README.md#agent.version)  | Beat version. | core | keyword | `6.0.0-rc2` |
+| [agent.name](../README.md#agent.name)  | Beat name. | core | keyword | `filebeat` |
+| [agent.id](../README.md#agent.id)  | Unique beat identifier. | core | keyword | `8a4f500d` |
 
 
 

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -8,12 +8,12 @@ ECS fields used in Filebeat for the apache module.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id to describe the event.* | (use case) | keyword | `8a4f500d` |
-| [@timestamp](https://github.com/elastic/ecs#@timestamp)  | Timestamp of the log line after processing. | core | date | `2016-05-23T08:05:34.853Z` |
-| [message](https://github.com/elastic/ecs#message)  | Log message of the event | core | text | `Hello World` |
-| [event.module](https://github.com/elastic/ecs#event.module)  | Currently fileset.module | core | keyword | `apache` |
-| [event.dataset](https://github.com/elastic/ecs#event.dataset)  | Currenly fileset.name | core | keyword | `access` |
-| [source.ip](https://github.com/elastic/ecs#source.ip)  | Source ip of the request. Currently apache.access.remote_ip | core | ip | `192.168.1.1` |
-| [user.name](https://github.com/elastic/ecs#user.name)  | User name in the request. Currently apache.access.user_name | core | keyword | `ruflin` |
+| [@timestamp](../README.md#@timestamp)  | Timestamp of the log line after processing. | core | date | `2016-05-23T08:05:34.853Z` |
+| [message](../README.md#message)  | Log message of the event | core | text | `Hello World` |
+| [event.module](../README.md#event.module)  | Currently fileset.module | core | keyword | `apache` |
+| [event.dataset](../README.md#event.dataset)  | Currenly fileset.name | core | keyword | `access` |
+| [source.ip](../README.md#source.ip)  | Source ip of the request. Currently apache.access.remote_ip | core | ip | `192.168.1.1` |
+| [user.name](../README.md#user.name)  | User name in the request. Currently apache.access.user_name | core | keyword | `ruflin` |
 | <a name="http.method"></a>*http.method* | *Http method, currently apache.access.method* | (use case) | keyword | `GET` |
 | <a name="http.url"></a>*http.url* | *Http url, currently apache.access.url* | (use case) | keyword | `http://elastic.co/` |
 | <a name="http.version"></a>*http.version* | *Http version, currently apache.access.http_version* | (use case) | keyword | `1.1` |

--- a/use-cases/kubernetes.md
+++ b/use-cases/kubernetes.md
@@ -8,9 +8,9 @@ You can monitor containers running in a Kubernetes cluster by adding Kubernetes-
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| [container.id](https://github.com/elastic/ecs#container.id)  | Unique container id. | core | keyword | `fdbef803fa2b` |
-| [container.name](https://github.com/elastic/ecs#container.name)  | Container name. | extended | keyword |  |
-| [host.hostname](https://github.com/elastic/ecs#host.hostname)  | Hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | core | keyword | `kube-high-cpu-42` |
+| [container.id](../README.md#container.id)  | Unique container id. | core | keyword | `fdbef803fa2b` |
+| [container.name](../README.md#container.name)  | Container name. | extended | keyword |  |
+| [host.hostname](../README.md#host.hostname)  | Hostname of the host.<br/>It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | core | keyword | `kube-high-cpu-42` |
 | <a name="kubernetes.pod.name"></a>*kubernetes.pod.name* | *Kubernetes pod name* | (use case) | keyword | `foo-webserver` |
 | <a name="kubernetes.namespace"></a>*kubernetes.namespace* | *Kubernetes namespace* | (use case) | keyword | `foo-team` |
 | <a name="kubernetes.labels"></a>*kubernetes.labels* | *Kubernetes labels map* | (use case) | object |  |

--- a/use-cases/logging.md
+++ b/use-cases/logging.md
@@ -9,10 +9,10 @@ ECS fields used in logging use cases.
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id of the log entry.* | (use case) | keyword | `8a4f500d` |
 | <a name="timestamp"></a>*timestamp* | *Timestamp of the log line.* | (use case) | date | `2016-05-23T08:05:34.853Z` |
-| [message](https://github.com/elastic/ecs#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable. | core | text | `Hello World` |
+| [message](../README.md#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable. | core | text | `Hello World` |
 | <a name="hostname"></a>*hostname* | *Hostname extracted from the log line.* | (use case) | keyword | `www.example.com` |
 | <a name="ip"></a>*ip* | *IP Address extracted from the log line. Can be IPv4 or IPv6.* | (use case) | ip | `192.168.1.12` |
-| [log.level](https://github.com/elastic/ecs#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc. | core | keyword | `ERR` |
+| [log.level](../README.md#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc. | core | keyword | `ERR` |
 | <a name="log.line"></a>*log.line* | *Line number the log event was collected from.* | (use case) | long | `18` |
 | <a name="log.offset"></a>*log.offset* | *Offset of the log event.* | (use case) | long | `12` |
 | <a name="source.&ast;"></a>*source.&ast;* | *Describes from where the log entries come from.<br/>* |  |  |  |

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -9,23 +9,23 @@ ECS fields used Metricbeat.
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id to describe the event.* | (use case) | keyword | `8a4f500d` |
 | <a name="timestamp"></a>*timestamp* | *Timestamp when the event was created.* | (use case) | date | `2016-05-23T08:05:34.853Z` |
-| [agent.version](https://github.com/elastic/ecs#agent.version)  | Beat version. | core | keyword | `6.0.0-rc2` |
-| [agent.name](https://github.com/elastic/ecs#agent.name)  | Beat name. | core | keyword | `filebeat` |
-| [agent.id](https://github.com/elastic/ecs#agent.id)  | Unique beat identifier. | core | keyword | `8a4f500d` |
+| [agent.version](../README.md#agent.version)  | Beat version. | core | keyword | `6.0.0-rc2` |
+| [agent.name](../README.md#agent.name)  | Beat name. | core | keyword | `filebeat` |
+| [agent.id](../README.md#agent.id)  | Unique beat identifier. | core | keyword | `8a4f500d` |
 | <a name="service.&ast;"></a>*service.&ast;* | *The service fields describe the service for / from which the data was collected.<br/>If logs or metrics are collected from Redis, `service.name` would be `redis`. This allows to find and correlate logs for a specicic service or even version with `service.version`.<br/>* |  |  |  |
-| [service.id](https://github.com/elastic/ecs#service.id)  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. For example in case of issues with one redis instance, it's possible to filter on the id to see metrics and logs for this single instance. | core | keyword | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6` |
-| [service.name](https://github.com/elastic/ecs#service.name)  | Name of the service data is collected from.<br/>The name is normally the same as the module name. | core | keyword | `elasticsearch` |
-| [service.version](https://github.com/elastic/ecs#service.version)  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service. | core | keyword | `3.2.4` |
+| [service.id](../README.md#service.id)  | Unique identifier of the running service.<br/>This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. For example in case of issues with one redis instance, it's possible to filter on the id to see metrics and logs for this single instance. | core | keyword | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6` |
+| [service.name](../README.md#service.name)  | Name of the service data is collected from.<br/>The name is normally the same as the module name. | core | keyword | `elasticsearch` |
+| [service.version](../README.md#service.version)  | Version of the service the data was collected from.<br/>This allows to look at a data set only for a specific version of a service. | core | keyword | `3.2.4` |
 | <a name="service.host"></a>*service.host* | *Host address that is used to connect to the service.<br/>This normally contains hostname + port.<br/>REVIEW: Should this be service.uri instead, sometimes it's more then just the host? It could also include a path or the protocol.* | (use case) | keyword | `elasticsearch:9200` |
 | <a name="request.rtt"></a>*request.rtt* | *Request round trip time.<br/>How long did the request take to fetch metrics from the service.<br/>REVIEW: THIS DOES NOT EXIST YET IN ECS.* | (use case) | long | `115` |
 | <a name="error.&ast;"></a>*error.&ast;* | *Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>* |  |  |  |
-| [error.message](https://github.com/elastic/ecs#error.message)  | Error message returned by the service during fetching metrics. | core | text |  |
-| [error.code](https://github.com/elastic/ecs#error.code)  | Error code returned by the service during fetching metrics. | core | keyword |  |
-| [host.hostname](https://github.com/elastic/ecs#host.hostname)  | Hostname of the system metricbeat is running on or user defined name. | core | keyword |  |
+| [error.message](../README.md#error.message)  | Error message returned by the service during fetching metrics. | core | text |  |
+| [error.code](../README.md#error.code)  | Error code returned by the service during fetching metrics. | core | keyword |  |
+| [host.hostname](../README.md#host.hostname)  | Hostname of the system metricbeat is running on or user defined name. | core | keyword |  |
 | <a name="host.timezone.offset.sec"></a>*host.timezone.offset.sec* | *Timezone offset of the host in seconds.* | (use case) | long |  |
-| [host.id](https://github.com/elastic/ecs#host.id)  | Unique host id. | core | keyword |  |
-| [event.module](https://github.com/elastic/ecs#event.module)  | Name of the module this data is coming from. | core | keyword | `mysql` |
-| [event.dataset](https://github.com/elastic/ecs#event.dataset)  | Name of the dataset.<br/>This contains the information which is currently stored in metricset.name and metricset.module. | core | keyword | `stats` |
+| [host.id](../README.md#host.id)  | Unique host id. | core | keyword |  |
+| [event.module](../README.md#event.module)  | Name of the module this data is coming from. | core | keyword | `mysql` |
+| [event.dataset](../README.md#event.dataset)  | Name of the dataset.<br/>This contains the information which is currently stored in metricset.name and metricset.module. | core | keyword | `stats` |
 
 
 

--- a/use-cases/tls.md
+++ b/use-cases/tls.md
@@ -8,9 +8,9 @@ You can store TLS-related metadata under `tls.`, when appropriate.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| [source.ip](https://github.com/elastic/ecs#source.ip)  | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip | `10.1.1.10` |
-| [destination.ip](https://github.com/elastic/ecs#destination.ip)  | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip | `5.5.5.5` |
-| [destination.port](https://github.com/elastic/ecs#destination.port)  | Port of the destination. | core | long | `443` |
+| [source.ip](../README.md#source.ip)  | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip | `10.1.1.10` |
+| [destination.ip](../README.md#destination.ip)  | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip | `5.5.5.5` |
+| [destination.port](../README.md#destination.port)  | Port of the destination. | core | long | `443` |
 | <a name="tls.version"></a>*tls.version* | *TLS version.* | (use case) | keyword | `TLSv1.2` |
 | <a name="tls.certificates"></a>*tls.certificates* | *An array of certificates.* | (use case) | keyword |  |
 | <a name="tls.servername"></a>*tls.servername* | *Server name requested by the client.* | (use case) | keyword | `localhost` |

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -9,7 +9,7 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| [@timestamp](https://github.com/elastic/ecs#@timestamp)  | Time at which the response was sent, and the web server log created. | core | date | `2016-05-23T08:05:34.853Z` |
+| [@timestamp](../README.md#@timestamp)  | Time at which the response was sent, and the web server log created. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="http.&ast;"></a>*http.&ast;* | *Fields related to HTTP requests and responses.<br/>* |  |  |  |
 | <a name="http.request.method"></a>*http.request.method* | *Http request method.* | (use case) | keyword | `GET, POST, PUT` |
 | <a name="http.request.referrer"></a>*http.request.referrer* | *Referrer for this HTTP request.* | (use case) | keyword | `https://blog.example.com/` |


### PR DESCRIPTION
This is important for Beta1, as people visiting elastic/ecs will soon be directed
to past versions (e.g. `v1.0.0-beta1`), if they're looking for official ECS
releases.

This fix ensures that navigating the links from the Readme to the use cases and
the links from use cases back to the readme keeps the person in the same branch
or tag. Prior to this, they would get sent back to the latest version of ECS.

In this PR:

- Make links to use cases relative
- Make links to field defs (from use cases) relative
- Fix last two instances of documentation links pointing to a specific version.
  They now link to the "current" stack version.

This addresses one element of #167.