### PR TITLE
Generate process.args as []string in Go code

### DIFF
--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -40,7 +40,7 @@ type Process struct {
 
 	// Process arguments.
 	// May be filtered to protect sensitive information.
-	Args string `ecs:"args"`
+	Args []string `ecs:"args"`
 
 	// Absolute path to the process executable.
 	Executable string `ecs:"executable"`

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -269,6 +269,8 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	switch {
 	case fieldName == "duration" && elasticsearchDataType == "long":
 		return "time.Duration"
+	case fieldName == "args" && elasticsearchDataType == "keyword":
+		return "[]string"
 	}
 
 	switch elasticsearchDataType {


### PR DESCRIPTION
Add special handling for the process.args field to ensure that it's generated as a []string.