### PR TITLE
Add automation around docs generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 env
 *.sw?
+
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ go:
 before_install:
 - make setup
 
+addons:
+  apt:
+    update: true
+    packages:
+      - xsltproc
+
 jobs:
   include:
     - stage: check
@@ -18,4 +24,4 @@ jobs:
       - make check
     - stage: docs
       script:
-      - make docs
+      - OPEN_DOCS="" make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,11 @@ go:
 before_install:
 - make setup
 
-script:
-- make check
+jobs:
+  include:
+    - stage: check
+      script:
+      - make check
+    - stage: docs
+      script:
+      - make docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
     update: true
     packages:
       - xsltproc
+      - libxml2-utils
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,6 @@ fields:
 	cat fields.tmp.yml >> fields.yml
 	rm -f fields.tmp.yml fields.tmp.yml.bak
 
-test:
-
-
 docs:
 	if [ ! -d $(PWD)/build/docs ]; then \
 		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,13 @@ fields:
 	cat fields.tmp.yml >> fields.yml
 	rm -f fields.tmp.yml fields.tmp.yml.bak
 
+test:
+
+	
 docs:
-ifneq (,$(wildcard ./build/docs/*),)
-	git clone --depth=1 https://github.com/elastic/docs.git ./build/docs
-endif
+	if [[ ! -d "./build/docs" ]]; then \
+		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
+	fi
 	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 -open -out ./build/html_docs
 
 .PHONY: generate schemas fmt check setup clean readme template fields docs

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+OPEN_DOCS?="-open"
+
 generate: schemas readme template fields
 
 schemas:
@@ -55,6 +57,6 @@ docs:
 		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
 	fi
 
-	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 -open -out ./build/html_docs
+	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 $(OPEN_DOCS) -out ./build/html_docs
 
 .PHONY: generate schemas fmt check setup clean readme template fields docs

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,12 @@ fields:
 
 test:
 
-	
+
 docs:
-	if [[ ! -d "./build/docs" ]]; then \
+	if [ ! -d $(PWD)/build/docs ]; then \
 		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
 	fi
+
 	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 -open -out ./build/html_docs
 
 .PHONY: generate schemas fmt check setup clean readme template fields docs

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fields:
 	rm -f fields.tmp.yml fields.tmp.yml.bak
 
 docs:
-ifneq (,$(wildcard ./build/docs/build_docs.py))
+ifneq (,$(wildcard ./build/docs/*),)
 	git clone --depth=1 https://github.com/elastic/docs.git ./build/docs
 endif
 	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 -open -out ./build/html_docs

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,10 @@ fields:
 	cat fields.tmp.yml >> fields.yml
 	rm -f fields.tmp.yml fields.tmp.yml.bak
 
-.PHONY: generate schemas fmt check setup clean readme template fields
+docs:
+ifneq (,$(wildcard ./build/docs/build_docs.py))
+	git clone --depth=1 https://github.com/elastic/docs.git ./build/docs
+endif
+	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 -open -out ./build/html_docs
+
+.PHONY: generate schemas fmt check setup clean readme template fields docs


### PR DESCRIPTION
This adds an almost empty `index.asciidoc` file to generate the initial asciidoc version of the docs. With this `make docs` can be used to generate and preview the docs.

This allows us to also validate the docs build in CI.