### PR TITLE
Make `user.group` a nesting of the `group` field set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file based on the
 
 ### Bugfixes
 
+* Remove the `user.group` `keyword` field, introduced in #204. Instead,
+  the `group` field set can be nested at `user.group` #308
+
 ### Added
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to this project will be documented in this file based on the
 ### Breaking changes
 
 * Remove the `user.group` `keyword` field, introduced in #204. Instead,
-  the `group` field set can be nested at `user.group` #308
+  the `group` field set can be nested at `user.group`. #308
 
 ### Bugfixes
 
-* Remove the `user.group` `keyword` field, introduced in #204. Instead,
-  the `group` field set can be nested at `user.group` #308
+* Field set name "group" was being used as a leaf field at `user.group`, instead
+ of being a nesting of the field set. This goes against a driving principle of ECS,
+ and has been corrected. #308
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file based on the
 
 ### Breaking changes
 
+* Remove the `user.group` `keyword` field, introduced in #204. Instead,
+  the `group` field set can be nested at `user.group` #308
+
 ### Bugfixes
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -271,6 +271,10 @@ Note also that the `geo` fields are not expected to be used directly at the top 
 The group fields are meant to represent groups that are relevant to the event.
 
 
+The `group` fields are expected to be nested at: `user.group`.
+
+Note also that the `group` fields may be used directly at the top level.
+
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="group.id"></a>group.id | Unique identifier for the group on the system/platform. | extended | keyword |  |
@@ -501,7 +505,6 @@ Note also that the `user` fields may be used directly at the top level.
 | <a name="user.full_name"></a>user.full_name | User's full name, if available. | extended | keyword | `Albert Einstein` |
 | <a name="user.email"></a>user.email | User email address. | extended | keyword |  |
 | <a name="user.hash"></a>user.hash | Unique user hash to correlate information for a user in anonymized form.<br/>Useful if `user.id` or `user.name` contain confidential information and cannot be used. | extended | keyword |  |
-| <a name="user.group"></a>user.group | Group the user is a part of. This field can contain a list of groups, if necessary. | extended | keyword |  |
 
 
 ## <a name="user_agent"></a> User agent fields

--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -39,8 +39,4 @@ type User struct {
 	// Useful if `user.id` or `user.name` contain confidential information and
 	// cannot be used.
 	Hash string `ecs:"hash"`
-
-	// Group the user is a part of. This field can contain a list of groups, if
-	// necessary.
-	Group string `ecs:"group"`
 }

--- a/fields.yml
+++ b/fields.yml
@@ -770,10 +770,16 @@
     - name: group
       title: Group
       group: 2
+      type: group
       description: >
         The group fields are meant to represent groups that are relevant to the
         event.
-      type: group
+    
+      reusable:
+        top_level: true
+        expected:
+          - user
+    
       fields:
     
         - name: id
@@ -1668,13 +1674,6 @@
     
             Useful if `user.id` or `user.name` contain confidential information and
             cannot be used.
-    
-        - name: group
-          level: extended
-          type: keyword
-          description: >
-            Group the user is a part of. This field can contain a list of groups, if
-            necessary.
     
     - name: user_agent
       title: User agent

--- a/schema.csv
+++ b/schema.csv
@@ -168,7 +168,6 @@ url.scheme,keyword,extended,https
 url.username,keyword,extended,
 user.email,keyword,extended,
 user.full_name,keyword,extended,Albert Einstein
-user.group,keyword,extended,
 user.hash,keyword,extended,
 user.id,keyword,core,
 user.name,keyword,core,albert

--- a/schema.json
+++ b/schema.json
@@ -1917,16 +1917,6 @@
         "required": false, 
         "type": "keyword"
       }, 
-      "user.group": {
-        "description": "Group the user is a part of. This field can contain a list of groups, if necessary.", 
-        "example": "", 
-        "footnote": "", 
-        "group": 2, 
-        "level": "extended", 
-        "name": "user.group", 
-        "required": false, 
-        "type": "keyword"
-      }, 
       "user.hash": {
         "description": "Unique user hash to correlate information for a user in anonymized form.\nUseful if `user.id` or `user.name` contain confidential information and cannot be used.", 
         "example": "", 

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -2,10 +2,16 @@
 - name: group
   title: Group
   group: 2
+  type: group
   description: >
     The group fields are meant to represent groups that are relevant to the
     event.
-  type: group
+
+  reusable:
+    top_level: true
+    expected:
+      - user
+
   fields:
 
     - name: id

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -52,10 +52,3 @@
 
         Useful if `user.id` or `user.name` contain confidential information and
         cannot be used.
-
-    - name: group
-      level: extended
-      type: keyword
-      description: >
-        Group the user is a part of. This field can contain a list of groups, if
-        necessary.

--- a/template.json
+++ b/template.json
@@ -788,10 +788,6 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "group": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "hash": {
               "ignore_above": 1024,
               "type": "keyword"


### PR DESCRIPTION
An error slipped in, and instead of nesting the `group` field set at `user.group`, we originally made this a `keyword` field.

This PR introduces a breaking change, but we are aiming to introduce this fix in ECS 1.0.0 GA.

The initial implementation went against our principle of not reusing top level object names elsewhere in the hierarchy, using different semantics.

This PR closes #304.