### PR TITLE
Adds a script that generates a JSON representation of the ECS schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ check-license-headers:
 # Clean deletes all temporary and generated content.
 .PHONY: clean
 clean:
-	rm -rf schema.csv schema.md fields.yml build
+	rm -rf schema.csv schema.md schema.json fields.yml build
 	# Clean all markdown files for use-cases
 	find ./use-cases -type f -name '*.md' -not -name 'README.md' -print0 | xargs -0 rm --
 

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,2015 @@
+{
+  "agent": {
+    "description": "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.\n", 
+    "fields": {
+      "agent.ephemeral_id": {
+        "description": "Ephemeral identifier of this agent (if one exists).\nThis id normally changes across restarts, but `agent.id` does not.", 
+        "example": "8a4f500f", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "agent.ephemeral_id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "agent.id": {
+        "description": "Unique identifier of this agent (if one exists).\nExample: For Beats this would be beat.id.", 
+        "example": "8a4f500d", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "agent.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "agent.name": {
+        "description": "Name of the agent.\nThis is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.\nIf no name is given, the name is often left empty.", 
+        "example": "foo", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "agent.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "agent.type": {
+        "description": "Type of the agent.\nThe agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine.", 
+        "example": "filebeat", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "agent.type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "agent.version": {
+        "description": "Version of the agent.", 
+        "example": "6.0.0-rc2", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "agent.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "agent", 
+    "title": "Agent", 
+    "type": "group"
+  }, 
+  "base": {
+    "description": "The base set contains all fields which are on the top level. These fields are common across all types of events.\n", 
+    "fields": {
+      "@timestamp": {
+        "description": "Date/time when the event originated.\nFor log events this is the date/time when the event was generated, and not when it was read.\nRequired field for all events.", 
+        "example": "2016-05-23T08:05:34.853Z", 
+        "footnote": "", 
+        "group": 1, 
+        "level": "core", 
+        "name": "@timestamp", 
+        "required": true, 
+        "type": "date"
+      }, 
+      "labels": {
+        "description": "Key/value pairs.\nCan be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.\nExample: `docker` and `k8s` labels.", 
+        "example": "{'application': 'foo-bar', 'env': 'production'}", 
+        "footnote": "", 
+        "group": 1, 
+        "level": "core", 
+        "name": "labels", 
+        "required": false, 
+        "type": "object"
+      }, 
+      "message": {
+        "description": "For log events the message field contains the log message.\nIn other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message.", 
+        "example": "Hello World", 
+        "footnote": "", 
+        "group": 1, 
+        "level": "core", 
+        "name": "message", 
+        "required": false, 
+        "type": "text"
+      }, 
+      "tags": {
+        "description": "List of keywords used to tag each event.", 
+        "example": "[\"production\", \"env2\"]", 
+        "footnote": "", 
+        "group": 1, 
+        "level": "core", 
+        "name": "tags", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 1, 
+    "name": "base", 
+    "title": "Base", 
+    "type": "group"
+  }, 
+  "client": {
+    "description": "A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term \"originator\" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
+    "fields": {
+      "client.address": {
+        "description": "Some event client addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "client.address", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "client.bytes": {
+        "description": "Bytes sent from the client to the server.", 
+        "example": "184", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "client.domain": {
+        "description": "Client domain.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "client.ip": {
+        "description": "IP address of the client.\nCan be one or multiple IPv4 or IPv6 addresses.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "client.mac": {
+        "description": "MAC address of the client.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "client.packets": {
+        "description": "Packets sent from the client to the server.", 
+        "example": "12", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.packets", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "client.port": {
+        "description": "Port of the client.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "client.port", 
+        "required": false, 
+        "type": "long"
+      }
+    }, 
+    "group": 2, 
+    "name": "client", 
+    "title": "Client", 
+    "type": "group"
+  }, 
+  "cloud": {
+    "description": "Fields related to the cloud or infrastructure the events are coming from.\n", 
+    "fields": {
+      "cloud.account.id": {
+        "description": "The cloud account or organization id used to identify different entities in a multi-tenant environment.\nExamples: AWS account id, Google Cloud ORG Id, or other unique identifier.", 
+        "example": "666777888999", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.account.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.availability_zone": {
+        "description": "Availability zone in which this host is running.", 
+        "example": "us-east-1c", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.availability_zone", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.instance.id": {
+        "description": "Instance ID of the host machine.", 
+        "example": "i-1234567890abcdef0", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.instance.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.instance.name": {
+        "description": "Instance name of the host machine.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.instance.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.machine.type": {
+        "description": "Machine type of the host machine.", 
+        "example": "t2.medium", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.machine.type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.provider": {
+        "description": "Name of the cloud provider. Example values are ec2, gce, or digitalocean.", 
+        "example": "ec2", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.provider", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "cloud.region": {
+        "description": "Region in which this host is running.", 
+        "example": "us-east-1", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "cloud.region", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "cloud", 
+    "title": "Cloud", 
+    "type": "group"
+  }, 
+  "container": {
+    "description": "Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.\n", 
+    "fields": {
+      "container.id": {
+        "description": "Unique container id.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "container.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "container.image.name": {
+        "description": "Name of the image the container was built on.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "container.image.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "container.image.tag": {
+        "description": "Container image tag.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "container.image.tag", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "container.labels": {
+        "description": "Image labels.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "container.labels", 
+        "required": false, 
+        "type": "object"
+      }, 
+      "container.name": {
+        "description": "Container name.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "container.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "container.runtime": {
+        "description": "Runtime managing this container.", 
+        "example": "docker", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "container.runtime", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "container", 
+    "title": "Container", 
+    "type": "group"
+  }, 
+  "destination": {
+    "description": "Destination fields describe details about the destination of a packet/event. Destination fields are usually populated in conjunction with source fields.\n", 
+    "fields": {
+      "destination.address": {
+        "description": "Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "destination.address", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "destination.bytes": {
+        "description": "Bytes sent from the destination to the source.", 
+        "example": "184", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "destination.domain": {
+        "description": "Destination domain.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "destination.ip": {
+        "description": "IP address of the destination.\nCan be one or multiple IPv4 or IPv6 addresses.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "destination.mac": {
+        "description": "MAC address of the destination.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "destination.packets": {
+        "description": "Packets sent from the destination to the source.", 
+        "example": "12", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.packets", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "destination.port": {
+        "description": "Port of the destination.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "destination.port", 
+        "required": false, 
+        "type": "long"
+      }
+    }, 
+    "group": 2, 
+    "name": "destination", 
+    "title": "Destination", 
+    "type": "group"
+  }, 
+  "ecs": {
+    "description": "Meta-information specific to ECS.\n", 
+    "fields": {
+      "ecs.version": {
+        "description": "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.\nThe current version is 1.0.0-beta2 .", 
+        "example": "1.0.0-beta2", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "ecs.version", 
+        "required": true, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "ecs", 
+    "title": "ECS", 
+    "type": "group"
+  }, 
+  "error": {
+    "description": "These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error.\n", 
+    "fields": {
+      "error.code": {
+        "description": "Error code describing the error.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "error.code", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "error.id": {
+        "description": "Unique identifier for the error.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "error.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "error.message": {
+        "description": "Error message.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "error.message", 
+        "required": false, 
+        "type": "text"
+      }
+    }, 
+    "group": 2, 
+    "name": "error", 
+    "title": "Error", 
+    "type": "group"
+  }, 
+  "event": {
+    "description": "The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.\n", 
+    "fields": {
+      "event.action": {
+        "description": "The action captured by the event.\nThis describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer.", 
+        "example": "user-password-change", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.action", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.category": {
+        "description": "Event category.\nThis contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution.", 
+        "example": "user-management", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.category", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.created": {
+        "description": "event.created contains the date when the event was created.\nThis timestamp is distinct from @timestamp in that @timestamp contains the processed timestamp. For logs these two timestamps can be different as the timestamp in the log line and when the event is read for example by Filebeat are not identical. `@timestamp` must contain the timestamp extracted from the log line, event.created when the log line is read. The same could apply to package capturing where @timestamp contains the timestamp extracted from the network package and event.created when the event was created.\nIn case the two timestamps are identical, @timestamp should be used.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.created", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "event.dataset": {
+        "description": "Name of the dataset.\nThe concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name.", 
+        "example": "stats", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.dataset", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.duration": {
+        "description": "Duration of the event in nanoseconds.\nIf event.start and event.end are known this value should be the difference between the end and start time.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.duration", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "event.end": {
+        "description": "event.end contains the date when the event ended or when the activity was last observed.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.end", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "event.hash": {
+        "description": "Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.", 
+        "example": "123456789012345678901234567890ABCD", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.hash", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.id": {
+        "description": "Unique ID to describe the event.", 
+        "example": "8a4f500d", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.kind": {
+        "description": "The kind of the event.\nThis gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution.", 
+        "example": "state", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.kind", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.module": {
+        "description": "Name of the module this data is coming from.\nThis information is coming from the modules used in Beats or Logstash.", 
+        "example": "mysql", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.module", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.original": {
+        "description": "Raw text message of entire event. Used to demonstrate log integrity.\nThis field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`.", 
+        "example": "Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.original", 
+        "required": false, 
+        "type": "(not indexed)"
+      }, 
+      "event.outcome": {
+        "description": "The outcome of the event.\nIf the event describes an action, this fields contains the outcome of that action. Examples outcomes are `success` and `failure`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution.", 
+        "example": "success", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.outcome", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.risk_score": {
+        "description": "Risk score or priority of the event (e.g. security solutions). Use your system's original value here.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.risk_score", 
+        "required": false, 
+        "type": "float"
+      }, 
+      "event.risk_score_norm": {
+        "description": "Normalized risk score or priority of the event, on a scale of 0 to 100.\nThis is mainly useful if you use more than one system that assigns risk scores, and you want to see a normalized value across all systems.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.risk_score_norm", 
+        "required": false, 
+        "type": "float"
+      }, 
+      "event.severity": {
+        "description": "Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.", 
+        "example": "7", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.severity", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "event.start": {
+        "description": "event.start contains the date when the event started or when the activity was first observed.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.start", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "event.timezone": {
+        "description": "This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise.\nAcceptable timezone formats are: a canonical ID (e.g. \"Europe/Amsterdam\"), abbreviated (e.g. \"EST\") or an HH:mm differential (e.g. \"-05:00\").", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "event.timezone", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "event.type": {
+        "description": "Reserved for future usage.\nPlease avoid using this field for user data.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.type", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "event", 
+    "title": "Event", 
+    "type": "group"
+  }, 
+  "file": {
+    "description": "A file is defined as a set of information that has been created on, or has existed on a filesystem. File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.\n", 
+    "fields": {
+      "file.ctime": {
+        "description": "Last time file metadata changed.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.ctime", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "file.device": {
+        "description": "Device that is the source of the file.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.device", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.extension": {
+        "description": "File extension.\nThis should allow easy filtering by file extensions.", 
+        "example": "png", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.extension", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.gid": {
+        "description": "Primary group ID (GID) of the file.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.gid", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.group": {
+        "description": "Primary group name of the file.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.group", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.inode": {
+        "description": "Inode representing the file in the filesystem.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.inode", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.mode": {
+        "description": "Mode of the file in octal representation.", 
+        "example": "416", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.mode", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.mtime": {
+        "description": "Last time file content was modified.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.mtime", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "file.owner": {
+        "description": "File owner's username.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.owner", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.path": {
+        "description": "Path to the file.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.path", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.size": {
+        "description": "File size in bytes (field is only added when `type` is `file`).", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.size", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "file.target_path": {
+        "description": "Target path for symlinks.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.target_path", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.type": {
+        "description": "File type (file, dir, or symlink).", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "file.uid": {
+        "description": "The user ID (UID) or security identifier (SID) of the file owner.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "file.uid", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "file", 
+    "title": "File", 
+    "type": "group"
+  }, 
+  "geo": {
+    "description": "Geo fields can carry data about a specific location related to an event or geo information derived from an IP field.\n", 
+    "fields": {
+      "geo.city_name": {
+        "description": "City name.", 
+        "example": "Montreal", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.city_name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.continent_name": {
+        "description": "Name of the continent.", 
+        "example": "North America", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.continent_name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.country_iso_code": {
+        "description": "Country ISO code.", 
+        "example": "CA", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.country_iso_code", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.country_name": {
+        "description": "Country name.", 
+        "example": "Canada", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.country_name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.location": {
+        "description": "Longitude and latitude.", 
+        "example": "{ \"lon\": -73.614830, \"lat\": 45.505918 }", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.location", 
+        "required": false, 
+        "type": "geo_point"
+      }, 
+      "geo.name": {
+        "description": "User-defined description of a location, at the level of granularity they care about.\nCould be the name of their data centers, the floor number, if this describes a local physical entity, city names.\nNot typically used in automated geolocation.", 
+        "example": "boston-dc", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "geo.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.region_iso_code": {
+        "description": "Region ISO code.", 
+        "example": "CA-QC", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.region_iso_code", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "geo.region_name": {
+        "description": "Region name.", 
+        "example": "Quebec", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "geo.region_name", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "geo", 
+    "title": "Geo", 
+    "type": "group"
+  }, 
+  "group": {
+    "description": "The group fields are meant to represent groups that are relevant to the event.\n", 
+    "fields": {
+      "group.id": {
+        "description": "Unique identifier for the group on the system/platform.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "group.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "group.name": {
+        "description": "Name of the group.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "group.name", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "group", 
+    "title": "Group", 
+    "type": "group"
+  }, 
+  "host": {
+    "description": "A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or on which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.\n", 
+    "fields": {
+      "host.architecture": {
+        "description": "Operating system architecture.", 
+        "example": "x86_64", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.architecture", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "host.hostname": {
+        "description": "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.hostname", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "host.id": {
+        "description": "Unique host id.\nAs hostname is not always unique, use values that are meaningful in your environment.\nExample: The current usage of `beat.name`.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "host.ip": {
+        "description": "Host ip address.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "host.mac": {
+        "description": "Host mac address.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "host.name": {
+        "description": "Name of the host.\nIt can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "host.type": {
+        "description": "Type of host.\nFor Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "host.type", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "host", 
+    "title": "Host", 
+    "type": "group"
+  }, 
+  "http": {
+    "description": "Fields related to HTTP activity.\n", 
+    "fields": {
+      "http.request.body.bytes": {
+        "description": "Size in bytes of the request body.", 
+        "example": "887", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.body.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "http.request.body.content": {
+        "description": "The full http request body.", 
+        "example": "Hello world", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.body.content", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "http.request.bytes": {
+        "description": "Total size in bytes of the request (body and headers).", 
+        "example": "1437", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "http.request.method": {
+        "description": "Http request method.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\"  section.", 
+        "example": "get, post, put", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.method", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "http.request.referrer": {
+        "description": "Referrer for this HTTP request.", 
+        "example": "https://blog.example.com/", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.referrer", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "http.response.body.bytes": {
+        "description": "Size in bytes of the response body.", 
+        "example": "887", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.response.body.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "http.response.body.content": {
+        "description": "The full http response body.", 
+        "example": "Hello world", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.response.body.content", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "http.response.bytes": {
+        "description": "Total size in bytes of the response (body and headers).", 
+        "example": "1437", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.response.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "http.response.status_code": {
+        "description": "Http response status code.", 
+        "example": "404", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.response.status_code", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "http.version": {
+        "description": "Http version.", 
+        "example": "1.1", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "http", 
+    "title": "HTTP", 
+    "type": "group"
+  }, 
+  "log": {
+    "description": "Fields which are specific to log events.\n", 
+    "fields": {
+      "log.level": {
+        "description": "Log level of the log event.\nSome examples are `WARN`, `ERR`, `INFO`.", 
+        "example": "ERR", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "log.level", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "log.original": {
+        "description": "This is the original log message and contains the full log message before splitting it up in multiple parts.\nIn contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.\nThis field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.", 
+        "example": "Sep 19 08:26:10 localhost My log", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "log.original", 
+        "required": false, 
+        "type": "(not indexed)"
+      }
+    }, 
+    "group": 2, 
+    "name": "log", 
+    "title": "Log", 
+    "type": "group"
+  }, 
+  "network": {
+    "description": "The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.\n", 
+    "fields": {
+      "network.application": {
+        "description": "A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
+        "example": "aim", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "network.application", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.bytes": {
+        "description": "Total bytes transferred in both directions.\nIf `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.", 
+        "example": "368", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "network.community_id": {
+        "description": "A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.\nLearn more at https://github.com/corelight/community-id-spec.", 
+        "example": "1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "network.community_id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.direction": {
+        "description": "Direction of the network traffic.\nRecommended values are:\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\nWhen mapping events from a host-based monitoring context, populate this field from the host's point of view.\nWhen mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter.", 
+        "example": "inbound", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.direction", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.forwarded_ip": {
+        "description": "Host IP address when the source IP address is the proxy.", 
+        "example": "192.1.1.2", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.forwarded_ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "network.iana_number": {
+        "description": "IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number.", 
+        "example": "6", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "network.iana_number", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.name": {
+        "description": "Name given by operators to sections of their network.", 
+        "example": "Guest Wifi", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "network.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.packets": {
+        "description": "Total packets transferred in both directions.\nIf `source.packets` and `destination.packets` are known, `network.packets` is their sum.", 
+        "example": "24", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.packets", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "network.protocol": {
+        "description": "L7 Network protocol name. ex. http, lumberjack, transport protocol.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
+        "example": "http", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.protocol", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.transport": {
+        "description": "Same as network.iana_number, but instead using the Keyword name of the transport layer (udp, tcp, ipv6-icmp, etc.)\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\"  section.", 
+        "example": "tcp", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.transport", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "network.type": {
+        "description": "In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
+        "example": "ipv4", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "network.type", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "network", 
+    "title": "Network", 
+    "type": "group"
+  }, 
+  "observer": {
+    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.  \n", 
+    "fields": {
+      "observer.hostname": {
+        "description": "Hostname of the observer.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.hostname", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.ip": {
+        "description": "IP address of the observer.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "observer.mac": {
+        "description": "MAC address of the observer", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.serial_number": {
+        "description": "Observer serial number.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "observer.serial_number", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.type": {
+        "description": "The type of the observer the data is coming from.\nThere is no predefined list of observer types. Some examples are `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`.", 
+        "example": "firewall", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.vendor": {
+        "description": "observer vendor information.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.vendor", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.version": {
+        "description": "Observer version.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "observer", 
+    "title": "Observer", 
+    "type": "group"
+  }, 
+  "organization": {
+    "description": "The organization fields enrich data with information about the company or entity the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple organizations.\n", 
+    "fields": {
+      "organization.id": {
+        "description": "Unique identifier for the organization.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "organization.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "organization.name": {
+        "description": "Organization name.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "organization.name", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "organization", 
+    "title": "Organization", 
+    "type": "group"
+  }, 
+  "os": {
+    "description": "The OS fields contain information about the operating system.\n", 
+    "fields": {
+      "os.family": {
+        "description": "OS family (such as redhat, debian, freebsd, windows).", 
+        "example": "debian", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.family", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "os.full": {
+        "description": "Operating system name, including the version or code name.", 
+        "example": "Mac OS Mojave", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.full", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "os.kernel": {
+        "description": "Operating system kernel version as a raw string.", 
+        "example": "4.4.0-112-generic", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.kernel", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "os.name": {
+        "description": "Operating system name, without the version.", 
+        "example": "Mac OS X", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "os.platform": {
+        "description": "Operating system platform (such centos, ubuntu, windows).", 
+        "example": "darwin", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.platform", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "os.version": {
+        "description": "Operating system version as a raw string.", 
+        "example": "10.14.1", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "os.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "os", 
+    "title": "Operating System", 
+    "type": "group"
+  }, 
+  "process": {
+    "description": "These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.\n", 
+    "fields": {
+      "process.args": {
+        "description": "Process arguments.\nMay be filtered to protect sensitive information.", 
+        "example": "['ssh', '-l', 'user', '10.0.0.16']", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.args", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.executable": {
+        "description": "Absolute path to the process executable.", 
+        "example": "/usr/bin/ssh", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.executable", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.name": {
+        "description": "Process name.\nSometimes called program name or similar.", 
+        "example": "ssh", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.pid": {
+        "description": "Process id.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "process.pid", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.ppid": {
+        "description": "Process parent id.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.ppid", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.start": {
+        "description": "The time the process started.", 
+        "example": "2016-05-23T08:05:34.853Z", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.start", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "process.thread.id": {
+        "description": "Thread ID.", 
+        "example": "4242", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.thread.id", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.title": {
+        "description": "Process title.\nThe proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.title", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.working_directory": {
+        "description": "The working directory of the process.", 
+        "example": "/home/alice", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.working_directory", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "process", 
+    "title": "Process", 
+    "type": "group"
+  }, 
+  "related": {
+    "description": "This field set is meant to facilitate pivoting around a piece of data. Some pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`. A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.\n", 
+    "fields": {
+      "related.ip": {
+        "description": "All of the IPs seen on your event.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "related.ip", 
+        "required": false, 
+        "type": "ip"
+      }
+    }, 
+    "group": 2, 
+    "name": "related", 
+    "title": "Related", 
+    "type": "group"
+  }, 
+  "server": {
+    "description": "A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term \"responder\" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
+    "fields": {
+      "server.address": {
+        "description": "Some event server addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "server.address", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "server.bytes": {
+        "description": "Bytes sent from the server to the client.", 
+        "example": "184", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "server.domain": {
+        "description": "Server domain.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "server.ip": {
+        "description": "IP address of the server.\nCan be one or multiple IPv4 or IPv6 addresses.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "server.mac": {
+        "description": "MAC address of the server.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "server.packets": {
+        "description": "Packets sent from the server to the client.", 
+        "example": "12", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.packets", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "server.port": {
+        "description": "Port of the server.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "server.port", 
+        "required": false, 
+        "type": "long"
+      }
+    }, 
+    "group": 2, 
+    "name": "server", 
+    "title": "Server", 
+    "type": "group"
+  }, 
+  "service": {
+    "description": "The service fields describe the service for or from which the data was collected. These fields help you find and correlate logs for a specific service and version.\n", 
+    "fields": {
+      "service.ephemeral_id": {
+        "description": "Ephemeral identifier of this service (if one exists).\nThis id normally changes across restarts, but `service.id` does not.", 
+        "example": "8a4f500f", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "service.ephemeral_id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "service.id": {
+        "description": "Unique identifier of the running service.\nThis id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service.\nExample: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.", 
+        "example": "d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "service.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "service.name": {
+        "description": "Name of the service data is collected from.\nThe name of the service is normally user given. This allows if two instances of the same service are running on the same machine they can be differentiated by the `service.name`.\nAlso it allows for distributed services that run on multiple hosts to correlate the related instances based on the name.\nIn the case of Elasticsearch the service.name could contain the cluster name. For Beats the service.name is by default a copy of the `service.type` field if no name is specified.", 
+        "example": "elasticsearch-metrics", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "service.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "service.state": {
+        "description": "Current state of the service.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "service.state", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "service.type": {
+        "description": "The type of the service data is collected from.\nThe type can be used to group and correlate logs and metrics from one service type.\nExample: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`.", 
+        "example": "elasticsearch", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "service.type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "service.version": {
+        "description": "Version of the service the data was collected from.\nThis allows to look at a data set only for a specific version of a service.", 
+        "example": "3.2.4", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "service.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "service", 
+    "title": "Service", 
+    "type": "group"
+  }, 
+  "source": {
+    "description": "Source fields describe details about the source of a packet/event. Source fields are usually populated in conjunction with destination fields.\n", 
+    "fields": {
+      "source.address": {
+        "description": "Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "source.address", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "source.bytes": {
+        "description": "Bytes sent from the source to the destination.", 
+        "example": "184", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.bytes", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "source.domain": {
+        "description": "Source domain.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "source.ip": {
+        "description": "IP address of the source.\nCan be one or multiple IPv4 or IPv6 addresses.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.ip", 
+        "required": false, 
+        "type": "ip"
+      }, 
+      "source.mac": {
+        "description": "MAC address of the source.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "source.packets": {
+        "description": "Packets sent from the source to the destination.", 
+        "example": "12", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.packets", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "source.port": {
+        "description": "Port of the source.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "source.port", 
+        "required": false, 
+        "type": "long"
+      }
+    }, 
+    "group": 2, 
+    "name": "source", 
+    "title": "Source", 
+    "type": "group"
+  }, 
+  "url": {
+    "description": "URL fields provide a complete URL, with scheme, host, and path.\n", 
+    "fields": {
+      "url.domain": {
+        "description": "Domain of the request, such as \"www.elastic.co\".\nIn some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.", 
+        "example": "www.elastic.co", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.fragment": {
+        "description": "Portion of the url after the `#`, such as \"top\".\nThe `#` is not part of the fragment.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.fragment", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.full": {
+        "description": "If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.", 
+        "example": "https://www.elastic.co:443/search?q=elasticsearch#top", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.full", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.original": {
+        "description": "Unmodified original url as seen in the event source.\nNote that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.\nThis field is meant to represent the URL as it was observed, complete or not.", 
+        "example": "https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.original", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.password": {
+        "description": "Password of the request.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.password", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.path": {
+        "description": "Path of the request, such as \"/search\".", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.path", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.port": {
+        "description": "Port of the request, such as 443.", 
+        "example": "443", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.port", 
+        "required": false, 
+        "type": "integer"
+      }, 
+      "url.query": {
+        "description": "The query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.query", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.scheme": {
+        "description": "Scheme of the request, such as \"https\".\nNote: The `:` is not part of the scheme.", 
+        "example": "https", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.scheme", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.username": {
+        "description": "Username of the request.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.username", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "url", 
+    "title": "URL", 
+    "type": "group"
+  }, 
+  "user": {
+    "description": "The user fields describe information about the user that is relevant to  the event. Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.\n", 
+    "fields": {
+      "user.email": {
+        "description": "User email address.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user.email", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user.full_name": {
+        "description": "User's full name, if available.", 
+        "example": "Albert Einstein", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user.full_name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user.group": {
+        "description": "Group the user is a part of. This field can contain a list of groups, if necessary.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user.group", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user.hash": {
+        "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user.hash", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user.id": {
+        "description": "One or multiple unique identifiers of the user.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "user.id", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user.name": {
+        "description": "Short name or login of the user.", 
+        "example": "albert", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "user.name", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "user", 
+    "title": "User", 
+    "type": "group"
+  }, 
+  "user_agent": {
+    "description": "The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.\n", 
+    "fields": {
+      "user_agent.device.name": {
+        "description": "Name of the device.", 
+        "example": "iPhone", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user_agent.device.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user_agent.name": {
+        "description": "Name of the user agent.", 
+        "example": "Safari", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user_agent.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user_agent.original": {
+        "description": "Unparsed version of the user_agent.", 
+        "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user_agent.original", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "user_agent.version": {
+        "description": "Version of the user agent.", 
+        "example": "12.0", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user_agent.version", 
+        "required": false, 
+        "type": "keyword"
+      }
+    }, 
+    "group": 2, 
+    "name": "user_agent", 
+    "title": "User agent", 
+    "type": "group"
+  }
+}


### PR DESCRIPTION
Adds a script that generates a JSON representation of the ECS schema in the following format:

* The root-level keys are ECS namespace `name`s
* Every root-level value is an object containing the properties of a namespace
* Every namespace object contains a `fields` object, where each key is the `name` of the field, and the value is an object containing the properties of the field

Formatted output as screenshots:

- root-level (collapsed):
![root-level](https://user-images.githubusercontent.com/4459398/49670240-3ed7e080-fa21-11e8-91a0-6ee48a32033c.png)
- an expanded root-level object:
![expanded](https://user-images.githubusercontent.com/4459398/49670237-3b445980-fa21-11e8-91da-753df351b516.png)

A sample root-level object for the `agent` namespace:

```
{
    "description": "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.\n",
    "fields": {
      "agent.ephemeral_id": {
        "description": "Ephemeral identifier of this agent (if one exists).\nThis id normally changes across restarts, but `agent.id` does not.",
        "example": "8a4f500f",
        "footnote": "",
        "group": 2,
        "level": "extended",
        "name": "agent.ephemeral_id",
        "required": false,
        "type": "keyword"
      },
      "agent.id": {
        "description": "Unique identifier of this agent (if one exists).\nExample: For Beats this would be beat.id.",
        "example": "8a4f500d",
        "footnote": "",
        "group": 2,
        "level": "core",
        "name": "agent.id",
        "required": false,
        "type": "keyword"
      },
      "agent.name": {
        "description": "Name of the agent.\nThis is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.\nIf no name is given, the name is often left empty.",
        "example": "foo",
        "footnote": "",
        "group": 2,
        "level": "core",
        "name": "agent.name",
        "required": false,
        "type": "keyword"
      },
      "agent.type": {
        "description": "Type of the agent.\nThe agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine.",
        "example": "filebeat",
        "footnote": "",
        "group": 2,
        "level": "core",
        "name": "agent.type",
        "required": false,
        "type": "keyword"
      },
      "agent.version": {
        "description": "Version of the agent.",
        "example": "6.0.0-rc2",
        "footnote": "",
        "group": 2,
        "level": "core",
        "name": "agent.version",
        "required": false,
        "type": "keyword"
      }
    },
    "group": 2,
    "name": "agent",
    "title": "Agent",
    "type": "group"
  }
```

https://github.com/elastic/ingest-dev/issues/131