### PR TITLE
DNS model

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Device fields are used to provide additional information about the device that i
 ## <a name="dns"></a> DNS fields
 
 DNS-specific event fields.
+
+
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="dns.id"></a>dns.id | The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response. | extended | keyword |  |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ ECS defines these fields.
  * [Container fields](#container)
  * [Destination fields](#destination)
  * [Device fields](#device)
+ * [DNS fields](#dns)
  * [ECS fields](#ecs)
  * [Error fields](#error)
  * [Event fields](#event)
@@ -78,7 +79,7 @@ The base set contains all fields which are on the top level. These fields are co
 |---|---|---|---|---|
 | <a name="@timestamp"></a>@timestamp | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="tags"></a>tags | List of keywords used to tag each event. | core | keyword | `["production", "env2"]` |
-| <a name="labels"></a>labels | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` |
+| <a name="labels"></a>labels | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'env': 'production', 'application': 'foo-bar'}` |
 | <a name="message"></a>message | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
 
 
@@ -160,6 +161,50 @@ Device fields are used to provide additional information about the device that i
 | <a name="device.version"></a>device.version | Device version. | core | keyword |  |
 | <a name="device.serial_number"></a>device.serial_number | Device serial number. | extended | keyword |  |
 | <a name="device.type"></a>device.type | The type of the device the data is coming from.<br/>There is no predefined list of device types. Some examples are `endpoint`, `firewall`, `ids`, `ips`, `proxy`. | core | keyword | `firewall` |
+
+
+## <a name="dns"></a> DNS fields
+
+DNS-specific event fields.
+| Field  | Description  | Level  | Type  | Example  |
+|---|---|---|---|---|
+| <a name="dns.id"></a>dns.id | The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response. | extended | keyword |  |
+| <a name="dns.op_code"></a>dns.op_code | The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response. | extended | keyword | `QUERY` |
+| <a name="dns.flags.authoritative"></a>dns.flags.authoritative | A DNS flag specifying that the responding server is an authority for the domain name used in the question. | extended | boolean |  |
+| <a name="dns.flags.recursion_available"></a>dns.flags.recursion_available | A DNS flag specifying whether recursive query support is available in the name server. | extended | boolean |  |
+| <a name="dns.flags.recursion_desired"></a>dns.flags.recursion_desired | A DNS flag specifying that the client directs the server to pursue a query recursively. Recursive query support is optional. | extended | boolean |  |
+| <a name="dns.flags.authentic_data"></a>dns.flags.authentic_data | A DNS flag specifying that the recursive server considers the response authentic. | extended | boolean |  |
+| <a name="dns.flags.checking_disabled"></a>dns.flags.checking_disabled | A DNS flag specifying that the client disables the server signature validation of the query. | extended | boolean |  |
+| <a name="dns.flags.truncated_response"></a>dns.flags.truncated_response | A DNS flag specifying that only the first 512 bytes of the reply were returned. | extended | boolean |  |
+| <a name="dns.response_code"></a>dns.response_code | The DNS status code. | extended | keyword | `NOERROR` |
+| <a name="dns.question.name"></a>dns.question.name | The domain name being queried. If the name field contains non-printable characters (below 32 or above 126), then those characters are represented as escaped base 10 integers (\DDD). Back slashes and quotes are escaped. Tabs, carriage returns, and line feeds are converted to \t, \r, and \n respectively. | core | keyword | `www.google.com.` |
+| <a name="dns.question.type"></a>dns.question.type | The type of records being queried. | core | keyword | `AAAA` |
+| <a name="dns.question.class"></a>dns.question.class | The class of of records being queried. | core | keyword | `IN` |
+| <a name="dns.question.etld_plus_one"></a>dns.question.etld_plus_one | The effective top-level domain (eTLD) plus one more label. For example, the eTLD+1 for "foo.bar.golang.org." is "golang.org.". The data for determining the eTLD comes from an embedded copy of the data from http://publicsuffix.org. | core | keyword | `amazon.co.uk.` |
+| <a name="dns.question.size"></a>dns.question.size | The size of name being queried (in bytes). | extended | keyword |  |
+| <a name="dns.answers"></a>dns.answers | An array containing a dictionary about each answer section returned by the server. | extended | object |  |
+| <a name="dns.answers_count"></a>dns.answers_count | The number of resource records contained in the `dns.answers` field. | extended | long |  |
+| <a name="dns.answers.name"></a>dns.answers.name | The domain name to which this resource record pertains. | extended | keyword | `example.com.` |
+| <a name="dns.answers.type"></a>dns.answers.type | The type of data contained in this resource record. | extended | keyword | `MX` |
+| <a name="dns.answers.class"></a>dns.answers.class | The class of DNS data contained in this resource record. | extended | keyword | `IN` |
+| <a name="dns.answers.ttl"></a>dns.answers.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | extended | long |  |
+| <a name="dns.answers.data"></a>dns.answers.data | The data describing the resource. The meaning of this data depends on the type and class of the resource record. | extended |  |  |
+| <a name="dns.authorities"></a>dns.authorities | An array containing a dictionary for each authority section from the answer. | extended | object |  |
+| <a name="dns.authorities_count"></a>dns.authorities_count | The number of resource records contained in the `dns.authorities` field. | extended | long |  |
+| <a name="dns.authorities.name"></a>dns.authorities.name | The domain name to which this resource record pertains. | extended |  | `example.com.` |
+| <a name="dns.authorities.type"></a>dns.authorities.type | The type of data contained in this resource record. | extended |  | `NS` |
+| <a name="dns.authorities.class"></a>dns.authorities.class | The class of DNS data contained in this resource record. | extended |  | `IN` |
+| <a name="dns.additionals"></a>dns.additionals | An array containing a dictionary for each additional section from the answer. | extended | object |  |
+| <a name="dns.additionals_count"></a>dns.additionals_count | The number of resource records contained in the `dns.additionals` field. | extended | long |  |
+| <a name="dns.additionals.name"></a>dns.additionals.name | The domain name to which this resource record pertains. | extended |  | `example.com.` |
+| <a name="dns.additionals.type"></a>dns.additionals.type | The type of data contained in this resource record. | extended |  | `NS` |
+| <a name="dns.additionals.class"></a>dns.additionals.class | The class of DNS data contained in this resource record. | extended |  | `IN` |
+| <a name="dns.additionals.ttl"></a>dns.additionals.ttl | The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached. | extended | long |  |
+| <a name="dns.additionals.data"></a>dns.additionals.data | The data describing the resource. The meaning of this data depends on the type and class of the resource record. | extended |  |  |
+| <a name="dns.opt.version"></a>dns.opt.version | The EDNS version. | extended |  | `0` |
+| <a name="dns.opt.do"></a>dns.opt.do | If set, the transaction uses DNSSEC. | extended | boolean |  |
+| <a name="dns.opt.ext_rcode"></a>dns.opt.ext_rcode | Extended response code field. | extended |  | `BADVERS` |
+| <a name="dns.opt.udp_size"></a>dns.opt.udp_size | Requestor's UDP payload size (in bytes). | extended | long |  |
 
 
 ## <a name="ecs"></a> ECS fields

--- a/fields.yml
+++ b/fields.yml
@@ -318,6 +318,287 @@
             `endpoint`, `firewall`, `ids`, `ips`, `proxy`.
           example: firewall
     
+    - name: dns
+      title: DNS
+      group: 2
+      description: DNS-specific event fields.
+      type: group
+      fields:
+    
+        - name: id
+          level: extended
+          type: keyword
+          description: >
+            The DNS packet identifier assigned by the program that generated the
+            query. The identifier is copied to the response.
+          phase: 0
+    
+        - name: op_code
+          level: extended
+          type: keyword
+          description: >
+            The DNS operation code that specifies the kind of query in the message.
+            This value is set by the originator of a query and copied into the
+            response.
+          example: QUERY
+          phase: 0
+    
+        - name: flags.authoritative
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying that the responding server is an authority for
+            the domain name used in the question.
+          phase: 0
+    
+        - name: flags.recursion_available
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying whether recursive query support is available in the
+            name server.
+          phase: 0
+    
+        - name: flags.recursion_desired
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying that the client directs the server to pursue a
+            query recursively. Recursive query support is optional.
+          phase: 0
+    
+        - name: flags.authentic_data
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying that the recursive server considers the response
+            authentic.
+          phase: 0
+    
+        - name: flags.checking_disabled
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying that the client disables the server
+            signature validation of the query.
+          phase: 0
+    
+        - name: flags.truncated_response
+          level: extended
+          type: boolean
+          description: >
+            A DNS flag specifying that only the first 512 bytes of the reply were
+            returned.
+          phase: 0
+    
+        - name: response_code
+          level: extended
+          type: keyword
+          description: The DNS status code.
+          example: NOERROR
+          phase: 0
+    
+        - name: question.name
+          level: core
+          type: keyword
+          description: >
+            The domain name being queried. If the name field contains non-printable
+            characters (below 32 or above 126), then those characters are represented
+            as escaped base 10 integers (\DDD). Back slashes and quotes are escaped.
+            Tabs, carriage returns, and line feeds are converted to \t, \r, and
+            \n respectively.
+          example: www.google.com.
+          phase: 0
+    
+        - name: question.type
+          level: core
+          type: keyword
+          description: The type of records being queried.
+          example: AAAA
+          phase: 0
+    
+        - name: question.class
+          level: core
+          type: keyword
+          description: The class of of records being queried.
+          example: IN
+          phase: 0
+    
+        - name: question.etld_plus_one
+          level: core
+          type: keyword
+          description: The effective top-level domain (eTLD) plus one more label.
+            For example, the eTLD+1 for "foo.bar.golang.org." is "golang.org.".
+            The data for determining the eTLD comes from an embedded copy of the
+            data from http://publicsuffix.org.
+          example: amazon.co.uk.
+          phase: 0
+    
+        - name: question.size
+          level: extended
+          type: keyword
+          description: The size of name being queried (in bytes).
+          phase: 0
+    
+        - name: answers
+          level: extended
+          type: object
+          description: >
+            An array containing a dictionary about each answer section returned by
+            the server.
+          phase: 0
+    
+        - name: answers_count
+          level: extended
+          type: long
+          description: >
+            The number of resource records contained in the `dns.answers` field.
+          phase: 0
+    
+        - name: answers.name
+          level: extended
+          type: keyword
+          description: The domain name to which this resource record pertains.
+          example: example.com.
+          phase: 0
+    
+        - name: answers.type
+          level: extended
+          type: keyword
+          description: The type of data contained in this resource record.
+          example: MX
+          phase: 0
+    
+        - name: answers.class
+          level: extended
+          type: keyword
+          description: The class of DNS data contained in this resource record.
+          example: IN
+          phase: 0
+    
+        - name: answers.ttl
+          level: extended
+          type: keyword
+          description: >
+            The time interval in seconds that this resource record may be cached
+            before it should be discarded. Zero values mean that the data should
+            not be cached.
+          type: long
+          phase: 0
+    
+        - name: answers.data
+          level: extended
+          description: >
+            The data describing the resource. The meaning of this data depends
+            on the type and class of the resource record.
+          phase: 0
+    
+        - name: authorities
+          level: extended
+          type: object
+          description: >
+            An array containing a dictionary for each authority section from the
+            answer.
+          phase: 0
+    
+        - name: authorities_count
+          level: extended
+          type: long
+          description: >
+            The number of resource records contained in the `dns.authorities` field.
+          phase: 0
+    
+        - name: authorities.name
+          level: extended
+          description: The domain name to which this resource record pertains.
+          example: example.com.
+          phase: 0
+    
+        - name: authorities.type
+          level: extended
+          description: The type of data contained in this resource record.
+          example: NS
+          phase: 0
+    
+        - name: authorities.class
+          level: extended
+          description: The class of DNS data contained in this resource record.
+          example: IN
+    
+        - name: additionals
+          level: extended
+          type: object
+          description: >
+            An array containing a dictionary for each additional section from the
+            answer.
+          phase: 0
+    
+        - name: additionals_count
+          level: extended
+          type: long
+          description: >
+            The number of resource records contained in the `dns.additionals` field.
+          phase: 0
+    
+        - name: additionals.name
+          level: extended
+          description: The domain name to which this resource record pertains.
+          example: example.com.
+          phase: 0
+    
+        - name: additionals.type
+          level: extended
+          description: The type of data contained in this resource record.
+          example: NS
+          phase: 0
+    
+        - name: additionals.class
+          level: extended
+          description: The class of DNS data contained in this resource record.
+          example: IN
+          phase: 0
+    
+        - name: additionals.ttl
+          level: extended
+          description: >
+            The time interval in seconds that this resource record may be cached
+            before it should be discarded. Zero values mean that the data should
+            not be cached.
+          type: long
+          phase: 0
+    
+        - name: additionals.data
+          level: extended
+          description: >
+            The data describing the resource. The meaning of this data depends
+            on the type and class of the resource record.
+          phase: 0
+    
+        - name: opt.version
+          level: extended
+          description: The EDNS version.
+          example: "0"
+          phase: 0
+    
+        - name: opt.do
+          level: extended
+          type: boolean
+          description: If set, the transaction uses DNSSEC.
+          phase: 0
+    
+        - name: opt.ext_rcode
+          level: extended
+          description: Extended response code field.
+          example: "BADVERS"
+          phase: 0
+    
+        - name: opt.udp_size
+          level: extended
+          type: long
+          description: Requestor's UDP payload size (in bytes).
+          phase: 0
+    
+    
     - name: ecs
       title: ECS
       group: 2

--- a/fields.yml
+++ b/fields.yml
@@ -321,7 +321,8 @@
     - name: dns
       title: DNS
       group: 2
-      description: DNS-specific event fields.
+      description: >
+        DNS-specific event fields.
       type: group
       fields:
     

--- a/schema.csv
+++ b/schema.csv
@@ -1,6 +1,6 @@
 Field,Type,Level,Example
 @timestamp,date,core,2016-05-23T08:05:34.853Z
-labels,object,core,"{'application': 'foo-bar', 'env': 'production'}"
+labels,object,core,"{'env': 'production', 'application': 'foo-bar'}"
 message,text,core,Hello World
 tags,keyword,core,"[""production"", ""env2""]"
 agent.ephemeral_id,keyword,extended,8a4f500f
@@ -32,6 +32,43 @@ device.serial_number,keyword,extended,
 device.type,keyword,core,firewall
 device.vendor,keyword,core,
 device.version,keyword,core,
+dns.additionals,object,extended,
+dns.additionals.class,,extended,IN
+dns.additionals.data,,extended,
+dns.additionals.name,,extended,example.com.
+dns.additionals.ttl,long,extended,
+dns.additionals.type,,extended,NS
+dns.additionals_count,long,extended,
+dns.answers,object,extended,
+dns.answers.class,keyword,extended,IN
+dns.answers.data,,extended,
+dns.answers.name,keyword,extended,example.com.
+dns.answers.ttl,long,extended,
+dns.answers.type,keyword,extended,MX
+dns.answers_count,long,extended,
+dns.authorities,object,extended,
+dns.authorities.class,,extended,IN
+dns.authorities.name,,extended,example.com.
+dns.authorities.type,,extended,NS
+dns.authorities_count,long,extended,
+dns.flags.authentic_data,boolean,extended,
+dns.flags.authoritative,boolean,extended,
+dns.flags.checking_disabled,boolean,extended,
+dns.flags.recursion_available,boolean,extended,
+dns.flags.recursion_desired,boolean,extended,
+dns.flags.truncated_response,boolean,extended,
+dns.id,keyword,extended,
+dns.op_code,keyword,extended,QUERY
+dns.opt.do,boolean,extended,
+dns.opt.ext_rcode,,extended,BADVERS
+dns.opt.udp_size,long,extended,
+dns.opt.version,,extended,0
+dns.question.class,keyword,core,IN
+dns.question.etld_plus_one,keyword,core,amazon.co.uk.
+dns.question.name,keyword,core,www.google.com.
+dns.question.size,keyword,extended,
+dns.question.type,keyword,core,AAAA
+dns.response_code,keyword,extended,NOERROR
 ecs.version,keyword,core,1.0.0-beta1
 error.code,keyword,core,
 error.id,keyword,core,

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -2,7 +2,8 @@
 - name: dns
   title: DNS
   group: 2
-  description: DNS-specific event fields.
+  description: >
+    DNS-specific event fields.
   type: group
   fields:
 

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -1,0 +1,281 @@
+---
+- name: dns
+  title: DNS
+  group: 2
+  description: DNS-specific event fields.
+  type: group
+  fields:
+
+    - name: id
+      level: extended
+      type: keyword
+      description: >
+        The DNS packet identifier assigned by the program that generated the
+        query. The identifier is copied to the response.
+      phase: 0
+
+    - name: op_code
+      level: extended
+      type: keyword
+      description: >
+        The DNS operation code that specifies the kind of query in the message.
+        This value is set by the originator of a query and copied into the
+        response.
+      example: QUERY
+      phase: 0
+
+    - name: flags.authoritative
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying that the responding server is an authority for
+        the domain name used in the question.
+      phase: 0
+
+    - name: flags.recursion_available
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying whether recursive query support is available in the
+        name server.
+      phase: 0
+
+    - name: flags.recursion_desired
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying that the client directs the server to pursue a
+        query recursively. Recursive query support is optional.
+      phase: 0
+
+    - name: flags.authentic_data
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying that the recursive server considers the response
+        authentic.
+      phase: 0
+
+    - name: flags.checking_disabled
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying that the client disables the server
+        signature validation of the query.
+      phase: 0
+
+    - name: flags.truncated_response
+      level: extended
+      type: boolean
+      description: >
+        A DNS flag specifying that only the first 512 bytes of the reply were
+        returned.
+      phase: 0
+
+    - name: response_code
+      level: extended
+      type: keyword
+      description: The DNS status code.
+      example: NOERROR
+      phase: 0
+
+    - name: question.name
+      level: core
+      type: keyword
+      description: >
+        The domain name being queried. If the name field contains non-printable
+        characters (below 32 or above 126), then those characters are represented
+        as escaped base 10 integers (\DDD). Back slashes and quotes are escaped.
+        Tabs, carriage returns, and line feeds are converted to \t, \r, and
+        \n respectively.
+      example: www.google.com.
+      phase: 0
+
+    - name: question.type
+      level: core
+      type: keyword
+      description: The type of records being queried.
+      example: AAAA
+      phase: 0
+
+    - name: question.class
+      level: core
+      type: keyword
+      description: The class of of records being queried.
+      example: IN
+      phase: 0
+
+    - name: question.etld_plus_one
+      level: core
+      type: keyword
+      description: The effective top-level domain (eTLD) plus one more label.
+        For example, the eTLD+1 for "foo.bar.golang.org." is "golang.org.".
+        The data for determining the eTLD comes from an embedded copy of the
+        data from http://publicsuffix.org.
+      example: amazon.co.uk.
+      phase: 0
+
+    - name: question.size
+      level: extended
+      type: keyword
+      description: The size of name being queried (in bytes).
+      phase: 0
+
+    - name: answers
+      level: extended
+      type: object
+      description: >
+        An array containing a dictionary about each answer section returned by
+        the server.
+      phase: 0
+
+    - name: answers_count
+      level: extended
+      type: long
+      description: >
+        The number of resource records contained in the `dns.answers` field.
+      phase: 0
+
+    - name: answers.name
+      level: extended
+      type: keyword
+      description: The domain name to which this resource record pertains.
+      example: example.com.
+      phase: 0
+
+    - name: answers.type
+      level: extended
+      type: keyword
+      description: The type of data contained in this resource record.
+      example: MX
+      phase: 0
+
+    - name: answers.class
+      level: extended
+      type: keyword
+      description: The class of DNS data contained in this resource record.
+      example: IN
+      phase: 0
+
+    - name: answers.ttl
+      level: extended
+      type: keyword
+      description: >
+        The time interval in seconds that this resource record may be cached
+        before it should be discarded. Zero values mean that the data should
+        not be cached.
+      type: long
+      phase: 0
+
+    - name: answers.data
+      level: extended
+      description: >
+        The data describing the resource. The meaning of this data depends
+        on the type and class of the resource record.
+      phase: 0
+
+    - name: authorities
+      level: extended
+      type: object
+      description: >
+        An array containing a dictionary for each authority section from the
+        answer.
+      phase: 0
+
+    - name: authorities_count
+      level: extended
+      type: long
+      description: >
+        The number of resource records contained in the `dns.authorities` field.
+      phase: 0
+
+    - name: authorities.name
+      level: extended
+      description: The domain name to which this resource record pertains.
+      example: example.com.
+      phase: 0
+
+    - name: authorities.type
+      level: extended
+      description: The type of data contained in this resource record.
+      example: NS
+      phase: 0
+
+    - name: authorities.class
+      level: extended
+      description: The class of DNS data contained in this resource record.
+      example: IN
+
+    - name: additionals
+      level: extended
+      type: object
+      description: >
+        An array containing a dictionary for each additional section from the
+        answer.
+      phase: 0
+
+    - name: additionals_count
+      level: extended
+      type: long
+      description: >
+        The number of resource records contained in the `dns.additionals` field.
+      phase: 0
+
+    - name: additionals.name
+      level: extended
+      description: The domain name to which this resource record pertains.
+      example: example.com.
+      phase: 0
+
+    - name: additionals.type
+      level: extended
+      description: The type of data contained in this resource record.
+      example: NS
+      phase: 0
+
+    - name: additionals.class
+      level: extended
+      description: The class of DNS data contained in this resource record.
+      example: IN
+      phase: 0
+
+    - name: additionals.ttl
+      level: extended
+      description: >
+        The time interval in seconds that this resource record may be cached
+        before it should be discarded. Zero values mean that the data should
+        not be cached.
+      type: long
+      phase: 0
+
+    - name: additionals.data
+      level: extended
+      description: >
+        The data describing the resource. The meaning of this data depends
+        on the type and class of the resource record.
+      phase: 0
+
+    - name: opt.version
+      level: extended
+      description: The EDNS version.
+      example: "0"
+      phase: 0
+
+    - name: opt.do
+      level: extended
+      type: boolean
+      description: If set, the transaction uses DNSSEC.
+      phase: 0
+
+    - name: opt.ext_rcode
+      level: extended
+      description: Extended response code field.
+      example: "BADVERS"
+      phase: 0
+
+    - name: opt.udp_size
+      level: extended
+      type: long
+      description: Requestor's UDP payload size (in bytes).
+      phase: 0
+

--- a/template.json
+++ b/template.json
@@ -171,6 +171,160 @@
             }
           }
         },
+        "dns": {
+          "properties": {
+            "additionals": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "additionals_count": {
+              "type": "long"
+            },
+            "answers": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ttl": {
+                  "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "answers_count": {
+              "type": "long"
+            },
+            "authorities": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
+            "authorities_count": {
+              "type": "long"
+            },
+            "flags": {
+              "properties": {
+                "authentic_data": {
+                  "type": "boolean"
+                },
+                "authoritative": {
+                  "type": "boolean"
+                },
+                "checking_disabled": {
+                  "type": "boolean"
+                },
+                "recursion_available": {
+                  "type": "boolean"
+                },
+                "recursion_desired": {
+                  "type": "boolean"
+                },
+                "truncated_response": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "op_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "opt": {
+              "properties": {
+                "do": {
+                  "type": "boolean"
+                },
+                "ext_rcode": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "udp_size": {
+                  "type": "long"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "question": {
+              "properties": {
+                "class": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "etld_plus_one": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "size": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "ecs": {
           "properties": {
             "version": {


### PR DESCRIPTION
Added DNS model based on [Packetbeat DNS fields](
https://www.elastic.co/guide/en/beats/packetbeat/current/exported-fields-dns.html)  + one extra field — `dns.question.size`, which represents a size of name being queried (in bytes). 

We calculate it using the next Logstash config:

```ruby
ruby {
      code => 'event.set("dns.question.size", event.get("dns.question.name").length)'
}
```

I've presented one of our alerts based on this field ("Exfiltration over DNS, Large Domain Name Request") on the next conferences:

- CONFidence 2018, Krakow: [Practical intelligence-driven defense](https://www.youtube.com/watch?v=VJRGZLNtEg4)
- EU ATT&CK Workshop 2018, Luxembourg: [Use Case Framework, MITM tactic](https://drive.google.com/drive/folders/1UG0uRbselLshlclt6Ah5L9eegqKL3e-9)

Resolve (?) issue #10 