### PR TITLE
Add `os.full`, to allow capturing full OS name string, including version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `event.timezone` to allow for proper interpretation of incomplete timestamps. #258
 * Add fields `source.address`, `destination.address`, `client.address`, and
   `server.address`. #247
+* Add `os.full_name` to capture OS name including version. #259
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ All notable changes to this project will be documented in this file based on the
 * Add `event.timezone` to allow for proper interpretation of incomplete timestamps. #258
 * Add fields `source.address`, `destination.address`, `client.address`, and
   `server.address`. #247
-* Add `os.full_name` to capture OS name including version. #259
+* Add `os.full` to capture full OS name, including version. #259
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/README.md
+++ b/README.md
@@ -380,7 +380,8 @@ Note also that the `os` fields are not expected to be used directly at the top l
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="os.platform"></a>os.platform | Operating system platform (such centos, ubuntu, windows). | extended | keyword | `darwin` |
-| <a name="os.name"></a>os.name | Operating system name. | extended | keyword | `Mac OS X` |
+| <a name="os.name"></a>os.name | Operating system name, without the version. | extended | keyword | `Mac OS X` |
+| <a name="os.full_name"></a>os.full_name | Operating system name, including the version. | extended | keyword | `Mac OS X 10.15.1` |
 | <a name="os.family"></a>os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` |
 | <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.12.6-rc2` |
 | <a name="os.kernel"></a>os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` |

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Note also that the `os` fields are not expected to be used directly at the top l
 | <a name="os.name"></a>os.name | Operating system name, without the version. | extended | keyword | `Mac OS X` |
 | <a name="os.full"></a>os.full | Operating system name, including the version. | extended | keyword | `Mac OS X 10.15.1` |
 | <a name="os.family"></a>os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` |
-| <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.12.6-rc2` |
+| <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.15.1` |
 | <a name="os.kernel"></a>os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` |
 
 

--- a/README.md
+++ b/README.md
@@ -381,9 +381,9 @@ Note also that the `os` fields are not expected to be used directly at the top l
 |---|---|---|---|---|
 | <a name="os.platform"></a>os.platform | Operating system platform (such centos, ubuntu, windows). | extended | keyword | `darwin` |
 | <a name="os.name"></a>os.name | Operating system name, without the version. | extended | keyword | `Mac OS X` |
-| <a name="os.full"></a>os.full | Operating system name, including the version. | extended | keyword | `Mac OS X 10.15.1` |
+| <a name="os.full"></a>os.full | Operating system name, including the version or code name. | extended | keyword | `Mac OS Mojave` |
 | <a name="os.family"></a>os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` |
-| <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.15.1` |
+| <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.14.1` |
 | <a name="os.kernel"></a>os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` |
 
 

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Note also that the `os` fields are not expected to be used directly at the top l
 |---|---|---|---|---|
 | <a name="os.platform"></a>os.platform | Operating system platform (such centos, ubuntu, windows). | extended | keyword | `darwin` |
 | <a name="os.name"></a>os.name | Operating system name, without the version. | extended | keyword | `Mac OS X` |
-| <a name="os.full_name"></a>os.full_name | Operating system name, including the version. | extended | keyword | `Mac OS X 10.15.1` |
+| <a name="os.full"></a>os.full | Operating system name, including the version. | extended | keyword | `Mac OS X 10.15.1` |
 | <a name="os.family"></a>os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` |
 | <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.12.6-rc2` |
 | <a name="os.kernel"></a>os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` |

--- a/fields.yml
+++ b/fields.yml
@@ -1208,7 +1208,7 @@
         - name: version
           level: extended
           type: keyword
-          example: "10.12.6-rc2"
+          example: "10.15.1"
           description: >
             Operating system version as a raw string.
     

--- a/fields.yml
+++ b/fields.yml
@@ -1191,7 +1191,7 @@
           description: >
             Operating system name, without the version.
     
-        - name: full_name
+        - name: full
           level: extended
           type: keyword
           example: "Mac OS X 10.15.1"

--- a/fields.yml
+++ b/fields.yml
@@ -1189,7 +1189,14 @@
           type: keyword
           example: "Mac OS X"
           description: >
-            Operating system name.
+            Operating system name, without the version.
+    
+        - name: full_name
+          level: extended
+          type: keyword
+          example: "Mac OS X 10.15.1"
+          description: >
+            Operating system name, including the version.
     
         - name: family
           level: extended

--- a/fields.yml
+++ b/fields.yml
@@ -1194,9 +1194,9 @@
         - name: full
           level: extended
           type: keyword
-          example: "Mac OS X 10.15.1"
+          example: "Mac OS Mojave"
           description: >
-            Operating system name, including the version.
+            Operating system name, including the version or code name.
     
         - name: family
           level: extended
@@ -1208,7 +1208,7 @@
         - name: version
           level: extended
           type: keyword
-          example: "10.15.1"
+          example: "10.14.1"
           description: >
             Operating system version as a raw string.
     

--- a/schema.csv
+++ b/schema.csv
@@ -121,7 +121,7 @@ observer.version,keyword,core,
 organization.id,keyword,extended,
 organization.name,keyword,extended,
 os.family,keyword,extended,debian
-os.full_name,keyword,extended,Mac OS X 10.15.1
+os.full,keyword,extended,Mac OS X 10.15.1
 os.kernel,keyword,extended,4.4.0-112-generic
 os.name,keyword,extended,Mac OS X
 os.platform,keyword,extended,darwin

--- a/schema.csv
+++ b/schema.csv
@@ -121,11 +121,11 @@ observer.version,keyword,core,
 organization.id,keyword,extended,
 organization.name,keyword,extended,
 os.family,keyword,extended,debian
-os.full,keyword,extended,Mac OS X 10.15.1
+os.full,keyword,extended,Mac OS Mojave
 os.kernel,keyword,extended,4.4.0-112-generic
 os.name,keyword,extended,Mac OS X
 os.platform,keyword,extended,darwin
-os.version,keyword,extended,10.15.1
+os.version,keyword,extended,10.14.1
 process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']"
 process.executable,keyword,extended,/usr/bin/ssh
 process.name,keyword,extended,ssh

--- a/schema.csv
+++ b/schema.csv
@@ -121,6 +121,7 @@ observer.version,keyword,core,
 organization.id,keyword,extended,
 organization.name,keyword,extended,
 os.family,keyword,extended,debian
+os.full_name,keyword,extended,Mac OS X 10.15.1
 os.kernel,keyword,extended,4.4.0-112-generic
 os.name,keyword,extended,Mac OS X
 os.platform,keyword,extended,darwin

--- a/schema.csv
+++ b/schema.csv
@@ -125,7 +125,7 @@ os.full,keyword,extended,Mac OS X 10.15.1
 os.kernel,keyword,extended,4.4.0-112-generic
 os.name,keyword,extended,Mac OS X
 os.platform,keyword,extended,darwin
-os.version,keyword,extended,10.12.6-rc2
+os.version,keyword,extended,10.15.1
 process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']"
 process.executable,keyword,extended,/usr/bin/ssh
 process.name,keyword,extended,ssh

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -43,7 +43,7 @@
     - name: version
       level: extended
       type: keyword
-      example: "10.12.6-rc2"
+      example: "10.15.1"
       description: >
         Operating system version as a raw string.
 

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -29,9 +29,9 @@
     - name: full
       level: extended
       type: keyword
-      example: "Mac OS X 10.15.1"
+      example: "Mac OS Mojave"
       description: >
-        Operating system name, including the version.
+        Operating system name, including the version or code name.
 
     - name: family
       level: extended
@@ -43,7 +43,7 @@
     - name: version
       level: extended
       type: keyword
-      example: "10.15.1"
+      example: "10.14.1"
       description: >
         Operating system version as a raw string.
 

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -24,7 +24,14 @@
       type: keyword
       example: "Mac OS X"
       description: >
-        Operating system name.
+        Operating system name, without the version.
+
+    - name: full_name
+      level: extended
+      type: keyword
+      example: "Mac OS X 10.15.1"
+      description: >
+        Operating system name, including the version.
 
     - name: family
       level: extended

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -26,7 +26,7 @@
       description: >
         Operating system name, without the version.
 
-    - name: full_name
+    - name: full
       level: extended
       type: keyword
       example: "Mac OS X 10.15.1"

--- a/template.json
+++ b/template.json
@@ -578,6 +578,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "full_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "kernel": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/template.json
+++ b/template.json
@@ -578,7 +578,7 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "full_name": {
+            "full": {
               "ignore_above": 1024,
               "type": "keyword"
             },


### PR DESCRIPTION
I think having a field with the full OS name (including version) is a useful concept, in addition to the broken up `name` + `version` fields. It makes some types of analysis much simpler.

I was inspired to add this when I realized that our user agent parser gives us such a string, and ECS doesn't have a home for it.