### PR TITLE
Change url.port datatype to long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file based on the
  of being a nesting of the field set. This goes against a driving principle of ECS,
  and has been corrected. #308
 * Replaced incorrect examples in `cloud.provider`. #330
-* Field `url.port` was defined as an `integer`, whereas we're using `long` everywhere else. The field is now set to `long`. #339
+* Changed the `url.port` type to `long`. #339
 
 ### Added
 
@@ -42,7 +42,6 @@ All notable changes to this project will be documented in this file based on the
 * Remove `network.inbound.bytes`, `network.inbound.packets`,
   `network.outbound.bytes` and `network.outbound.packets`. #179
 * Changed the `event.type` definition to be only reserved. #242
-* Changed the `url.port` type to `long`. #339
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file based on the
  of being a nesting of the field set. This goes against a driving principle of ECS,
  and has been corrected. #308
 * Replaced incorrect examples in `cloud.provider`. #330
+* Field `url.port` was defined as an `integer`, whereas we're using `long` everywhere else. The field is now set to `long`. #339
 
 ### Added
 
@@ -41,6 +42,7 @@ All notable changes to this project will be documented in this file based on the
 * Remove `network.inbound.bytes`, `network.inbound.packets`,
   `network.outbound.bytes` and `network.outbound.packets`. #179
 * Changed the `event.type` definition to be only reserved. #242
+* Changed the `url.port` type to `long`. #339
 
 ### Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ URL fields provide support for complete or partial URLs, and supports the breaki
 | <a name="url.full"></a>url.full | If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source. | extended | keyword | `https://www.elastic.co:443/search?q=elasticsearch#top` |
 | <a name="url.scheme"></a>url.scheme | Scheme of the request, such as "https".<br/>Note: The `:` is not part of the scheme. | extended | keyword | `https` |
 | <a name="url.domain"></a>url.domain | Domain of the url, such as "www.elastic.co".<br/>In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field. | extended | keyword | `www.elastic.co` |
-| <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | integer | `443` |
+| <a name="url.port"></a>url.port | Port of the request, such as 443. | extended | long | `443` |
 | <a name="url.path"></a>url.path | Path of the request, such as "/search". | extended | keyword |  |
 | <a name="url.query"></a>url.query | The query field describes the query string of the request, such as "q=elasticsearch".<br/>The `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases. | extended | keyword |  |
 | <a name="url.fragment"></a>url.fragment | Portion of the url after the `#`, such as "top".<br/>The `#` is not part of the fragment. | extended | keyword |  |

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -45,7 +45,7 @@ type Url struct {
 	Domain string `ecs:"domain"`
 
 	// Port of the request, such as 443.
-	Port int32 `ecs:"port"`
+	Port int64 `ecs:"port"`
 
 	// Path of the request, such as "/search".
 	Path string `ecs:"path"`

--- a/fields.yml
+++ b/fields.yml
@@ -1699,7 +1699,7 @@
     
         - name: port
           level: extended
-          type: integer
+          type: long
           description: >
             Port of the request, such as 443.
           example: 443

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -247,7 +247,7 @@ url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,
 url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.1.0-dev
 url.password,keyword,extended,,1.1.0-dev
 url.path,keyword,extended,,1.1.0-dev
-url.port,integer,extended,443,1.1.0-dev
+url.port,long,extended,443,1.1.0-dev
 url.query,keyword,extended,,1.1.0-dev
 url.scheme,keyword,extended,https,1.1.0-dev
 url.username,keyword,extended,,1.1.0-dev

--- a/generated/ecs/fields_flat.yml
+++ b/generated/ecs/fields_flat.yml
@@ -2505,7 +2505,7 @@ url.port:
   level: extended
   name: port
   short: Port of the request, such as 443.
-  type: integer
+  type: long
 url.query:
   description: 'The query field describes the query string of the request, such as
     "q=elasticsearch".

--- a/generated/ecs/fields_nested.yml
+++ b/generated/ecs/fields_nested.yml
@@ -1980,7 +1980,7 @@ url:
       level: extended
       name: port
       short: Port of the request, such as 443.
-      type: integer
+      type: long
     query:
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1148,7 +1148,7 @@
               "type": "keyword"
             }, 
             "port": {
-              "type": "integer"
+              "type": "long"
             }, 
             "query": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1147,7 +1147,7 @@
             "type": "keyword"
           }, 
           "port": {
-            "type": "integer"
+            "type": "long"
           }, 
           "query": {
             "ignore_above": 1024, 

--- a/generated/legacy/schema.csv
+++ b/generated/legacy/schema.csv
@@ -162,7 +162,7 @@ url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top
 url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
 url.password,keyword,extended,
 url.path,keyword,extended,
-url.port,integer,extended,443
+url.port,long,extended,443
 url.query,keyword,extended,
 url.scheme,keyword,extended,https
 url.username,keyword,extended,

--- a/schema.json
+++ b/schema.json
@@ -1856,7 +1856,7 @@
         "level": "extended", 
         "name": "url.port", 
         "required": false, 
-        "type": "integer"
+        "type": "long"
       }, 
       "url.query": {
         "description": "The query field describes the query string of the request, such as \"q=elasticsearch\".\nThe `?` is excluded from the query string. If a URL contains no `?`, there is no query field. If there is a `?` but no query, the query field exists with an empty string. The `exists` query can be used to differentiate between the two cases.", 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -56,7 +56,7 @@
 
     - name: port
       level: extended
-      type: integer
+      type: long
       description: >
         Port of the request, such as 443.
       example: 443


### PR DESCRIPTION
This discrepancy was noticed when I replaced the Go template generator with a
new one, in #336. Looks like the Beats generator was making the field `long`
even if the definition said `integer`.