### PR TITLE
Add network locality fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file based on the
 
 * Added pointer in description of `http` field set to `url` field set. #330
 * Added an optional short field description. #330
+* Add `network.locality`, `source.locality`, and `desination.locality`. #288
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Destination fields are usually populated in conjunction with source fields.
 | <a name="destination.domain"></a>destination.domain | Destination domain. | core | keyword |  |
 | <a name="destination.bytes"></a>destination.bytes | Bytes sent from the destination to the source. | core | long | `184` |
 | <a name="destination.packets"></a>destination.packets | Packets sent from the destination to the source. | core | long | `12` |
+| <a name="destination.locality"></a>destination.locality | Locality can be either `private` or `public`. `private` indicates that the destination IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the destination IP is outside of the private ranges. | extended | keyword | `public` |
 
 
 ## <a name="ecs"></a> ECS fields
@@ -365,6 +366,7 @@ The network.* fields should be populated with details about the network activity
 | <a name="network.community_id"></a>network.community_id | A hash of source and destination IPs and ports, as well as the protocol used in a communication. This is a tool-agnostic standard to identify flows.<br/>Learn more at https://github.com/corelight/community-id-spec. | extended | keyword | `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=` |
 | <a name="network.bytes"></a>network.bytes | Total bytes transferred in both directions.<br/>If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum. | core | long | `368` |
 | <a name="network.packets"></a>network.packets | Total packets transferred in both directions.<br/>If `source.packets` and `destination.packets` are known, `network.packets` is their sum. | core | long | `24` |
+| <a name="network.locality"></a>network.locality | Locality can be either `private` or `public`. `private` indicates that both sides of the flow have IP addresses in the ranges reserved for private networks as defined below. `public` indicates that at least one side of the flow is outside of the private ranges. The IP addresses used in determining this field's value are `source.ip` and `destination.ip`.<br/>Address ranges that are considered private are * Loopback (127.0.0.0/8, ::1/128) * Unspecified (0.0.0.0, ::) * IPv4 Broadcast (255.255.255.255) * RFC 1918 - IPv4 Local Unicast (10/8, 172.16/12, 192.168/16) * RFC 3927 - IPv4 Link-Local Unicast (169.254.0.0/16) * RFC 5771 - IPv4 Local Multicast (224.0.0.0/4) * RFC 4193 - IPv6 Local Unicast (fc00::/7) * RFC 4291 - IPv6 Link-Local Unicast (fe80::/10) * RFC 4291 - IPv6 Link-Local Multicast (ff02::/8) * RFC 4291 - IPv6 Interface Local Multicast (ff01::/8) | extended | keyword | `public` |
 
 
 ## <a name="observer"></a> Observer fields
@@ -504,6 +506,7 @@ Source fields are usually populated in conjunction with destination fields.
 | <a name="source.domain"></a>source.domain | Source domain. | core | keyword |  |
 | <a name="source.bytes"></a>source.bytes | Bytes sent from the source to the destination. | core | long | `184` |
 | <a name="source.packets"></a>source.packets | Packets sent from the source to the destination. | core | long | `12` |
+| <a name="source.locality"></a>source.locality | Locality can be either `private` or `public`. `private` indicates that the source IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the source IP is outside of the private ranges. | extended | keyword | `public` |
 
 
 ## <a name="url"></a> URL fields

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Client / server representations can add semantic context to an exchange, which i
 | <a name="client.port"></a>client.port | Port of the client. | core | long |  |
 | <a name="client.mac"></a>client.mac | MAC address of the client. | core | keyword |  |
 | <a name="client.domain"></a>client.domain | Client domain. | core | keyword |  |
+| <a name="client.locality"></a>client.locality | Locality can be either `private` or `public`. `private` indicates that the client IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the client IP is outside of the private ranges. | extended | keyword | `public` |
 | <a name="client.bytes"></a>client.bytes | Bytes sent from the client to the server. | core | long | `184` |
 | <a name="client.packets"></a>client.packets | Packets sent from the client to the server. | core | long | `12` |
 
@@ -177,9 +178,9 @@ Destination fields are usually populated in conjunction with source fields.
 | <a name="destination.port"></a>destination.port | Port of the destination. | core | long |  |
 | <a name="destination.mac"></a>destination.mac | MAC address of the destination. | core | keyword |  |
 | <a name="destination.domain"></a>destination.domain | Destination domain. | core | keyword |  |
+| <a name="destination.locality"></a>destination.locality | Locality can be either `private` or `public`. `private` indicates that the destination IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the destination IP is outside of the private ranges. | extended | keyword | `public` |
 | <a name="destination.bytes"></a>destination.bytes | Bytes sent from the destination to the source. | core | long | `184` |
 | <a name="destination.packets"></a>destination.packets | Packets sent from the destination to the source. | core | long | `12` |
-| <a name="destination.locality"></a>destination.locality | Locality can be either `private` or `public`. `private` indicates that the destination IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the destination IP is outside of the private ranges. | extended | keyword | `public` |
 
 
 ## <a name="ecs"></a> ECS fields
@@ -469,6 +470,7 @@ Client / server representations can add semantic context to an exchange, which i
 | <a name="server.port"></a>server.port | Port of the server. | core | long |  |
 | <a name="server.mac"></a>server.mac | MAC address of the server. | core | keyword |  |
 | <a name="server.domain"></a>server.domain | Server domain. | core | keyword |  |
+| <a name="server.locality"></a>server.locality | Locality can be either `private` or `public`. `private` indicates that the server IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the server IP is outside of the private ranges. | extended | keyword | `public` |
 | <a name="server.bytes"></a>server.bytes | Bytes sent from the server to the client. | core | long | `184` |
 | <a name="server.packets"></a>server.packets | Packets sent from the server to the client. | core | long | `12` |
 
@@ -504,9 +506,9 @@ Source fields are usually populated in conjunction with destination fields.
 | <a name="source.port"></a>source.port | Port of the source. | core | long |  |
 | <a name="source.mac"></a>source.mac | MAC address of the source. | core | keyword |  |
 | <a name="source.domain"></a>source.domain | Source domain. | core | keyword |  |
+| <a name="source.locality"></a>source.locality | Locality can be either `private` or `public`. `private` indicates that the source IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the source IP is outside of the private ranges. | extended | keyword | `public` |
 | <a name="source.bytes"></a>source.bytes | Bytes sent from the source to the destination. | core | long | `184` |
 | <a name="source.packets"></a>source.packets | Packets sent from the source to the destination. | core | long | `12` |
-| <a name="source.locality"></a>source.locality | Locality can be either `private` or `public`. `private` indicates that the source IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the source IP is outside of the private ranges. | extended | keyword | `public` |
 
 
 ## <a name="url"></a> URL fields

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -53,6 +53,12 @@ type Client struct {
 	// Client domain.
 	Domain string `ecs:"domain"`
 
+	// Locality can be either `private` or `public`. `private` indicates that
+	// the client IP address is the ranges reserved for private networks as
+	// defined in `network.locality`. `public` indicates that the client IP is
+	// outside of the private ranges.
+	Locality string `ecs:"locality"`
+
 	// Bytes sent from the client to the server.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -42,6 +42,12 @@ type Destination struct {
 	// Destination domain.
 	Domain string `ecs:"domain"`
 
+	// Locality can be either `private` or `public`. `private` indicates that
+	// the destination IP address is the ranges reserved for private networks
+	// as defined in `network.locality`. `public` indicates that the
+	// destination IP is outside of the private ranges.
+	Locality string `ecs:"locality"`
+
 	// Bytes sent from the destination to the source.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -92,4 +92,19 @@ type Network struct {
 	// If `source.packets` and `destination.packets` are known,
 	// `network.packets` is their sum.
 	Packets int64 `ecs:"packets"`
+
+	// Locality can be either `private` or `public`. `private` indicates that
+	// both sides of the flow have IP addresses in the ranges reserved for
+	// private networks as defined below. `public` indicates that at least one
+	// side of the flow is outside of the private ranges. The IP addresses used
+	// in determining this field's value are `source.ip` and `destination.ip`.
+	// Address ranges that are considered private are * Loopback (127.0.0.0/8,
+	// ::1/128) * Unspecified (0.0.0.0, ::) * IPv4 Broadcast (255.255.255.255)
+	// * RFC 1918 - IPv4 Local Unicast (10/8, 172.16/12, 192.168/16) * RFC 3927
+	// - IPv4 Link-Local Unicast (169.254.0.0/16) * RFC 5771 - IPv4 Local
+	// Multicast (224.0.0.0/4) * RFC 4193 - IPv6 Local Unicast (fc00::/7) * RFC
+	// 4291 - IPv6 Link-Local Unicast (fe80::/10) * RFC 4291 - IPv6 Link-Local
+	// Multicast (ff02::/8) * RFC 4291 - IPv6 Interface Local Multicast
+	// (ff01::/8)
+	Locality string `ecs:"locality"`
 }

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -53,6 +53,12 @@ type Server struct {
 	// Server domain.
 	Domain string `ecs:"domain"`
 
+	// Locality can be either `private` or `public`. `private` indicates that
+	// the server IP address is the ranges reserved for private networks as
+	// defined in `network.locality`. `public` indicates that the server IP is
+	// outside of the private ranges.
+	Locality string `ecs:"locality"`
+
 	// Bytes sent from the server to the client.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -42,6 +42,12 @@ type Source struct {
 	// Source domain.
 	Domain string `ecs:"domain"`
 
+	// Locality can be either `private` or `public`. `private` indicates that
+	// the source IP address is the ranges reserved for private networks as
+	// defined in `network.locality`. `public` indicates that the source IP is
+	// outside of the private ranges.
+	Locality string `ecs:"locality"`
+
 	// Bytes sent from the source to the destination.
 	Bytes int64 `ecs:"bytes"`
 

--- a/fields.yml
+++ b/fields.yml
@@ -389,6 +389,16 @@
           description: >
             Packets sent from the destination to the source.
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the destination IP address is the ranges reserved for private networks
+            as defined in `network.locality`. `public` indicates that the
+            destination IP is outside of the private ranges.
+    
     - name: ecs
       title: ECS
       group: 2
@@ -1187,6 +1197,29 @@
             If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
           example: 24
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            both sides of the flow have IP addresses in the ranges reserved for
+            private networks as defined below. `public` indicates that at least one
+            side of the flow is outside of the private ranges. The IP addresses used
+            in determining this field's value are `source.ip` and `destination.ip`.
+    
+            Address ranges that are considered private are
+            * Loopback (127.0.0.0/8, ::1/128)
+            * Unspecified (0.0.0.0, ::)
+            * IPv4 Broadcast (255.255.255.255)
+            * RFC 1918 - IPv4 Local Unicast (10/8, 172.16/12, 192.168/16)
+            * RFC 3927 - IPv4 Link-Local Unicast (169.254.0.0/16)
+            * RFC 5771 - IPv4 Local Multicast (224.0.0.0/4)
+            * RFC 4193 - IPv6 Local Unicast (fc00::/7)
+            * RFC 4291 - IPv6 Link-Local Unicast (fe80::/10)
+            * RFC 4291 - IPv6 Link-Local Multicast (ff02::/8)
+            * RFC 4291 - IPv6 Interface Local Multicast (ff01::/8)
+    
     - name: observer
       title: Observer
       group: 2
@@ -1642,6 +1675,16 @@
           example: 12
           description: >
             Packets sent from the source to the destination.
+    
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the source IP address is the ranges reserved for private networks as
+            defined in `network.locality`. `public` indicates that the source IP is
+            outside of the private ranges.
     
     - name: url
       title: URL

--- a/fields.yml
+++ b/fields.yml
@@ -189,6 +189,16 @@
           description: >
             Client domain.
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the client IP address is the ranges reserved for private networks as
+            defined in `network.locality`. `public` indicates that the client IP is
+            outside of the private ranges.
+    
         # Metrics
         - name: bytes
           level: core
@@ -374,6 +384,16 @@
           description: >
             Destination domain.
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the destination IP address is the ranges reserved for private networks
+            as defined in `network.locality`. `public` indicates that the
+            destination IP is outside of the private ranges.
+    
         # Metrics
         - name: bytes
           level: core
@@ -389,15 +409,7 @@
           description: >
             Packets sent from the destination to the source.
     
-        - name: locality
-          level: extended
-          type: keyword
-          example: public
-          description: >
-            Locality can be either `private` or `public`. `private` indicates that
-            the destination IP address is the ranges reserved for private networks
-            as defined in `network.locality`. `public` indicates that the
-            destination IP is outside of the private ranges.
+    
     
     - name: ecs
       title: ECS
@@ -1509,6 +1521,16 @@
           description: >
             Server domain.
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the server IP address is the ranges reserved for private networks
+            as defined in `network.locality`. `public` indicates that the
+            server IP is outside of the private ranges.
+    
         # Metrics
         - name: bytes
           level: core
@@ -1661,6 +1683,16 @@
           description: >
             Source domain.
     
+        - name: locality
+          level: extended
+          type: keyword
+          example: public
+          description: >
+            Locality can be either `private` or `public`. `private` indicates that
+            the source IP address is the ranges reserved for private networks as
+            defined in `network.locality`. `public` indicates that the source IP is
+            outside of the private ranges.
+    
         # Metrics
         - name: bytes
           level: core
@@ -1676,15 +1708,7 @@
           description: >
             Packets sent from the source to the destination.
     
-        - name: locality
-          level: extended
-          type: keyword
-          example: public
-          description: >
-            Locality can be either `private` or `public`. `private` indicates that
-            the source IP address is the ranges reserved for private networks as
-            defined in `network.locality`. `public` indicates that the source IP is
-            outside of the private ranges.
+    
     
     - name: url
       title: URL

--- a/schema.csv
+++ b/schema.csv
@@ -12,6 +12,7 @@ client.address,keyword,extended,
 client.bytes,long,core,184
 client.domain,keyword,core,
 client.ip,ip,core,
+client.locality,keyword,extended,public
 client.mac,keyword,core,
 client.packets,long,core,12
 client.port,long,core,
@@ -142,6 +143,7 @@ server.address,keyword,extended,
 server.bytes,long,core,184
 server.domain,keyword,core,
 server.ip,ip,core,
+server.locality,keyword,extended,public
 server.mac,keyword,core,
 server.packets,long,core,12
 server.port,long,core,

--- a/schema.csv
+++ b/schema.csv
@@ -32,6 +32,7 @@ destination.address,keyword,extended,
 destination.bytes,long,core,184
 destination.domain,keyword,core,
 destination.ip,ip,core,
+destination.locality,keyword,extended,public
 destination.mac,keyword,core,
 destination.packets,long,core,12
 destination.port,long,core,
@@ -106,6 +107,7 @@ network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=
 network.direction,keyword,core,inbound
 network.forwarded_ip,ip,core,192.1.1.2
 network.iana_number,keyword,extended,6
+network.locality,keyword,extended,public
 network.name,keyword,extended,Guest Wifi
 network.packets,long,core,24
 network.protocol,keyword,core,http
@@ -153,6 +155,7 @@ source.address,keyword,extended,
 source.bytes,long,core,184
 source.domain,keyword,core,
 source.ip,ip,core,
+source.locality,keyword,extended,public
 source.mac,keyword,core,
 source.packets,long,core,12
 source.port,long,core,

--- a/schema.json
+++ b/schema.json
@@ -150,6 +150,16 @@
         "required": false, 
         "type": "ip"
       }, 
+      "client.locality": {
+        "description": "Locality can be either `private` or `public`. `private` indicates that the client IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the client IP is outside of the private ranges.", 
+        "example": "public", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "client.locality", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "client.mac": {
         "description": "MAC address of the client.", 
         "example": "", 
@@ -376,6 +386,16 @@
         "name": "destination.ip", 
         "required": false, 
         "type": "ip"
+      }, 
+      "destination.locality": {
+        "description": "Locality can be either `private` or `public`. `private` indicates that the destination IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the destination IP is outside of the private ranges.", 
+        "example": "public", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "destination.locality", 
+        "required": false, 
+        "type": "keyword"
       }, 
       "destination.mac": {
         "description": "MAC address of the destination.", 
@@ -1207,6 +1227,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "network.locality": {
+        "description": "Locality can be either `private` or `public`. `private` indicates that both sides of the flow have IP addresses in the ranges reserved for private networks as defined below. `public` indicates that at least one side of the flow is outside of the private ranges. The IP addresses used in determining this field's value are `source.ip` and `destination.ip`.\nAddress ranges that are considered private are * Loopback (127.0.0.0/8, ::1/128) * Unspecified (0.0.0.0, ::) * IPv4 Broadcast (255.255.255.255) * RFC 1918 - IPv4 Local Unicast (10/8, 172.16/12, 192.168/16) * RFC 3927 - IPv4 Link-Local Unicast (169.254.0.0/16) * RFC 5771 - IPv4 Local Multicast (224.0.0.0/4) * RFC 4193 - IPv6 Local Unicast (fc00::/7) * RFC 4291 - IPv6 Link-Local Unicast (fe80::/10) * RFC 4291 - IPv6 Link-Local Multicast (ff02::/8) * RFC 4291 - IPv6 Interface Local Multicast (ff01::/8)", 
+        "example": "public", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "network.locality", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "network.name": {
         "description": "Name given by operators to sections of their network.", 
         "example": "Guest Wifi", 
@@ -1601,6 +1631,16 @@
         "required": false, 
         "type": "ip"
       }, 
+      "server.locality": {
+        "description": "Locality can be either `private` or `public`. `private` indicates that the server IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the server IP is outside of the private ranges.", 
+        "example": "public", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "server.locality", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "server.mac": {
         "description": "MAC address of the server.", 
         "example": "", 
@@ -1748,6 +1788,16 @@
         "name": "source.ip", 
         "required": false, 
         "type": "ip"
+      }, 
+      "source.locality": {
+        "description": "Locality can be either `private` or `public`. `private` indicates that the source IP address is the ranges reserved for private networks as defined in `network.locality`. `public` indicates that the source IP is outside of the private ranges.", 
+        "example": "public", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "source.locality", 
+        "required": false, 
+        "type": "keyword"
       }, 
       "source.mac": {
         "description": "MAC address of the source.", 

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -51,6 +51,16 @@
       description: >
         Client domain.
 
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the client IP address is the ranges reserved for private networks as
+        defined in `network.locality`. `public` indicates that the client IP is
+        outside of the private ranges.
+
     # Metrics
     - name: bytes
       level: core

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -49,6 +49,16 @@
       description: >
         Destination domain.
 
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the destination IP address is the ranges reserved for private networks
+        as defined in `network.locality`. `public` indicates that the
+        destination IP is outside of the private ranges.
+
     # Metrics
     - name: bytes
       level: core
@@ -64,12 +74,4 @@
       description: >
         Packets sent from the destination to the source.
 
-    - name: locality
-      level: extended
-      type: keyword
-      example: public
-      description: >
-        Locality can be either `private` or `public`. `private` indicates that
-        the destination IP address is the ranges reserved for private networks
-        as defined in `network.locality`. `public` indicates that the
-        destination IP is outside of the private ranges.
+

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -63,3 +63,13 @@
       example: 12
       description: >
         Packets sent from the destination to the source.
+
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the destination IP address is the ranges reserved for private networks
+        as defined in `network.locality`. `public` indicates that the
+        destination IP is outside of the private ranges.

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -137,3 +137,26 @@
 
         If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
       example: 24
+
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        both sides of the flow have IP addresses in the ranges reserved for
+        private networks as defined below. `public` indicates that at least one
+        side of the flow is outside of the private ranges. The IP addresses used
+        in determining this field's value are `source.ip` and `destination.ip`.
+
+        Address ranges that are considered private are
+        * Loopback (127.0.0.0/8, ::1/128)
+        * Unspecified (0.0.0.0, ::)
+        * IPv4 Broadcast (255.255.255.255)
+        * RFC 1918 - IPv4 Local Unicast (10/8, 172.16/12, 192.168/16)
+        * RFC 3927 - IPv4 Link-Local Unicast (169.254.0.0/16)
+        * RFC 5771 - IPv4 Local Multicast (224.0.0.0/4)
+        * RFC 4193 - IPv6 Local Unicast (fc00::/7)
+        * RFC 4291 - IPv6 Link-Local Unicast (fe80::/10)
+        * RFC 4291 - IPv6 Link-Local Multicast (ff02::/8)
+        * RFC 4291 - IPv6 Interface Local Multicast (ff01::/8)

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -51,6 +51,16 @@
       description: >
         Server domain.
 
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the server IP address is the ranges reserved for private networks
+        as defined in `network.locality`. `public` indicates that the
+        server IP is outside of the private ranges.
+
     # Metrics
     - name: bytes
       level: core

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -49,6 +49,16 @@
       description: >
         Source domain.
 
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the source IP address is the ranges reserved for private networks as
+        defined in `network.locality`. `public` indicates that the source IP is
+        outside of the private ranges.
+
     # Metrics
     - name: bytes
       level: core
@@ -64,12 +74,4 @@
       description: >
         Packets sent from the source to the destination.
 
-    - name: locality
-      level: extended
-      type: keyword
-      example: public
-      description: >
-        Locality can be either `private` or `public`. `private` indicates that
-        the source IP address is the ranges reserved for private networks as
-        defined in `network.locality`. `public` indicates that the source IP is
-        outside of the private ranges.
+

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -63,3 +63,13 @@
       example: 12
       description: >
         Packets sent from the source to the destination.
+
+    - name: locality
+      level: extended
+      type: keyword
+      example: public
+      description: >
+        Locality can be either `private` or `public`. `private` indicates that
+        the source IP address is the ranges reserved for private networks as
+        defined in `network.locality`. `public` indicates that the source IP is
+        outside of the private ranges.

--- a/template.json
+++ b/template.json
@@ -166,6 +166,10 @@
             "ip": {
               "type": "ip"
             },
+            "locality": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -508,6 +512,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "locality": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "name": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -718,6 +726,10 @@
             },
             "ip": {
               "type": "ip"
+            },
+            "locality": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "mac": {
               "ignore_above": 1024,

--- a/template.json
+++ b/template.json
@@ -63,6 +63,10 @@
             "ip": {
               "type": "ip"
             },
+            "locality": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -670,6 +674,10 @@
             },
             "ip": {
               "type": "ip"
+            },
+            "locality": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "mac": {
               "ignore_above": 1024,


### PR DESCRIPTION
This adds `network.locality` that simply has a value of either private or public. If either `source.ip` or `destination.ip` are public IP addresses then network.locality is elevated to "public". Otherwise if both `source.ip` and `destination.ip` are non-public then `network.locality` is private.

The IPv4 and IPv6 ranges that are considered private are strictly specified in the definition of `network.locality`.

This is a useful means of filtering on flows. Some common queries I use are

- `network.locality:public and source.locality:public`
- `network.locality:public and destination.locality:public`