### PR TITLE
Add minimal field set to represent groups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `host.name` field and clarify usage of `host.hostname`.
 * Add `event.start` and `event.end` date fields.
 * Create new `related` field set with `related.ip`. #206
-* Add `user.groups` field. #204
+* Add `user.group` field. #204
 * Create new `group` field set with `group.id` and `group.name`. #203
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `event.start` and `event.end` date fields.
 * Create new `related` field set with `related.ip`. #206
 * Add `user.groups` field. #204
+* Create new `group` field set with `group.id` and `group.name`. #203
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -258,8 +258,8 @@ The group fields are meant to represent groups that are relevant to the event.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="group.id"></a>group.id | Unique identifier for the group on the system/platform. | core | keyword |  |
-| <a name="group.name"></a>group.name | Name of the group. | core | keyword |  |
+| <a name="group.id"></a>group.id | Unique identifier for the group on the system/platform. | extended | keyword |  |
+| <a name="group.name"></a>group.name | Name of the group. | extended | keyword |  |
 
 
 ## <a name="host"></a> Host fields

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ ECS defines these fields.
  * [Event fields](#event)
  * [File fields](#file)
  * [Geo fields](#geo)
+ * [Group fields](#group)
  * [Host fields](#host)
  * [Log fields](#log)
  * [Network fields](#network)
@@ -248,6 +249,17 @@ Note also that the `geo` fields are not expected to be used directly at the top 
 | <a name="geo.location"></a>geo.location | Longitude and latitude. | core | geo_point | `{ "lon": -73.614830, "lat": 45.505918 }` |
 | <a name="geo.region_name"></a>geo.region_name | Region name. | core | keyword | `Quebec` |
 | <a name="geo.city_name"></a>geo.city_name | City name. | core | keyword | `Montreal` |
+
+
+## <a name="group"></a> Group fields
+
+The group fields are meant to represent groups that are relevant to the event.
+
+
+| Field  | Description  | Level  | Type  | Example  |
+|---|---|---|---|---|
+| <a name="group.id"></a>group.id | Unique identifier for the group on the system/platform. | core | keyword |  |
+| <a name="group.name"></a>group.name | Name of the group. | core | keyword |  |
 
 
 ## <a name="host"></a> Host fields

--- a/fields.yml
+++ b/fields.yml
@@ -670,13 +670,13 @@
       fields:
     
         - name: id
-          level: core
+          level: extended
           type: keyword
           description: >
             Unique identifier for the group on the system/platform.
     
         - name: name
-          level: core
+          level: extended
           type: keyword
           description: >
             Name of the group.

--- a/fields.yml
+++ b/fields.yml
@@ -660,6 +660,27 @@
             City name.
           example: Montreal
     
+    - name: group
+      title: Group
+      group: 2
+      description: >
+        The group fields are meant to represent groups that are relevant to the
+        event.
+      type: group
+      fields:
+    
+        - name: id
+          level: core
+          type: keyword
+          description: >
+            Unique identifier for the group on the system/platform.
+    
+        - name: name
+          level: core
+          type: keyword
+          description: >
+            Name of the group.
+    
     - name: host
       title: Host
       group: 2

--- a/schema.csv
+++ b/schema.csv
@@ -70,6 +70,8 @@ geo.continent_name,keyword,core,North America
 geo.country_iso_code,keyword,core,CA
 geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }"
 geo.region_name,keyword,core,Quebec
+group.id,keyword,core,
+group.name,keyword,core,
 host.architecture,keyword,core,x86_64
 host.hostname,keyword,core,
 host.id,keyword,core,

--- a/schema.csv
+++ b/schema.csv
@@ -70,8 +70,8 @@ geo.continent_name,keyword,core,North America
 geo.country_iso_code,keyword,core,CA
 geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }"
 geo.region_name,keyword,core,Quebec
-group.id,keyword,core,
-group.name,keyword,core,
+group.id,keyword,extended,
+group.name,keyword,extended,
 host.architecture,keyword,core,x86_64
 host.hostname,keyword,core,
 host.id,keyword,core,

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -1,0 +1,21 @@
+---
+- name: group
+  title: Group
+  group: 2
+  description: >
+    The group fields are meant to represent groups that are relevant to the
+    event.
+  type: group
+  fields:
+
+    - name: id
+      level: core
+      type: keyword
+      description: >
+        Unique identifier for the group on the system/platform.
+
+    - name: name
+      level: core
+      type: keyword
+      description: >
+        Name of the group.

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -9,13 +9,13 @@
   fields:
 
     - name: id
-      level: core
+      level: extended
       type: keyword
       description: >
         Unique identifier for the group on the system/platform.
 
     - name: name
-      level: core
+      level: extended
       type: keyword
       description: >
         Name of the group.

--- a/template.json
+++ b/template.json
@@ -334,6 +334,18 @@
             }
           }
         },
+        "group": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "host": {
           "properties": {
             "architecture": {


### PR DESCRIPTION
We may want more fields under `group.` eventually, but I figured we could start with the two most obvious fields.

Note that we're already starting to use them in the Beats transition to ECS. E.g. https://github.com/elastic/beats/pull/9138