### PR TITLE
Adjust the maturity warning for ECS to be aligned with GA / SemVer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ See CONTRIBUTING.md for more details on setting up.
 
 -->
 
-WARNING: This is the master branch. The current release v1.0.0-beta2
-can be found [here](https://github.com/elastic/ecs/tree/v1.0.0-beta2).
+WARNING: This is a development branch. The official releases can be found
+[here](https://github.com/elastic/ecs/releases).
 
 # Elastic Common Schema (ECS)
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is appreciated.
-For contributions please read the [Contributing Guide](CONTRIBUTING.md).
+## Maturity
+
+With ECS turning 1.0, the team will will approach improvements by following SemVer.
+This means we will only do breaking changes at major versions, and that
+we will improve ECS in a backwards compatible manner in the meantime.
+We plan to align major ECS releases with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).
 
 <a name="ecs-version"></a>
 # Versions
@@ -30,6 +36,7 @@ For contributions please read the [Contributing Guide](CONTRIBUTING.md).
 The master branch of this repository should never be considered an
 official release of ECS. You can browse official releases of ECS
 [here](https://github.com/elastic/ecs/releases).
+
 
 Please note that when the README.md file and other generated files
 (like schema.csv and template.json) are not in agreement,

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ analytics and security analytics.
 
 ## Maturity
 
-With ECS turning 1.0, the team will approach improvements by following SemVer.
-This means that breaking changes will be limited to major versions, and that
-improvements will be implemented in a backwards-compatible manner in the meantime.
+With ECS turning 1.0, the team will approach improvements by following
+[Semantic Versioning](https://semver.org/).
 Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ analytics and security analytics.
 
 ## Maturity
 
-With ECS turning 1.0, the team will will approach improvements by following SemVer.
-This means we will only do breaking changes at major versions, and that
-we will improve ECS in a backwards compatible manner in the meantime.
-We plan to align major ECS releases with major Elastic Stack releases.
+With ECS turning 1.0, the team will approach improvements by following SemVer.
+This means that breaking changes will be limited to major versions, and that
+improvements will be implemented in a backwards-compatible manner in the meantime.
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.
 For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,9 +15,8 @@ analytics and security analytics.
 [[ecs-maturity]]
 === Maturity
 
-With ECS turning 1.0, the team will approach improvements by following SemVer.
-This means that breaking changes will be limited to major versions, and that
-improvements will be implemented in a backwards-compatible manner in the meantime.
+With ECS turning 1.0, the team will approach improvements by following
+https://semver.org/[Semantic Versioning].
 Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,10 +15,10 @@ analytics and security analytics.
 [[ecs-maturity]]
 === Maturity
 
-With ECS turning 1.0, the team will will approach improvements by following SemVer.
-This means we will only do breaking changes at major versions, and that
-we will improve ECS in a backwards compatible manner in the meantime.
-We plan to align major ECS releases with major Elastic Stack releases.
+With ECS turning 1.0, the team will approach improvements by following SemVer.
+This means that breaking changes will be limited to major versions, and that
+improvements will be implemented in a backwards-compatible manner in the meantime.
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.
 For contributions please read the

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -14,9 +14,16 @@ ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is
-appreciated. For contributions please read the
+[[ecs-maturity]]
+=== Maturity
+
+With ECS turning 1.0, the team will will approach improvements by following SemVer.
+This means we will only do breaking changes at major versions, and that
+we will improve ECS in a backwards compatible manner in the meantime.
+We plan to align major ECS releases with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the
 https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md[Contribution
 Guidelines].
 
@@ -24,10 +31,10 @@ Guidelines].
 [[ecs-field-types]]
 === Types of fields
 
-* *Core fields.* Fields that are most common across all use cases. 
-Focus on populating these fields first. 
+* *Core fields.* Fields that are most common across all use cases.
+Focus on populating these fields first.
 
-* *Extended fields.* Any fields that are not a core field. 
+* *Extended fields.* Any fields that are not a core field.
 Extended fields may apply to more narrow use cases, or may be more open
 to interpretation depending on the use case. Extended fields are more likely to
 change over time.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -7,8 +7,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 [[ecs-reference]]
 == Elastic Common Schema (ECS) Reference
 
-beta[]
-
 The Elastic Common Schema (ECS) defines a common set of fields for
 ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -10,8 +10,8 @@ See CONTRIBUTING.md for more details on setting up.
 
 -->
 
-WARNING: This is the master branch. The current release v1.0.0-beta2
-can be found [here](https://github.com/elastic/ecs/tree/v1.0.0-beta2).
+WARNING: This is a development branch. The official releases can be found
+[here](https://github.com/elastic/ecs/releases).
 
 # Elastic Common Schema (ECS)
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,9 +20,15 @@ ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is appreciated.
-For contributions please read the [Contributing Guide](CONTRIBUTING.md).
+## Maturity
+
+With ECS turning 1.0, the team will will approach improvements by following SemVer.
+This means we will only do breaking changes at major versions, and that
+we will improve ECS in a backwards compatible manner in the meantime.
+We plan to align major ECS releases with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).
 
 <a name="ecs-version"></a>
 # Versions
@@ -30,6 +36,7 @@ For contributions please read the [Contributing Guide](CONTRIBUTING.md).
 The master branch of this repository should never be considered an
 official release of ECS. You can browse official releases of ECS
 [here](https://github.com/elastic/ecs/releases).
+
 
 Please note that when the README.md file and other generated files
 (like schema.csv and template.json) are not in agreement,

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,9 +22,8 @@ analytics and security analytics.
 
 ## Maturity
 
-With ECS turning 1.0, the team will approach improvements by following SemVer.
-This means that breaking changes will be limited to major versions, and that
-improvements will be implemented in a backwards-compatible manner in the meantime.
+With ECS turning 1.0, the team will approach improvements by following
+[Semantic Versioning](https://semver.org/).
 Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -22,10 +22,10 @@ analytics and security analytics.
 
 ## Maturity
 
-With ECS turning 1.0, the team will will approach improvements by following SemVer.
-This means we will only do breaking changes at major versions, and that
-we will improve ECS in a backwards compatible manner in the meantime.
-We plan to align major ECS releases with major Elastic Stack releases.
+With ECS turning 1.0, the team will approach improvements by following SemVer.
+This means that breaking changes will be limited to major versions, and that
+improvements will be implemented in a backwards-compatible manner in the meantime.
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
 
 Any feedback on the general structure, missing fields, or existing fields is appreciated.
 For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
This PR contains a few changes:

- Adjusting the wording of the maturity warning in the Markdown and Asciidoc files
- Removal of the asciidoc beta label
- Replace the warning mention at the top of the readme to be less maintenance to maintain