### PR TITLE
Update go version to 1.11.x on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 - linux
 
 go:
-- 1.10.x
+- 1.11.x
 
 before_install:
 - make setup


### PR DESCRIPTION
Beats updated to 1.11 and as some of our scripts rely on Beats, we should updated too.