### PR TITLE
Improve user_agent examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,10 +497,10 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.original"></a>user_agent.original | Unparsed version of the user_agent. | extended | keyword |  |
-| <a name="user_agent.name"></a>user_agent.name | Name of the user agent. | extended | keyword | `Chrome` |
-| <a name="user_agent.version"></a>user_agent.version | Version of the user agent. | extended | keyword |  |
-| <a name="user_agent.device.name"></a>user_agent.device.name | Name of the device. | extended | keyword | `Chrome` |
+| <a name="user_agent.original"></a>user_agent.original | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
+| <a name="user_agent.name"></a>user_agent.name | Name of the user agent. | extended | keyword | `Safari` |
+| <a name="user_agent.version"></a>user_agent.version | Version of the user agent. | extended | keyword | `12.0` |
+| <a name="user_agent.device.name"></a>user_agent.device.name | Name of the device. | extended | keyword | `iPhone` |
 
 
 

--- a/fields.yml
+++ b/fields.yml
@@ -1565,11 +1565,12 @@
           index: false
           description: >
             Unparsed version of the user_agent.
+          example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
     
         - name: name
           level: extended
           type: keyword
-          example: Chrome
+          example: Safari
           description: >
             Name of the user agent.
         - name: version
@@ -1577,10 +1578,11 @@
           type: keyword
           description: >
             Version of the user agent.
+          example: 12.0
     
         - name: device.name
           level: extended
           type: keyword
-          example: Chrome
+          example: iPhone
           description: >
             Name of the device.

--- a/schema.csv
+++ b/schema.csv
@@ -162,7 +162,7 @@ user.group,keyword,extended,
 user.hash,keyword,extended,
 user.id,keyword,core,
 user.name,keyword,core,albert
-user_agent.device.name,keyword,extended,Chrome
-user_agent.name,keyword,extended,Chrome
-user_agent.original,keyword,extended,
-user_agent.version,keyword,extended,
+user_agent.device.name,keyword,extended,iPhone
+user_agent.name,keyword,extended,Safari
+user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
+user_agent.version,keyword,extended,12.0

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -14,11 +14,12 @@
       index: false
       description: >
         Unparsed version of the user_agent.
+      example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
 
     - name: name
       level: extended
       type: keyword
-      example: Chrome
+      example: Safari
       description: >
         Name of the user agent.
     - name: version
@@ -26,10 +27,11 @@
       type: keyword
       description: >
         Version of the user agent.
+      example: 12.0
 
     - name: device.name
       level: extended
       type: keyword
-      example: Chrome
+      example: iPhone
       description: >
         Name of the device.

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -17,9 +17,9 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 | [http.response.body](../README.md#http.response.body)  | The full http response body. | extended | keyword | `Hello world` |
 | [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
-| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword |  |
+| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
 | <a name="user_agent.device"></a>*user_agent.device* | *Name of the physical device.* | (use case) | keyword |  |
-| [user_agent.version](../README.md#user_agent.version)  | Version of the physical device. | extended | keyword |  |
+| [user_agent.version](../README.md#user_agent.version)  | Version of the physical device. | extended | keyword | `12.0` |
 | <a name="user_agent.major"></a>*user_agent.major* | *Major version of the user agent.* | (use case) | long |  |
 | <a name="user_agent.minor"></a>*user_agent.minor* | *Minor version of the user agent.* | (use case) | long |  |
 | <a name="user_agent.patch"></a>*user_agent.patch* | *Patch version of the user agent.* | (use case) | keyword |  |


### PR DESCRIPTION
Had one incorrect example (device.name: Chrome), so I decided to flesh out all
of the examples for UA.