### PR TITLE
Remove src/dst.hostname, rename url.hostname to url.domain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes to this project will be documented in this file based on the
 * Rename `event.version` to `ecs.version`. #169
 * Remove the `http` field set temporarily. #171
 * Remove the `user_agent` field set temporarily. #172
+* Rename `url.hostname` to `url.domain`. #175
+* Remove `source.hostname` and `destination.hostname`. #175
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 |---|---|---|---|---|
 | <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.domain"></a>url.domain | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
+| <a name="url.domain"></a>url.domain | Domain of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 |---|---|---|---|---|
 | <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.hostname"></a>url.hostname | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
+| <a name="url.domain"></a>url.domain | Hostname of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `hostname` field. | extended | keyword | `elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |

--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ Destination fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="destination.ip"></a>destination.ip | IP address of the destination.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
-| <a name="destination.hostname"></a>destination.hostname | Hostname of the destination. | core | keyword |  |
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain. | core | keyword |  |
@@ -353,7 +352,6 @@ Source fields describe details about the destination of a packet/event.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="source.ip"></a>source.ip | IP address of the source.<br/>Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  |
-| <a name="source.hostname"></a>source.hostname | Hostname of the source. | core | keyword |  |
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain. | core | keyword |  |

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ The service fields describe the service for or from which the data was collected
 
 ## <a name="source"></a> Source fields
 
-Source fields describe details about the source of the event.
+Source fields describe details about the destination of a packet/event.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ Source fields describe details about the destination of a packet/event.
 
 ## <a name="url"></a> URL fields
 
-URL fields provide a complete URL, with scheme, host, and path. The URL object can be reused in other prefixes, such as `host.url.*` for example. Keep the structure consistent whenever you use URL fields.
+URL fields provide a complete URL, with scheme, host, and path.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -364,9 +364,9 @@ URL fields provide a complete URL, with scheme, host, and path. The URL object c
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://elastic.co:443/search?q=elasticsearch#top` |
+| <a name="url.original"></a>url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.domain"></a>url.domain | Domain of the request, such as "elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `elastic.co` |
+| <a name="url.domain"></a>url.domain | Domain of the request, such as "www.elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `www.elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |

--- a/fields.yml
+++ b/fields.yml
@@ -1097,9 +1097,7 @@
     - name: url
       title: URL
       description: >
-        URL fields provide a complete URL, with scheme, host, and path. The URL
-        object can be reused in other prefixes, such as `host.url.*` for
-        example. Keep the structure consistent whenever you use URL fields.
+        URL fields provide a complete URL, with scheme, host, and path.
       type: group
       fields:
     

--- a/fields.yml
+++ b/fields.yml
@@ -252,12 +252,6 @@
     
             Can be one or multiple IPv4 or IPv6 addresses.
     
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the destination.
-    
         - name: port
           level: core
           type: long
@@ -1081,12 +1075,6 @@
             IP address of the source.
     
             Can be one or multiple IPv4 or IPv6 addresses.
-    
-        - name: hostname
-          level: core
-          type: keyword
-          description: >
-            Hostname of the source.
     
         - name: port
           level: core

--- a/fields.yml
+++ b/fields.yml
@@ -1069,7 +1069,8 @@
       title: Source
       group: 2
       description: >
-        Source fields describe details about the source of the event.
+        Source fields describe details about the destination of a
+        packet/event.
       type: group
       fields:
     

--- a/fields.yml
+++ b/fields.yml
@@ -1123,10 +1123,10 @@
           level: extended
           type: keyword
           description: >
-            Hostname of the request, such as "elastic.co".
+            Domain of the request, such as "elastic.co".
     
             In some cases a URL may refer to an IP and/or port directly, without a
-            domain name. In this case, the IP address would go to the `hostname` field.
+            domain name. In this case, the IP address would go to the `domain` field.
           example: elastic.co
     
         - name: port

--- a/fields.yml
+++ b/fields.yml
@@ -1119,7 +1119,7 @@
             Note: The `:` is not part of the scheme.
           example: https
     
-        - name: hostname
+        - name: domain
           level: extended
           type: keyword
           description: >

--- a/fields.yml
+++ b/fields.yml
@@ -1108,7 +1108,7 @@
           type: keyword
           description: >
             Full original url. The field is stored as keyword.
-          example: https://elastic.co:443/search?q=elasticsearch#top
+          example: https://www.elastic.co:443/search?q=elasticsearch#top
     
         - name: scheme
           level: extended
@@ -1123,11 +1123,11 @@
           level: extended
           type: keyword
           description: >
-            Domain of the request, such as "elastic.co".
+            Domain of the request, such as "www.elastic.co".
     
             In some cases a URL may refer to an IP and/or port directly, without a
             domain name. In this case, the IP address would go to the `domain` field.
-          example: elastic.co
+          example: www.elastic.co
     
         - name: port
           level: extended

--- a/schema.csv
+++ b/schema.csv
@@ -112,8 +112,8 @@ source.domain,keyword,core,
 source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,
+url.domain,keyword,extended,elastic.co
 url.fragment,keyword,extended,
-url.hostname,keyword,extended,elastic.co
 url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,extended,
 url.path,keyword,extended,

--- a/schema.csv
+++ b/schema.csv
@@ -112,9 +112,9 @@ source.domain,keyword,core,
 source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,
-url.domain,keyword,extended,elastic.co
+url.domain,keyword,extended,www.elastic.co
 url.fragment,keyword,extended,
-url.original,keyword,extended,https://elastic.co:443/search?q=elasticsearch#top
+url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top
 url.password,keyword,extended,
 url.path,keyword,extended,
 url.port,integer,extended,443

--- a/schema.csv
+++ b/schema.csv
@@ -22,7 +22,6 @@ container.labels,object,extended,
 container.name,keyword,extended,
 container.runtime,keyword,extended,docker
 destination.domain,keyword,core,
-destination.hostname,keyword,core,
 destination.ip,ip,core,
 destination.mac,keyword,core,
 destination.port,long,core,
@@ -110,7 +109,6 @@ service.state,keyword,core,
 service.type,keyword,core,elasticsearch
 service.version,keyword,core,3.2.4
 source.domain,keyword,core,
-source.hostname,keyword,core,
 source.ip,ip,core,
 source.mac,keyword,core,
 source.port,long,core,

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -16,12 +16,6 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the destination.
-
     - name: port
       level: core
       type: long

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -16,12 +16,6 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
-    - name: hostname
-      level: core
-      type: keyword
-      description: >
-        Hostname of the source.
-
     - name: port
       level: core
       type: long

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -3,7 +3,8 @@
   title: Source
   group: 2
   description: >
-    Source fields describe details about the source of the event.
+    Source fields describe details about the destination of a
+    packet/event.
   type: group
   fields:
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -13,7 +13,7 @@
       type: keyword
       description: >
         Full original url. The field is stored as keyword.
-      example: https://elastic.co:443/search?q=elasticsearch#top
+      example: https://www.elastic.co:443/search?q=elasticsearch#top
 
     - name: scheme
       level: extended
@@ -28,11 +28,11 @@
       level: extended
       type: keyword
       description: >
-        Domain of the request, such as "elastic.co".
+        Domain of the request, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a
         domain name. In this case, the IP address would go to the `domain` field.
-      example: elastic.co
+      example: www.elastic.co
 
     - name: port
       level: extended

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -24,7 +24,7 @@
         Note: The `:` is not part of the scheme.
       example: https
 
-    - name: hostname
+    - name: domain
       level: extended
       type: keyword
       description: >

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -28,10 +28,10 @@
       level: extended
       type: keyword
       description: >
-        Hostname of the request, such as "elastic.co".
+        Domain of the request, such as "elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a
-        domain name. In this case, the IP address would go to the `hostname` field.
+        domain name. In this case, the IP address would go to the `domain` field.
       example: elastic.co
 
     - name: port

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -2,9 +2,7 @@
 - name: url
   title: URL
   description: >
-    URL fields provide a complete URL, with scheme, host, and path. The URL
-    object can be reused in other prefixes, such as `host.url.*` for
-    example. Keep the structure consistent whenever you use URL fields.
+    URL fields provide a complete URL, with scheme, host, and path.
   type: group
   fields:
 

--- a/template.json
+++ b/template.json
@@ -551,11 +551,11 @@
         },
         "url": {
           "properties": {
-            "fragment": {
+            "domain": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "hostname": {
+            "fragment": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/template.json
+++ b/template.json
@@ -128,10 +128,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "ip": {
               "type": "ip"
             },
@@ -534,10 +530,6 @@
         "source": {
           "properties": {
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "hostname": {
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
`domain` is now the place to store the host address under `source`, `destination` and `url`.

Also in this PR:

- Remove ambiguous mention in `url` description talking about reuse. Since we
  haven't officially made `url` reuseable yet, I took it out for now. People
  are free to reuse everything everywhere, as it's just them defining new fields
  around the official ECS fields. But the spec making this statement about it
  in a different manner than the official reuseable objects is needlessly confusing.
- Tweak the url example a bit.
- Bring `source` description in line with `destination`'s

Closes #166, and addresses part of #84.