### PR TITLE
Backport #333 to 1.0: Clarify `geo` field set description. (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file based on the
 * Clarified the definition of the host fields #325
 * Clarified the difference between `@timestamp` and `event.created`. #329
 * Specify the `object_type` for field `labels`. #331
+* Loosen up definition of `geo` field set. Not necessarily geo-ip based, since `geo.name`. #333
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ File objects can be associated with host events, network events, and/or file eve
 
 ## <a name="geo"></a> Geo fields
 
-Geo fields can carry data about a specific location related to an event or geo information derived from an IP field.
+Geo fields can carry data about a specific location related to an event.
+
+This geolocation information can be derived from techniques such as Geo IP, or be user-supplied.
 
 
 The `geo` fields are expected to be nested at: `client.geo`, `destination.geo`, `host.geo`, `observer.geo`, `server.geo`, `source.geo`.

--- a/fields.yml
+++ b/fields.yml
@@ -747,8 +747,10 @@
       group: 2
       short: Fields describing a location.
       description: >
-        Geo fields can carry data about a specific location related to an event
-        or geo information derived from an IP field.
+        Geo fields can carry data about a specific location related to an event.
+    
+        This geolocation information can be derived from techniques such as Geo IP,
+        or be user-supplied.
       reusable:
         top_level: false
         expected:

--- a/schema.json
+++ b/schema.json
@@ -810,7 +810,7 @@
     "type": "group"
   }, 
   "geo": {
-    "description": "Geo fields can carry data about a specific location related to an event or geo information derived from an IP field.\n", 
+    "description": "Geo fields can carry data about a specific location related to an event.\nThis geolocation information can be derived from techniques such as Geo IP, or be user-supplied.\n", 
     "fields": {
       "geo.city_name": {
         "description": "City name.", 

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -4,8 +4,10 @@
   group: 2
   short: Fields describing a location.
   description: >
-    Geo fields can carry data about a specific location related to an event
-    or geo information derived from an IP field.
+    Geo fields can carry data about a specific location related to an event.
+
+    This geolocation information can be derived from techniques such as Geo IP,
+    or be user-supplied.
   reusable:
     top_level: false
     expected:


### PR DESCRIPTION
Backport of PR #333 to 1.0 branch. Original message:

Loosened up the definition of `geo` fieldset. Not necessarily geo-ip based.