### PR TITLE
Backport #277, #282 and #285 to branch 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 - linux
 
 go:
-- 1.10.x
+- 1.11.x
 
 before_install:
 - make setup

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Common Schema
-Copyright 2018 Elastic N.V.
+Copyright 2018 Elasticsearch B.V.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/template.json
+++ b/template.json
@@ -3,7 +3,7 @@
     "ecs-1.0.0-*"
   ],
   "mappings": {
-    "doc": {
+    "_doc": {
       "_meta": {
         "version": "1.0.0"
       },


### PR DESCRIPTION
The goal of this backport is mainly about the copyright attribution (#285).

This also backports #277 and #282 to the 1.0 branch.