### PR TITLE
Re-introduce `http` precisely as it was, as of #d8cece6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `url.full` field. #207
 * Add `process.executable` field. #209
 * Add `process.working_directory` and `process.start`. #215
+* Reintroduce `http`. #237
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ A host is defined as a general computing instance. ECS host.* fields should be p
 
 ## <a name="http"></a> HTTP fields
 
-Fields related to HTTP requests and responses.
+Fields related to HTTP activity.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ ECS defines these fields.
  * [Geo fields](#geo)
  * [Group fields](#group)
  * [Host fields](#host)
+ * [HTTP fields](#http)
  * [Log fields](#log)
  * [Network fields](#network)
  * [Organization fields](#organization)
@@ -276,6 +277,20 @@ A host is defined as a general computing instance. ECS host.* fields should be p
 | <a name="host.mac"></a>host.mac | Host mac address. | core | keyword |  |
 | <a name="host.type"></a>host.type | Type of host.<br/>For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | core | keyword |  |
 | <a name="host.architecture"></a>host.architecture | Operating system architecture. | core | keyword | `x86_64` |
+
+
+## <a name="http"></a> HTTP fields
+
+Fields related to HTTP requests and responses.
+
+
+| Field  | Description  | Level  | Type  | Example  |
+|---|---|---|---|---|
+| <a name="http.request.method"></a>http.request.method | Http request method. | extended | keyword | `GET, POST, PUT` |
+| <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
+| <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
+| <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |
+| <a name="http.version"></a>http.version | Http version. | extended | keyword | `1.1` |
 
 
 ## <a name="log"></a> Log fields

--- a/fields.yml
+++ b/fields.yml
@@ -745,6 +745,49 @@
           description: >
             Operating system architecture.
     
+    - name: http
+      title: HTTP
+      group: 2
+      description: >
+        Fields related to HTTP requests and responses.
+      type: group
+      fields:
+    
+        - name: request.method
+          level: extended
+          type: keyword
+          description: >
+            Http request method.
+          example: GET, POST, PUT
+    
+        - name: request.referrer
+          level: extended
+          type: keyword
+          description: >
+            Referrer for this HTTP request.
+          example: https://blog.example.com/
+    
+        - name: response.status_code
+          level: extended
+          type: long
+          description: >
+            Http response status code.
+          example: 404
+    
+        - name: response.body
+          level: extended
+          type: keyword
+          description: >
+            The full http response body.
+          example: Hello world
+    
+        - name: version
+          level: extended
+          type: keyword
+          description: >
+            Http version.
+          example: 1.1
+    
     - name: log
       title: Log
       description: >

--- a/fields.yml
+++ b/fields.yml
@@ -749,7 +749,7 @@
       title: HTTP
       group: 2
       description: >
-        Fields related to HTTP requests and responses.
+        Fields related to HTTP activity.
       type: group
       fields:
     

--- a/schema.csv
+++ b/schema.csv
@@ -79,6 +79,11 @@ host.ip,ip,core,
 host.mac,keyword,core,
 host.name,keyword,core,
 host.type,keyword,core,
+http.request.method,keyword,extended,"GET, POST, PUT"
+http.request.referrer,keyword,extended,https://blog.example.com/
+http.response.body,keyword,extended,Hello world
+http.response.status_code,long,extended,404
+http.version,keyword,extended,1.1
 log.level,keyword,core,ERR
 log.original,keyword,core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,AIM

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -3,7 +3,7 @@
   title: HTTP
   group: 2
   description: >
-    Fields related to HTTP requests and responses.
+    Fields related to HTTP activity.
   type: group
   fields:
 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -1,0 +1,43 @@
+---
+- name: http
+  title: HTTP
+  group: 2
+  description: >
+    Fields related to HTTP requests and responses.
+  type: group
+  fields:
+
+    - name: request.method
+      level: extended
+      type: keyword
+      description: >
+        Http request method.
+      example: GET, POST, PUT
+
+    - name: request.referrer
+      level: extended
+      type: keyword
+      description: >
+        Referrer for this HTTP request.
+      example: https://blog.example.com/
+
+    - name: response.status_code
+      level: extended
+      type: long
+      description: >
+        Http response status code.
+      example: 404
+
+    - name: response.body
+      level: extended
+      type: keyword
+      description: >
+        The full http response body.
+      example: Hello world
+
+    - name: version
+      level: extended
+      type: keyword
+      description: >
+        Http version.
+      example: 1.1

--- a/template.json
+++ b/template.json
@@ -377,6 +377,37 @@
             }
           }
         },
+        "http": {
+          "properties": {
+            "request": {
+              "properties": {
+                "method": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "referrer": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "response": {
+              "properties": {
+                "body": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "status_code": {
+                  "type": "long"
+                }
+              }
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "labels": {
           "type": "object"
         },

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -16,7 +16,7 @@ ECS fields used in Filebeat for the apache module.
 | [user.name](../README.md#user.name)  | User name in the request. Currently apache.access.user_name | core | keyword | `ruflin` |
 | <a name="http.method"></a>*http.method* | *Http method, currently apache.access.method* | (use case) | keyword | `GET` |
 | <a name="http.url"></a>*http.url* | *Http url, currently apache.access.url* | (use case) | keyword | `http://elastic.co/` |
-| <a name="http.version"></a>*http.version* | *Http version, currently apache.access.http_version* | (use case) | keyword | `1.1` |
+| [http.version](../README.md#http.version)  | Http version, currently apache.access.http_version | extended | keyword | `1.1` |
 | <a name="http.response.code"></a>*http.response.code* | *Http response code, currently apache.access.response_code* | (use case) | keyword | `404` |
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes* | *Http response body bytes sent, currently apache.access.body_sent.bytes* | (use case) | long | `117` |
 | <a name="http.referer"></a>*http.referer* | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard* | (use case) | keyword | `http://elastic.co/` |

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -11,11 +11,11 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 |---|---|---|---|---|
 | [@timestamp](../README.md#@timestamp)  | Time at which the response was sent, and the web server log created. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="http.&ast;"></a>*http.&ast;* | *Fields related to HTTP requests and responses.<br/>* |  |  |  |
-| <a name="http.request.method"></a>*http.request.method* | *Http request method.* | (use case) | keyword | `GET, POST, PUT` |
-| <a name="http.request.referrer"></a>*http.request.referrer* | *Referrer for this HTTP request.* | (use case) | keyword | `https://blog.example.com/` |
-| <a name="http.response.status_code"></a>*http.response.status_code* | *Http response status code.* | (use case) | long | `404` |
-| <a name="http.response.body"></a>*http.response.body* | *The full http response body.* | (use case) | keyword | `Hello world` |
-| <a name="http.version"></a>*http.version* | *Http version.* | (use case) | keyword | `1.1` |
+| [http.request.method](../README.md#http.request.method)  | Http request method. | extended | keyword | `GET, POST, PUT` |
+| [http.request.referrer](../README.md#http.request.referrer)  | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
+| [http.response.status_code](../README.md#http.response.status_code)  | Http response status code. | extended | long | `404` |
+| [http.response.body](../README.md#http.response.body)  | The full http response body. | extended | keyword | `Hello world` |
+| [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
 | <a name="user_agent.original"></a>*user_agent.original* | *Unparsed version of the user_agent.* | (use case) | keyword |  |
 | <a name="user_agent.device"></a>*user_agent.device* | *Name of the physical device.* | (use case) | keyword |  |


### PR DESCRIPTION
The goal of this PR is strictly to re-introduce the \`http\` field set as it was, not to work on enhancements to the field set. Those enhancements belong into separate PRs.

We've decided to leave http at the top level for the inaugural release of ECS.  We are still considering nesting all protocol breakdowns eventually, but this will come at a later date.

This reverts #171