### PR TITLE
Use type for queryable object types for labels and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file based on the
 ## Unreleased
 
 ### Breaking changes
+* Change type of labels to `json`.
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The base set contains all fields which are on the top level. These fields are co
 |---|---|---|---|---|
 | <a name="@timestamp"></a>@timestamp | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="tags"></a>tags | List of keywords used to tag each event. | core | keyword | `["production", "env2"]` |
-| <a name="labels"></a>labels | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` |
+| <a name="labels"></a>labels | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | json | `{'application': 'foo-bar', 'env': 'production'}` |
 | <a name="message"></a>message | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
 
 
@@ -130,7 +130,7 @@ Container fields are used for meta information about the specific container that
 | <a name="container.image.name"></a>container.image.name | Name of the image the container was built on. | extended | keyword |  |
 | <a name="container.image.tag"></a>container.image.tag | Container image tag. | extended | keyword |  |
 | <a name="container.name"></a>container.name | Container name. | extended | keyword |  |
-| <a name="container.labels"></a>container.labels | Image labels. | extended | object |  |
+| <a name="container.labels"></a>container.labels | Image labels. | extended | json |  |
 
 
 ## <a name="destination"></a> Destination fields

--- a/fields.yml
+++ b/fields.yml
@@ -99,7 +99,7 @@
     
         - name: labels
           level: core
-          type: object
+          type: json
           example: {env: production, application: foo-bar}
           description: >
             Key/value pairs.
@@ -230,8 +230,7 @@
     
         - name: labels
           level: extended
-          type: object
-          object_type: keyword
+          type: json
           description: >
             Image labels.
     

--- a/schema.csv
+++ b/schema.csv
@@ -1,6 +1,6 @@
 Field,Type,Level,Example
 @timestamp,date,core,2016-05-23T08:05:34.853Z
-labels,object,core,"{'application': 'foo-bar', 'env': 'production'}"
+labels,json,core,"{'application': 'foo-bar', 'env': 'production'}"
 message,text,core,Hello World
 tags,keyword,core,"[""production"", ""env2""]"
 agent.ephemeral_id,keyword,extended,8a4f500f
@@ -18,7 +18,7 @@ cloud.region,keyword,extended,us-east-1
 container.id,keyword,core,
 container.image.name,keyword,extended,
 container.image.tag,keyword,extended,
-container.labels,object,extended,
+container.labels,json,extended,
 container.name,keyword,extended,
 container.runtime,keyword,extended,docker
 destination.domain,keyword,core,

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -28,7 +28,7 @@
 
     - name: labels
       level: core
-      type: object
+      type: json
       example: {env: production, application: foo-bar}
       description: >
         Key/value pairs.

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -42,7 +42,6 @@
 
     - name: labels
       level: extended
-      type: object
-      object_type: keyword
+      type: json
       description: >
         Image labels.

--- a/template.json
+++ b/template.json
@@ -110,7 +110,7 @@
               }
             },
             "labels": {
-              "type": "object"
+              "type": "json"
             },
             "name": {
               "ignore_above": 1024,
@@ -366,7 +366,7 @@
           }
         },
         "labels": {
-          "type": "object"
+          "type": "json"
         },
         "log": {
           "properties": {

--- a/use-cases/kubernetes.md
+++ b/use-cases/kubernetes.md
@@ -13,8 +13,8 @@ You can monitor containers running in a Kubernetes cluster by adding Kubernetes-
 | [host.hostname](../README.md#host.hostname)  | Hostname of the host.<br/>It normally contains what the `hostname` command returns on the host machine. | core | keyword | `kube-high-cpu-42` |
 | <a name="kubernetes.pod.name"></a>*kubernetes.pod.name* | *Kubernetes pod name* | (use case) | keyword | `foo-webserver` |
 | <a name="kubernetes.namespace"></a>*kubernetes.namespace* | *Kubernetes namespace* | (use case) | keyword | `foo-team` |
-| <a name="kubernetes.labels"></a>*kubernetes.labels* | *Kubernetes labels map* | (use case) | object |  |
-| <a name="kubernetes.annotations"></a>*kubernetes.annotations* | *Kubernetes annotations map* | (use case) | object |  |
+| <a name="kubernetes.labels"></a>*kubernetes.labels* | *Kubernetes labels map* | (use case) | json |  |
+| <a name="kubernetes.annotations"></a>*kubernetes.annotations* | *Kubernetes annotations map* | (use case) | json |  |
 | <a name="kubernetes.container.name"></a>*kubernetes.container.name* | *Kubernetes container name. This name is unique within the pod only. It is different from the `container.name` field.* | (use case) | keyword |  |
 
 

--- a/use-cases/kubernetes.yml
+++ b/use-cases/kubernetes.yml
@@ -35,12 +35,12 @@ fields:
     example: foo-team
 
   - name: labels
-    type: object
+    type: json
     description: >
       Kubernetes labels map
 
   - name: annotations
-    type: object
+    type: json
     description: >
       Kubernetes annotations map
 


### PR DESCRIPTION
There is a new [ES datatype](https://github.com/elastic/elasticsearch/issues/33003) in development that will allow to store json objects with any field name, what will allow to have fields inside these objects with dots. This helps to avoid mapping conflicts as the ones we have seen with docker and kubernetes labels in beats.

I propose that ECS recommends the use of this type for this sort of values.

Not to be merged before the type is available in ES.