### PR TITLE
Backport #275 to 1.0: Add automation around docs generation (#275)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.pyc
 env
 *.sw?
+
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,18 @@ go:
 before_install:
 - make setup
 
-script:
-- make check
+addons:
+  apt:
+    update: true
+    packages:
+      - xsltproc
+      - libxml2-utils
+
+jobs:
+  include:
+    - stage: check
+      script:
+      - make check
+    - stage: docs
+      script:
+      - OPEN_DOCS="" make docs

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+OPEN_DOCS?="-open"
+
 generate: schemas readme template fields generator
 
 # Run the new generator
@@ -59,4 +61,11 @@ fields:
 	cat fields.tmp.yml >> fields.yml
 	rm -f fields.tmp.yml fields.tmp.yml.bak
 
-.PHONY: generate schemas fmt check setup clean readme template fields
+docs:
+	if [ ! -d $(PWD)/build/docs ]; then \
+		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
+	fi
+
+	./build/docs/build_docs.pl --doc ./docs/index.asciidoc --chunk=1 $(OPEN_DOCS) -out ./build/html_docs
+
+.PHONY: generate schemas fmt check setup clean readme template fields docs


### PR DESCRIPTION
Backport of PR #275 to 1.0 branch. Original message:

This adds an almost empty `index.asciidoc` file to generate the initial asciidoc version of the docs. With this `make docs` can be used to generate and preview the docs.