### PR TITLE
Re-introduce HTTP protocol breakdown at `network.http`

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Fields related to network data.
 | <a name="network.outbound.packets"></a>network.outbound.packets | Network outbound packets. | core | long | `12` |
 | <a name="network.total.bytes"></a>network.total.bytes | Network total bytes. The sum of inbound.bytes + outbound.bytes. | core | long | `368` |
 | <a name="network.total.packets"></a>network.total.packets | Network outbound packets. The sum of inbound.packets + outbound.packets | core | long | `24` |
+| <a name="network.http"></a>network.http | The detailed breakdown of an HTTP request and response. | extended | object |  |
 | <a name="network.http.request.method"></a>network.http.request.method | Http request method. | extended | keyword | `GET, POST, PUT` |
 | <a name="network.http.request.referrer"></a>network.http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | <a name="network.http.response.status_code"></a>network.http.response.status_code | Http response status code. | extended | long | `404` |

--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ Fields related to network data.
 | <a name="network.outbound.packets"></a>network.outbound.packets | Network outbound packets. | core | long | `12` |
 | <a name="network.total.bytes"></a>network.total.bytes | Network total bytes. The sum of inbound.bytes + outbound.bytes. | core | long | `368` |
 | <a name="network.total.packets"></a>network.total.packets | Network outbound packets. The sum of inbound.packets + outbound.packets | core | long | `24` |
+| <a name="network.http.request.method"></a>network.http.request.method | Http request method. | extended | keyword | `GET, POST, PUT` |
+| <a name="network.http.request.referrer"></a>network.http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
+| <a name="network.http.response.status_code"></a>network.http.response.status_code | Http response status code. | extended | long | `404` |
+| <a name="network.http.response.body"></a>network.http.response.body | The full http response body. | extended | keyword | `Hello world` |
+| <a name="network.http.version"></a>network.http.version | Http version. | extended | keyword | `1.1` |
 
 
 ## <a name="organization"></a> Organization fields

--- a/fields.yml
+++ b/fields.yml
@@ -904,6 +904,44 @@
             Network outbound packets. The sum of inbound.packets + outbound.packets
           example: 24
     
+        # Protocol breakdowns
+    
+        # HTTP
+        - name: http.request.method
+          level: extended
+          type: keyword
+          description: >
+            Http request method.
+          example: GET, POST, PUT
+    
+        - name: http.request.referrer
+          level: extended
+          type: keyword
+          description: >
+            Referrer for this HTTP request.
+          example: https://blog.example.com/
+    
+        - name: http.response.status_code
+          level: extended
+          type: long
+          description: >
+            Http response status code.
+          example: 404
+    
+        - name: http.response.body
+          level: extended
+          type: keyword
+          description: >
+            The full http response body.
+          example: Hello world
+    
+        - name: http.version
+          level: extended
+          type: keyword
+          description: >
+            Http version.
+          example: 1.1
+    
     - name: organization
       title: Organization
       group: 2

--- a/fields.yml
+++ b/fields.yml
@@ -907,6 +907,12 @@
         # Protocol breakdowns
     
         # HTTP
+        - name: http
+          level: extended
+          type: object
+          description: >
+            The detailed breakdown of an HTTP request and response.
+    
         - name: http.request.method
           level: extended
           type: keyword

--- a/schema.csv
+++ b/schema.csv
@@ -84,6 +84,11 @@ log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
+network.http.request.method,keyword,extended,"GET, POST, PUT"
+network.http.request.referrer,keyword,extended,https://blog.example.com/
+network.http.response.body,keyword,extended,Hello world
+network.http.response.status_code,long,extended,404
+network.http.version,keyword,extended,1.1
 network.iana_number,keyword,extended,6
 network.inbound.bytes,long,core,184
 network.inbound.packets,long,core,12

--- a/schema.csv
+++ b/schema.csv
@@ -84,6 +84,7 @@ log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
+network.http,object,extended,
 network.http.request.method,keyword,extended,"GET, POST, PUT"
 network.http.request.referrer,keyword,extended,https://blog.example.com/
 network.http.response.body,keyword,extended,Hello world

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -121,6 +121,12 @@
     # Protocol breakdowns
 
     # HTTP
+    - name: http
+      level: extended
+      type: object
+      description: >
+        The detailed breakdown of an HTTP request and response.
+
     - name: http.request.method
       level: extended
       type: keyword

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -117,3 +117,41 @@
       description: >
         Network outbound packets. The sum of inbound.packets + outbound.packets
       example: 24
+
+    # Protocol breakdowns
+
+    # HTTP
+    - name: http.request.method
+      level: extended
+      type: keyword
+      description: >
+        Http request method.
+      example: GET, POST, PUT
+
+    - name: http.request.referrer
+      level: extended
+      type: keyword
+      description: >
+        Referrer for this HTTP request.
+      example: https://blog.example.com/
+
+    - name: http.response.status_code
+      level: extended
+      type: long
+      description: >
+        Http response status code.
+      example: 404
+
+    - name: http.response.body
+      level: extended
+      type: keyword
+      description: >
+        The full http response body.
+      example: Hello world
+
+    - name: http.version
+      level: extended
+      type: keyword
+      description: >
+        Http version.
+      example: 1.1

--- a/template.json
+++ b/template.json
@@ -440,7 +440,8 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
-              }
+              },
+              "type": "object"
             },
             "iana_number": {
               "ignore_above": 1024,

--- a/template.json
+++ b/template.json
@@ -411,6 +411,37 @@
             "forwarded_ip": {
               "type": "ip"
             },
+            "http": {
+              "properties": {
+                "request": {
+                  "properties": {
+                    "method": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "referrer": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "response": {
+                  "properties": {
+                    "body": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "status_code": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "iana_number": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
We're considering the idea of nesting protocol breakdowns under `network.`. HTTP is the first one we're incorporating.

Doing so will make it clear where all protocol breakdowns belong, whether or not they are officially in ECS.

If we go this route, we'll likely need to change the documentation format a bit, to be able to link to each protocol breakdown defined in ECS, and also split the yml files to define each protocol breakdown in their own file. Although this work would be done as a separate PR.