### PR TITLE
Clarify network definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project will be documented in this file based on the
 * Improved the definition of the file fields #196
 * Improved the definition of the agent fields #192
 * Improve definition of events, logs, and metrics in event section #194
+* Improved the definition of network fields in intro section #197
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Fields which are specific to log events.
 
 ## <a name="network"></a> Network fields
 
-The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
+The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Fields which are specific to log events.
 
 ## <a name="network"></a> Network fields
 
-Fields related to network data.
+The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/fields.yml
+++ b/fields.yml
@@ -788,7 +788,7 @@
       title: Network
       group: 2
       description: >
-        The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
+        The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
       type: group
       fields:
     

--- a/fields.yml
+++ b/fields.yml
@@ -788,7 +788,7 @@
       title: Network
       group: 2
       description: >
-        Fields related to network data.
+        The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
       type: group
       fields:
     

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -3,7 +3,7 @@
   title: Network
   group: 2
   description: >
-    Fields related to network data.
+    The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
   type: group
   fields:
 

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -3,7 +3,7 @@
   title: Network
   group: 2
   description: >
-    The network is defined as the communication path over which a host or network event happens. Network events do not include the transmission of an event from a host or device to the Elastic Stack. The network.* fields should be populated with details about the network activity associated with an event.
+    The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
   type: group
   fields:
 


### PR DESCRIPTION
Added detail about network fields, specifically that these fields can be populated for both network and host-based events.