### PR TITLE
Add host.containerized and os.codename

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ A host is defined as a general computing instance. ECS host.* fields should be p
 | <a name="host.mac"></a>host.mac | Host mac address. | core | keyword |  |
 | <a name="host.type"></a>host.type | Type of host.<br/>For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | core | keyword |  |
 | <a name="host.architecture"></a>host.architecture | Operating system architecture. | core | keyword | `x86_64` |
+| <a name="host.containerized"></a>host.containerized | True if the host is running in a containerized environment. | core | keyword | `True` |
 
 
 ## <a name="http"></a> HTTP fields
@@ -387,6 +388,7 @@ Note also that the `os` fields are not expected to be used directly at the top l
 | <a name="os.family"></a>os.family | OS family (such as redhat, debian, freebsd, windows). | extended | keyword | `debian` |
 | <a name="os.version"></a>os.version | Operating system version as a raw string. | extended | keyword | `10.14.1` |
 | <a name="os.kernel"></a>os.kernel | Operating system kernel version as a raw string. | extended | keyword | `4.4.0-112-generic` |
+| <a name="os.codename"></a>os.codename | Operating system codename as a raw string. | extended | keyword | `Longhorn` |
 
 
 ## <a name="process"></a> Process fields

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -55,4 +55,7 @@ type Host struct {
 
 	// Operating system architecture.
 	Architecture string `ecs:"architecture"`
+
+	// True if the host is running in a containerized environment.
+	Containerized string `ecs:"containerized"`
 }

--- a/code/go/ecs/os.go
+++ b/code/go/ecs/os.go
@@ -38,4 +38,7 @@ type Os struct {
 
 	// Operating system kernel version as a raw string.
 	Kernel string `ecs:"kernel"`
+
+	// Operating system codename as a raw string.
+	Codename string `ecs:"codename"`
 }

--- a/fields.yml
+++ b/fields.yml
@@ -852,7 +852,13 @@
           example: "x86_64"
           description: >
             Operating system architecture.
-    
+        
+        - name: containerized
+          level: core
+          type: keyword
+          example: true
+          description: >
+            True if the host is running in a containerized environment.
     - name: http
       title: HTTP
       group: 2
@@ -1220,7 +1226,13 @@
           example: "4.4.0-112-generic"
           description: >
             Operating system kernel version as a raw string.
-    
+        
+        - name: codename
+          level: extended
+          type: keyword
+          example: "Longhorn"
+          description: >
+            Operating system codename as a raw string.
     - name: process
       title: Process
       group: 2

--- a/schema.csv
+++ b/schema.csv
@@ -82,6 +82,7 @@ geo.region_name,keyword,core,Quebec
 group.id,keyword,extended,
 group.name,keyword,extended,
 host.architecture,keyword,core,x86_64
+host.containerized,keyword,core,True
 host.hostname,keyword,core,
 host.id,keyword,core,
 host.ip,ip,core,
@@ -120,6 +121,7 @@ observer.vendor,keyword,core,
 observer.version,keyword,core,
 organization.id,keyword,extended,
 organization.name,keyword,extended,
+os.codename,keyword,extended,Longhorn
 os.family,keyword,extended,debian
 os.full,keyword,extended,Mac OS Mojave
 os.kernel,keyword,extended,4.4.0-112-generic

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -63,3 +63,10 @@
       example: "x86_64"
       description: >
         Operating system architecture.
+    
+    - name: containerized
+      level: core
+      type: keyword
+      example: true
+      description: >
+        True if the host is running in a containerized environment.

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -53,3 +53,10 @@
       example: "4.4.0-112-generic"
       description: >
         Operating system kernel version as a raw string.
+    
+    - name: codename
+      level: extended
+      type: keyword
+      example: "Longhorn"
+      description: >
+        Operating system codename as a raw string.

--- a/template.json
+++ b/template.json
@@ -383,6 +383,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "containerized": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "hostname": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -574,6 +578,10 @@
         },
         "os": {
           "properties": {
+            "codename": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "family": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
This came up in https://github.com/elastic/ecs/issues/75 and https://github.com/elastic/beats/issues/9154.

These fields seem useful. I notice no other fields in ECS are boolean, so this may be a first.