### PR TITLE
Introduction of an optional short field description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ All notable changes to this project will be documented in this file based on the
 * Field set name "group" was being used as a leaf field at `user.group`, instead
  of being a nesting of the field set. This goes against a driving principle of ECS,
  and has been corrected. #308
+* Replaced incorrect `ec2` example in `cloud.provider` with `aws`. #330
 
 ### Added
+
+* Added pointer in description of `http` field set to `url` field set. #330
+* Added an optional short field description. #330
 
 ### Improvements
 * Clarified the definition of the host fields #325
 * Specify the `object_type` for field `labels`. #331
+
+* Clarified the definition of the host fields. #325
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ All notable changes to this project will be documented in this file based on the
 * Clarified the definition of the host fields #325
 * Specify the `object_type` for field `labels`. #331
 
-* Clarified the definition of the host fields. #325
-
 ### Deprecated
 
 ## [1.0.0-beta2](https://github.com/elastic/ecs/compare/v1.0.0-beta1...v1.0.0-beta2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file based on the
 * Field set name "group" was being used as a leaf field at `user.group`, instead
  of being a nesting of the field set. This goes against a driving principle of ECS,
  and has been corrected. #308
-* Replaced incorrect `ec2` example in `cloud.provider` with `aws`. #330
+* Replaced incorrect examples in `cloud.provider`. #330
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ The base set contains all fields which are on the top level. These fields are co
 
 ## <a name="agent"></a> Agent fields
 
-The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
+The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
+
+Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -107,7 +109,9 @@ Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it
 
 ## <a name="client"></a> Client fields
 
-A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
+A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.
+
+For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
 
 Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
 
@@ -144,7 +148,9 @@ Examples: If Metricbeat is running on an EC2 host and fetches data from its host
 
 ## <a name="container"></a> Container fields
 
-Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+Container fields are used for meta information about the specific container that is the source of information.
+
+These fields help correlate data based containers from any runtime.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -159,7 +165,9 @@ Container fields are used for meta information about the specific container that
 
 ## <a name="destination"></a> Destination fields
 
-Destination fields describe details about the destination of a packet/event. Destination fields are usually populated in conjunction with source fields.
+Destination fields describe details about the destination of a packet/event.
+
+Destination fields are usually populated in conjunction with source fields.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -185,7 +193,9 @@ Meta-information specific to ECS.
 
 ## <a name="error"></a> Error fields
 
-These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error.
+These fields can represent errors of any kind.
+
+Use them for errors that happen while fetching events or in cases where the event itself contains an error.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -197,7 +207,9 @@ These fields can represent errors of any kind. Use them for errors that happen w
 
 ## <a name="event"></a> Event fields
 
-The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+The event fields are used for context information about the log or metric event itself.
+
+A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -224,7 +236,9 @@ The event fields are used for context information about the log or metric event 
 
 ## <a name="file"></a> File fields
 
-A file is defined as a set of information that has been created on, or has existed on a filesystem. File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
+A file is defined as a set of information that has been created on, or has existed on a filesystem.
+
+File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -283,7 +297,9 @@ Note also that the `group` fields may be used directly at the top level.
 
 ## <a name="host"></a> Host fields
 
-A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+A host is defined as a general computing instance.
+
+ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -329,7 +345,9 @@ Fields which are specific to log events.
 
 ## <a name="network"></a> Network fields
 
-The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
+The network is defined as the communication path over which a host or network event happens.
+
+The network.* fields should be populated with details about the network activity associated with an event.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -349,7 +367,9 @@ The network is defined as the communication path over which a host or network ev
 
 ## <a name="observer"></a> Observer fields
 
-An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
+An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
+
+This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -365,7 +385,9 @@ An observer is defined as a special network, security, or application device use
 
 ## <a name="organization"></a> Organization fields
 
-The organization fields enrich data with information about the company or entity the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple organizations.
+The organization fields enrich data with information about the company or entity the data is associated with.
+
+These fields help you arrange or filter data stored in an index by one or multiple organizations.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -395,7 +417,9 @@ Note also that the `os` fields are not expected to be used directly at the top l
 
 ## <a name="process"></a> Process fields
 
-These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.
+These fields contain information about a process.
+
+These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -413,7 +437,11 @@ These fields contain information about a process. These fields can help you corr
 
 ## <a name="related"></a> Related fields
 
-This field set is meant to facilitate pivoting around a piece of data. Some pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`. A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
+This field set is meant to facilitate pivoting around a piece of data.
+
+Some pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`.
+
+A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -423,7 +451,9 @@ This field set is meant to facilitate pivoting around a piece of data. Some piec
 
 ## <a name="server"></a> Server fields
 
-A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.
+
+For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
 
 Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
 
@@ -441,7 +471,9 @@ Client / server representations can add semantic context to an exchange, which i
 
 ## <a name="service"></a> Service fields
 
-The service fields describe the service for or from which the data was collected. These fields help you find and correlate logs for a specific service and version.
+The service fields describe the service for or from which the data was collected.
+
+These fields help you find and correlate logs for a specific service and version.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -456,7 +488,9 @@ The service fields describe the service for or from which the data was collected
 
 ## <a name="source"></a> Source fields
 
-Source fields describe details about the source of a packet/event. Source fields are usually populated in conjunction with destination fields.
+Source fields describe details about the source of a packet/event.
+
+Source fields are usually populated in conjunction with destination fields.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -491,7 +525,9 @@ URL fields provide a complete URL, with scheme, host, and path.
 
 ## <a name="user"></a> User fields
 
-The user fields describe information about the user that is relevant to  the event. Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.
+The user fields describe information about the user that is relevant to  the event.
+
+Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.
 
 
 The `user` fields are expected to be nested at: `client.user`, `destination.user`, `host.user`, `server.user`, `source.user`.
@@ -509,7 +545,9 @@ Note also that the `user` fields may be used directly at the top level.
 
 ## <a name="user_agent"></a> User agent fields
 
-The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+The user_agent fields normally come from a browser request.
+
+They often show up in web service logs coming from the parsed user agent string.
 
 
 | Field  | Description  | Level  | Type  | Example  |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ECS defines these fields.
 
 ## <a name="base"></a> Base fields
 
-The base set contains all fields which are on the top level. These fields are common across all types of events.
+The `base` field set contains all fields which are on the top level. These fields are common across all types of events.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -85,7 +85,7 @@ The base set contains all fields which are on the top level. These fields are co
 | <a name="@timestamp"></a>@timestamp | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="tags"></a>tags | List of keywords used to tag each event. | core | keyword | `["production", "env2"]` |
 | <a name="labels"></a>labels | Custom key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` |
-| <a name="message"></a>message | For log events the message field contains the log message, optimized for viewing in a log viewer.<br/>For structured logs without an original message field, other field can be concatenated to form a human-readable summary of the event.<br/>If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
+| <a name="message"></a>message | For log events the message field contains the log message, optimized for viewing in a log viewer.<br/>For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.<br/>If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
 
 
 ## <a name="agent"></a> Agent fields
@@ -134,7 +134,7 @@ Fields related to the cloud or infrastructure the events are coming from.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="cloud.provider"></a>cloud.provider | Name of the cloud provider. Example values are aws, azure, gce, or digitalocean. | extended | keyword | `ec2` |
+| <a name="cloud.provider"></a>cloud.provider | Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean. | extended | keyword | `ec2` |
 | <a name="cloud.availability_zone"></a>cloud.availability_zone | Availability zone in which this host is running. | extended | keyword | `us-east-1c` |
 | <a name="cloud.region"></a>cloud.region | Region in which this host is running. | extended | keyword | `us-east-1` |
 | <a name="cloud.instance.id"></a>cloud.instance.id | Instance ID of the host machine. | extended | keyword | `i-1234567890abcdef0` |
@@ -320,12 +320,12 @@ Fields related to HTTP activity. Use the `url` field set to store the url of the
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="http.request.method"></a>http.request.method | Http request method.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS"  section. | extended | keyword | `get, post, put` |
-| <a name="http.request.body.content"></a>http.request.body.content | The full http request body. | extended | keyword | `Hello world` |
+| <a name="http.request.method"></a>http.request.method | HTTP request method.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS"  section. | extended | keyword | `get, post, put` |
+| <a name="http.request.body.content"></a>http.request.body.content | The full HTTP request body. | extended | keyword | `Hello world` |
 | <a name="http.request.referrer"></a>http.request.referrer | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
-| <a name="http.response.status_code"></a>http.response.status_code | Http response status code. | extended | long | `404` |
-| <a name="http.response.body.content"></a>http.response.body.content | The full http response body. | extended | keyword | `Hello world` |
-| <a name="http.version"></a>http.version | Http version. | extended | keyword | `1.1` |
+| <a name="http.response.status_code"></a>http.response.status_code | HTTP response status code. | extended | long | `404` |
+| <a name="http.response.body.content"></a>http.response.body.content | The full HTTP response body. | extended | keyword | `Hello world` |
+| <a name="http.version"></a>http.version | HTTP version. | extended | keyword | `1.1` |
 | <a name="http.request.bytes"></a>http.request.bytes | Total size in bytes of the request (body and headers). | extended | long | `1437` |
 | <a name="http.request.body.bytes"></a>http.request.body.bytes | Size in bytes of the request body. | extended | long | `887` |
 | <a name="http.response.bytes"></a>http.response.bytes | Total size in bytes of the response (body and headers). | extended | long | `1437` |
@@ -439,7 +439,7 @@ These fields can help you correlate metrics information with a process id/name f
 
 This field set is meant to facilitate pivoting around a piece of data.
 
-Some pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`.
+Some pieces of information can be seen in many places in an ECS event. To facilitate searching for them, store an array of all seen values to their corresponding field in `related.`.
 
 A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
 
@@ -506,7 +506,7 @@ Source fields are usually populated in conjunction with destination fields.
 
 ## <a name="url"></a> URL fields
 
-URL fields provide a complete URL, with scheme, host, and path.
+URL fields provide support for complete or partial URLs, and supports the breaking down into scheme, domain, path, and so on.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -514,7 +514,7 @@ URL fields provide a complete URL, with scheme, host, and path.
 | <a name="url.original"></a>url.original | Unmodified original url as seen in the event source.<br/>Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.<br/>This field is meant to represent the URL as it was observed, complete or not. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch` |
 | <a name="url.full"></a>url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
-| <a name="url.domain"></a>url.domain | Domain of the request, such as "www.elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `www.elastic.co` |
+| <a name="url.domain"></a>url.domain | Domain of the url, such as "www.elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `www.elastic.co` |
 | <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |
@@ -525,7 +525,7 @@ URL fields provide a complete URL, with scheme, host, and path.
 
 ## <a name="user"></a> User fields
 
-The user fields describe information about the user that is relevant to  the event.
+The user fields describe information about the user that is relevant to the event.
 
 Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ The base set contains all fields which are on the top level. These fields are co
 |---|---|---|---|---|
 | <a name="@timestamp"></a>@timestamp | Date/time when the event originated.<br/>For log events this is the date/time when the event was generated, and not when it was read.<br/>Required field for all events. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="tags"></a>tags | List of keywords used to tag each event. | core | keyword | `["production", "env2"]` |
-| <a name="labels"></a>labels | Key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` |
-| <a name="message"></a>message | For log events the message field contains the log message.<br/>In other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
+| <a name="labels"></a>labels | Custom key/value pairs.<br/>Can be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.<br/>Example: `docker` and `k8s` labels. | core | object | `{'application': 'foo-bar', 'env': 'production'}` |
+| <a name="message"></a>message | For log events the message field contains the log message, optimized for viewing in a log viewer.<br/>For structured logs without an original message field, other field can be concatenated to form a human-readable summary of the event.<br/>If multiple messages exist, they can be combined into one message. | core | text | `Hello World` |
 
 
 ## <a name="agent"></a> Agent fields
@@ -96,7 +96,7 @@ The agent fields contain the data about the software entity, if any, that collec
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
 | <a name="agent.version"></a>agent.version | Version of the agent. | core | keyword | `6.0.0-rc2` |
-| <a name="agent.name"></a>agent.name | Name of the agent.<br/>This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.<br/>If no name is given, the name is often left empty. | core | keyword | `foo` |
+| <a name="agent.name"></a>agent.name | Custom name of the agent.<br/>This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.<br/>If no name is given, the name is often left empty. | core | keyword | `foo` |
 | <a name="agent.type"></a>agent.type | Type of the agent.<br/>The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | core | keyword | `filebeat` |
 | <a name="agent.id"></a>agent.id | Unique identifier of this agent (if one exists).<br/>Example: For Beats this would be beat.id. | core | keyword | `8a4f500d` |
 | <a name="agent.ephemeral_id"></a>agent.ephemeral_id | Ephemeral identifier of this agent (if one exists).<br/>This id normally changes across restarts, but `agent.id` does not. | extended | keyword | `8a4f500f` |
@@ -130,7 +130,7 @@ Fields related to the cloud or infrastructure the events are coming from.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="cloud.provider"></a>cloud.provider | Name of the cloud provider. Example values are ec2, gce, or digitalocean. | extended | keyword | `ec2` |
+| <a name="cloud.provider"></a>cloud.provider | Name of the cloud provider. Example values are aws, azure, gce, or digitalocean. | extended | keyword | `ec2` |
 | <a name="cloud.availability_zone"></a>cloud.availability_zone | Availability zone in which this host is running. | extended | keyword | `us-east-1c` |
 | <a name="cloud.region"></a>cloud.region | Region in which this host is running. | extended | keyword | `us-east-1` |
 | <a name="cloud.instance.id"></a>cloud.instance.id | Instance ID of the host machine. | extended | keyword | `i-1234567890abcdef0` |
@@ -180,7 +180,7 @@ Meta-information specific to ECS.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="ecs.version"></a>ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.<br/>When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.<br/>The current version is 1.0.0-beta2 . | core | keyword | `1.0.0-beta2` |
+| <a name="ecs.version"></a>ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.<br/>When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.<br/>The current version is 1.0.0-beta2. | core | keyword | `1.0.0-beta2` |
 
 
 ## <a name="error"></a> Error fields
@@ -210,7 +210,7 @@ The event fields are used for context information about the log or metric event 
 | <a name="event.type"></a>event.type | Reserved for future usage.<br/>Please avoid using this field for user data. | core | keyword |  |
 | <a name="event.module"></a>event.module | Name of the module this data is coming from.<br/>This information is coming from the modules used in Beats or Logstash. | core | keyword | `mysql` |
 | <a name="event.dataset"></a>event.dataset | Name of the dataset.<br/>The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name. | core | keyword | `stats` |
-| <a name="event.severity"></a>event.severity | Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events. | core | long | `7` |
+| <a name="event.severity"></a>event.severity | Severity describes the original severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events. | core | long | `7` |
 | <a name="event.original"></a>event.original | Raw text message of entire event. Used to demonstrate log integrity.<br/>This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. | core | (not indexed) | `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232` |
 | <a name="event.hash"></a>event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | extended | keyword | `123456789012345678901234567890ABCD` |
 | <a name="event.duration"></a>event.duration | Duration of the event in nanoseconds.<br/>If event.start and event.end are known this value should be the difference between the end and start time. | core | long |  |
@@ -299,7 +299,7 @@ A host is defined as a general computing instance. ECS host.* fields should be p
 
 ## <a name="http"></a> HTTP fields
 
-Fields related to HTTP activity.
+Fields related to HTTP activity. Use the `url` field set to store the url of the request.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -323,7 +323,7 @@ Fields which are specific to log events.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| <a name="log.level"></a>log.level | Log level of the log event.<br/>Some examples are `WARN`, `ERR`, `INFO`. | core | keyword | `ERR` |
+| <a name="log.level"></a>log.level | Original log level of the log event.<br/>Some examples are `warn`, `error`, `i`. | core | keyword | `err` |
 | <a name="log.original"></a>log.original | This is the original log message and contains the full log message before splitting it up in multiple parts.<br/>In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.<br/>This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`. | core | (not indexed) | `Sep 19 08:26:10 localhost My log` |
 
 
@@ -338,7 +338,7 @@ The network is defined as the communication path over which a host or network ev
 | <a name="network.type"></a>network.type | In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS" section. | core | keyword | `ipv4` |
 | <a name="network.iana_number"></a>network.iana_number | IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml). Standardized list of protocols. This aligns well with NetFlow and sFlow related logs which use the IANA Protocol Number. | extended | keyword | `6` |
 | <a name="network.transport"></a>network.transport | Same as network.iana_number, but instead using the Keyword name of the transport layer (udp, tcp, ipv6-icmp, etc.)<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS"  section. | core | keyword | `tcp` |
-| <a name="network.application"></a>network.application | A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS" section. | extended | keyword | `aim` |
+| <a name="network.application"></a>network.application | A name given to an application level protocol. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS" section. | extended | keyword | `aim` |
 | <a name="network.protocol"></a>network.protocol | L7 Network protocol name. ex. http, lumberjack, transport protocol.<br/>The field value must be normalized to lowercase for querying. See "Lowercase Capitalization" in the "Implementing ECS" section. | core | keyword | `http` |
 | <a name="network.direction"></a>network.direction | Direction of the network traffic.<br/>Recommended values are:<br/>  * inbound<br/>  * outbound<br/>  * internal<br/>  * external<br/>  * unknown<br/><br/>When mapping events from a host-based monitoring context, populate this field from the host's point of view.<br/>When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter. | core | keyword | `inbound` |
 | <a name="network.forwarded_ip"></a>network.forwarded_ip | Host IP address when the source IP address is the proxy. | core | ip | `192.1.1.2` |
@@ -349,7 +349,7 @@ The network is defined as the communication path over which a host or network ev
 
 ## <a name="observer"></a> Observer fields
 
-An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.  
+An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
 
 
 | Field  | Description  | Level  | Type  | Example  |
@@ -403,7 +403,7 @@ These fields contain information about a process. These fields can help you corr
 | <a name="process.pid"></a>process.pid | Process id. | core | long |  |
 | <a name="process.name"></a>process.name | Process name.<br/>Sometimes called program name or similar. | extended | keyword | `ssh` |
 | <a name="process.ppid"></a>process.ppid | Process parent id. | extended | long |  |
-| <a name="process.args"></a>process.args | Process arguments.<br/>May be filtered to protect sensitive information. | extended | keyword | `['ssh', '-l', 'user', '10.0.0.16']` |
+| <a name="process.args"></a>process.args | Array of process arguments.<br/>May be filtered to protect sensitive information. | extended | keyword | `['ssh', '-l', 'user', '10.0.0.16']` |
 | <a name="process.executable"></a>process.executable | Absolute path to the process executable. | extended | keyword | `/usr/bin/ssh` |
 | <a name="process.title"></a>process.title | Process title.<br/>The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | extended | keyword |  |
 | <a name="process.thread.id"></a>process.thread.id | Thread ID. | extended | long | `4242` |

--- a/code/go/ecs/agent.go
+++ b/code/go/ecs/agent.go
@@ -21,9 +21,10 @@ package ecs
 
 // The agent fields contain the data about the software entity, if any, that
 // collects, detects, or observes events on a host, or takes measurements on a
-// host. Examples include Beats. Agents may also run on observers. ECS agent.*
-// fields shall be populated with details of the agent running on the host or
-// observer where the event happened or the measurement was taken.
+// host.
+// Examples include Beats. Agents may also run on observers. ECS agent.* fields
+// shall be populated with details of the agent running on the host or observer
+// where the event happened or the measurement was taken.
 type Agent struct {
 	// Version of the agent.
 	Version string `ecs:"version"`

--- a/code/go/ecs/agent.go
+++ b/code/go/ecs/agent.go
@@ -28,7 +28,7 @@ type Agent struct {
 	// Version of the agent.
 	Version string `ecs:"version"`
 
-	// Name of the agent.
+	// Custom name of the agent.
 	// This is a name that can be given to an agent. This can be helpful if for
 	// example two Filebeat instances are running on the same host but a human
 	// readable separation is needed on which Filebeat instance data is coming

--- a/code/go/ecs/base.go
+++ b/code/go/ecs/base.go
@@ -23,8 +23,8 @@ import (
 	"time"
 )
 
-// The base set contains all fields which are on the top level. These fields
-// are common across all types of events.
+// The `base` field set contains all fields which are on the top level. These
+// fields are common across all types of events.
 type Base struct {
 	// Date/time when the event originated.
 	// For log events this is the date/time when the event was generated, and
@@ -43,7 +43,7 @@ type Base struct {
 
 	// For log events the message field contains the log message, optimized for
 	// viewing in a log viewer.
-	// For structured logs without an original message field, other field can
+	// For structured logs without an original message field, other fields can
 	// be concatenated to form a human-readable summary of the event.
 	// If multiple messages exist, they can be combined into one message.
 	Message string `ecs:"message"`

--- a/code/go/ecs/base.go
+++ b/code/go/ecs/base.go
@@ -35,15 +35,16 @@ type Base struct {
 	// List of keywords used to tag each event.
 	Tags string `ecs:"tags"`
 
-	// Key/value pairs.
+	// Custom key/value pairs.
 	// Can be used to add meta information to events. Should not contain nested
 	// objects. All values are stored as keyword.
 	// Example: `docker` and `k8s` labels.
 	Labels map[string]interface{} `ecs:"labels"`
 
-	// For log events the message field contains the log message.
-	// In other use cases the message field can be used to concatenate
-	// different values which are then freely searchable. If multiple messages
-	// exist, they can be combined into one message.
+	// For log events the message field contains the log message, optimized for
+	// viewing in a log viewer.
+	// For structured logs without an original message field, other field can
+	// be concatenated to form a human-readable summary of the event.
+	// If multiple messages exist, they can be combined into one message.
 	Message string `ecs:"message"`
 }

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -20,14 +20,14 @@
 package ecs
 
 // A client is defined as the initiator of a network connection for events
-// regarding sessions, connections, or bidirectional flow records. For TCP
-// events, the client is the initiator of the TCP connection that sends the SYN
-// packet(s). For other protocols, the client is generally the initiator or
-// requestor in the network transaction. Some systems use the term "originator"
-// to refer the client in TCP connections. The client fields describe details
-// about the system acting as the client in the network event. Client fields
-// are usually populated in conjunction with server fields.  Client fields are
-// generally not populated for packet-level events.
+// regarding sessions, connections, or bidirectional flow records.
+// For TCP events, the client is the initiator of the TCP connection that sends
+// the SYN packet(s). For other protocols, the client is generally the
+// initiator or requestor in the network transaction. Some systems use the term
+// "originator" to refer the client in TCP connections. The client fields
+// describe details about the system acting as the client in the network event.
+// Client fields are usually populated in conjunction with server fields.
+// Client fields are generally not populated for packet-level events.
 // Client / server representations can add semantic context to an exchange,
 // which is helpful to visualize the data in certain situations. If your
 // context falls in that category, you should still ensure that source and

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -21,7 +21,7 @@ package ecs
 
 // Fields related to the cloud or infrastructure the events are coming from.
 type Cloud struct {
-	// Name of the cloud provider. Example values are aws, azure, gce, or
+	// Name of the cloud provider. Example values are aws, azure, gcp, or
 	// digitalocean.
 	Provider string `ecs:"provider"`
 

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -21,7 +21,7 @@ package ecs
 
 // Fields related to the cloud or infrastructure the events are coming from.
 type Cloud struct {
-	// Name of the cloud provider. Example values are ec2, gce, or
+	// Name of the cloud provider. Example values are aws, azure, gce, or
 	// digitalocean.
 	Provider string `ecs:"provider"`
 

--- a/code/go/ecs/container.go
+++ b/code/go/ecs/container.go
@@ -20,8 +20,8 @@
 package ecs
 
 // Container fields are used for meta information about the specific container
-// that is the source of information. These fields help correlate data based
-// containers from any runtime.
+// that is the source of information.
+// These fields help correlate data based containers from any runtime.
 type Container struct {
 	// Runtime managing this container.
 	Runtime string `ecs:"runtime"`

--- a/code/go/ecs/ecs.go
+++ b/code/go/ecs/ecs.go
@@ -26,6 +26,6 @@ type ECS struct {
 	// When querying across multiple indices -- which may conform to slightly
 	// different ECS versions -- this field lets integrations adjust to the
 	// schema version of the events.
-	// The current version is 1.0.0-beta2 .
+	// The current version is 1.0.0-beta2.
 	Version string `ecs:"version"`
 }

--- a/code/go/ecs/error.go
+++ b/code/go/ecs/error.go
@@ -19,9 +19,9 @@
 
 package ecs
 
-// These fields can represent errors of any kind. Use them for errors that
-// happen while fetching events or in cases where the event itself contains an
-// error.
+// These fields can represent errors of any kind.
+// Use them for errors that happen while fetching events or in cases where the
+// event itself contains an error.
 type Error struct {
 	// Unique identifier for the error.
 	ID string `ecs:"id"`

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -24,15 +24,15 @@ import (
 )
 
 // The event fields are used for context information about the log or metric
-// event itself. A log is defined as an event containing details of something
-// that happened. Log events must include the time at which the thing happened.
-// Examples of log events include a process starting on a host, a network
-// packet being sent from a source to a destination, or a network connection
-// between a client and a server being initiated or closed. A metric is defined
-// as an event containing one or more numerical or categorical measurements and
-// the time at which the measurement was taken. Examples of metric events
-// include memory pressure measured on a host, or vulnerabilities measured on a
-// scanned host.
+// event itself.
+// A log is defined as an event containing details of something that happened.
+// Log events must include the time at which the thing happened. Examples of
+// log events include a process starting on a host, a network packet being sent
+// from a source to a destination, or a network connection between a client and
+// a server being initiated or closed. A metric is defined as an event
+// containing one or more numerical or categorical measurements and the time at
+// which the measurement was taken. Examples of metric events include memory
+// pressure measured on a host, or vulnerabilities measured on a scanned host.
 type Event struct {
 	// Unique ID to describe the event.
 	ID string `ecs:"id"`

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -80,9 +80,10 @@ type Event struct {
 	// in metricset.name and metricset.module or fileset.name.
 	Dataset string `ecs:"dataset"`
 
-	// Severity describes the severity of the event. What the different
-	// severity values mean can very different between use cases. It's up to
-	// the implementer to make sure severities are consistent across events.
+	// Severity describes the original severity of the event. What the
+	// different severity values mean can very different between use cases.
+	// It's up to the implementer to make sure severities are consistent across
+	// events.
 	Severity int64 `ecs:"severity"`
 
 	// Raw text message of entire event. Used to demonstrate log integrity.

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -24,10 +24,11 @@ import (
 )
 
 // A file is defined as a set of information that has been created on, or has
-// existed on a filesystem. File objects can be associated with host events,
-// network events, and/or file events (e.g., those produced by File Integrity
-// Monitoring [FIM] products or services). File fields provide details about
-// the affected file associated with the event or metric.
+// existed on a filesystem.
+// File objects can be associated with host events, network events, and/or file
+// events (e.g., those produced by File Integrity Monitoring [FIM] products or
+// services). File fields provide details about the affected file associated
+// with the event or metric.
 type File struct {
 	// Path to the file.
 	Path string `ecs:"path"`

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -19,10 +19,10 @@
 
 package ecs
 
-// A host is defined as a general computing instance. ECS host.* fields should
-// be populated with details about the host on which the event happened, or
-// from which the measurement was taken. Host types include hardware, virtual
-// machines, Docker containers, and Kubernetes nodes.
+// A host is defined as a general computing instance.
+// ECS host.* fields should be populated with details about the host on which
+// the event happened, or from which the measurement was taken. Host types
+// include hardware, virtual machines, Docker containers, and Kubernetes nodes.
 type Host struct {
 	// Hostname of the host.
 	// It normally contains what the `hostname` command returns on the host

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -19,7 +19,8 @@
 
 package ecs
 
-// Fields related to HTTP activity.
+// Fields related to HTTP activity. Use the `url` field set to store the url of
+// the request.
 type Http struct {
 	// Http request method.
 	// The field value must be normalized to lowercase for querying. See

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -22,24 +22,24 @@ package ecs
 // Fields related to HTTP activity. Use the `url` field set to store the url of
 // the request.
 type Http struct {
-	// Http request method.
+	// HTTP request method.
 	// The field value must be normalized to lowercase for querying. See
 	// "Lowercase Capitalization" in the "Implementing ECS"  section.
 	RequestMethod string `ecs:"request.method"`
 
-	// The full http request body.
+	// The full HTTP request body.
 	RequestBodyContent string `ecs:"request.body.content"`
 
 	// Referrer for this HTTP request.
 	RequestReferrer string `ecs:"request.referrer"`
 
-	// Http response status code.
+	// HTTP response status code.
 	ResponseStatusCode int64 `ecs:"response.status_code"`
 
-	// The full http response body.
+	// The full HTTP response body.
 	ResponseBodyContent string `ecs:"response.body.content"`
 
-	// Http version.
+	// HTTP version.
 	Version string `ecs:"version"`
 
 	// Total size in bytes of the request (body and headers).

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -21,8 +21,8 @@ package ecs
 
 // Fields which are specific to log events.
 type Log struct {
-	// Log level of the log event.
-	// Some examples are `WARN`, `ERR`, `INFO`.
+	// Original log level of the log event.
+	// Some examples are `warn`, `error`, `i`.
 	Level string `ecs:"level"`
 
 	// This is the original log message and contains the full log message

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -20,8 +20,9 @@
 package ecs
 
 // The network is defined as the communication path over which a host or
-// network event happens. The network.* fields should be populated with details
-// about the network activity associated with an event.
+// network event happens.
+// The network.* fields should be populated with details about the network
+// activity associated with an event.
 type Network struct {
 	// Name given by operators to sections of their network.
 	Name string `ecs:"name"`

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -44,11 +44,11 @@ type Network struct {
 	// "Lowercase Capitalization" in the "Implementing ECS"  section.
 	Transport string `ecs:"transport"`
 
-	// A name given to an application. This can be arbitrarily assigned for
-	// things like microservices, but also apply to things like skype, icq,
-	// facebook, twitter. This would be used in situations where the vendor or
-	// service can be decoded such as from the source/dest IP owners, ports, or
-	// wire format.
+	// A name given to an application level protocol. This can be arbitrarily
+	// assigned for things like microservices, but also apply to things like
+	// skype, icq, facebook, twitter. This would be used in situations where
+	// the vendor or service can be decoded such as from the source/dest IP
+	// owners, ports, or wire format.
 	// The field value must be normalized to lowercase for querying. See
 	// "Lowercase Capitalization" in the "Implementing ECS" section.
 	Application string `ecs:"application"`

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -21,15 +21,15 @@ package ecs
 
 // An observer is defined as a special network, security, or application device
 // used to detect, observe, or create network, security, or application-related
-// events and metrics. This could be a custom hardware appliance or a server
-// that has been configured to run special network, security, or application
-// software. Examples include firewalls, intrusion detection/prevention
-// systems, network monitoring sensors, web application firewalls, data loss
-// prevention systems, and APM servers. The observer.* fields shall be
-// populated with details of the system, if any, that detects, observes and/or
-// creates a network, security, or application event or metric. Message queues
-// and ETL components used in processing events or metrics are not considered
-// observers in ECS.
+// events and metrics.
+// This could be a custom hardware appliance or a server that has been
+// configured to run special network, security, or application software.
+// Examples include firewalls, intrusion detection/prevention systems, network
+// monitoring sensors, web application firewalls, data loss prevention systems,
+// and APM servers. The observer.* fields shall be populated with details of
+// the system, if any, that detects, observes and/or creates a network,
+// security, or application event or metric. Message queues and ETL components
+// used in processing events or metrics are not considered observers in ECS.
 type Observer struct {
 	// MAC address of the observer
 	MAC string `ecs:"mac"`

--- a/code/go/ecs/organization.go
+++ b/code/go/ecs/organization.go
@@ -20,8 +20,9 @@
 package ecs
 
 // The organization fields enrich data with information about the company or
-// entity the data is associated with. These fields help you arrange or filter
-// data stored in an index by one or multiple organizations.
+// entity the data is associated with.
+// These fields help you arrange or filter data stored in an index by one or
+// multiple organizations.
 type Organization struct {
 	// Organization name.
 	Name string `ecs:"name"`

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -23,10 +23,10 @@ import (
 	"time"
 )
 
-// These fields contain information about a process. These fields can help you
-// correlate metrics information with a process id/name from a log message.
-// The `process.pid` often stays in the metric itself and is copied to the
-// global field for correlation.
+// These fields contain information about a process.
+// These fields can help you correlate metrics information with a process
+// id/name from a log message.  The `process.pid` often stays in the metric
+// itself and is copied to the global field for correlation.
 type Process struct {
 	// Process id.
 	PID int64 `ecs:"pid"`

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -38,7 +38,7 @@ type Process struct {
 	// Process parent id.
 	PPID int64 `ecs:"ppid"`
 
-	// Process arguments.
+	// Array of process arguments.
 	// May be filtered to protect sensitive information.
 	Args []string `ecs:"args"`
 

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -20,9 +20,9 @@
 package ecs
 
 // This field set is meant to facilitate pivoting around a piece of data.
-// Some pieces of information can be seen in many places in ECS. To facilitate
-// searching for them, append values to their corresponding field in
-// `related.`.
+// Some pieces of information can be seen in many places in an ECS event. To
+// facilitate searching for them, store an array of all seen values to their
+// corresponding field in `related.`.
 // A concrete example is IP addresses, which can be under host, observer,
 // source, destination, client, server, and network.forwarded_ip. If you append
 // all IPs to `related.ip`, you can then search for a given IP trivially, no

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -19,13 +19,14 @@
 
 package ecs
 
-// This field set is meant to facilitate pivoting around a piece of data. Some
-// pieces of information can be seen in many places in ECS. To facilitate
+// This field set is meant to facilitate pivoting around a piece of data.
+// Some pieces of information can be seen in many places in ECS. To facilitate
 // searching for them, append values to their corresponding field in
-// `related.`. A concrete example is IP addresses, which can be under host,
-// observer, source, destination, client, server, and network.forwarded_ip. If
-// you append all IPs to `related.ip`, you can then search for a given IP
-// trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
+// `related.`.
+// A concrete example is IP addresses, which can be under host, observer,
+// source, destination, client, server, and network.forwarded_ip. If you append
+// all IPs to `related.ip`, you can then search for a given IP trivially, no
+// matter where it appeared, by querying `related.ip:a.b.c.d`.
 type Related struct {
 	// All of the IPs seen on your event.
 	IP string `ecs:"ip"`

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -20,14 +20,14 @@
 package ecs
 
 // A Server is defined as the responder in a network connection for events
-// regarding sessions, connections, or bidirectional flow records. For TCP
-// events, the server is the receiver of the initial SYN packet(s) of the TCP
-// connection. For other protocols, the server is generally the responder in
-// the network transaction. Some systems actually use the term "responder" to
-// refer the server in TCP connections. The server fields describe details
-// about the system acting as the server in the network event. Server fields
-// are usually populated in conjunction with client fields. Server fields are
-// generally not populated for packet-level events.
+// regarding sessions, connections, or bidirectional flow records.
+// For TCP events, the server is the receiver of the initial SYN packet(s) of
+// the TCP connection. For other protocols, the server is generally the
+// responder in the network transaction. Some systems actually use the term
+// "responder" to refer the server in TCP connections. The server fields
+// describe details about the system acting as the server in the network event.
+// Server fields are usually populated in conjunction with client fields.
+// Server fields are generally not populated for packet-level events.
 // Client / server representations can add semantic context to an exchange,
 // which is helpful to visualize the data in certain situations. If your
 // context falls in that category, you should still ensure that source and

--- a/code/go/ecs/service.go
+++ b/code/go/ecs/service.go
@@ -20,8 +20,9 @@
 package ecs
 
 // The service fields describe the service for or from which the data was
-// collected. These fields help you find and correlate logs for a specific
-// service and version.
+// collected.
+// These fields help you find and correlate logs for a specific service and
+// version.
 type Service struct {
 	// Unique identifier of the running service.
 	// This id should uniquely identify this service. This makes it possible to

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -19,8 +19,8 @@
 
 package ecs
 
-// Source fields describe details about the source of a packet/event. Source
-// fields are usually populated in conjunction with destination fields.
+// Source fields describe details about the source of a packet/event.
+// Source fields are usually populated in conjunction with destination fields.
 type Source struct {
 	// Some event source addresses are defined ambiguously. The event will
 	// sometimes list an IP, a domain or a unix socket.  You should always

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -19,7 +19,8 @@
 
 package ecs
 
-// URL fields provide a complete URL, with scheme, host, and path.
+// URL fields provide support for complete or partial URLs, and supports the
+// breaking down into scheme, domain, path, and so on.
 type Url struct {
 	// Unmodified original url as seen in the event source.
 	// Note that in network monitoring, the observed URL may be a full URL,
@@ -37,7 +38,7 @@ type Url struct {
 	// Note: The `:` is not part of the scheme.
 	Scheme string `ecs:"scheme"`
 
-	// Domain of the request, such as "www.elastic.co".
+	// Domain of the url, such as "www.elastic.co".
 	// In some cases a URL may refer to an IP and/or port directly, without a
 	// domain name. In this case, the IP address would go to the `domain`
 	// field.

--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -20,8 +20,9 @@
 package ecs
 
 // The user fields describe information about the user that is relevant to  the
-// event. Fields can have one entry or multiple entries. If a user has more
-// than one id, provide an array that includes all of them.
+// event.
+// Fields can have one entry or multiple entries. If a user has more than one
+// id, provide an array that includes all of them.
 type User struct {
 	// One or multiple unique identifiers of the user.
 	ID string `ecs:"id"`

--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -19,7 +19,7 @@
 
 package ecs
 
-// The user fields describe information about the user that is relevant to  the
+// The user fields describe information about the user that is relevant to the
 // event.
 // Fields can have one entry or multiple entries. If a user has more than one
 // id, provide an array that includes all of them.

--- a/code/go/ecs/user_agent.go
+++ b/code/go/ecs/user_agent.go
@@ -19,8 +19,9 @@
 
 package ecs
 
-// The user_agent fields normally come from a browser request. They often show
-// up in web service logs coming from the parsed user agent string.
+// The user_agent fields normally come from a browser request.
+// They often show up in web service logs coming from the parsed user agent
+// string.
 type UserAgent struct {
 	// Unparsed version of the user_agent.
 	Original string `ecs:"original"`

--- a/fields.yml
+++ b/fields.yml
@@ -8,6 +8,7 @@
     - name: agent
       title: Agent
       group: 2
+      short: Fields about the monitoring agent.
       description: >
         The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
     
@@ -78,8 +79,10 @@
     - name: base
       title: Base
       group: 1
+      short: All fields defined directly at the top level
       description: >
-        The base set contains all fields which are on the top level. These fields are common across all types of events.
+        The `base` field set contains all fields which are on the top level.
+        These fields are common across all types of events.
       type: group
       fields:
         - name: "@timestamp"
@@ -126,7 +129,7 @@
             For log events the message field contains the log message, optimized for
             viewing in a log viewer.
     
-            For structured logs without an original message field, other field can
+            For structured logs without an original message field, other fields can
             be concatenated to form a human-readable summary of the event.
     
             If multiple messages exist, they can be combined into one message.
@@ -134,6 +137,7 @@
     - name: client
       title: Client
       group: 2
+      short: Fields about the client side of a network connection, used with server.
       description: >
         A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.
     
@@ -200,6 +204,7 @@
     - name: cloud
       title: Cloud
       group: 2
+      short: Fields about the cloud resource.
       description: >
         Fields related to the cloud or infrastructure the events
         are coming from.
@@ -217,7 +222,7 @@
           type: keyword
           short: Name of the cloud provider.
           description: >
-            Name of the cloud provider. Example values are aws, azure, gce, or
+            Name of the cloud provider. Example values are aws, azure, gcp, or
             digitalocean.
     
         - name: availability_zone
@@ -269,6 +274,7 @@
     - name: container
       title: Container
       group: 2
+      short: Fields describing the container that generated this event.
       description: >
         Container fields are used for meta information about the specific container
         that is the source of information.
@@ -318,6 +324,7 @@
     - name: destination
       title: Destination
       group: 2
+      short: Fields about the destination side of a network connection, used with source.
       description: >
         Destination fields describe details about the destination of a packet/event.
     
@@ -405,6 +412,7 @@
     - name: error
       title: Error
       group: 2
+      short: Fields about errors of any kind.
       description: >
         These fields can represent errors of any kind.
     
@@ -434,6 +442,7 @@
     - name: event
       title: Event
       group: 2
+      short: Fields breaking down the event details.
       description: >
         The event fields are used for context information about the log or metric event itself.
     
@@ -645,6 +654,7 @@
     - name: file
       group: 2
       title: File
+      short: Fields describing files.
       description: >
          A file is defined as a set of information that has been created on, or has existed on a filesystem.
     
@@ -733,6 +743,7 @@
     - name: geo
       title: Geo
       group: 2
+      short: Fields describing a location.
       description: >
         Geo fields can carry data about a specific location related to an event
         or geo information derived from an IP field.
@@ -814,6 +825,7 @@
       title: Group
       group: 2
       type: group
+      short: User's group relevant to the event.
       description: >
         The group fields are meant to represent groups that are relevant to the
         event.
@@ -840,6 +852,7 @@
     - name: host
       title: Host
       group: 2
+      short: Fields describing the relevant computing instance.
       description: >
         A host is defined as a general computing instance.
     
@@ -911,6 +924,7 @@
     - name: http
       title: HTTP
       group: 2
+      short: Fields describing an HTTP request.
       description: >
         Fields related to HTTP activity. Use the `url` field set to store the url of the request.
       type: group
@@ -919,9 +933,9 @@
         - name: request.method
           level: extended
           type: keyword
-          short: Http request method.
+          short: HTTP request method.
           description: >
-            Http request method.
+            HTTP request method.
     
             The field value must be normalized to lowercase for querying. See
             "Lowercase Capitalization" in the "Implementing ECS"  section.
@@ -931,7 +945,7 @@
           level: extended
           type: keyword
           description: >
-            The full http request body.
+            The full HTTP request body.
           example: Hello world
     
         - name: request.referrer
@@ -945,21 +959,21 @@
           level: extended
           type: long
           description: >
-            Http response status code.
+            HTTP response status code.
           example: 404
     
         - name: response.body.content
           level: extended
           type: keyword
           description: >
-            The full http response body.
+            The full HTTP response body.
           example: Hello world
     
         - name: version
           level: extended
           type: keyword
           description: >
-            Http version.
+            HTTP version.
           example: 1.1
     
         # Metrics
@@ -1031,6 +1045,7 @@
     - name: network
       title: Network
       group: 2
+      short: Fields describing the communication path over which the event happened.
       description: >
         The network is defined as the communication path over which a host or network event happens.
     
@@ -1169,6 +1184,7 @@
     - name: observer
       title: Observer
       group: 2
+      short: Fields describing an entity observing the event from outside the host.
       description: >
         An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
     
@@ -1219,6 +1235,7 @@
     - name: organization
       title: Organization
       group: 2
+      short: Fields describing the organization or company the event is associated with.
       description: >
         The organization fields enrich data with information about the company or entity
         the data is associated with.
@@ -1242,6 +1259,7 @@
     - name: os
       title: Operating System
       group: 2
+      short: OS fields contain information about the operating system.
       description: >
         The OS fields contain information about the operating system.
       reusable:
@@ -1298,6 +1316,7 @@
     - name: process
       title: Process
       group: 2
+      short: These fields contain information about a process.
       description: >
         These fields contain information about a process.
     
@@ -1381,12 +1400,13 @@
     - name: related
       title: Related
       group: 2
+      short: Fields meant to facilitate pivoting around a piece of data.
       description: >
         This field set is meant to facilitate pivoting around a piece of data.
     
-        Some pieces of information can be seen in many places in ECS. To facilitate
-        searching for them, append values to their corresponding field in
-        `related.`.
+        Some pieces of information can be seen in many places in an ECS event.
+        To facilitate searching for them, store an array of all seen values to their
+        corresponding field in `related.`.
     
         A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
       type: group
@@ -1401,6 +1421,7 @@
     - name: server
       title: Server
       group: 2
+      short: Fields about the server side of a network connection, used with client.
       description: >
         A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.
     
@@ -1467,6 +1488,7 @@
     - name: service
       title: Service
       group: 2
+      short: Fields describing the service for or from which the data was collected.
       description: >
         The service fields describe the service for or from which the data was collected.
     
@@ -1553,6 +1575,7 @@
     - name: source
       title: Source
       group: 2
+      short: Fields about the source side of a network connection, used with destination.
       description: >
         Source fields describe details about the source of a packet/event.
     
@@ -1616,8 +1639,10 @@
     
     - name: url
       title: URL
+      short: Fields that let you store URLs in various forms.
       description: >
-        URL fields provide a complete URL, with scheme, host, and path.
+        URL fields provide support for complete or partial URLs, and supports the
+        breaking down into scheme, domain, path, and so on.
       type: group
       fields:
     
@@ -1649,7 +1674,7 @@
         - name: scheme
           level: extended
           type: keyword
-          short: Scheme of the request.
+          short: Scheme of the url.
           description: >
             Scheme of the request, such as "https".
     
@@ -1659,9 +1684,9 @@
         - name: domain
           level: extended
           type: keyword
-          short: Domain of the request.
+          short: Domain of the url.
           description: >
-            Domain of the request, such as "www.elastic.co".
+            Domain of the url, such as "www.elastic.co".
     
             In some cases a URL may refer to an IP and/or port directly, without a
             domain name. In this case, the IP address would go to the `domain` field.
@@ -1717,9 +1742,10 @@
     - name: user
       title: User
       group: 2
+      short: Fields to describe the user relevant to the event.
       description: >
         The user fields describe information about the user that is relevant
-        to  the event.
+        to the event.
     
         Fields can have one entry or multiple entries. If a
         user has more than one id, provide an array that includes all of
@@ -1774,6 +1800,7 @@
     - name: user_agent
       title: User agent
       group: 2
+      short: Fields to describe a browser user_agent string.
       description: >
         The user_agent fields normally come from a browser request.
     

--- a/fields.yml
+++ b/fields.yml
@@ -29,8 +29,9 @@
         - name: name
           level: core
           type: keyword
+          short: Custom name of the agent.
           description: >
-            Name of the agent.
+            Custom name of the agent.
     
             This is a name that can be given to an agent. This can be helpful if
             for example two Filebeat instances are running on the same host
@@ -43,6 +44,7 @@
         - name: type
           level: core
           type: keyword
+          short: Type of the agent.
           description: >
             Type of the agent.
     
@@ -54,6 +56,7 @@
         - name: id
           level: core
           type: keyword
+          short: Unique identifier of this agent.
           description: >
             Unique identifier of this agent (if one exists).
     
@@ -63,6 +66,7 @@
         - name: ephemeral_id
           level: extended
           type: keyword
+          short: Ephemeral identifier of this agent.
           description: >
             Ephemeral identifier of this agent (if one exists).
     
@@ -81,6 +85,7 @@
           level: core
           required: true
           example: "2016-05-23T08:05:34.853Z"
+          short: Date/time when the event originated.
           description: >
             Date/time when the event originated.
     
@@ -101,8 +106,9 @@
           type: object
           object_type: keyword
           example: {env: production, application: foo-bar}
+          short: Custom key/value pairs.
           description: >
-            Key/value pairs.
+            Custom key/value pairs.
     
             Can be used to add meta information to events. Should not contain nested
             objects. All values are stored as keyword.
@@ -113,12 +119,15 @@
           level: core
           type: text
           example: "Hello World"
+          short: Log message optimized for viewing in a log viewer.
           description: >
-            For log events the message field contains the log message.
+            For log events the message field contains the log message, optimized for
+            viewing in a log viewer.
     
-            In other use cases the message field can be used to concatenate
-            different values which are then freely searchable. If multiple
-            messages exist, they can be combined into one message.
+            For structured logs without an original message field, other field can
+            be concatenated to form a human-readable summary of the event.
+    
+            If multiple messages exist, they can be combined into one message.
     
     - name: client
       title: Client
@@ -133,6 +142,7 @@
         - name: address
           level: extended
           type: keyword
+          short: Client network address.
           description: >
             Some event client addresses are defined ambiguously. The event will
             sometimes list an IP, a domain or a unix socket.  You should always
@@ -144,6 +154,7 @@
         - name: ip
           level: core
           type: ip
+          short: IP address of the client.
           description: >
             IP address of the client.
     
@@ -200,8 +211,9 @@
           level: extended
           example: ec2
           type: keyword
+          short: Name of the cloud provider.
           description: >
-            Name of the cloud provider. Example values are ec2, gce, or
+            Name of the cloud provider. Example values are aws, azure, gce, or
             digitalocean.
     
         - name: availability_zone
@@ -242,6 +254,7 @@
           level: extended
           type: keyword
           example: 666777888999
+          short: The cloud account or organization id.
           description: >
             The cloud account or organization id used to identify different
             entities in a multi-tenant environment.
@@ -309,6 +322,7 @@
         - name: address
           level: extended
           type: keyword
+          short: Destination network address.
           description: >
             Some event destination addresses are defined ambiguously. The event will
             sometimes list an IP, a domain or a unix socket.  You should always
@@ -320,6 +334,7 @@
         - name: ip
           level: core
           type: ip
+          short: IP address of the destination.
           description: >
             IP address of the destination.
     
@@ -370,6 +385,7 @@
           level: core
           type: keyword
           required: true
+          short: ECS version this event conforms to.
           description: >
             ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.
     
@@ -377,7 +393,7 @@
             different ECS versions -- this field lets integrations adjust to the
             schema version of the events.
     
-            The current version is 1.0.0-beta2 .
+            The current version is 1.0.0-beta2.
           example: 1.0.0-beta2
     
     - name: error
@@ -425,6 +441,7 @@
         - name: kind
           level: extended
           type: keyword
+          short: The kind of the event.
           description: >
             The kind of the event.
     
@@ -438,6 +455,7 @@
         - name: category
           level: core
           type: keyword
+          short: Event category.
           description: >
             Event category.
     
@@ -452,6 +470,7 @@
         - name: action
           level: core
           type: keyword
+          short: The action captured by the event.
           description: >
             The action captured by the event.
     
@@ -463,6 +482,7 @@
         - name: outcome
           level: extended
           type: keyword
+          short: The outcome of the event.
           description: >
             The outcome of the event.
     
@@ -476,6 +496,7 @@
         - name: type
           level: core
           type: keyword
+          short: Reserved for future usage.
           description: >
             Reserved for future usage.
     
@@ -493,6 +514,7 @@
         - name: dataset
           level: core
           type: keyword
+          short: Name of the dataset.
           description: >
             Name of the dataset.
     
@@ -505,8 +527,9 @@
           level: core
           type: long
           example: "7"
+          short: Original severity of the event.
           description: >
-            Severity describes the severity of the event. What the different
+            Severity describes the original severity of the event. What the different
             severity values mean can very different between use cases. It's up to
             the implementer to make sure severities are consistent across events.
     
@@ -521,6 +544,7 @@
               threatmanager&#124;1.0&#124;100&#124;
               worm successfully stopped&#124;10&#124;src=10.0.0.1
               dst=2.1.2.2spt=1232"
+          short: Raw text message of entire event.
           description: >
               Raw text message of entire event. Used to demonstrate log integrity.
     
@@ -540,6 +564,7 @@
         - name: duration
           level: core
           type: long
+          short: Duration of the event in nanoseconds.
           description: >
             Duration of the event in nanoseconds.
     
@@ -549,6 +574,7 @@
         - name: timezone
           level: extended
           type: keyword
+          short: Event time zone.
           description: >
             This field should be populated when the event's timestamp does not include
             timezone information already (e.g. default Syslog timestamps). It's
@@ -560,6 +586,7 @@
         - name: created
           level: core
           type: date
+          short: Time when the event was first read by an agent or by your pipeline.
           description: >
             event.created contains the date when the event was created.
     
@@ -598,6 +625,7 @@
         - name: risk_score_norm
           level: extended
           type: float
+          short: Normalized risk score or priority of the event (0-100).
           description: >
             Normalized risk score or priority of the event, on a scale of 0 to 100.
     
@@ -625,6 +653,7 @@
       - name: extension
         level: extended
         type: keyword
+        short: File extension.
         description: >
           File extension.
     
@@ -759,6 +788,7 @@
         - name: name
           level: extended
           type: keyword
+          short: User-defined description of a location.
           description: >
             User-defined description of a location, at the level of granularity they care about.
     
@@ -806,6 +836,7 @@
         - name: hostname
           level: core
           type: keyword
+          short: Hostname of the host.
           description: >
             Hostname of the host.
     
@@ -814,6 +845,7 @@
         - name: name
           level: core
           type: keyword
+          short: Name of the host.
           description: >
             Name of the host.
     
@@ -824,6 +856,7 @@
         - name: id
           level: core
           type: keyword
+          short: Unique host id.
           description: >
             Unique host id.
     
@@ -846,6 +879,7 @@
         - name: type
           level: core
           type: keyword
+          short: Type of host.
           description: >
             Type of host.
     
@@ -864,13 +898,14 @@
       title: HTTP
       group: 2
       description: >
-        Fields related to HTTP activity.
+        Fields related to HTTP activity. Use the `url` field set to store the url of the request.
       type: group
       fields:
     
         - name: request.method
           level: extended
           type: keyword
+          short: Http request method.
           description: >
             Http request method.
     
@@ -953,11 +988,12 @@
         - name: level
           level: core
           type: keyword
+          short: Log level of the log event.
           description: >
-            Log level of the log event.
+            Original log level of the log event.
     
-            Some examples are `WARN`, `ERR`, `INFO`.
-          example: ERR
+            Some examples are `warn`, `error`, `i`.
+          example: err
     
         - name: original
           level: core
@@ -965,8 +1001,8 @@
           example: "Sep 19 08:26:10 localhost My log"
           index: false
           doc_values: false
+          short: Original log message with light interpretation only (encoding, newlines).
           description: >
-    
             This is the original log message and contains the full log message
             before splitting it up in multiple parts.
     
@@ -996,6 +1032,7 @@
         - name: type
           level: core
           type: keyword
+          short: In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc
           description: >
             In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc
     
@@ -1006,6 +1043,7 @@
         - name: iana_number
           level: extended
           type: keyword
+          short: IANA Protocol Number.
           description: >
               IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
               Standardized list of protocols. This aligns well with NetFlow and
@@ -1015,6 +1053,7 @@
         - name: transport
           level: core
           type: keyword
+          short: Protocol Name corresponding to the field `iana_number`.
           description: >
             Same as network.iana_number, but instead using the Keyword name of the
             transport layer (udp, tcp, ipv6-icmp, etc.)
@@ -1026,8 +1065,10 @@
         - name: application
           level: extended
           type: keyword
+          short: >
+            Application level protocol name.
           description: >
-            A name given to an application. This can be arbitrarily assigned for
+            A name given to an application level protocol. This can be arbitrarily assigned for
             things like microservices, but also apply to things like skype, icq,
             facebook, twitter. This would be used in situations where the vendor
             or service can be decoded such as from the source/dest IP owners,
@@ -1040,6 +1081,7 @@
         - name: protocol
           level: core
           type: keyword
+          short: L7 Network protocol name.
           description: >
             L7 Network protocol name. ex. http, lumberjack, transport protocol.
     
@@ -1050,6 +1092,7 @@
         - name: direction
           level: core
           type: keyword
+          short: Direction of the network traffic.
           description: >
             Direction of the network traffic.
     
@@ -1077,6 +1120,7 @@
         - name: community_id
           level: extended
           type: keyword
+          short: A hash of source and destination IPs and ports.
           description: >
             A hash of source and destination IPs and ports, as well as the protocol
             used in a communication. This is a tool-agnostic standard to identify
@@ -1089,6 +1133,7 @@
         - name: bytes
           level: core
           type: long
+          short: Total bytes transferred in both directions.
           description: >
             Total bytes transferred in both directions.
     
@@ -1098,6 +1143,7 @@
         - name: packets
           level: core
           type: long
+          short: Total packets transferred in both directions.
           description: >
             Total packets transferred in both directions.
     
@@ -1108,7 +1154,7 @@
       title: Observer
       group: 2
       description: >
-        An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.  
+        An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
       type: group
       fields:
         - name: mac
@@ -1144,6 +1190,7 @@
         - name: type
           level: core
           type: keyword
+          short: The type of the observer the data is coming from.
           description: >
             The type of the observer the data is coming from.
     
@@ -1249,6 +1296,7 @@
         - name: name
           level: extended
           type: keyword
+          short: Process name.
           description: >
             Process name.
     
@@ -1264,8 +1312,9 @@
         - name: args
           level: extended
           type: keyword
+          short: Array of process arguments.
           description: >
-            Process arguments.
+            Array of process arguments.
     
             May be filtered to protect sensitive information.
           example: ["ssh", "-l", "user", "10.0.0.16"]
@@ -1280,6 +1329,7 @@
         - name: title
           level: extended
           type: keyword
+          short: Process title.
           description: >
             Process title.
     
@@ -1338,6 +1388,7 @@
         - name: address
           level: extended
           type: keyword
+          short: Server network address.
           description: >
             Some event server addresses are defined ambiguously. The event will
             sometimes list an IP, a domain or a unix socket.  You should always
@@ -1349,6 +1400,7 @@
         - name: ip
           level: core
           type: ip
+          short: IP address of the server.
           description: >
             IP address of the server.
     
@@ -1400,6 +1452,7 @@
         - name: id
           level: core
           type: keyword
+          short: Unique identifier of the running service.
           description: >
             Unique identifier of the running service.
     
@@ -1415,6 +1468,7 @@
           level: core
           type: keyword
           example: "elasticsearch-metrics"
+          short: Name of the service.
           description: >
             Name of the service data is collected from.
     
@@ -1433,6 +1487,7 @@
           level: core
           type: keyword
           example: "elasticsearch"
+          short: The type of the service.
           description: >
             The type of the service data is collected from.
     
@@ -1452,6 +1507,7 @@
           level: core
           type: keyword
           example: "3.2.4"
+          short: Version of the service.
           description: >
             Version of the service the data was collected from.
     
@@ -1461,6 +1517,7 @@
         - name: ephemeral_id
           level: extended
           type: keyword
+          short: Ephemeral identifier of this service.
           description: >
             Ephemeral identifier of this service (if one exists).
     
@@ -1479,6 +1536,7 @@
         - name: address
           level: extended
           type: keyword
+          short: Source network address.
           description: >
             Some event source addresses are defined ambiguously. The event will
             sometimes list an IP, a domain or a unix socket.  You should always
@@ -1490,6 +1548,7 @@
         - name: ip
           level: core
           type: ip
+          short: IP address of the source.
           description: >
             IP address of the source.
     
@@ -1538,6 +1597,7 @@
         - name: original
           level: extended
           type: keyword
+          short: Unmodified original url as seen in the event source.
           description: >
             Unmodified original url as seen in the event source.
     
@@ -1552,6 +1612,7 @@
         - name: full
           level: extended
           type: keyword
+          short: Full unparsed URL.
           description: >
             If full URLs are important to your use case, they should be stored in
             `url.full`, whether this field is reconstructed or present in the
@@ -1561,6 +1622,7 @@
         - name: scheme
           level: extended
           type: keyword
+          short: Scheme of the request.
           description: >
             Scheme of the request, such as "https".
     
@@ -1570,6 +1632,7 @@
         - name: domain
           level: extended
           type: keyword
+          short: Domain of the request.
           description: >
             Domain of the request, such as "www.elastic.co".
     
@@ -1593,6 +1656,7 @@
         - name: query
           level: extended
           type: keyword
+          short: Query string of the request.
           description: >
             The query field describes the query string of the request,
             such as "q=elasticsearch".
@@ -1605,6 +1669,7 @@
         - name: fragment
           level: extended
           type: keyword
+          short: Portion of the url after the `#`.
           description: >
             Portion of the url after the `#`, such as "top".
     
@@ -1670,6 +1735,7 @@
         - name: hash
           level: extended
           type: keyword
+          short: Unique user hash to correlate information for a user in anonymized form.
           description: >
             Unique user hash to correlate information for a user in anonymized form.
     

--- a/fields.yml
+++ b/fields.yml
@@ -9,7 +9,9 @@
       title: Agent
       group: 2
       description: >
-        The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
+        The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
+    
+        Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
       footnote: >
         Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the
         agent running in the app/service. The agent information does not change if
@@ -133,7 +135,9 @@
       title: Client
       group: 2
       description: >
-        A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
+        A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.
+    
+        For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
     
         Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
       type: group
@@ -267,8 +271,9 @@
       group: 2
       description: >
         Container fields are used for meta information about the specific container
-        that is the source of information. These fields help correlate data based
-        containers from any runtime.
+        that is the source of information.
+    
+        These fields help correlate data based containers from any runtime.
       type: group
       fields:
     
@@ -315,6 +320,7 @@
       group: 2
       description: >
         Destination fields describe details about the destination of a packet/event.
+    
         Destination fields are usually populated in conjunction with source fields.
       type: group
       fields:
@@ -400,8 +406,10 @@
       title: Error
       group: 2
       description: >
-        These fields can represent errors of any kind. Use them for errors that
-        happen while fetching events or in cases where the event itself contains an error.
+        These fields can represent errors of any kind.
+    
+        Use them for errors that happen while fetching events or in cases where the
+        event itself contains an error.
     
       type: group
       fields:
@@ -427,7 +435,9 @@
       title: Event
       group: 2
       description: >
-        The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+        The event fields are used for context information about the log or metric event itself.
+    
+        A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
       type: group
       fields:
     
@@ -636,7 +646,9 @@
       group: 2
       title: File
       description: >
-         A file is defined as a set of information that has been created on, or has existed on a filesystem. File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
+         A file is defined as a set of information that has been created on, or has existed on a filesystem.
+    
+         File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
       type: group
       fields:
     
@@ -829,7 +841,9 @@
       title: Host
       group: 2
       description: >
-        A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+        A host is defined as a general computing instance.
+    
+        ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
       type: group
       fields:
     
@@ -1018,7 +1032,9 @@
       title: Network
       group: 2
       description: >
-        The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
+        The network is defined as the communication path over which a host or network event happens.
+    
+        The network.* fields should be populated with details about the network activity associated with an event.
       type: group
       fields:
     
@@ -1154,7 +1170,9 @@
       title: Observer
       group: 2
       description: >
-        An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
+        An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
+    
+        This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
       type: group
       fields:
         - name: mac
@@ -1203,7 +1221,9 @@
       group: 2
       description: >
         The organization fields enrich data with information about the company or entity
-        the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple
+        the data is associated with.
+    
+        These fields help you arrange or filter data stored in an index by one or multiple
         organizations.
       type: group
       fields:
@@ -1280,6 +1300,7 @@
       group: 2
       description: >
         These fields contain information about a process.
+    
         These fields can help you correlate metrics information with a process id/name
         from a log message.  The `process.pid` often stays in the metric itself and is
         copied to the global field for correlation.
@@ -1362,9 +1383,11 @@
       group: 2
       description: >
         This field set is meant to facilitate pivoting around a piece of data.
+    
         Some pieces of information can be seen in many places in ECS. To facilitate
         searching for them, append values to their corresponding field in
         `related.`.
+    
         A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
       type: group
       fields:
@@ -1379,7 +1402,9 @@
       title: Server
       group: 2
       description: >
-        A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+        A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.
+    
+        For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
     
         Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
       type: group
@@ -1443,8 +1468,9 @@
       title: Service
       group: 2
       description: >
-        The service fields describe the service for or from which the data was
-        collected. These fields help you find and correlate logs for a specific
+        The service fields describe the service for or from which the data was collected.
+    
+        These fields help you find and correlate logs for a specific
         service and version.
       type: group
       fields:
@@ -1529,6 +1555,7 @@
       group: 2
       description: >
         Source fields describe details about the source of a packet/event.
+    
         Source fields are usually populated in conjunction with destination fields.
       type: group
       fields:
@@ -1692,7 +1719,9 @@
       group: 2
       description: >
         The user fields describe information about the user that is relevant
-        to  the event. Fields can have one entry or multiple entries. If a
+        to  the event.
+    
+        Fields can have one entry or multiple entries. If a
         user has more than one id, provide an array that includes all of
         them.
       reusable:
@@ -1746,8 +1775,9 @@
       title: User agent
       group: 2
       description: >
-        The user_agent fields normally come from a browser request. They often
-        show up in web service logs coming from the parsed user agent string.
+        The user_agent fields normally come from a browser request.
+    
+        They often show up in web service logs coming from the parsed user agent string.
       type: group
       fields:
     

--- a/schema.csv
+++ b/schema.csv
@@ -98,7 +98,7 @@ http.response.body.content,keyword,extended,Hello world
 http.response.bytes,long,extended,1437
 http.response.status_code,long,extended,404
 http.version,keyword,extended,1.1
-log.level,keyword,core,ERR
+log.level,keyword,core,err
 log.original,(not indexed),core,Sep 19 08:26:10 localhost My log
 network.application,keyword,extended,aim
 network.bytes,long,core,368

--- a/schema.json
+++ b/schema.json
@@ -59,7 +59,7 @@
     "type": "group"
   }, 
   "base": {
-    "description": "The base set contains all fields which are on the top level. These fields are common across all types of events.\n", 
+    "description": "The `base` field set contains all fields which are on the top level. These fields are common across all types of events.\n", 
     "fields": {
       "@timestamp": {
         "description": "Date/time when the event originated.\nFor log events this is the date/time when the event was generated, and not when it was read.\nRequired field for all events.", 
@@ -82,7 +82,7 @@
         "type": "object"
       }, 
       "message": {
-        "description": "For log events the message field contains the log message, optimized for viewing in a log viewer.\nFor structured logs without an original message field, other field can be concatenated to form a human-readable summary of the event.\nIf multiple messages exist, they can be combined into one message.", 
+        "description": "For log events the message field contains the log message, optimized for viewing in a log viewer.\nFor structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.\nIf multiple messages exist, they can be combined into one message.", 
         "example": "Hello World", 
         "footnote": "", 
         "group": 1, 
@@ -240,7 +240,7 @@
         "type": "keyword"
       }, 
       "cloud.provider": {
-        "description": "Name of the cloud provider. Example values are aws, azure, gce, or digitalocean.", 
+        "description": "Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.", 
         "example": "ec2", 
         "footnote": "", 
         "group": 2, 
@@ -1020,7 +1020,7 @@
         "type": "long"
       }, 
       "http.request.body.content": {
-        "description": "The full http request body.", 
+        "description": "The full HTTP request body.", 
         "example": "Hello world", 
         "footnote": "", 
         "group": 2, 
@@ -1040,7 +1040,7 @@
         "type": "long"
       }, 
       "http.request.method": {
-        "description": "Http request method.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\"  section.", 
+        "description": "HTTP request method.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\"  section.", 
         "example": "get, post, put", 
         "footnote": "", 
         "group": 2, 
@@ -1070,7 +1070,7 @@
         "type": "long"
       }, 
       "http.response.body.content": {
-        "description": "The full http response body.", 
+        "description": "The full HTTP response body.", 
         "example": "Hello world", 
         "footnote": "", 
         "group": 2, 
@@ -1090,7 +1090,7 @@
         "type": "long"
       }, 
       "http.response.status_code": {
-        "description": "Http response status code.", 
+        "description": "HTTP response status code.", 
         "example": "404", 
         "footnote": "", 
         "group": 2, 
@@ -1100,7 +1100,7 @@
         "type": "long"
       }, 
       "http.version": {
-        "description": "Http version.", 
+        "description": "HTTP version.", 
         "example": "1.1", 
         "footnote": "", 
         "group": 2, 
@@ -1540,7 +1540,7 @@
     "type": "group"
   }, 
   "related": {
-    "description": "This field set is meant to facilitate pivoting around a piece of data.\nSome pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`.\nA concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.\n", 
+    "description": "This field set is meant to facilitate pivoting around a piece of data.\nSome pieces of information can be seen in many places in an ECS event. To facilitate searching for them, store an array of all seen values to their corresponding field in `related.`.\nA concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.\n", 
     "fields": {
       "related.ip": {
         "description": "All of the IPs seen on your event.", 
@@ -1786,10 +1786,10 @@
     "type": "group"
   }, 
   "url": {
-    "description": "URL fields provide a complete URL, with scheme, host, and path.\n", 
+    "description": "URL fields provide support for complete or partial URLs, and supports the breaking down into scheme, domain, path, and so on.\n", 
     "fields": {
       "url.domain": {
-        "description": "Domain of the request, such as \"www.elastic.co\".\nIn some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.", 
+        "description": "Domain of the url, such as \"www.elastic.co\".\nIn some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.", 
         "example": "www.elastic.co", 
         "footnote": "", 
         "group": 2, 
@@ -1895,7 +1895,7 @@
     "type": "group"
   }, 
   "user": {
-    "description": "The user fields describe information about the user that is relevant to  the event.\nFields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.\n", 
+    "description": "The user fields describe information about the user that is relevant to the event.\nFields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.\n", 
     "fields": {
       "user.email": {
         "description": "User email address.", 

--- a/schema.json
+++ b/schema.json
@@ -23,7 +23,7 @@
         "type": "keyword"
       }, 
       "agent.name": {
-        "description": "Name of the agent.\nThis is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.\nIf no name is given, the name is often left empty.", 
+        "description": "Custom name of the agent.\nThis is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.\nIf no name is given, the name is often left empty.", 
         "example": "foo", 
         "footnote": "", 
         "group": 2, 
@@ -72,7 +72,7 @@
         "type": "date"
       }, 
       "labels": {
-        "description": "Key/value pairs.\nCan be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.\nExample: `docker` and `k8s` labels.", 
+        "description": "Custom key/value pairs.\nCan be used to add meta information to events. Should not contain nested objects. All values are stored as keyword.\nExample: `docker` and `k8s` labels.", 
         "example": "{'application': 'foo-bar', 'env': 'production'}", 
         "footnote": "", 
         "group": 1, 
@@ -82,7 +82,7 @@
         "type": "object"
       }, 
       "message": {
-        "description": "For log events the message field contains the log message.\nIn other use cases the message field can be used to concatenate different values which are then freely searchable. If multiple messages exist, they can be combined into one message.", 
+        "description": "For log events the message field contains the log message, optimized for viewing in a log viewer.\nFor structured logs without an original message field, other field can be concatenated to form a human-readable summary of the event.\nIf multiple messages exist, they can be combined into one message.", 
         "example": "Hello World", 
         "footnote": "", 
         "group": 1, 
@@ -240,7 +240,7 @@
         "type": "keyword"
       }, 
       "cloud.provider": {
-        "description": "Name of the cloud provider. Example values are ec2, gce, or digitalocean.", 
+        "description": "Name of the cloud provider. Example values are aws, azure, gce, or digitalocean.", 
         "example": "ec2", 
         "footnote": "", 
         "group": 2, 
@@ -417,7 +417,7 @@
     "description": "Meta-information specific to ECS.\n", 
     "fields": {
       "ecs.version": {
-        "description": "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.\nThe current version is 1.0.0-beta2 .", 
+        "description": "ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.\nWhen querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events.\nThe current version is 1.0.0-beta2.", 
         "example": "1.0.0-beta2", 
         "footnote": "", 
         "group": 2, 
@@ -615,7 +615,7 @@
         "type": "float"
       }, 
       "event.severity": {
-        "description": "Severity describes the severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.", 
+        "description": "Severity describes the original severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 
@@ -1007,7 +1007,7 @@
     "type": "group"
   }, 
   "http": {
-    "description": "Fields related to HTTP activity.\n", 
+    "description": "Fields related to HTTP activity. Use the `url` field set to store the url of the request.\n", 
     "fields": {
       "http.request.body.bytes": {
         "description": "Size in bytes of the request body.", 
@@ -1119,8 +1119,8 @@
     "description": "Fields which are specific to log events.\n", 
     "fields": {
       "log.level": {
-        "description": "Log level of the log event.\nSome examples are `WARN`, `ERR`, `INFO`.", 
-        "example": "ERR", 
+        "description": "Original log level of the log event.\nSome examples are `warn`, `error`, `i`.", 
+        "example": "err", 
         "footnote": "", 
         "group": 2, 
         "level": "core", 
@@ -1148,7 +1148,7 @@
     "description": "The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.\n", 
     "fields": {
       "network.application": {
-        "description": "A name given to an application. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
+        "description": "A name given to an application level protocol. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
         "example": "aim", 
         "footnote": "", 
         "group": 2, 
@@ -1264,7 +1264,7 @@
     "type": "group"
   }, 
   "observer": {
-    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.  \n", 
+    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.\n", 
     "fields": {
       "observer.hostname": {
         "description": "Hostname of the observer.", 
@@ -1444,7 +1444,7 @@
     "description": "These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.\n", 
     "fields": {
       "process.args": {
-        "description": "Process arguments.\nMay be filtered to protect sensitive information.", 
+        "description": "Array of process arguments.\nMay be filtered to protect sensitive information.", 
         "example": "['ssh', '-l', 'user', '10.0.0.16']", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
   "agent": {
-    "description": "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.\n", 
+    "description": "The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.\nExamples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.\n", 
     "fields": {
       "agent.ephemeral_id": {
         "description": "Ephemeral identifier of this agent (if one exists).\nThis id normally changes across restarts, but `agent.id` does not.", 
@@ -108,7 +108,7 @@
     "type": "group"
   }, 
   "client": {
-    "description": "A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term \"originator\" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
+    "description": "A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.\nFor TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term \"originator\" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
     "fields": {
       "client.address": {
         "description": "Some event client addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
@@ -266,7 +266,7 @@
     "type": "group"
   }, 
   "container": {
-    "description": "Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.\n", 
+    "description": "Container fields are used for meta information about the specific container that is the source of information.\nThese fields help correlate data based containers from any runtime.\n", 
     "fields": {
       "container.id": {
         "description": "Unique container id.", 
@@ -335,7 +335,7 @@
     "type": "group"
   }, 
   "destination": {
-    "description": "Destination fields describe details about the destination of a packet/event. Destination fields are usually populated in conjunction with source fields.\n", 
+    "description": "Destination fields describe details about the destination of a packet/event.\nDestination fields are usually populated in conjunction with source fields.\n", 
     "fields": {
       "destination.address": {
         "description": "Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
@@ -433,7 +433,7 @@
     "type": "group"
   }, 
   "error": {
-    "description": "These fields can represent errors of any kind. Use them for errors that happen while fetching events or in cases where the event itself contains an error.\n", 
+    "description": "These fields can represent errors of any kind.\nUse them for errors that happen while fetching events or in cases where the event itself contains an error.\n", 
     "fields": {
       "error.code": {
         "description": "Error code describing the error.", 
@@ -472,7 +472,7 @@
     "type": "group"
   }, 
   "event": {
-    "description": "The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.\n", 
+    "description": "The event fields are used for context information about the log or metric event itself.\nA log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.\n", 
     "fields": {
       "event.action": {
         "description": "The action captured by the event.\nThis describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer.", 
@@ -661,7 +661,7 @@
     "type": "group"
   }, 
   "file": {
-    "description": "A file is defined as a set of information that has been created on, or has existed on a filesystem. File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.\n", 
+    "description": "A file is defined as a set of information that has been created on, or has existed on a filesystem.\nFile objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.\n", 
     "fields": {
       "file.ctime": {
         "description": "Last time file metadata changed.", 
@@ -928,7 +928,7 @@
     "type": "group"
   }, 
   "host": {
-    "description": "A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.\n", 
+    "description": "A host is defined as a general computing instance.\nECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.\n", 
     "fields": {
       "host.architecture": {
         "description": "Operating system architecture.", 
@@ -1145,7 +1145,7 @@
     "type": "group"
   }, 
   "network": {
-    "description": "The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.\n", 
+    "description": "The network is defined as the communication path over which a host or network event happens.\nThe network.* fields should be populated with details about the network activity associated with an event.\n", 
     "fields": {
       "network.application": {
         "description": "A name given to an application level protocol. This can be arbitrarily assigned for things like microservices, but also apply to things like skype, icq, facebook, twitter. This would be used in situations where the vendor or service can be decoded such as from the source/dest IP owners, ports, or wire format.\nThe field value must be normalized to lowercase for querying. See \"Lowercase Capitalization\" in the \"Implementing ECS\" section.", 
@@ -1264,7 +1264,7 @@
     "type": "group"
   }, 
   "observer": {
-    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.\n", 
+    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.\nThis could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.\n", 
     "fields": {
       "observer.hostname": {
         "description": "Hostname of the observer.", 
@@ -1343,7 +1343,7 @@
     "type": "group"
   }, 
   "organization": {
-    "description": "The organization fields enrich data with information about the company or entity the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple organizations.\n", 
+    "description": "The organization fields enrich data with information about the company or entity the data is associated with.\nThese fields help you arrange or filter data stored in an index by one or multiple organizations.\n", 
     "fields": {
       "organization.id": {
         "description": "Unique identifier for the organization.", 
@@ -1441,7 +1441,7 @@
     "type": "group"
   }, 
   "process": {
-    "description": "These fields contain information about a process. These fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.\n", 
+    "description": "These fields contain information about a process.\nThese fields can help you correlate metrics information with a process id/name from a log message.  The `process.pid` often stays in the metric itself and is copied to the global field for correlation.\n", 
     "fields": {
       "process.args": {
         "description": "Array of process arguments.\nMay be filtered to protect sensitive information.", 
@@ -1540,7 +1540,7 @@
     "type": "group"
   }, 
   "related": {
-    "description": "This field set is meant to facilitate pivoting around a piece of data. Some pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`. A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.\n", 
+    "description": "This field set is meant to facilitate pivoting around a piece of data.\nSome pieces of information can be seen in many places in ECS. To facilitate searching for them, append values to their corresponding field in `related.`.\nA concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.\n", 
     "fields": {
       "related.ip": {
         "description": "All of the IPs seen on your event.", 
@@ -1559,7 +1559,7 @@
     "type": "group"
   }, 
   "server": {
-    "description": "A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term \"responder\" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
+    "description": "A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.\nFor TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term \"responder\" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.\nClient / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.\n", 
     "fields": {
       "server.address": {
         "description": "Some event server addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
@@ -1638,7 +1638,7 @@
     "type": "group"
   }, 
   "service": {
-    "description": "The service fields describe the service for or from which the data was collected. These fields help you find and correlate logs for a specific service and version.\n", 
+    "description": "The service fields describe the service for or from which the data was collected.\nThese fields help you find and correlate logs for a specific service and version.\n", 
     "fields": {
       "service.ephemeral_id": {
         "description": "Ephemeral identifier of this service (if one exists).\nThis id normally changes across restarts, but `service.id` does not.", 
@@ -1707,7 +1707,7 @@
     "type": "group"
   }, 
   "source": {
-    "description": "Source fields describe details about the source of a packet/event. Source fields are usually populated in conjunction with destination fields.\n", 
+    "description": "Source fields describe details about the source of a packet/event.\nSource fields are usually populated in conjunction with destination fields.\n", 
     "fields": {
       "source.address": {
         "description": "Some event source addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field.\nThen it should be duplicated to `.ip` or `.domain`, depending on which one it is.", 
@@ -1895,7 +1895,7 @@
     "type": "group"
   }, 
   "user": {
-    "description": "The user fields describe information about the user that is relevant to  the event. Fields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.\n", 
+    "description": "The user fields describe information about the user that is relevant to  the event.\nFields can have one entry or multiple entries. If a user has more than one id, provide an array that includes all of them.\n", 
     "fields": {
       "user.email": {
         "description": "User email address.", 
@@ -1954,7 +1954,7 @@
     "type": "group"
   }, 
   "user_agent": {
-    "description": "The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.\n", 
+    "description": "The user_agent fields normally come from a browser request.\nThey often show up in web service logs coming from the parsed user agent string.\n", 
     "fields": {
       "user_agent.device.name": {
         "description": "Name of the device.", 

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -3,7 +3,9 @@
   title: Agent
   group: 2
   description: >
-    The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host. Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
+    The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
+
+    Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
   footnote: >
     Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the
     agent running in the app/service. The agent information does not change if

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -23,8 +23,9 @@
     - name: name
       level: core
       type: keyword
+      short: Custom name of the agent.
       description: >
-        Name of the agent.
+        Custom name of the agent.
 
         This is a name that can be given to an agent. This can be helpful if
         for example two Filebeat instances are running on the same host
@@ -37,6 +38,7 @@
     - name: type
       level: core
       type: keyword
+      short: Type of the agent.
       description: >
         Type of the agent.
 
@@ -48,6 +50,7 @@
     - name: id
       level: core
       type: keyword
+      short: Unique identifier of this agent.
       description: >
         Unique identifier of this agent (if one exists).
 
@@ -57,6 +60,7 @@
     - name: ephemeral_id
       level: extended
       type: keyword
+      short: Ephemeral identifier of this agent.
       description: >
         Ephemeral identifier of this agent (if one exists).
 

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -2,6 +2,7 @@
 - name: agent
   title: Agent
   group: 2
+  short: Fields about the monitoring agent.
   description: >
     The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
 

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -52,7 +52,7 @@
         For log events the message field contains the log message, optimized for
         viewing in a log viewer.
 
-        For structured logs without an original message field, other field can
+        For structured logs without an original message field, other fields can
         be concatenated to form a human-readable summary of the event.
 
         If multiple messages exist, they can be combined into one message.

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -11,6 +11,7 @@
       level: core
       required: true
       example: "2016-05-23T08:05:34.853Z"
+      short: Date/time when the event originated.
       description: >
         Date/time when the event originated.
 
@@ -31,8 +32,9 @@
       type: object
       object_type: keyword
       example: {env: production, application: foo-bar}
+      short: Custom key/value pairs.
       description: >
-        Key/value pairs.
+        Custom key/value pairs.
 
         Can be used to add meta information to events. Should not contain nested
         objects. All values are stored as keyword.
@@ -43,9 +45,12 @@
       level: core
       type: text
       example: "Hello World"
+      short: Log message optimized for viewing in a log viewer.
       description: >
-        For log events the message field contains the log message.
+        For log events the message field contains the log message, optimized for
+        viewing in a log viewer.
 
-        In other use cases the message field can be used to concatenate
-        different values which are then freely searchable. If multiple
-        messages exist, they can be combined into one message.
+        For structured logs without an original message field, other field can
+        be concatenated to form a human-readable summary of the event.
+
+        If multiple messages exist, they can be combined into one message.

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -2,6 +2,7 @@
 - name: base
   title: Base
   group: 1
+  short: All fields defined directly at the top level
   description: >
     The base set contains all fields which are on the top level. These fields are common across all types of events.
   type: group

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -4,7 +4,8 @@
   group: 1
   short: All fields defined directly at the top level
   description: >
-    The base set contains all fields which are on the top level. These fields are common across all types of events.
+    The `base` field set contains all fields which are on the top level.
+    These fields are common across all types of events.
   type: group
   fields:
     - name: "@timestamp"

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -3,7 +3,9 @@
   title: Client
   group: 2
   description: >
-    A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
+    A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.
+
+    For TCP events, the client is the initiator of the TCP connection that sends the SYN packet(s). For other protocols, the client is generally the initiator or requestor in the network transaction. Some systems use the term "originator" to refer the client in TCP connections. The client fields describe details about the system acting as the client in the network event. Client fields are usually populated in conjunction with server fields.  Client fields are generally not populated for packet-level events.
 
     Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
   type: group

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -2,6 +2,7 @@
 - name: client
   title: Client
   group: 2
+  short: Fields about the client side of a network connection, used with server.
   description: >
     A client is defined as the initiator of a network connection for events regarding sessions, connections, or bidirectional flow records.
 

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -12,6 +12,7 @@
     - name: address
       level: extended
       type: keyword
+      short: Client network address.
       description: >
         Some event client addresses are defined ambiguously. The event will
         sometimes list an IP, a domain or a unix socket.  You should always
@@ -23,6 +24,7 @@
     - name: ip
       level: core
       type: ip
+      short: IP address of the client.
       description: >
         IP address of the client.
 

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -2,6 +2,7 @@
 - name: cloud
   title: Cloud
   group: 2
+  short: Fields about the cloud resource.
   description: >
     Fields related to the cloud or infrastructure the events
     are coming from.

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -20,7 +20,7 @@
       type: keyword
       short: Name of the cloud provider.
       description: >
-        Name of the cloud provider. Example values are aws, azure, gce, or
+        Name of the cloud provider. Example values are aws, azure, gcp, or
         digitalocean.
 
     - name: availability_zone

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -17,8 +17,9 @@
       level: extended
       example: ec2
       type: keyword
+      short: Name of the cloud provider.
       description: >
-        Name of the cloud provider. Example values are ec2, gce, or
+        Name of the cloud provider. Example values are aws, azure, gce, or
         digitalocean.
 
     - name: availability_zone
@@ -59,6 +60,7 @@
       level: extended
       type: keyword
       example: 666777888999
+      short: The cloud account or organization id.
       description: >
         The cloud account or organization id used to identify different
         entities in a multi-tenant environment.

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -4,8 +4,9 @@
   group: 2
   description: >
     Container fields are used for meta information about the specific container
-    that is the source of information. These fields help correlate data based
-    containers from any runtime.
+    that is the source of information.
+
+    These fields help correlate data based containers from any runtime.
   type: group
   fields:
 

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -2,6 +2,7 @@
 - name: container
   title: Container
   group: 2
+  short: Fields describing the container that generated this event.
   description: >
     Container fields are used for meta information about the specific container
     that is the source of information.

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -4,6 +4,7 @@
   group: 2
   description: >
     Destination fields describe details about the destination of a packet/event.
+
     Destination fields are usually populated in conjunction with source fields.
   type: group
   fields:

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -2,6 +2,7 @@
 - name: destination
   title: Destination
   group: 2
+  short: Fields about the destination side of a network connection, used with source.
   description: >
     Destination fields describe details about the destination of a packet/event.
 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -11,6 +11,7 @@
     - name: address
       level: extended
       type: keyword
+      short: Destination network address.
       description: >
         Some event destination addresses are defined ambiguously. The event will
         sometimes list an IP, a domain or a unix socket.  You should always
@@ -22,6 +23,7 @@
     - name: ip
       level: core
       type: ip
+      short: IP address of the destination.
       description: >
         IP address of the destination.
 

--- a/schemas/ecs.yml
+++ b/schemas/ecs.yml
@@ -11,6 +11,7 @@
       level: core
       type: keyword
       required: true
+      short: ECS version this event conforms to.
       description: >
         ECS version this event conforms to. `ecs.version` is a required field and must exist in all events.
 
@@ -18,5 +19,5 @@
         different ECS versions -- this field lets integrations adjust to the
         schema version of the events.
 
-        The current version is 1.0.0-beta2 .
+        The current version is 1.0.0-beta2.
       example: 1.0.0-beta2

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -2,6 +2,7 @@
 - name: error
   title: Error
   group: 2
+  short: Fields about errors of any kind.
   description: >
     These fields can represent errors of any kind.
 

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -3,8 +3,10 @@
   title: Error
   group: 2
   description: >
-    These fields can represent errors of any kind. Use them for errors that
-    happen while fetching events or in cases where the event itself contains an error.
+    These fields can represent errors of any kind.
+
+    Use them for errors that happen while fetching events or in cases where the
+    event itself contains an error.
 
   type: group
   fields:

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -2,6 +2,7 @@
 - name: event
   title: Event
   group: 2
+  short: Fields breaking down the event details.
   description: >
     The event fields are used for context information about the log or metric event itself.
 

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -17,6 +17,7 @@
     - name: kind
       level: extended
       type: keyword
+      short: The kind of the event.
       description: >
         The kind of the event.
 
@@ -30,6 +31,7 @@
     - name: category
       level: core
       type: keyword
+      short: Event category.
       description: >
         Event category.
 
@@ -44,6 +46,7 @@
     - name: action
       level: core
       type: keyword
+      short: The action captured by the event.
       description: >
         The action captured by the event.
 
@@ -55,6 +58,7 @@
     - name: outcome
       level: extended
       type: keyword
+      short: The outcome of the event.
       description: >
         The outcome of the event.
 
@@ -68,6 +72,7 @@
     - name: type
       level: core
       type: keyword
+      short: Reserved for future usage.
       description: >
         Reserved for future usage.
 
@@ -85,6 +90,7 @@
     - name: dataset
       level: core
       type: keyword
+      short: Name of the dataset.
       description: >
         Name of the dataset.
 
@@ -97,8 +103,9 @@
       level: core
       type: long
       example: "7"
+      short: Original severity of the event.
       description: >
-        Severity describes the severity of the event. What the different
+        Severity describes the original severity of the event. What the different
         severity values mean can very different between use cases. It's up to
         the implementer to make sure severities are consistent across events.
 
@@ -113,6 +120,7 @@
           threatmanager&#124;1.0&#124;100&#124;
           worm successfully stopped&#124;10&#124;src=10.0.0.1
           dst=2.1.2.2spt=1232"
+      short: Raw text message of entire event.
       description: >
           Raw text message of entire event. Used to demonstrate log integrity.
 
@@ -132,6 +140,7 @@
     - name: duration
       level: core
       type: long
+      short: Duration of the event in nanoseconds.
       description: >
         Duration of the event in nanoseconds.
 
@@ -141,6 +150,7 @@
     - name: timezone
       level: extended
       type: keyword
+      short: Event time zone.
       description: >
         This field should be populated when the event's timestamp does not include
         timezone information already (e.g. default Syslog timestamps). It's
@@ -152,6 +162,7 @@
     - name: created
       level: core
       type: date
+      short: Time when the event was first read by an agent or by your pipeline.
       description: >
         event.created contains the date when the event was created.
 
@@ -190,6 +201,7 @@
     - name: risk_score_norm
       level: extended
       type: float
+      short: Normalized risk score or priority of the event (0-100).
       description: >
         Normalized risk score or priority of the event, on a scale of 0 to 100.
 

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -3,7 +3,9 @@
   title: Event
   group: 2
   description: >
-    The event fields are used for context information about the log or metric event itself. A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
+    The event fields are used for context information about the log or metric event itself.
+
+    A log is defined as an event containing details of something that happened. Log events must include the time at which the thing happened. Examples of log events include a process starting on a host, a network packet being sent from a source to a destination, or a network connection between a client and a server being initiated or closed. A metric is defined as an event containing one or more numerical or categorical measurements and the time at which the measurement was taken. Examples of metric events include memory pressure measured on a host, or vulnerabilities measured on a scanned host.
   type: group
   fields:
 

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -3,7 +3,9 @@
   group: 2
   title: File
   description: >
-     A file is defined as a set of information that has been created on, or has existed on a filesystem. File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
+     A file is defined as a set of information that has been created on, or has existed on a filesystem.
+
+     File objects can be associated with host events, network events, and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services). File fields provide details about the affected file associated with the event or metric.
   type: group
   fields:
 

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -2,6 +2,7 @@
 - name: file
   group: 2
   title: File
+  short: Fields describing files.
   description: >
      A file is defined as a set of information that has been created on, or has existed on a filesystem.
 

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -20,6 +20,7 @@
   - name: extension
     level: extended
     type: keyword
+    short: File extension.
     description: >
       File extension.
 

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -2,6 +2,7 @@
 - name: geo
   title: Geo
   group: 2
+  short: Fields describing a location.
   description: >
     Geo fields can carry data about a specific location related to an event
     or geo information derived from an IP field.

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -69,6 +69,7 @@
     - name: name
       level: extended
       type: keyword
+      short: User-defined description of a location.
       description: >
         User-defined description of a location, at the level of granularity they care about.
 

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -3,6 +3,7 @@
   title: Group
   group: 2
   type: group
+  short: User's group relevant to the event.
   description: >
     The group fields are meant to represent groups that are relevant to the
     event.

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -10,6 +10,7 @@
     - name: hostname
       level: core
       type: keyword
+      short: Hostname of the host.
       description: >
         Hostname of the host.
 
@@ -18,6 +19,7 @@
     - name: name
       level: core
       type: keyword
+      short: Name of the host.
       description: >
         Name of the host.
 
@@ -28,6 +30,7 @@
     - name: id
       level: core
       type: keyword
+      short: Unique host id.
       description: >
         Unique host id.
 
@@ -50,6 +53,7 @@
     - name: type
       level: core
       type: keyword
+      short: Type of host.
       description: >
         Type of host.
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -2,6 +2,7 @@
 - name: host
   title: Host
   group: 2
+  short: Fields describing the relevant computing instance.
   description: >
     A host is defined as a general computing instance.
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -3,7 +3,9 @@
   title: Host
   group: 2
   description: >
-    A host is defined as a general computing instance. ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+    A host is defined as a general computing instance.
+
+    ECS host.* fields should be populated with details about the host on which the event happened, or from which the measurement was taken. Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
   type: group
   fields:
 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -2,6 +2,7 @@
 - name: http
   title: HTTP
   group: 2
+  short: Fields describing an HTTP request.
   description: >
     Fields related to HTTP activity. Use the `url` field set to store the url of the request.
   type: group

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -3,13 +3,14 @@
   title: HTTP
   group: 2
   description: >
-    Fields related to HTTP activity.
+    Fields related to HTTP activity. Use the `url` field set to store the url of the request.
   type: group
   fields:
 
     - name: request.method
       level: extended
       type: keyword
+      short: Http request method.
       description: >
         Http request method.
 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -11,9 +11,9 @@
     - name: request.method
       level: extended
       type: keyword
-      short: Http request method.
+      short: HTTP request method.
       description: >
-        Http request method.
+        HTTP request method.
 
         The field value must be normalized to lowercase for querying. See
         "Lowercase Capitalization" in the "Implementing ECS"  section.
@@ -23,7 +23,7 @@
       level: extended
       type: keyword
       description: >
-        The full http request body.
+        The full HTTP request body.
       example: Hello world
 
     - name: request.referrer
@@ -37,21 +37,21 @@
       level: extended
       type: long
       description: >
-        Http response status code.
+        HTTP response status code.
       example: 404
 
     - name: response.body.content
       level: extended
       type: keyword
       description: >
-        The full http response body.
+        The full HTTP response body.
       example: Hello world
 
     - name: version
       level: extended
       type: keyword
       description: >
-        Http version.
+        HTTP version.
       example: 1.1
 
     # Metrics

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -9,11 +9,12 @@
     - name: level
       level: core
       type: keyword
+      short: Log level of the log event.
       description: >
-        Log level of the log event.
+        Original log level of the log event.
 
-        Some examples are `WARN`, `ERR`, `INFO`.
-      example: ERR
+        Some examples are `warn`, `error`, `i`.
+      example: err
 
     - name: original
       level: core
@@ -21,8 +22,8 @@
       example: "Sep 19 08:26:10 localhost My log"
       index: false
       doc_values: false
+      short: Original log message with light interpretation only (encoding, newlines).
       description: >
-
         This is the original log message and contains the full log message
         before splitting it up in multiple parts.
 

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -17,6 +17,7 @@
     - name: type
       level: core
       type: keyword
+      short: In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc
       description: >
         In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc
 
@@ -27,6 +28,7 @@
     - name: iana_number
       level: extended
       type: keyword
+      short: IANA Protocol Number.
       description: >
           IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
           Standardized list of protocols. This aligns well with NetFlow and
@@ -36,6 +38,7 @@
     - name: transport
       level: core
       type: keyword
+      short: Protocol Name corresponding to the field `iana_number`.
       description: >
         Same as network.iana_number, but instead using the Keyword name of the
         transport layer (udp, tcp, ipv6-icmp, etc.)
@@ -47,8 +50,10 @@
     - name: application
       level: extended
       type: keyword
+      short: >
+        Application level protocol name.
       description: >
-        A name given to an application. This can be arbitrarily assigned for
+        A name given to an application level protocol. This can be arbitrarily assigned for
         things like microservices, but also apply to things like skype, icq,
         facebook, twitter. This would be used in situations where the vendor
         or service can be decoded such as from the source/dest IP owners,
@@ -61,6 +66,7 @@
     - name: protocol
       level: core
       type: keyword
+      short: L7 Network protocol name.
       description: >
         L7 Network protocol name. ex. http, lumberjack, transport protocol.
 
@@ -71,6 +77,7 @@
     - name: direction
       level: core
       type: keyword
+      short: Direction of the network traffic.
       description: >
         Direction of the network traffic.
 
@@ -98,6 +105,7 @@
     - name: community_id
       level: extended
       type: keyword
+      short: A hash of source and destination IPs and ports.
       description: >
         A hash of source and destination IPs and ports, as well as the protocol
         used in a communication. This is a tool-agnostic standard to identify
@@ -110,6 +118,7 @@
     - name: bytes
       level: core
       type: long
+      short: Total bytes transferred in both directions.
       description: >
         Total bytes transferred in both directions.
 
@@ -119,6 +128,7 @@
     - name: packets
       level: core
       type: long
+      short: Total packets transferred in both directions.
       description: >
         Total packets transferred in both directions.
 

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -2,6 +2,7 @@
 - name: network
   title: Network
   group: 2
+  short: Fields describing the communication path over which the event happened.
   description: >
     The network is defined as the communication path over which a host or network event happens.
 

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -3,7 +3,9 @@
   title: Network
   group: 2
   description: >
-    The network is defined as the communication path over which a host or network event happens. The network.* fields should be populated with details about the network activity associated with an event.
+    The network is defined as the communication path over which a host or network event happens.
+
+    The network.* fields should be populated with details about the network activity associated with an event.
   type: group
   fields:
 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -2,7 +2,7 @@
 - name: observer
   title: Observer
   group: 2
-  short: Fields describing an agent observing the event from outside the host.
+  short: Fields describing an entity observing the event from outside the host.
   description: >
     An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -3,7 +3,9 @@
   title: Observer
   group: 2
   description: >
-    An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
+    An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
+
+    This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
   type: group
   fields:
     - name: mac

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -2,6 +2,7 @@
 - name: observer
   title: Observer
   group: 2
+  short: Fields describing an agent observing the event from outside the host.
   description: >
     An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -3,7 +3,7 @@
   title: Observer
   group: 2
   description: >
-    An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.  
+    An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics. This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
   type: group
   fields:
     - name: mac
@@ -39,6 +39,7 @@
     - name: type
       level: core
       type: keyword
+      short: The type of the observer the data is coming from.
       description: >
         The type of the observer the data is coming from.
 

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -4,7 +4,9 @@
   group: 2
   description: >
     The organization fields enrich data with information about the company or entity
-    the data is associated with. These fields help you arrange or filter data stored in an index by one or multiple
+    the data is associated with.
+
+    These fields help you arrange or filter data stored in an index by one or multiple
     organizations.
   type: group
   fields:

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -2,6 +2,7 @@
 - name: organization
   title: Organization
   group: 2
+  short: Fields describing the organization or company the event is associated with.
   description: >
     The organization fields enrich data with information about the company or entity
     the data is associated with.

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -1,6 +1,7 @@
 - name: os
   title: Operating System
   group: 2
+  short: OS fields contain information about the operating system.
   description: >
     The OS fields contain information about the operating system.
   reusable:

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -2,6 +2,7 @@
 - name: process
   title: Process
   group: 2
+  short: These fields contain information about a process.
   description: >
     These fields contain information about a process.
 

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -4,6 +4,7 @@
   group: 2
   description: >
     These fields contain information about a process.
+
     These fields can help you correlate metrics information with a process id/name
     from a log message.  The `process.pid` often stays in the metric itself and is
     copied to the global field for correlation.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -20,6 +20,7 @@
     - name: name
       level: extended
       type: keyword
+      short: Process name.
       description: >
         Process name.
 
@@ -35,8 +36,9 @@
     - name: args
       level: extended
       type: keyword
+      short: Array of process arguments.
       description: >
-        Process arguments.
+        Array of process arguments.
 
         May be filtered to protect sensitive information.
       example: ["ssh", "-l", "user", "10.0.0.16"]
@@ -51,6 +53,7 @@
     - name: title
       level: extended
       type: keyword
+      short: Process title.
       description: >
         Process title.
 

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -4,9 +4,11 @@
   group: 2
   description: >
     This field set is meant to facilitate pivoting around a piece of data.
+
     Some pieces of information can be seen in many places in ECS. To facilitate
     searching for them, append values to their corresponding field in
     `related.`.
+
     A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
   type: group
   fields:

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -2,12 +2,13 @@
 - name: related
   title: Related
   group: 2
+  short: Fields meant to facilitate pivoting around a piece of data.
   description: >
     This field set is meant to facilitate pivoting around a piece of data.
 
-    Some pieces of information can be seen in many places in ECS. To facilitate
-    searching for them, append values to their corresponding field in
-    `related.`.
+    Some pieces of information can be seen in many places in an ECS event.
+    To facilitate searching for them, store an array of all seen values to their
+    corresponding field in `related.`.
 
     A concrete example is IP addresses, which can be under host, observer, source, destination, client, server, and network.forwarded_ip. If you append all IPs to `related.ip`, you can then search for a given IP trivially, no matter where it appeared, by querying `related.ip:a.b.c.d`.
   type: group

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -3,7 +3,9 @@
   title: Server
   group: 2
   description: >
-    A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records. For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
+    A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.
+
+    For TCP events, the server is the receiver of the initial SYN packet(s) of the TCP connection. For other protocols, the server is generally the responder in the network transaction. Some systems actually use the term "responder" to refer the server in TCP connections. The server fields describe details about the system acting as the server in the network event. Server fields are usually populated in conjunction with client fields. Server fields are generally not populated for packet-level events.
 
     Client / server representations can add semantic context to an exchange, which is helpful to visualize the data in certain situations. If your context falls in that category, you should still ensure that source and destination are filled appropriately.
   type: group

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -2,6 +2,7 @@
 - name: server
   title: Server
   group: 2
+  short: Fields about the server side of a network connection, used with client.
   description: >
     A Server is defined as the responder in a network connection for events regarding sessions, connections, or bidirectional flow records.
 

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -12,6 +12,7 @@
     - name: address
       level: extended
       type: keyword
+      short: Server network address.
       description: >
         Some event server addresses are defined ambiguously. The event will
         sometimes list an IP, a domain or a unix socket.  You should always
@@ -23,6 +24,7 @@
     - name: ip
       level: core
       type: ip
+      short: IP address of the server.
       description: >
         IP address of the server.
 

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -3,8 +3,9 @@
   title: Service
   group: 2
   description: >
-    The service fields describe the service for or from which the data was
-    collected. These fields help you find and correlate logs for a specific
+    The service fields describe the service for or from which the data was collected.
+
+    These fields help you find and correlate logs for a specific
     service and version.
   type: group
   fields:

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -2,6 +2,7 @@
 - name: service
   title: Service
   group: 2
+  short: Fields describing the service for or from which the data was collected.
   description: >
     The service fields describe the service for or from which the data was collected.
 

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -12,6 +12,7 @@
     - name: id
       level: core
       type: keyword
+      short: Unique identifier of the running service.
       description: >
         Unique identifier of the running service.
 
@@ -27,6 +28,7 @@
       level: core
       type: keyword
       example: "elasticsearch-metrics"
+      short: Name of the service.
       description: >
         Name of the service data is collected from.
 
@@ -45,6 +47,7 @@
       level: core
       type: keyword
       example: "elasticsearch"
+      short: The type of the service.
       description: >
         The type of the service data is collected from.
 
@@ -64,6 +67,7 @@
       level: core
       type: keyword
       example: "3.2.4"
+      short: Version of the service.
       description: >
         Version of the service the data was collected from.
 
@@ -73,6 +77,7 @@
     - name: ephemeral_id
       level: extended
       type: keyword
+      short: Ephemeral identifier of this service.
       description: >
         Ephemeral identifier of this service (if one exists).
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -4,6 +4,7 @@
   group: 2
   description: >
     Source fields describe details about the source of a packet/event.
+
     Source fields are usually populated in conjunction with destination fields.
   type: group
   fields:

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -11,6 +11,7 @@
     - name: address
       level: extended
       type: keyword
+      short: Source network address.
       description: >
         Some event source addresses are defined ambiguously. The event will
         sometimes list an IP, a domain or a unix socket.  You should always
@@ -22,6 +23,7 @@
     - name: ip
       level: core
       type: ip
+      short: IP address of the source.
       description: >
         IP address of the source.
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -2,6 +2,7 @@
 - name: source
   title: Source
   group: 2
+  short: Fields about the source side of a network connection, used with destination.
   description: >
     Source fields describe details about the source of a packet/event.
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -36,7 +36,7 @@
     - name: scheme
       level: extended
       type: keyword
-      short: Scheme of the request.
+      short: Scheme of the url.
       description: >
         Scheme of the request, such as "https".
 
@@ -46,9 +46,9 @@
     - name: domain
       level: extended
       type: keyword
-      short: Domain of the request.
+      short: Domain of the url.
       description: >
-        Domain of the request, such as "www.elastic.co".
+        Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a
         domain name. In this case, the IP address would go to the `domain` field.

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -1,8 +1,10 @@
 ---
 - name: url
   title: URL
+  short: Fields that let you store URLs in various forms.
   description: >
-    URL fields provide a complete URL, with scheme, host, and path.
+    URL fields provide support for complete or partial URLs, and supports the
+    breaking down into scheme, domain, path, and so on.
   type: group
   fields:
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -9,6 +9,7 @@
     - name: original
       level: extended
       type: keyword
+      short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
 
@@ -23,6 +24,7 @@
     - name: full
       level: extended
       type: keyword
+      short: Full unparsed URL.
       description: >
         If full URLs are important to your use case, they should be stored in
         `url.full`, whether this field is reconstructed or present in the
@@ -32,6 +34,7 @@
     - name: scheme
       level: extended
       type: keyword
+      short: Scheme of the request.
       description: >
         Scheme of the request, such as "https".
 
@@ -41,6 +44,7 @@
     - name: domain
       level: extended
       type: keyword
+      short: Domain of the request.
       description: >
         Domain of the request, such as "www.elastic.co".
 
@@ -64,6 +68,7 @@
     - name: query
       level: extended
       type: keyword
+      short: Query string of the request.
       description: >
         The query field describes the query string of the request,
         such as "q=elasticsearch".
@@ -76,6 +81,7 @@
     - name: fragment
       level: extended
       type: keyword
+      short: Portion of the url after the `#`.
       description: >
         Portion of the url after the `#`, such as "top".
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -4,7 +4,9 @@
   group: 2
   description: >
     The user fields describe information about the user that is relevant
-    to  the event. Fields can have one entry or multiple entries. If a
+    to  the event.
+
+    Fields can have one entry or multiple entries. If a
     user has more than one id, provide an array that includes all of
     them.
   reusable:

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -2,9 +2,10 @@
 - name: user
   title: User
   group: 2
+  short: Fields to describe the user relevant to the event.
   description: >
     The user fields describe information about the user that is relevant
-    to  the event.
+    to the event.
 
     Fields can have one entry or multiple entries. If a
     user has more than one id, provide an array that includes all of

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -47,6 +47,7 @@
     - name: hash
       level: extended
       type: keyword
+      short: Unique user hash to correlate information for a user in anonymized form.
       description: >
         Unique user hash to correlate information for a user in anonymized form.
 

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -2,6 +2,7 @@
 - name: user_agent
   title: User agent
   group: 2
+  short: Fields to describe a browser user_agent string.
   description: >
     The user_agent fields normally come from a browser request.
 

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -3,8 +3,9 @@
   title: User agent
   group: 2
   description: >
-    The user_agent fields normally come from a browser request. They often
-    show up in web service logs coming from the parsed user agent string.
+    The user_agent fields normally come from a browser request.
+
+    They often show up in web service logs coming from the parsed user agent string.
   type: group
   fields:
 


### PR DESCRIPTION
This PR adds a `short:` description to the YAML format for defining fields. All fields who need a short description for easy display in cramped spaces now have one.

This PR does not address the outputs which would benefit from this new short description. This should be addressed in a separate PR per output. PRs welcome, BTW ;-)

In reviewing all of these field descriptions, some main descriptions were adjusted as well.

A few other concerns have been addressed also:

- Replace incorrect `ec2` example in `cloud.provider` with `aws`.
  - closes #317
- Add pointer in description of `http` field set to `url` field set.
- Split up all field set definitions in multiple paragraphs.

I can extract to their own PR, if needed.

## Questions

- [x] @andrewgoldstein Do you feel like we need a "short" description for "key" descriptions as well? (E.g. [client field set description](https://github.com/elastic/ecs/blob/v1.0.0-beta2/schemas/client.yml#L5-L6))
  - Yes we need it. Obvious when looking at fieldset headings in the asciidoc format. They're part of this PR