### PR TITLE
Introduce size metrics for HTTP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file based on the
 ## Unreleased
 
 ### Breaking changes
-* Changed `device.*` fields to `observer.*` fields to eliminate user confusion. #238
 
+* Changed `device.*` fields to `observer.*` fields to eliminate user confusion. #238
 * Rename `network.total.bytes` to `network.bytes` and `network.total.packets`
   to `network.packets`. #179
 * Remove `network.inbound.bytes`, `network.inbound.packets`,
@@ -30,6 +30,9 @@ All notable changes to this project will be documented in this file based on the
 * Add `process.executable` field. #209
 * Add `process.working_directory` and `process.start`. #215
 * Reintroduce `http`. #237
+  * Move `http.response.body` to `http.response.body.content`. #239
+  * Add `http.request.body.content`. #239
+  * Add HTTP size metric fields. #239
 * Add `user.full_name` field. #201
 * Add `network.community_id` field. #208
 * Add fields `geo.country_name` and `geo.region_iso_code`. #214

--- a/README.md
+++ b/README.md
@@ -301,12 +301,12 @@ Fields related to HTTP activity.
 | <a name="http.request.method"></a>http.request.method | Http request method.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS"  section. | extended | keyword | `get, post, put` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
-| <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |
+| <a name="http.response.body.content"></a>http.response.body.content | The full http response body. | extended | keyword | `Hello world` |
 | <a name="http.version"></a>http.version | Http version. | extended | keyword | `1.1` |
-| <a name="http.request.bytes.total"></a>http.request.bytes.total | Size in bytes of the request body and headers combined. | extended | long | `1437` |
-| <a name="http.request.bytes.body"></a>http.request.bytes.body | Size in bytes of the request body. | extended | long | `887` |
-| <a name="http.response.bytes.total"></a>http.response.bytes.total | Size in bytes of the response body and headers combined. | extended | long | `1437` |
-| <a name="http.response.bytes.body"></a>http.response.bytes.body | Size in bytes of the response body. | extended | long | `887` |
+| <a name="http.request.bytes"></a>http.request.bytes | Total size in bytes of the request (body and headers). | extended | long | `1437` |
+| <a name="http.request.body.bytes"></a>http.request.body.bytes | Size in bytes of the request body. | extended | long | `887` |
+| <a name="http.response.bytes"></a>http.response.bytes | Total size in bytes of the response (body and headers). | extended | long | `1437` |
+| <a name="http.response.body.bytes"></a>http.response.body.bytes | Size in bytes of the response body. | extended | long | `887` |
 
 
 ## <a name="log"></a> Log fields

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Fields related to HTTP activity.
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="http.request.method"></a>http.request.method | Http request method.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS"  section. | extended | keyword | `get, post, put` |
+| <a name="http.request.body.content"></a>http.request.body.content | The full http request body. | extended | keyword | `Hello world` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
 | <a name="http.response.body.content"></a>http.response.body.content | The full http response body. | extended | keyword | `Hello world` |

--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ Fields related to HTTP activity.
 | <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
 | <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |
 | <a name="http.version"></a>http.version | Http version. | extended | keyword | `1.1` |
+| <a name="http.request.bytes.total"></a>http.request.bytes.total | Size in bytes of the request body and headers combined. | extended | long | `1437` |
+| <a name="http.request.bytes.body"></a>http.request.bytes.body | Size in bytes of the request body. | extended | long | `887` |
+| <a name="http.response.bytes.total"></a>http.response.bytes.total | Size in bytes of the response body and headers combined. | extended | long | `1437` |
+| <a name="http.response.bytes.body"></a>http.response.bytes.body | Size in bytes of the response body. | extended | long | `887` |
 
 
 ## <a name="log"></a> Log fields

--- a/fields.yml
+++ b/fields.yml
@@ -883,7 +883,7 @@
             Http response status code.
           example: 404
     
-        - name: response.body
+        - name: response.body.content
           level: extended
           type: keyword
           description: >
@@ -898,28 +898,28 @@
           example: 1.1
     
         # Metrics
-        - name: request.bytes.total
+        - name: request.bytes
           level: extended
           type: long
           description: >
-            Size in bytes of the request body and headers combined.
+            Total size in bytes of the request (body and headers).
           example: 1437
     
-        - name: request.bytes.body
+        - name: request.body.bytes
           level: extended
           type: long
           description: >
             Size in bytes of the request body.
           example: 887
     
-        - name: response.bytes.total
+        - name: response.bytes
           level: extended
           type: long
           description: >
-            Size in bytes of the response body and headers combined.
+            Total size in bytes of the response (body and headers).
           example: 1437
     
-        - name: response.bytes.body
+        - name: response.body.bytes
           level: extended
           type: long
           description: >

--- a/fields.yml
+++ b/fields.yml
@@ -897,6 +897,36 @@
             Http version.
           example: 1.1
     
+        # Metrics
+        - name: request.bytes.total
+          level: extended
+          type: long
+          description: >
+            Size in bytes of the request body and headers combined.
+          example: 1437
+    
+        - name: request.bytes.body
+          level: extended
+          type: long
+          description: >
+            Size in bytes of the request body.
+          example: 887
+    
+        - name: response.bytes.total
+          level: extended
+          type: long
+          description: >
+            Size in bytes of the response body and headers combined.
+          example: 1437
+    
+        - name: response.bytes.body
+          level: extended
+          type: long
+          description: >
+            Size in bytes of the response body.
+          example: 887
+    
+    
     - name: log
       title: Log
       description: >

--- a/fields.yml
+++ b/fields.yml
@@ -869,6 +869,13 @@
             "Lowercase Capitalization" in the "Implementing ECS"  section.
           example: get, post, put
     
+        - name: request.body.content
+          level: extended
+          type: keyword
+          description: >
+            The full http request body.
+          example: Hello world
+    
         - name: request.referrer
           level: extended
           type: keyword

--- a/schema.csv
+++ b/schema.csv
@@ -88,13 +88,13 @@ host.ip,ip,core,
 host.mac,keyword,core,
 host.name,keyword,core,
 host.type,keyword,core,
-http.request.bytes.body,long,extended,887
-http.request.bytes.total,long,extended,1437
+http.request.body.bytes,long,extended,887
+http.request.bytes,long,extended,1437
 http.request.method,keyword,extended,"get, post, put"
 http.request.referrer,keyword,extended,https://blog.example.com/
-http.response.body,keyword,extended,Hello world
-http.response.bytes.body,long,extended,887
-http.response.bytes.total,long,extended,1437
+http.response.body.bytes,long,extended,887
+http.response.body.content,keyword,extended,Hello world
+http.response.bytes,long,extended,1437
 http.response.status_code,long,extended,404
 http.version,keyword,extended,1.1
 log.level,keyword,core,ERR

--- a/schema.csv
+++ b/schema.csv
@@ -89,6 +89,7 @@ host.mac,keyword,core,
 host.name,keyword,core,
 host.type,keyword,core,
 http.request.body.bytes,long,extended,887
+http.request.body.content,keyword,extended,Hello world
 http.request.bytes,long,extended,1437
 http.request.method,keyword,extended,"get, post, put"
 http.request.referrer,keyword,extended,https://blog.example.com/

--- a/schema.csv
+++ b/schema.csv
@@ -88,9 +88,13 @@ host.ip,ip,core,
 host.mac,keyword,core,
 host.name,keyword,core,
 host.type,keyword,core,
+http.request.bytes.body,long,extended,887
+http.request.bytes.total,long,extended,1437
 http.request.method,keyword,extended,"get, post, put"
 http.request.referrer,keyword,extended,https://blog.example.com/
 http.response.body,keyword,extended,Hello world
+http.response.bytes.body,long,extended,887
+http.response.bytes.total,long,extended,1437
 http.response.status_code,long,extended,404
 http.version,keyword,extended,1.1
 log.level,keyword,core,ERR

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -31,7 +31,7 @@
         Http response status code.
       example: 404
 
-    - name: response.body
+    - name: response.body.content
       level: extended
       type: keyword
       description: >
@@ -46,28 +46,28 @@
       example: 1.1
 
     # Metrics
-    - name: request.bytes.total
+    - name: request.bytes
       level: extended
       type: long
       description: >
-        Size in bytes of the request body and headers combined.
+        Total size in bytes of the request (body and headers).
       example: 1437
 
-    - name: request.bytes.body
+    - name: request.body.bytes
       level: extended
       type: long
       description: >
         Size in bytes of the request body.
       example: 887
 
-    - name: response.bytes.total
+    - name: response.bytes
       level: extended
       type: long
       description: >
-        Size in bytes of the response body and headers combined.
+        Total size in bytes of the response (body and headers).
       example: 1437
 
-    - name: response.bytes.body
+    - name: response.body.bytes
       level: extended
       type: long
       description: >

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -17,6 +17,13 @@
         "Lowercase Capitalization" in the "Implementing ECS"  section.
       example: get, post, put
 
+    - name: request.body.content
+      level: extended
+      type: keyword
+      description: >
+        The full http request body.
+      example: Hello world
+
     - name: request.referrer
       level: extended
       type: keyword

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -44,3 +44,33 @@
       description: >
         Http version.
       example: 1.1
+
+    # Metrics
+    - name: request.bytes.total
+      level: extended
+      type: long
+      description: >
+        Size in bytes of the request body and headers combined.
+      example: 1437
+
+    - name: request.bytes.body
+      level: extended
+      type: long
+      description: >
+        Size in bytes of the request body.
+      example: 887
+
+    - name: response.bytes.total
+      level: extended
+      type: long
+      description: >
+        Size in bytes of the response body and headers combined.
+      example: 1437
+
+    - name: response.bytes.body
+      level: extended
+      type: long
+      description: >
+        Size in bytes of the response body.
+      example: 887
+

--- a/template.json
+++ b/template.json
@@ -412,6 +412,16 @@
           "properties": {
             "request": {
               "properties": {
+                "bytes": {
+                  "properties": {
+                    "body": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    }
+                  }
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -427,6 +437,16 @@
                 "body": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "bytes": {
+                  "properties": {
+                    "body": {
+                      "type": "long"
+                    },
+                    "total": {
+                      "type": "long"
+                    }
+                  }
                 },
                 "status_code": {
                   "type": "long"

--- a/template.json
+++ b/template.json
@@ -416,6 +416,10 @@
                   "properties": {
                     "bytes": {
                       "type": "long"
+                    },
+                    "content": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },

--- a/template.json
+++ b/template.json
@@ -412,15 +412,15 @@
           "properties": {
             "request": {
               "properties": {
-                "bytes": {
+                "body": {
                   "properties": {
-                    "body": {
-                      "type": "long"
-                    },
-                    "total": {
+                    "bytes": {
                       "type": "long"
                     }
                   }
+                },
+                "bytes": {
+                  "type": "long"
                 },
                 "method": {
                   "ignore_above": 1024,
@@ -435,18 +435,18 @@
             "response": {
               "properties": {
                 "body": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "bytes": {
                   "properties": {
-                    "body": {
+                    "bytes": {
                       "type": "long"
                     },
-                    "total": {
-                      "type": "long"
+                    "content": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
+                },
+                "bytes": {
+                  "type": "long"
                 },
                 "status_code": {
                   "type": "long"

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -14,7 +14,7 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 | [http.request.method](../README.md#http.request.method)  | Http request method. | extended | keyword | `GET, POST, PUT` |
 | [http.request.referrer](../README.md#http.request.referrer)  | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | [http.response.status_code](../README.md#http.response.status_code)  | Http response status code. | extended | long | `404` |
-| [http.response.body](../README.md#http.response.body)  | The full http response body. | extended | keyword | `Hello world` |
+| <a name="http.response.body"></a>*http.response.body* | *The full http response body.* | (use case) | keyword | `Hello world` |
 | [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
 | [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -14,7 +14,7 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 | [http.request.method](../README.md#http.request.method)  | Http request method. | extended | keyword | `GET, POST, PUT` |
 | [http.request.referrer](../README.md#http.request.referrer)  | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | [http.response.status_code](../README.md#http.response.status_code)  | Http response status code. | extended | long | `404` |
-| <a name="http.response.body"></a>*http.response.body* | *The full http response body.* | (use case) | keyword | `Hello world` |
+| [http.response.body.content](../README.md#http.response.body.content)  | The full http response body. | extended | keyword | `Hello world` |
 | [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
 | [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |

--- a/use-cases/web-logs.yml
+++ b/use-cases/web-logs.yml
@@ -46,7 +46,7 @@ fields:
         Http response status code.
       example: 404
 
-    - name: response.body
+    - name: response.body.content
       type: keyword
       description: >
         The full http response body.


### PR DESCRIPTION
This PR introduces the concept of metrics for HTTP events. It currently adds only the metrics for body and total (which includes headers). It's missing the obvious third wheel, header sizes. I wouldn't mind adding them if people feel strongly about it, but I haven't seen it come up in the few web server logging directives I've reviewed.

Speaking of which, here are some equivalencies:

- `http.request.bytes.total`: Apache httpd's `%I`, NGINX `$request_length`
- `http.request.bytes.body`: content-length header, NGINX `$content_length`, Traefik `RequestContentSize`
- `http.response.bytes.total`: Apache httpd's `%O`, NGINX `$bytes_sent`
- `http.response.bytes.body`: Apache httpd's `%B`, NGINX `$body_bytes_sent`, Traefik `DownstreamContentSize` (I think)

I do think logging both makes sense, for people who want detailed metrics.

In recent ECS migrations of Beats modules, I've seen a few modules using a `content_length` field. So there's a need for the metrics. However I feel like the term "content_length" comes with a bit too much meaning to start from there and define the other fields.

I'm open to discussing other ways of naming the fields. We could use "size" instead of bytes, or not nest so much (e.g. `.size`, `.body_size` and if we go there, `.header_size`).

- [x] Note that this PR is built on top of #237. It shouldn't be merged before it.