### PR TITLE
Introduce network.community_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `process.working_directory` and `process.start`. #215
 * Reintroduce `http`. #237
 * Add `user.full_name` field. #201
+* Add `network.community.id` field. #208
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable changes to this project will be documented in this file based on the
 * Add `process.working_directory` and `process.start`. #215
 * Reintroduce `http`. #237
 * Add `user.full_name` field. #201
-* Add `network.community.id` field. #208
 * Add `network.community_id` field. #208
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file based on the
 * Reintroduce `http`. #237
 * Add `user.full_name` field. #201
 * Add `network.community.id` field. #208
+* Add `network.community_id` field. #208
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The network is defined as the communication path over which a host or network ev
 | <a name="network.protocol"></a>network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol | core | keyword | `http` |
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown | core | keyword | `inbound` |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` |
-| <a name="network.community.id"></a>network.community.id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.<br/>Learn more at https://github.com/corelight/community-id-spec. | extended | keyword | `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=` |
+| <a name="network.community_id"></a>network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.<br/>Learn more at https://github.com/corelight/community-id-spec. | extended | keyword | `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=` |
 | <a name="network.inbound.bytes"></a>network.inbound.bytes | Network inbound bytes. | core | long | `184` |
 | <a name="network.inbound.packets"></a>network.inbound.packets | Network inbound packets. | core | long | `12` |
 | <a name="network.outbound.bytes"></a>network.outbound.bytes | Network outbound bytes. | core | long | `184` |

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ The network is defined as the communication path over which a host or network ev
 | <a name="network.protocol"></a>network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol | core | keyword | `http` |
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * unknown | core | keyword | `inbound` |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` |
+| <a name="network.community.id"></a>network.community.id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.<br/>Learn more at https://github.com/corelight/community-id-spec. | extended | keyword | `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=` |
 | <a name="network.inbound.bytes"></a>network.inbound.bytes | Network inbound bytes. | core | long | `184` |
 | <a name="network.inbound.packets"></a>network.inbound.packets | Network inbound packets. | core | long | `12` |
 | <a name="network.outbound.bytes"></a>network.outbound.bytes | Network outbound bytes. | core | long | `184` |

--- a/fields.yml
+++ b/fields.yml
@@ -899,7 +899,7 @@
             Host IP address when the source IP address is the proxy.
           example: 192.1.1.2
     
-        - name: community.id
+        - name: community_id
           level: extended
           type: keyword
           description: >

--- a/fields.yml
+++ b/fields.yml
@@ -899,6 +899,17 @@
             Host IP address when the source IP address is the proxy.
           example: 192.1.1.2
     
+        - name: community.id
+          level: extended
+          type: keyword
+          description: >
+            A hash of source and destination IPs and ports, as well as the protocol
+            used in a communication. This is a tool-agnostic standard to identify
+            flows.
+    
+            Learn more at https://github.com/corelight/community-id-spec.
+          example: '1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0='
+    
         # Metrics
         - name: inbound.bytes
           level: core

--- a/schema.csv
+++ b/schema.csv
@@ -87,6 +87,7 @@ http.version,keyword,extended,1.1
 log.level,keyword,core,ERR
 log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM
+network.community.id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
 network.iana_number,keyword,extended,6

--- a/schema.csv
+++ b/schema.csv
@@ -87,7 +87,7 @@ http.version,keyword,extended,1.1
 log.level,keyword,core,ERR
 log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM
-network.community.id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
+network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
 network.iana_number,keyword,extended,6

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -75,6 +75,17 @@
         Host IP address when the source IP address is the proxy.
       example: 192.1.1.2
 
+    - name: community.id
+      level: extended
+      type: keyword
+      description: >
+        A hash of source and destination IPs and ports, as well as the protocol
+        used in a communication. This is a tool-agnostic standard to identify
+        flows.
+
+        Learn more at https://github.com/corelight/community-id-spec.
+      example: '1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0='
+
     # Metrics
     - name: inbound.bytes
       level: core

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -75,7 +75,7 @@
         Host IP address when the source IP address is the proxy.
       example: 192.1.1.2
 
-    - name: community.id
+    - name: community_id
       level: extended
       type: keyword
       description: >

--- a/template.json
+++ b/template.json
@@ -435,6 +435,14 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "community": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "direction": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/template.json
+++ b/template.json
@@ -435,13 +435,9 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "community": {
-              "properties": {
-                "id": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
+            "community_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "direction": {
               "ignore_above": 1024,


### PR DESCRIPTION
I'm introducing this with a dot before the ID, rather than an underscore. The
standard is defined such as there can be new versions in the future, and when
that happens, we may want to introduce additional fields under `community.`,
to help make sense of this.

Let me know if that sounds reasonable.

[Community ID spec](https://github.com/corelight/community-id-spec)