### PR TITLE
Convert ECS doc from MD to asciidoc guide: initial setup

### DIFF
--- a/docs/contributing.asciidoc
+++ b/docs/contributing.asciidoc
@@ -1,0 +1,8 @@
+[[ecs-contributing]]
+== Contributing to {ecs}
+
+All information related to ECS is versioned in the https://github.com/elastic/ecs[elastic/ecs] repository. All
+changes to ECS happen through Pull Requests submitted through Git.
+
+See the https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md[Contribution Guidelines].
+

--- a/docs/conventions.asciidoc
+++ b/docs/conventions.asciidoc
@@ -1,0 +1,76 @@
+//[[ecs-conventions]]
+== {ecs} Conventions
+
+{ecs} is most effective when you understand and follow conventions.
+
+[float]
+=== Multi-fields text indexing
+
+Elasticsearch can index text using:
+
+* *Text.* Text indexing allows for full text search, or searching arbitrary words that
+  are part of the field. 
+  See https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html[Text datatype]
+  in the {es} Reference Guide.
+* *Keywords.* Keyword indexing offers faster exact match filtering and prefix search,
+  and makes aggregations (for Kibana visualizations) possible.
+  See the {es} Reference Guide for more information on 
+  https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html[exact match filtering],
+  https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html[prefix search], or 
+  https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html[aggregations].
+
+
+[float]
+==== Default Elasticsearch convention
+  
+Unless your index mapping or index template specifies otherwise
+(as the ECS index template does),
+Elasticsearch indexes text field as `text` at the canonical field name,
+and indexes a second time as `keyword`, nested in a multi-field.
+
+Default Elasticsearch convention:
+
+* Canonical field: `myfield` is `text`
+* Multi-field: `myfield.keyword` is `keyword`
+
+[float]
+==== ECS multi-field convention for text
+
+For monitoring use cases, `keyword` indexing is needed almost exclusively, with
+full text search on very few fields. Given this premise, ECS defaults
+all text indexing to `keyword` at the top level (with very few exceptions).
+Any use case that requires full text search indexing on additional fields
+https://www.elastic.co/guide/en/elasticsearch/reference/current/multi-fields.html[multi-field].
+for full text search. Doing so does not conflict with ECS,
+as the canonical field name will remain `keyword` indexed.
+
+ECS multi-field convention for text:
+
+* Canonical field: `myfield` is `keyword`
+* Multi-field: `myfield.text` is `text`
+
+[float]
+==== Exceptions
+
+The only exceptions to this convention are fields `message` and `error.message`,
+which are indexed for full text search only, with no multi-field.
+These two fields don't follow the new convention because they are deemed too big
+of a breaking change with these two widely used fields in Beats.
+
+Any future field that will be indexed for full text search in ECS will however
+follow the multi-field convention where `text` indexing is nested in the multi-field.
+
+[float]
+=== IDs and most codes are keywords, not integers
+
+Despite the fact that IDs and codes (e.g. error codes) are often integers,
+this is not always the case.
+Since we want to make it possible to map as many systems and data sources
+to ECS as possible, we default to using the `keyword` type for IDs and codes.
+
+Some specific kinds of codes are always integers, like HTTP status codes.
+If those have a specific corresponding specific field (as HTTP status does),
+its type can safely be an integer type.
+But generic field like `error.code` cannot have this guarantee, and are therefore `keyword`.
+
+

--- a/docs/fields-gen.asciidoc
+++ b/docs/fields-gen.asciidoc
@@ -1,0 +1,386 @@
+[[ecs-base]]
+=== Base fields
+
+The base set contains all fields which are on the top level. These fields are common across all types of events.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| [[@timestamp]] | Date/time when the event originated. 
+For log events this is the date/time when the event was generated, and not when it was read.
+Required field for all events. | core | date | `2016-05-23T08:05:34.853Z` 
+| tags | List of keywords used to tag each event. | core | keyword | `["production", "env2"]` 
+| labels | Key/value pairs.
+Can be used to add meta information to events. Should not contain nested objects. 
+All values are stored as keyword.
+Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` 
+| message | For log events the message field contains the log message.
+In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message. | core | text | `Hello World` 
+|=======================================================================
+
+
+[[ecs-agent]]
+=== Agent fields
+
+The agent fields contain the data about the agent/client/shipper that created the event.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| agent.version | Version of the agent. | core | keyword | `6.0.0-rc2` 
+| agent.name | Name of the agent. This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from. If no name is given, the name is often left empty. | core | keyword | `foo` 
+| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | core | keyword | `filebeat` 
+| agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | core | keyword | `8a4f500d` 
+| agent.ephemeral_id | Ephemeral identifier of this agent (if one exists). This id normally changes across restarts, but `agent.id` does not. | extended | keyword | `8a4f500f` 
+|=======================================================================
+
+Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the agent running in the app/service. The agent information does not change if data is sent through queuing systems like Kafka, Redis, or processing systems such as Logstash or APM Server.
+
+[[ecs-cloud]]
+=== Cloud fields
+
+Fields related to the cloud or infrastructure the events are coming from.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| cloud.provider | Name of the cloud provider. Example values are ec2, gce, or digitalocean. | extended | keyword | `ec2` 
+| cloud.availability_zone | Availability zone in which this host is running. | extended | keyword | `us-east-1c` 
+| cloud.region | Region in which this host is running. | extended | keyword | `us-east-1` 
+| cloud.instance.id | Instance ID of the host machine. | extended | keyword | `i-1234567890abcdef0` 
+| cloud.instance.name | Instance name of the host machine. | extended | keyword |  
+| cloud.machine.type | Machine type of the host machine. | extended | keyword | `t2.medium` 
+| cloud.account.id | The cloud account or organization id used to identify different entities in a multi-tenant environment. 
+
+Examples: AWS account id, Google Cloud ORG Id, or other unique identifier. | extended | keyword | `666777888999` 
+|=======================================================================
+
+Examples: If Metricbeat is running on an EC2 host and fetches data from its host, the cloud info contains the data about this machine. If Metricbeat runs on a remote machine outside the cloud and fetches data from a service running in the cloud, the field contains cloud data from the machine the service is running on.
+
+[[ecs-container]]
+=== Container fields
+
+Container fields are used for meta information about the specific container that
+is the source of information. These fields help correlate data based containers
+from any runtime.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| container.runtime | Runtime managing this container. | extended | keyword | `docker` 
+| container.id | Unique container id. | core | keyword |
+| container.image.name | Name of the image the container was built on. | extended | keyword  |
+| container.image.tag | Container image tag. | extended | keyword | 
+| container.name | Container name. | extended | keyword |  
+| container.labels | Image labels. | extended | object |  
+|=======================================================================
+
+[[ecs-destination]]
+=== Destination fields
+
+Destination fields describe details about the destination of a packet/event.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| destination.ip | IP address of the destination. Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  
+| destination.port | Port of the destination. | core | long |  
+| destination.mac | MAC address of the destination. | core | keyword |  
+| destination.domain | Destination domain. | core | keyword |  
+|=======================================================================
+
+[[ecs-device]]
+=== Device fields
+
+Device fields are used to provide additional information about the device that
+is the source of the information. This could be a firewall, network device, etc.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| device.mac | MAC address of the device | core | keyword |  
+| device.ip | IP address of the device. | core | ip |  
+| device.hostname | Hostname of the device. | core | keyword |  
+| device.vendor | Device vendor information. | core | keyword |  
+| device.version | Device version. | core | keyword |  
+| device.serial_number | Device serial number. | extended | keyword |  
+| device.type | The type of the device the data is coming from. There is no predefined list of device types. Some examples are `endpoint`, `firewall`, `ids`, `ips`, `proxy`. | core | keyword | `firewall` 
+|=======================================================================
+
+[[ecs-ecs]]
+=== ECS fields
+
+Meta-information specific to ECS.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| ecs.version | ECS version for this event. `ecs.version` is a required field and must exist in all events. 
+
+Different indices may conform to different ECS versions. 
+This field helps integrations adjust to the correct schema version for events when you query across multiple indices.
+The current version is 1.0.0-beta1 . | core | keyword | `1.0.0-beta1` 
+|=======================================================================
+
+// Can we make the version a VARIABLE so that it's always up-to-date?
+
+[[ecs-error]]
+=== Error fields
+
+These fields can represent errors of any kind. Use them for errors that happen
+while fetching events or in cases where the event itself contains an error.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| error.id | Unique identifier for the error. | core | keyword |  
+| error.message | Error message. | core | text |  
+| error.code | Error code describing the error. | core | keyword |  
+|=======================================================================
+
+
+[[ecs-event]]
+=== Event fields
+
+The event fields are used for context information about the data itself.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| event.id | Unique ID to describe the event. | core | keyword | `8a4f500d` 
+| event.kind | The kind of the event.  This gives information about what type of information the event contains, without being specific to the contents of the event.  Examples are `event`, `state`, `alarm`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | extended | keyword | `state` 
+| event.category | Event category.  This contains high-level information about the contents of the event. It is more generic than `event.action`, in the sense that typically a category contains multiple actions. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | core | keyword | `user-management` 
+| event.action | The action captured by the event.  This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | core | keyword | `user-password-change` 
+| event.outcome | The outcome of the event.  If the event describes an action, this fields contains the outcome of that action. Examples outcomes are `success` and `failure`. Warning: In future versions of ECS, we plan to provide a list of acceptable values for this field, please use with caution. | extended | keyword | `success` 
+| event.type | Reserved for future usage.  Please avoid using this field for user data. | core | keyword |  
+| event.module | Name of the module this data is coming from.  This information is coming from the modules used in Beats or Logstash. | core | keyword | `mysql` 
+| event.dataset | Name of the dataset.  The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name. | core | keyword | `stats` 
+| event.severity | Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events. | core | long | `7` 
+| event.original | Raw text message of entire event. Used to demonstrate log integrity.  This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. | core | (not indexed) | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232` 
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | extended | keyword | `123456789012345678901234567890ABCD` 
+| event.duration | Duration of the event in nanoseconds.  If event.start and event.end are known this value should be the difference between the end and start time. | core | long |  
+| event.timezone | This field should be populated when the event's timestamp does not include timezone information already (e.g. default Syslog timestamps). It's optional otherwise.  Acceptable timezone formats are: a canonical ID (e.g. "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential (e.g. "-05:00"). | extended | keyword |  
+| event.created | event.created contains the date when the event was created.  This timestamp is distinct from @timestamp in that @timestamp contains the processed timestamp. For logs these two timestamps can be different as the timestamp in the log line and when the event is read for example by Filebeat are not identical. `@timestamp` must contain the timestamp extracted from the log line, event.created when the log line is read. The same could apply to package capturing where @timestamp contains the timestamp extracted from the network package and event.created when the event was created.  In case the two timestamps are identical, @timestamp should be used. | core | date |  
+| event.start | event.start contains the date when the event started or when the activity was first observed. | extended | date |  
+| event.end | event.end contains the date when the event ended or when the activity was last observed. | extended | date |  
+| event.risk_score | Risk score or priority of the event (e.g. security solutions). Use your system's original value here. | core | float |  
+| event.risk_score_norm | Normalized risk score or priority of the event, on a scale of 0 to 100.  This is mainly useful if you use more than one system that assigns risk scores, and you want to see a normalized value across all systems. | extended | float |  
+|=======================================================================
+
+[[ecs-file]]
+=== File fields
+
+File fields provide details about each file.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| file.path | Path to the file. | extended | keyword |  
+| file.target_path | Target path for symlinks. | extended | keyword |  
+| file.extension | File extension. This should allow easy filtering by file extensions. | extended | keyword | `png` 
+| file.type | File type (file, dir, or symlink). | extended | keyword |  
+| file.device | Device that is the source of the file. | extended | keyword |  
+| file.inode | Inode representing the file in the filesystem. | extended | keyword |  
+| file.uid | The user ID (UID) or security identifier (SID) of the file owner. | extended | keyword |  
+| file.owner | File owner's username. | extended | keyword |  
+| file.gid | Primary group ID (GID) of the file. | extended | keyword |  
+| file.group | Primary group name of the file. | extended | keyword |  
+| file.mode | Mode of the file in octal representation. | extended | keyword | `416` |
+| file.size | File size in bytes (field is only added when `type` is `file`). | extended | long |  
+| file.mtime | Last time file content was modified. | extended | date |  
+| file.ctime | Last time file metadata changed. | extended | date |  
+|=======================================================================
+
+[[ecs-geo]]
+=== Geo fields
+
+Geo fields can carry data about a specific location related to an event or geo information derived from an IP field.
+
+The `geo` fields are expected to be nested at: `destination.geo`, `device.geo`, `host.geo`, `source.geo`.
+
+Note also that the `geo` fields are not expected to be used directly at the top level.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| geo.continent_name | Name of the continent. | core | keyword | `North America` 
+| geo.country_iso_code | Country ISO code. | core | keyword | `CA` 
+| geo.location | Longitude and latitude. | core | geo_point | `{ "lon": -73.614830, "lat": 45.505918 }` 
+| geo.region_name | Region name. | core | keyword | `Quebec` 
+| geo.city_name | City name. | core | keyword | `Montreal` 
+|=======================================================================
+
+[[ecs-host]]
+=== Host fields
+
+Host fields provide information related to a host. A host can be a physical
+machine, a virtual machine, or a Docker container. Normally the host information
+is related to the machine on which the event was generated/collected, but they
+can be used differently if needed. 
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | core | keyword | 
+| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | core | keyword | 
+| host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | core | keyword | 
+| host.ip | Host ip address. | core | ip |  
+| host.mac | Host mac address. | core | keyword |  
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | core | keyword | 
+| host.architecture | Operating system architecture. | core | keyword | `x86_64` 
+|=======================================================================
+
+[[ecs-log]]
+=== Log fields
+
+Fields which are specific to log events.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| log.level | Log level of the log event. Some examples are `WARN`, `ERR`, `INFO`. | core | keyword | `ERR` |
+| log.original | This is the original log message and contains the full log message before splitting it up in multiple parts. In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message. This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`. | core | keyword | `Sep 19 08:26:10 localhost My log` |
+|=======================================================================
+
+[[ecs-network]]
+=== Network fields
+
+Fields related to network data.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| network.name | Name given by operators to sections of their network. | extended | keyword | `Guest Wifi` 
+| network.type | In the OSI Model this would be the Network Layer. IPv4, IPv6, IPSec, PIM, etc | core | keyword | `IPv4` 
+| network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | extended | keyword | `6`
+| network.transport | Same as network.iana_number, but instead using the Keyword name of the transport layer (UDP, TCP, IPv6-ICMP, etc.) | core | keyword | `TCP` 
+| network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format. | extended | keyword | `AIM`
+| network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol | core | keyword | `http` 
+| network.direction | Direction of the network traffic. Recommended values are:   * inbound   * outbound   * unknown | core | keyword | `inbound` 
+| network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` 
+| network.inbound.bytes | Network inbound bytes. | core | long | `184` 
+| network.inbound.packets | Network inbound packets. | core | long | `12` 
+| network.outbound.bytes | Network outbound bytes. | core | long | `184` 
+| network.outbound.packets | Network outbound packets. | core | long | `12` 
+| network.total.bytes | Network total bytes. The sum of inbound.bytes + outbound.bytes. | core | long | `368` 
+| network.total.packets | Network outbound packets. The sum of inbound.packets + outbound.packets | core | long | `24` 
+|=======================================================================
+
+[[ecs-organization]]
+=== Organization fields
+
+The organization fields enrich data with information about the company or entity the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple organizations.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| organization.name | Organization name. | extended | keyword |  
+| organization.id | Unique identifier for the organization. | extended | keyword |  
+|=======================================================================
+
+[[ecs-os]]
+=== Operating System fields
+
+The OS fields contain information about the operating system.
+
+The `os` fields are expected to be nested at: `device.os`, `host.os`, `user_agent.os`.
+Note also that the `os` fields are not expected to be used directly at the top level.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| os.platform | Operating system platform (such centos, ubuntu, windows). | extended | keyword | `darwin` 
+| os.name | Operating system name. | extended | keyword | `Mac OS X` 
+| os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` 
+| os.version | Operating system version as a raw string. | extended | keyword | `10.12.6-rc2` 
+| os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` 
+|=======================================================================
+
+[[ecs-process]]
+=== Process fields
+
+These fields contain information about a process. These fields can help you
+correlate metrics information with a process id/name from a log message.  The
+`process.pid` often stays in the metric itself and is copied to the global field
+for correlation.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| process.args | Process arguments. May be filtered to protect sensitive information. | extended | keyword | `['-l', 'user', '10.0.0.16']` 
+| process.name | Process name. Sometimes called program name or similar. | extended | keyword | `ssh` 
+| process.pid | Process id. | core | long |  
+| process.ppid | Process parent id. | extended | long |  
+| process.title | Process title. The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | extended | keyword |  
+|=======================================================================
+
+[[ecs-service]]
+=== Service fields
+
+The service fields describe the service for or from which the data was
+collected. These fields help you find and correlate logs for a specific service
+and version.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| service.id | Unique identifier of the running service. This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service. Example: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance. | core | keyword | `d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6` 
+| service.name | Name of the service data is collected from. The name of the service is normally user given. This allows if two instances of the same service are running on the same machine they can be differentiated by the `service.name`. Also it allows for distributed services that run on multiple hosts to correlate the related instances based on the name. In the case of Elasticsearch the service.name could contain the cluster name. For Beats the service.name is by default a copy of the `service.type` field if no name is specified. | core | keyword | `elasticsearch-metrics` 
+| service.type | The type of the service data is collected from. The type can be used to group and correlate logs and metrics from one service type. Example: If logs or metrics are collected from Elasticsearch, `service.type` would be `elasticsearch`. | core | keyword | `elasticsearch` 
+| service.state | Current state of the service. | core | keyword |  
+| service.version | Version of the service the data was collected from. This allows to look at a data set only for a specific version of a service. | core | keyword | `3.2.4` 
+| service.ephemeral_id | Ephemeral identifier of this service (if one exists). This id normally changes across restarts, but `service.id` does not. | extended | keyword | `8a4f500f` 
+|=======================================================================
+
+[[ecs-source]]
+=== Source fields
+
+Source fields describe details about the destination of a packet/event.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| source.ip | IP address of the source. Can be one or multiple IPv4 or IPv6 addresses. | core | ip |  
+| source.port | Port of the source. | core | long |  
+| source.mac | MAC address of the source. | core | keyword |  
+| source.domain | Source domain. | core | keyword |  
+|=======================================================================
+
+[[ecs-url]]
+=== URL fields
+
+URL fields provide a complete URL, with scheme, host, and path.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| url.original | Full original url. The field is stored as keyword. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` 
+| url.scheme | Scheme of the request, such as "https". Note: The `:` is not part of the scheme. | extended | keyword | `https` 
+| url.domain | Domain of the request, such as "www.elastic.co". In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `www.elastic.co` 
+| url.port | Port of the request, such as 443. | extended | integer | `443` 
+| url.path | Path of the request, such as "/search". | extended | keyword |  
+| url.query | The query field describes the query string of the request, such as "q=elasticsearch". The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  
+| url.fragment | Portion of the url after the `#`, such as "top". The `#` is not part of the fragment. | extended | keyword |  
+| url.username | Username of the request. | extended | keyword |  
+| url.password | Password of the request. | extended | keyword |  
+|=======================================================================
+
+[[ecs-user]]
+=== User fields
+
+The user fields describe information about the user that is relevant to  the event. Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.
+
+The `user` fields are expected to be nested at: `destination.user`, `host.user`, `source.user`.
+
+Note also that the `user` fields may be used directly at the top level.
+
+[cols="<,<,<,<,<",options="header",]
+|=======================================================================
+| Field  | Description  | Level  | Type  | Example 
+| user.id | One or multiple unique identifiers of the user. | core | keyword |  
+| user.name | Name of the user. The field is a keyword, and will not be tokenized. | core | keyword |  
+| user.email | User email address. | extended | keyword |  
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | extended | keyword | 
+|=======================================================================
+
+

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -1,0 +1,57 @@
+[[ecs-fields]]
+== {ecs} Fields
+
+// Add a list of field types w/ brief description so user can get a 
+// sense of what we're offering without having to scroll.
+
+// Pull in generated field content using `include` statements
+
+[cols="<,<",options="header",]
+|=======================================================================
+| Fields  | Description  
+| <<ecs-base,Base>> | The base set contains all fields which are on the top level.
+ These fields are common across all types of events.
+| <<ecs-agent,Agent>> | The agent fields contain data about the 
+agent/client/shipper that created the event.
+| <<ecs-cloud,Cloud>> | Fields related to the cloud or infrastructure the events are
+ coming from.
+| <<ecs-container,Container>> | Container fields are used for meta information about the specific container that
+is the source of information. These fields help correlate data based containers
+from any runtime.
+| <<ecs-destination,Destination>> | Destination fields describe details about the destination of a packet/event.
+| <<ecs-device,Device>> | Device fields are used to provide additional information 
+about the device that is the source of the information. This could be a firewall, network device, etc.
+| <<ecs-ecs,ECS>> | Meta-information specific to ECS.
+| <<ecs-error,Error>> | These fields can represent errors of any kind. Use them for errors that happen
+while fetching events or in cases where the event itself contains an error.
+| <<ecs-event,Event>> | The event fields are used for context information about the data itself.
+| <<ecs-file,File>> | File fields provide details about each file.
+| <<ecs-geo,Geo>> | Geo fields can carry data about a specific location related to 
+an event or geo information derived from an IP field.
+The `geo` fields are expected to be nested at: `destination.geo`, `device.geo`, `host.geo`, `source.geo`.
+| <<ecs-host,Host>> | Host fields provide information related to a host. A host can be a physical
+machine, a virtual machine, or a Docker container.
+| <<ecs-log,Log>> | Fields which are specific to log events.
+| <<ecs-network,Network>> | Fields related to network data.
+| <<ecs-organization,Organization>> | The organization fields enrich data with 
+  information about the company or entity the data is associated with. These fields help
+  you arrange or filter data stored in an index by one or multiple organizations.
+| <<ecs-os,Operating System>> | The OS fields contain information about the operating system.
+| <<ecs-process,Process>> | These fields contain information about a process. These fields can help you
+correlate metrics information with a process id/name from a log message.  The
+`process.pid` often stays in the metric itself and is copied to the global field
+for correlation.
+| <<ecs-service,Service>> | The service fields describe the service for or from which the data was
+collected. These fields help you find and correlate logs for a specific service
+and version.
+| <<ecs-source,Source>> | Source fields describe details about the destination of a packet/event.
+| <<ecs-url,URL>> | URL fields provide a complete URL, with scheme, host, and path.
+| <<ecs-user,User>> | The user fields describe information about the user 
+ that is relevant to the event. Fields can have one entry or multiple entries. 
+ If a user has more than one id, provide an array that includes all of them.
+|=======================================================================
+
+include::fields-gen.asciidoc[]
+
+
+

--- a/docs/glossary.asciidoc
+++ b/docs/glossary.asciidoc
@@ -1,0 +1,12 @@
+//[[ecs-glossary]]
+== Glossary of {ecs} Terms
+
+[[glossary-ecs]] 
+ECS ::
+
+Elastic Common Schema. A common set of document fields, field names, and their respective entity
+relationships to be used in the storage of log messages and other data in
+Elasticsearch.
+
+
+

--- a/docs/guidelines.asciidoc
+++ b/docs/guidelines.asciidoc
@@ -1,0 +1,33 @@
+//[[ecs-guidelines]]
+== Guidelines and Best Practices
+
+The {ecs} schema serves best when you follow schema guidelines and best
+practices.
+
+[float]
+=== General guidelines
+
+* The document MUST have the `@timestamp` field.
+* Use the https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-types.html[data type]
+  defined for an ECS field.
+* Use the `ecs.version` field to define which version of ECS is used.
+* Map as many fields as possible to ECS.
+* TBD: Include guidelines on when people should contribute to the spec. Link to Contributing.
+
+[float]
+==== Guidelines for writing fields
+
+* All fields must be lower case
+* Combine words using underscore
+* No special characters except `_`
+
+[float]
+==== Guidelines for naming fields
+
+* *Present tense.* Use present tense unless field describes historical information.
+* *Singular or plural.* Use singular and plural names properly to reflect the field content. For example, use `requests_per_sec` rather than `request_per_sec`.
+* *General to specific.* Organise the prefixes from general to specific to allow grouping fields into objects with a prefix like `host.*`.
+* *Avoid repetition.* Avoid stuttering of words. If part of the field name is already in the prefix, do not repeat it. Example: `host.host_ip` should be `host.ip`.
+* *Use prefixes.* Fields must be prefixed except for the base fields. For example all `host` fields are prefixed with `host.`. See `dot` notation in FAQ for more details.
+* *Avoid abbreviations when possible*. A few exceptions like `ip` exist.
+

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,73 @@
+:doctype: book
+:ecs: ECS
+
+
+include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+[[ecs-reference]]
+== Elastic Common Schema (ECS) Reference
+
+beta[]
+
+The Elastic Common Schema (ECS) defines a common set of fields for
+ingesting data into Elasticsearch. A common schema helps you correlate
+data from sources like logs and metrics or IT operations
+analytics and security analytics.
+
+ECS is still under development and backward compatibility is not guaranteed. Any
+feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the  https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md[Contribution Guidelines].
+
+[float]
+[[versions]]
+=== Versions
+
+The master branch of this repository should never be considered an
+official release of ECS. You can browse https://github.com/elastic/ecs/releases[official releases] of ECS.
+
+Please note that when the README.md file and other generated files
+(like schema.csv and template.json) are not in agreement,
+the README.md should be considered the official spec.
+The other two files are simply provided as a convenience, and may not always be
+fully up to date.
+
+/////
+Working TOC
+
+ECS Intro
+  Versions
+  MINI TOC???
+Fields (generated)
+  Base
+  Agent
+  Cloud
+  ETC
+* Use Case header = Use Cases (generated)
+* Implementing
+* About (FAQs)
+* Contributing
+* GLOSSARY? 
+
+* Mike's stuff (https://docs.google.com/document/d/1srylXQDgO0z5rbwho1o8nKIxr9icTTl_nXZGYbElxYs/edit#heading=h.y1xeds3o3jae)
+
+ECS Definitions and Entity Relationships
+** ECS data model
+** Definitions
+** Top-Level Namespaces/Objects
+** Reusable Namespaces/Objects
+** Assets and Asset Lists
+** Pseudonymized and Anonymized Data in ECS
+** Threat and Vulnerability Data in ECS
+** Revisit inbound, outbound bytes/packets
+
+
+//////
+
+include::fields.asciidoc[]
+include::conventions.asciidoc[]
+include::guidelines.asciidoc[]
+include::use-cases.asciidoc[]
+include::contributing.asciidoc[]
+include::glossary.asciidoc[]
+

--- a/docs/use-cases-header.md
+++ b/docs/use-cases-header.md
@@ -1,7 +1,0 @@
-# <a name="use-cases"></a>Use cases
-
-These are example on how ECS fields can be used in different use cases. Most use
-cases not only contain ECS fields but additional fields which are not in ECS to
-describe the full use case. The fields which are not in ECS are in italic.
-
-Contributions of additional uses cases on top of ECS are welcome.

--- a/docs/use-cases-header.md
+++ b/docs/use-cases-header.md
@@ -1,0 +1,7 @@
+# <a name="use-cases"></a>Use cases
+
+These are example on how ECS fields can be used in different use cases. Most use
+cases not only contain ECS fields but additional fields which are not in ECS to
+describe the full use case. The fields which are not in ECS are in italic.
+
+Contributions of additional uses cases on top of ECS are welcome.

--- a/docs/use-cases.asciidoc
+++ b/docs/use-cases.asciidoc
@@ -1,0 +1,23 @@
+[[ecs-use-cases]]
+== Use Cases
+
+The power and versatility of {ecs} is best illustrated through use cases. 
+
+NOTE: Some use cases contain ECS fields and additional fields which are not
+in ECS to describe the full use case. The fields which are not in ECS are in
+italic.
+
+ * https://github.com/elastic/ecs/blob/master/use-cases/apm.md[APM]
+ * https://github.com/elastic/ecs/blob/master/use-cases/auditbeat.md[Auditbeat]
+ * https://github.com/elastic/ecs/blob/master/use-cases/beats.md[Beats]
+ * https://github.com/elastic/ecs/blob/master/use-cases/filebeat-apache-access.md[Filebeat Apache]
+ * https://github.com/elastic/ecs/blob/master/use-cases/kubernetes.md[Kubernetes]
+ * https://github.com/elastic/ecs/blob/master/use-cases/logging.md[Logging]
+ * https://github.com/elastic/ecs/blob/master/use-cases/metricbeat.md[Metricbeat]
+ * https://github.com/elastic/ecs/blob/master/use-cases/tls.md[TLS]
+ * https://github.com/elastic/ecs/blob/master/use-cases/web-logs.md[Parsing web server logs]
+
+We welcome https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md[contributions] of additional ECS uses cases. 
+
+
+


### PR DESCRIPTION
Convert ECS readme.md file to asciidoc to be published at https://www.elastic.co/guide/index.html.
https://ecs-simple.firebaseapp.com/

Issue #276 opened to track additional steps

