### PR TITLE
`http.request.method` must be lowercase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable changes to this project will be documented in this file based on the
 * Improved the definitions for `event.category` and `event.action`. #242
 * Clarify the semantics of `network.direction`. #212
 * Add `source.bytes`, `source.packets`, `destination.bytes` and `destination.packets`. #179
+* Clarify that `http.request.method` must be lowercase. #245
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Fields related to HTTP activity.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="http.request.method"></a>http.request.method | Http request method. The field value must be capitalized. | extended | keyword | `GET, POST, PUT` |
+| <a name="http.request.method"></a>http.request.method | Http request method.<br/>The field value must be lowercase. | extended | keyword | `GET, POST, PUT` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
 | <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Fields related to HTTP activity.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="http.request.method"></a>http.request.method | Http request method. | extended | keyword | `GET, POST, PUT` |
+| <a name="http.request.method"></a>http.request.method | Http request method. The field value must be capitalized. | extended | keyword | `GET, POST, PUT` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
 | <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |

--- a/fields.yml
+++ b/fields.yml
@@ -818,7 +818,7 @@
           level: extended
           type: keyword
           description: >
-            Http request method.
+            Http request method. The field value must be capitalized.
           example: GET, POST, PUT
     
         - name: request.referrer

--- a/fields.yml
+++ b/fields.yml
@@ -818,7 +818,9 @@
           level: extended
           type: keyword
           description: >
-            Http request method. The field value must be capitalized.
+            Http request method.
+    
+            The field value must be lowercase.
           example: GET, POST, PUT
     
         - name: request.referrer

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -11,7 +11,9 @@
       level: extended
       type: keyword
       description: >
-        Http request method. The field value must be capitalized.
+        Http request method.
+
+        The field value must be lowercase.
       example: GET, POST, PUT
 
     - name: request.referrer

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -11,7 +11,7 @@
       level: extended
       type: keyword
       description: >
-        Http request method.
+        Http request method. The field value must be capitalized.
       example: GET, POST, PUT
 
     - name: request.referrer


### PR DESCRIPTION
Without this, aggregation results will list the same method multiple times, when there's capitalization differences ('get' vs 'GET').