### PR TITLE
Index `user_agent.original`, after all.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ All notable changes to this project will be documented in this file based on the
 * Add fields `geo.country_name` and `geo.region_iso_code`. #214
 * Add `event.kind` and `event.outcome`. #242
 * Add `client` and `server` objects and fields. #236
-* Reintroduce a streamlined `user_agent` field set. #240
+* Reintroduce a streamlined `user_agent` field set. #240, #262
 * Add `geo.name` for ad hoc location names. #248
 * Add `event.timezone` to allow for proper interpretation of incomplete timestamps. #258
 

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ The user_agent fields normally come from a browser request. They often show up i
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="user_agent.original"></a>user_agent.original | Unparsed version of the user_agent. | extended | (not indexed) | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
+| <a name="user_agent.original"></a>user_agent.original | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
 | <a name="user_agent.name"></a>user_agent.name | Name of the user agent. | extended | keyword | `Safari` |
 | <a name="user_agent.version"></a>user_agent.version | Version of the user agent. | extended | keyword | `12.0` |
 | <a name="user_agent.device.name"></a>user_agent.device.name | Name of the device. | extended | keyword | `iPhone` |

--- a/fields.yml
+++ b/fields.yml
@@ -1581,7 +1581,6 @@
         - name: original
           level: extended
           type: keyword
-          index: false
           description: >
             Unparsed version of the user_agent.
           example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"

--- a/schema.csv
+++ b/schema.csv
@@ -164,5 +164,5 @@ user.id,keyword,core,
 user.name,keyword,core,albert
 user_agent.device.name,keyword,extended,iPhone
 user_agent.name,keyword,extended,Safari
-user_agent.original,(not indexed),extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
+user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
 user_agent.version,keyword,extended,12.0

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -11,7 +11,6 @@
     - name: original
       level: extended
       type: keyword
-      index: false
       description: >
         Unparsed version of the user_agent.
       example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"

--- a/template.json
+++ b/template.json
@@ -778,7 +778,6 @@
             },
             "original": {
               "ignore_above": 1024,
-              "index": false,
               "type": "keyword"
             },
             "version": {

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -21,7 +21,7 @@ ECS fields used in Filebeat for the apache module.
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes* | *Http response body bytes sent, currently apache.access.body_sent.bytes* | (use case) | long | `117` |
 | <a name="http.referer"></a>*http.referer* | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard* | (use case) | keyword | `http://elastic.co/` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *User agent fields as in schema. Currently under apache.access.user_agent.*<br/>* |  |  |  |
-| [user_agent.original](../README.md#user_agent.original)  | Original user agent. Currently apache.access.agent | extended | (not indexed) | `http://elastic.co/` |
+| [user_agent.original](../README.md#user_agent.original)  | Original user agent. Currently apache.access.agent | extended | keyword | `http://elastic.co/` |
 | <a name="geoip.&ast;"></a>*geoip.&ast;* | *User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>* |  |  |  |
 | <a name="geoip...."></a>*geoip....* | *All geoip fields.* | (use case) | keyword |  |
 

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -17,7 +17,7 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 | [http.response.body](../README.md#http.response.body)  | The full http response body. | extended | keyword | `Hello world` |
 | [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
-| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | (not indexed) | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
+| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
 | <a name="user_agent.device"></a>*user_agent.device* | *Name of the physical device.* | (use case) | keyword |  |
 | [user_agent.version](../README.md#user_agent.version)  | Version of the physical device. | extended | keyword | `12.0` |
 | <a name="user_agent.major"></a>*user_agent.major* | *Major version of the user agent.* | (use case) | long |  |


### PR DESCRIPTION
After discussions on PR #240, me and @ruflin synced up and agreed that indexing the `user_agent.original` would actually be useful (as opposed to `event.original` and `log.original`).