### PR TITLE
clarify host definition wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
-* Clarified the definition of the host fields #320
+* Clarified the definition of the host fields #325
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 ### Improvements
+* Clarified the definition of the host fields #320
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Note also that the `group` fields may be used directly at the top level.
 
 ## <a name="host"></a> Host fields
 
-A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or on which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -20,8 +20,8 @@
 package ecs
 
 // A host is defined as a general computing instance. ECS host.* fields should
-// be populated with details about the host on which the event happened, or on
-// which the measurement was taken. Host types include hardware, virtual
+// be populated with details about the host on which the event happened, or
+// from which the measurement was taken. Host types include hardware, virtual
 // machines, Docker containers, and Kubernetes nodes.
 type Host struct {
 	// Hostname of the host.

--- a/fields.yml
+++ b/fields.yml
@@ -798,7 +798,7 @@
       title: Host
       group: 2
       description: >
-        A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or on which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+        A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
       type: group
       fields:
     

--- a/schema.json
+++ b/schema.json
@@ -928,7 +928,7 @@
     "type": "group"
   }, 
   "host": {
-    "description": "A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or on which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.\n", 
+    "description": "A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.\n", 
     "fields": {
       "host.architecture": {
         "description": "Operating system architecture.", 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -3,7 +3,7 @@
   title: Host
   group: 2
   description: >
-    A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or on which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+    A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
   type: group
   fields:
 


### PR DESCRIPTION
_**WAS:**_ "ECS host.* fields should be populated with details about the host on which the event happened, or **on** which the measurement was taken."

**_NOW:_** "ECS host.* fields should be populated with details about the host on which the event happened, or **from** which the measurement was taken."