### PR TITLE
Add `http.request.body`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file based on the
 * Reintroduce a streamlined `user_agent` field set. #240
 * Add `geo.name` for ad hoc location names. #248
 * Add `event.timezone` to allow for proper interpretation of incomplete timestamps. #258
+* Add `http.request.body`. #263
 
 ### Improvements
 * Improved the definition of the file fields #196

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ Fields related to HTTP activity.
 |---|---|---|---|---|
 | <a name="http.request.method"></a>http.request.method | Http request method. | extended | keyword | `GET, POST, PUT` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
-| <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
+| <a name="http.request.body"></a>http.request.body | The full http request body. | extended | keyword | `Hello world` |
 | <a name="http.response.body"></a>http.response.body | The full http response body. | extended | keyword | `Hello world` |
+| <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
 | <a name="http.version"></a>http.version | Http version. | extended | keyword | `1.1` |
 
 

--- a/fields.yml
+++ b/fields.yml
@@ -851,12 +851,12 @@
             Referrer for this HTTP request.
           example: https://blog.example.com/
     
-        - name: response.status_code
+        - name: request.body
           level: extended
-          type: long
+          type: keyword
           description: >
-            Http response status code.
-          example: 404
+            The full http request body.
+          example: Hello world
     
         - name: response.body
           level: extended
@@ -864,6 +864,13 @@
           description: >
             The full http response body.
           example: Hello world
+    
+        - name: response.status_code
+          level: extended
+          type: long
+          description: >
+            Http response status code.
+          example: 404
     
         - name: version
           level: extended

--- a/schema.csv
+++ b/schema.csv
@@ -86,6 +86,7 @@ host.ip,ip,core,
 host.mac,keyword,core,
 host.name,keyword,core,
 host.type,keyword,core,
+http.request.body,keyword,extended,Hello world
 http.request.method,keyword,extended,"GET, POST, PUT"
 http.request.referrer,keyword,extended,https://blog.example.com/
 http.response.body,keyword,extended,Hello world

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -21,12 +21,12 @@
         Referrer for this HTTP request.
       example: https://blog.example.com/
 
-    - name: response.status_code
+    - name: request.body
       level: extended
-      type: long
+      type: keyword
       description: >
-        Http response status code.
-      example: 404
+        The full http request body.
+      example: Hello world
 
     - name: response.body
       level: extended
@@ -34,6 +34,13 @@
       description: >
         The full http response body.
       example: Hello world
+
+    - name: response.status_code
+      level: extended
+      type: long
+      description: >
+        Http response status code.
+      example: 404
 
     - name: version
       level: extended

--- a/template.json
+++ b/template.json
@@ -404,6 +404,10 @@
           "properties": {
             "request": {
               "properties": {
+                "body": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"


### PR DESCRIPTION
If we allow for deep inspection of response body already, I don't see why we wouldn't have a field for the request body as well. I think this was simply overlooked?

This would address an issue we have with migrating the Filebeat elasticsearch log module: https://github.com/elastic/beats/pull/9293