### PR TITLE
Proposal for more straightforward network metrics fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file based on the
 
 ### Breaking changes
 
+* Rename `network.total.bytes` to `network.bytes` and `network.total.packets`
+  to `network.packets`. #179
+* Remove `network.inbound.bytes`, `network.inbound.packets`,
+  `network.outbound.bytes` and `network.outbound.packets`. #179
+
 ### Bugfixes
 
 * Fix obvious mistake in the definition of "source", where it said "destination"
@@ -35,6 +40,8 @@ All notable changes to this project will be documented in this file based on the
 * Improved the definition of host fields #195
 
 * Clarify the semantics of `network.direction`. #212
+
+* Add `source.bytes`, `source.packets`, `destination.bytes` and `destination.packets`. #179
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ Destination fields describe details about the destination of a packet/event.
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain. | core | keyword |  |
+| <a name="destination.bytes"></a>destination.bytes | Bytes sent from the destination to the source. | core | long | `184` |
+| <a name="destination.packets"></a>destination.packets | Packets sent from the destination to the source. | core | long | `12` |
 
 
 ## <a name="device"></a> Device fields
@@ -322,12 +324,8 @@ The network is defined as the communication path over which a host or network ev
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * internal<br/>  * external<br/>  * unknown<br/><br/>When mapping events from a host-based monitoring context, populate this field from the host's point of view.<br/>When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter. | core | keyword | `inbound` |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` |
 | <a name="network.community_id"></a>network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.<br/>Learn more at https://github.com/corelight/community-id-spec. | extended | keyword | `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=` |
-| <a name="network.inbound.bytes"></a>network.inbound.bytes | Network inbound bytes. | core | long | `184` |
-| <a name="network.inbound.packets"></a>network.inbound.packets | Network inbound packets. | core | long | `12` |
-| <a name="network.outbound.bytes"></a>network.outbound.bytes | Network outbound bytes. | core | long | `184` |
-| <a name="network.outbound.packets"></a>network.outbound.packets | Network outbound packets. | core | long | `12` |
-| <a name="network.total.bytes"></a>network.total.bytes | Network total bytes. The sum of inbound.bytes + outbound.bytes. | core | long | `368` |
-| <a name="network.total.packets"></a>network.total.packets | Network outbound packets. The sum of inbound.packets + outbound.packets | core | long | `24` |
+| <a name="network.bytes"></a>network.bytes | Total bytes transferred in both directions.<br/>If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum. | core | long | `368` |
+| <a name="network.packets"></a>network.packets | Total packets transferred in both directions.<br/>If `source.packets` and `destination.packets` are known, `network.packets` is their sum. | core | long | `24` |
 
 
 ## <a name="organization"></a> Organization fields
@@ -415,6 +413,8 @@ Source fields describe details about the source of a packet/event.
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain. | core | keyword |  |
+| <a name="source.bytes"></a>source.bytes | Bytes sent from the source to the destination. | core | long | `184` |
+| <a name="source.packets"></a>source.packets | Packets sent from the source to the destination. | core | long | `12` |
 
 
 ## <a name="url"></a> URL fields

--- a/fields.yml
+++ b/fields.yml
@@ -269,6 +269,21 @@
           description: >
             Destination domain.
     
+        # Metrics
+        - name: bytes
+          level: core
+          type: long
+          example: 184
+          description: >
+            Bytes sent from the destination to the source.
+    
+        - name: packets
+          level: core
+          type: long
+          example: 12
+          description: >
+            Packets sent from the destination to the source.
+    
     - name: device
       title: Device
       group: 2
@@ -933,46 +948,22 @@
           example: '1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0='
     
         # Metrics
-        - name: inbound.bytes
+        - name: bytes
           level: core
           type: long
           description: >
-            Network inbound bytes.
-          example: 184
+            Total bytes transferred in both directions.
     
-        - name: inbound.packets
-          level: core
-          type: long
-          description: >
-            Network inbound packets.
-          example: 12
-    
-        - name: outbound.bytes
-          level: core
-          type: long
-          description: >
-            Network outbound bytes.
-          example: 184
-    
-        - name: outbound.packets
-          level: core
-          type: long
-          description: >
-            Network outbound packets.
-          example: 12
-    
-        - name: total.bytes
-          level: core
-          type: long
-          description: >
-            Network total bytes. The sum of inbound.bytes + outbound.bytes.
+            If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.
           example: 368
     
-        - name: total.packets
+        - name: packets
           level: core
           type: long
           description: >
-            Network outbound packets. The sum of inbound.packets + outbound.packets
+            Total packets transferred in both directions.
+    
+            If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
           example: 24
     
     - name: organization
@@ -1260,6 +1251,21 @@
           type: keyword
           description: >
             Source domain.
+    
+        # Metrics
+        - name: bytes
+          level: core
+          type: long
+          example: 184
+          description: >
+            Bytes sent from the source to the destination.
+    
+        - name: packets
+          level: core
+          type: long
+          example: 12
+          description: >
+            Packets sent from the source to the destination.
     
     - name: url
       title: URL

--- a/schema.csv
+++ b/schema.csv
@@ -21,9 +21,11 @@ container.image.tag,keyword,extended,
 container.labels,object,extended,
 container.name,keyword,extended,
 container.runtime,keyword,extended,docker
+destination.bytes,long,core,184
 destination.domain,keyword,core,
 destination.ip,ip,core,
 destination.mac,keyword,core,
+destination.packets,long,core,12
 destination.port,long,core,
 device.hostname,keyword,core,
 device.ip,ip,core,
@@ -89,18 +91,14 @@ http.version,keyword,extended,1.1
 log.level,keyword,core,ERR
 log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM
+network.bytes,long,core,368
 network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
 network.iana_number,keyword,extended,6
-network.inbound.bytes,long,core,184
-network.inbound.packets,long,core,12
 network.name,keyword,extended,Guest Wifi
-network.outbound.bytes,long,core,184
-network.outbound.packets,long,core,12
+network.packets,long,core,24
 network.protocol,keyword,core,http
-network.total.bytes,long,core,368
-network.total.packets,long,core,24
 network.transport,keyword,core,TCP
 network.type,keyword,core,IPv4
 organization.id,keyword,extended,
@@ -126,9 +124,11 @@ service.name,keyword,core,elasticsearch-metrics
 service.state,keyword,core,
 service.type,keyword,core,elasticsearch
 service.version,keyword,core,3.2.4
+source.bytes,long,core,184
 source.domain,keyword,core,
 source.ip,ip,core,
 source.mac,keyword,core,
+source.packets,long,core,12
 source.port,long,core,
 url.domain,keyword,extended,www.elastic.co
 url.fragment,keyword,extended,

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -33,3 +33,18 @@
       type: keyword
       description: >
         Destination domain.
+
+    # Metrics
+    - name: bytes
+      level: core
+      type: long
+      example: 184
+      description: >
+        Bytes sent from the destination to the source.
+
+    - name: packets
+      level: core
+      type: long
+      example: 12
+      description: >
+        Packets sent from the destination to the source.

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -95,44 +95,20 @@
       example: '1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0='
 
     # Metrics
-    - name: inbound.bytes
+    - name: bytes
       level: core
       type: long
       description: >
-        Network inbound bytes.
-      example: 184
+        Total bytes transferred in both directions.
 
-    - name: inbound.packets
-      level: core
-      type: long
-      description: >
-        Network inbound packets.
-      example: 12
-
-    - name: outbound.bytes
-      level: core
-      type: long
-      description: >
-        Network outbound bytes.
-      example: 184
-
-    - name: outbound.packets
-      level: core
-      type: long
-      description: >
-        Network outbound packets.
-      example: 12
-
-    - name: total.bytes
-      level: core
-      type: long
-      description: >
-        Network total bytes. The sum of inbound.bytes + outbound.bytes.
+        If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.
       example: 368
 
-    - name: total.packets
+    - name: packets
       level: core
       type: long
       description: >
-        Network outbound packets. The sum of inbound.packets + outbound.packets
+        Total packets transferred in both directions.
+
+        If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
       example: 24

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -33,3 +33,18 @@
       type: keyword
       description: >
         Source domain.
+
+    # Metrics
+    - name: bytes
+      level: core
+      type: long
+      example: 184
+      description: >
+        Bytes sent from the source to the destination.
+
+    - name: packets
+      level: core
+      type: long
+      example: 12
+      description: >
+        Packets sent from the source to the destination.

--- a/template.json
+++ b/template.json
@@ -124,6 +124,9 @@
         },
         "destination": {
           "properties": {
+            "bytes": {
+              "type": "long"
+            },
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -134,6 +137,9 @@
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "packets": {
+              "type": "long"
             },
             "port": {
               "type": "long"
@@ -443,6 +449,9 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "bytes": {
+              "type": "long"
+            },
             "community_id": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -458,43 +467,16 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "inbound": {
-              "properties": {
-                "bytes": {
-                  "type": "long"
-                },
-                "packets": {
-                  "type": "long"
-                }
-              }
-            },
             "name": {
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "outbound": {
-              "properties": {
-                "bytes": {
-                  "type": "long"
-                },
-                "packets": {
-                  "type": "long"
-                }
-              }
+            "packets": {
+              "type": "long"
             },
             "protocol": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "total": {
-              "properties": {
-                "bytes": {
-                  "type": "long"
-                },
-                "packets": {
-                  "type": "long"
-                }
-              }
             },
             "transport": {
               "ignore_above": 1024,
@@ -619,6 +601,9 @@
         },
         "source": {
           "properties": {
+            "bytes": {
+              "type": "long"
+            },
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -629,6 +614,9 @@
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "packets": {
+              "type": "long"
             },
             "port": {
               "type": "long"


### PR DESCRIPTION
Prior to this PR, the network metrics are defined like this:

- `network.inbound.bytes`
- `network.inbound.packets`
- `network.outbound.bytes`
- `network.outbound.packets`
- `network.total.bytes`
- `network.total.packets`

Discussions around ambiguity of inbound/outbound naming have come up multiple times,
more or less directly in #2, #51, #63, and at various other times internally.

The issues with inbound/outbound metrics:

- Inbound/outbound can mean relative to the host, or to the organization's network.
- From a host POV, mapping of source => destination to either "inbound" or "outbound"
  has to change, depending on whether the host is receiving the connection inbound,
  or initiating a connection outbound.
- From the POV of a network device, inbound/outbound to the organization's network
  can usually be determined accurately, but the device has nowhere to store
  metrics about internal only traffic.
  - Similarly, an ISP handling traffic between two external endpoints has nowhere
    to store metrics about the traffic.

The solution proposed here is to store metrics in fields that carry less ambiguous
meaning.

- `source.bytes` = sent by source
- `destination.bytes` = sent by destination
- `network.bytes` = total

- `source.packets` = sent by source
- `destination.packets` = sent by destination
- `network.packets` = total

The case where source and destination cannot be accurately determined is still
not fully addressed, other than setting `network.direction:unknown`. It may be
useful to eventually allow for storing the heuristic used to define which end
was assigned the name "source" and "destination".

This PR introduces breaking changes by removing the old fields.

- The new field for total went from `network.total.bytes/packets` to `network.bytes/packets`,
  to be as concise as the other new fields.
- A case could be made that the inbound/outbound fields could remain, and only be
  populated when the situation permits. If they can be populated reliably in a
  given environment, they may help at visualizing inbound/outbound more directly.