### PR TITLE
Backport #344 to 1.0: Adjust the maturity warning for ECS to be aligned with GA / SemVer (#344)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is appreciated.
-For contributions please read the [Contributing Guide](CONTRIBUTING.md).
+## Maturity
+
+With ECS turning 1.0, the team will approach improvements by following
+[Semantic Versioning](https://semver.org/).
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).
 
 <a name="ecs-version"></a>
 # Versions
@@ -30,6 +35,7 @@ For contributions please read the [Contributing Guide](CONTRIBUTING.md).
 The master branch of this repository should never be considered an
 official release of ECS. You can browse official releases of ECS
 [here](https://github.com/elastic/ecs/releases).
+
 
 Please note that when the README.md file and other generated files
 (like schema.csv and template.json) are not in agreement,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -7,16 +7,20 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 [[ecs-reference]]
 == Elastic Common Schema (ECS) Reference
 
-beta[]
-
 The Elastic Common Schema (ECS) defines a common set of fields for
 ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is
-appreciated. For contributions please read the
+[[ecs-maturity]]
+=== Maturity
+
+With ECS turning 1.0, the team will approach improvements by following
+https://semver.org/[Semantic Versioning].
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the
 https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md[Contribution
 Guidelines].
 
@@ -24,10 +28,10 @@ Guidelines].
 [[ecs-field-types]]
 === Types of fields
 
-* *Core fields.* Fields that are most common across all use cases. 
-Focus on populating these fields first. 
+* *Core fields.* Fields that are most common across all use cases.
+Focus on populating these fields first.
 
-* *Extended fields.* Any fields that are not a core field. 
+* *Extended fields.* Any fields that are not a core field.
 Extended fields may apply to more narrow use cases, or may be more open
 to interpretation depending on the use case. Extended fields are more likely to
 change over time.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,9 +20,14 @@ ingesting data into Elasticsearch. A common schema helps you correlate
 data from sources like logs and metrics or IT operations
 analytics and security analytics.
 
-ECS is still under development and backward compatibility is not guaranteed. Any
-feedback on the general structure, missing fields, or existing fields is appreciated.
-For contributions please read the [Contributing Guide](CONTRIBUTING.md).
+## Maturity
+
+With ECS turning 1.0, the team will approach improvements by following
+[Semantic Versioning](https://semver.org/).
+Generally major ECS releases are planned to be aligned with major Elastic Stack releases.
+
+Any feedback on the general structure, missing fields, or existing fields is appreciated.
+For contributions please read the [Contribution Guidelines](CONTRIBUTING.md).
 
 <a name="ecs-version"></a>
 # Versions
@@ -30,6 +35,7 @@ For contributions please read the [Contributing Guide](CONTRIBUTING.md).
 The master branch of this repository should never be considered an
 official release of ECS. You can browse official releases of ECS
 [here](https://github.com/elastic/ecs/releases).
+
 
 Please note that when the README.md file and other generated files
 (like schema.csv and template.json) are not in agreement,

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -247,7 +247,7 @@ url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,
 url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.0.0-beta2
 url.password,keyword,extended,,1.0.0-beta2
 url.path,keyword,extended,,1.0.0-beta2
-url.port,integer,extended,443,1.0.0-beta2
+url.port,long,extended,443,1.0.0-beta2
 url.query,keyword,extended,,1.0.0-beta2
 url.scheme,keyword,extended,https,1.0.0-beta2
 url.username,keyword,extended,,1.0.0-beta2

--- a/generated/ecs/fields_flat.yml
+++ b/generated/ecs/fields_flat.yml
@@ -2505,7 +2505,7 @@ url.port:
   level: extended
   name: port
   short: Port of the request, such as 443.
-  type: integer
+  type: long
 url.query:
   description: 'The query field describes the query string of the request, such as
     "q=elasticsearch".

--- a/generated/ecs/fields_nested.yml
+++ b/generated/ecs/fields_nested.yml
@@ -1980,7 +1980,7 @@ url:
       level: extended
       name: port
       short: Port of the request, such as 443.
-      type: integer
+      type: long
     query:
       description: 'The query field describes the query string of the request, such
         as "q=elasticsearch".

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1148,7 +1148,7 @@
               "type": "keyword"
             }, 
             "port": {
-              "type": "integer"
+              "type": "long"
             }, 
             "query": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1147,7 +1147,7 @@
             "type": "keyword"
           }, 
           "port": {
-            "type": "integer"
+            "type": "long"
           }, 
           "query": {
             "ignore_above": 1024, 


### PR DESCRIPTION
Backport of PR #344 to 1.0 branch.