### PR TITLE
Clarify event definition - add metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 * Improved the definition of the file fields #196
 * Improved the definition of the agent fields #192
-* Improve definition of events and metrics in event section #194
 * Improve definition of events, logs, and metrics in event section #194
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file based on the
 * Improved the definition of the file fields #196
 * Improved the definition of the agent fields #192
 * Improve definition of events and metrics in event section #194
+* Improve definition of events, logs, and metrics in event section #194
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file based on the
 ### Improvements
 * Improved the definition of the file fields #196
 * Improved the definition of the agent fields #192
+* Improve definition of events and metrics in event section #194
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ These fields can represent errors of any kind. Use them for errors that happen w
 
 ## <a name="event"></a> Event fields
 
-The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ These fields can represent errors of any kind. Use them for errors that happen w
 
 ## <a name="event"></a> Event fields
 
-The event fields are used for context information about the data itself.
+The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/fields.yml
+++ b/fields.yml
@@ -370,7 +370,7 @@
       title: Event
       group: 2
       description: >
-        The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+        The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
       type: group
       fields:
     

--- a/fields.yml
+++ b/fields.yml
@@ -370,7 +370,7 @@
       title: Event
       group: 2
       description: >
-        The event fields are used for context information about the data itself.
+        The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
       type: group
       fields:
     

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -3,7 +3,7 @@
   title: Event
   group: 2
   description: >
-    The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+    The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
   type: group
   fields:
 

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -3,7 +3,7 @@
   title: Event
   group: 2
   description: >
-    The event fields are used for context information about the data itself.
+    The event fields are used for context information about the event or metric itself. An event is defined as a log message containing details of something that happened. Events must include the time at which the thing happened. Examples of events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as a log message containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
   type: group
   fields:
 


### PR DESCRIPTION
Improve the definition of the event fields at the start of the event section.  Also mention that metrics details are to be included in the event fields.