### PR TITLE
State that source and destination are also a pair.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Container fields are used for meta information about the specific container that
 
 ## <a name="destination"></a> Destination fields
 
-Destination fields describe details about the destination of a packet/event.
+Destination fields describe details about the destination of a packet/event. Destination fields are usually populated in conjuction with source fields.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -404,7 +404,7 @@ The service fields describe the service for or from which the data was collected
 
 ## <a name="source"></a> Source fields
 
-Source fields describe details about the source of a packet/event.
+Source fields describe details about the source of a packet/event. Source fields are usually populated in conjuction with destination fields.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/fields.yml
+++ b/fields.yml
@@ -239,7 +239,7 @@
       group: 2
       description: >
         Destination fields describe details about the destination of a
-        packet/event.
+        packet/event. Destination fields are usually populated in conjuction with source fields.
       type: group
       fields:
     
@@ -1222,7 +1222,7 @@
       group: 2
       description: >
         Source fields describe details about the source of a
-        packet/event.
+        packet/event. Source fields are usually populated in conjuction with destination fields.
       type: group
       fields:
     

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -4,7 +4,7 @@
   group: 2
   description: >
     Destination fields describe details about the destination of a
-    packet/event.
+    packet/event. Destination fields are usually populated in conjuction with source fields.
   type: group
   fields:
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -4,7 +4,7 @@
   group: 2
   description: >
     Source fields describe details about the source of a
-    packet/event.
+    packet/event. Source fields are usually populated in conjuction with destination fields.
   type: group
   fields:
 


### PR DESCRIPTION
Just like client and server (#236).

I actually think the phrasing for these pairs should be more forceful. I would replace "usually populated in conjunction" with "must be populated in conjunction".

We'll already have to manage two pairs of endpoint names instead of one. A lot of content will be affected by this. The last thing I would want is to actually have to deal with even more of them: source-server, client-destination, server-destination ;-)