### PR TITLE
Require that source/destination are always populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ All notable changes to this project will be documented in this file based on the
 * Clarify that `network.transport`, `network.type`, `network.application`,
   and `network.protocol` must be lowercase. #251
 * Clarify that `http.request.method` must be lowercase. #251
+* Clarify that source/destination should be filled, even if client/server is
+  being used. #265
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it
 
 A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
 
+Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
+
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
@@ -417,6 +419,8 @@ This field set is meant to facilitate pivoting around a piece of data. Some piec
 ## <a name="server"></a> Server fields
 
 A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+
+Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/fields.yml
+++ b/fields.yml
@@ -124,6 +124,8 @@
       group: 2
       description: >
         A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
+    
+        Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
       type: group
       fields:
     
@@ -1314,6 +1316,8 @@
       group: 2
       description: >
         A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+    
+        Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
       type: group
       fields:
     

--- a/fields.yml
+++ b/fields.yml
@@ -298,8 +298,8 @@
       title: Destination
       group: 2
       description: >
-        Destination fields describe details about the destination of a
-        packet/event. Destination fields are usually populated in conjunction with source fields.
+        Destination fields describe details about the destination of a packet/event.
+        Destination fields are usually populated in conjunction with source fields.
       type: group
       fields:
     
@@ -1453,8 +1453,8 @@
       title: Source
       group: 2
       description: >
-        Source fields describe details about the source of a
-        packet/event. Source fields are usually populated in conjunction with destination fields.
+        Source fields describe details about the source of a packet/event.
+        Source fields are usually populated in conjunction with destination fields.
       type: group
       fields:
     

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -4,6 +4,8 @@
   group: 2
   description: >
     A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
+
+    Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
   type: group
   fields:
 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -3,8 +3,8 @@
   title: Destination
   group: 2
   description: >
-    Destination fields describe details about the destination of a
-    packet/event. Destination fields are usually populated in conjunction with source fields.
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
   type: group
   fields:
 

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -4,6 +4,8 @@
   group: 2
   description: >
     A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+
+    Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
   type: group
   fields:
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -3,8 +3,8 @@
   title: Source
   group: 2
   description: >
-    Source fields describe details about the source of a
-    packet/event. Source fields are usually populated in conjunction with destination fields.
+    Source fields describe details about the source of a packet/event.
+    Source fields are usually populated in conjunction with destination fields.
   type: group
   fields:
 


### PR DESCRIPTION
This ensures that the most broadly applicable pair is always populated, and
can therefore always be queried.

Closes #246