### PR TITLE
Add field process.thread.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ All notable changes to this project will be documented in this file based on the
 ### Bugfixes
 
 ### Added
-* Add `host.name` field and clarify usage of `host.hostname`.
-* Add `event.start` and `event.end` date fields.
+* Add `host.name` field and clarify usage of `host.hostname`. #187
+* Add `event.start` and `event.end` date fields. #185
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 * Add `host.name` field and clarify usage of `host.hostname`. #187
 * Add `event.start` and `event.end` date fields. #185
+* Add `process.thread.id` field. #200
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -339,9 +339,10 @@ These fields contain information about a process. These fields can help you corr
 |---|---|---|---|---|
 | <a name="process.args"></a>process.args | Process arguments.<br/>May be filtered to protect sensitive information. | extended | keyword | `['-l', 'user', '10.0.0.16']` |
 | <a name="process.name"></a>process.name | Process name.<br/>Sometimes called program name or similar. | extended | keyword | `ssh` |
-| <a name="process.pid"></a>process.pid | Process id. | core | long |  |
+| <a name="process.pid"></a>process.pid | Process id. | core | long | `4242` |
 | <a name="process.ppid"></a>process.ppid | Process parent id. | extended | long |  |
 | <a name="process.title"></a>process.title | Process title.<br/>The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | extended | keyword |  |
+| <a name="process.thread.id"></a>process.thread.id | Thread ID. | extended | long | `4242` |
 
 
 ## <a name="service"></a> Service fields

--- a/fields.yml
+++ b/fields.yml
@@ -987,7 +987,7 @@
           type: long
           description: >
             Process id.
-          exmple: ssh
+          example: 4242
     
         - name: ppid
           level: extended
@@ -1003,6 +1003,13 @@
     
             The proctitle, some times the same as process name. Can also be different:
             for example a browser setting its title to the web page currently opened.
+    
+        - name: thread.id
+          level: extended
+          type: long
+          example: 4242
+          description: >
+            Thread ID.
     
     - name: service
       title: Service

--- a/schema.csv
+++ b/schema.csv
@@ -102,8 +102,9 @@ os.platform,keyword,extended,darwin
 os.version,keyword,extended,10.12.6-rc2
 process.args,keyword,extended,"['-l', 'user', '10.0.0.16']"
 process.name,keyword,extended,ssh
-process.pid,long,core,
+process.pid,long,core,4242
 process.ppid,long,extended,
+process.thread.id,long,extended,4242
 process.title,keyword,extended,
 service.ephemeral_id,keyword,extended,8a4f500f
 service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -33,7 +33,7 @@
       type: long
       description: >
         Process id.
-      exmple: ssh
+      example: 4242
 
     - name: ppid
       level: extended
@@ -49,3 +49,10 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
+
+    - name: thread.id
+      level: extended
+      type: long
+      example: 4242
+      description: >
+        Thread ID.

--- a/template.json
+++ b/template.json
@@ -503,6 +503,13 @@
             "ppid": {
               "type": "long"
             },
+            "thread": {
+              "properties": {
+                "id": {
+                  "type": "long"
+                }
+              }
+            },
             "title": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
Note that nesting the ID under `thread.` leaves the door open to eventually
tracking interesting things about threads. Name, priority.