### PR TITLE
Define field formats that were defined in Beats but not yet in ECS.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -11,6 +11,7 @@
   It generates schema.csv, Elasticsearch 6 and 7 templates, and field documentation
   for the main website. #336
 * Generator for the Beats fields.ecs.yml file. #379
+* Added field formats to all `.bytes` fields and `event.duration`. #385
 
 ### Improvements
 

--- a/fields.yml
+++ b/fields.yml
@@ -989,6 +989,7 @@
         - name: request.bytes
           level: extended
           type: long
+          format: bytes
           description: >
             Total size in bytes of the request (body and headers).
           example: 1437
@@ -996,6 +997,7 @@
         - name: request.body.bytes
           level: extended
           type: long
+          format: bytes
           description: >
             Size in bytes of the request body.
           example: 887
@@ -1003,6 +1005,7 @@
         - name: response.bytes
           level: extended
           type: long
+          format: bytes
           description: >
             Total size in bytes of the response (body and headers).
           example: 1437
@@ -1010,10 +1013,10 @@
         - name: response.body.bytes
           level: extended
           type: long
+          format: bytes
           description: >
             Size in bytes of the response body.
           example: 887
-    
     
     - name: log
       title: Log

--- a/fields.yml
+++ b/fields.yml
@@ -192,6 +192,7 @@
     
         # Metrics
         - name: bytes
+          format: bytes
           level: core
           type: long
           example: 184
@@ -377,6 +378,7 @@
     
         # Metrics
         - name: bytes
+          format: bytes
           level: core
           type: long
           example: 184
@@ -585,6 +587,8 @@
         - name: duration
           level: core
           type: long
+          format: duration
+          input_format: nanoseconds
           short: Duration of the event in nanoseconds.
           description: >
             Duration of the event in nanoseconds.
@@ -1169,6 +1173,7 @@
         - name: bytes
           level: core
           type: long
+          format: bytes
           short: Total bytes transferred in both directions.
           description: >
             Total bytes transferred in both directions.
@@ -1477,6 +1482,7 @@
     
         # Metrics
         - name: bytes
+          format: bytes
           level: core
           type: long
           example: 184
@@ -1629,6 +1635,7 @@
     
         # Metrics
         - name: bytes
+          format: bytes
           level: core
           type: long
           example: 184

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -143,6 +143,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       description: Bytes sent from the client to the server.
       example: 184
     - name: domain
@@ -382,6 +383,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       description: Bytes sent from the destination to the source.
       example: 184
     - name: domain
@@ -609,6 +611,8 @@
     - name: duration
       level: core
       type: long
+      format: duration
+      input_format: nanoseconds
       description: 'Duration of the event in nanoseconds.
 
         If event.start and event.end are known this value should be the difference
@@ -1185,6 +1189,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       description: 'Total bytes transferred in both directions.
 
         If `source.bytes` and `destination.bytes` are known, `network.bytes` is their
@@ -1594,6 +1599,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       description: Bytes sent from the server to the client.
       example: 184
     - name: domain
@@ -1807,6 +1813,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       description: Bytes sent from the source to the destination.
       example: 184
     - name: domain

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1079,6 +1079,7 @@
     - name: request.body.bytes
       level: extended
       type: long
+      format: bytes
       description: Size in bytes of the request body.
       example: 887
     - name: request.body.content
@@ -1090,6 +1091,7 @@
     - name: request.bytes
       level: extended
       type: long
+      format: bytes
       description: Total size in bytes of the request (body and headers).
       example: 1437
     - name: request.method
@@ -1110,6 +1112,7 @@
     - name: response.body.bytes
       level: extended
       type: long
+      format: bytes
       description: Size in bytes of the response body.
       example: 887
     - name: response.body.content
@@ -1121,6 +1124,7 @@
     - name: response.bytes
       level: extended
       type: long
+      format: bytes
       description: Total size in bytes of the response (body and headers).
       example: 1437
     - name: response.status_code

--- a/generated/ecs/fields_flat.yml
+++ b/generated/ecs/fields_flat.yml
@@ -1369,6 +1369,7 @@ http.request.body.bytes:
   description: Size in bytes of the request body.
   example: 887
   flat_name: http.request.body.bytes
+  format: bytes
   level: extended
   name: request.body.bytes
   short: Size in bytes of the request body.
@@ -1386,6 +1387,7 @@ http.request.bytes:
   description: Total size in bytes of the request (body and headers).
   example: 1437
   flat_name: http.request.bytes
+  format: bytes
   level: extended
   name: request.bytes
   short: Total size in bytes of the request (body and headers).
@@ -1415,6 +1417,7 @@ http.response.body.bytes:
   description: Size in bytes of the response body.
   example: 887
   flat_name: http.response.body.bytes
+  format: bytes
   level: extended
   name: response.body.bytes
   short: Size in bytes of the response body.
@@ -1432,6 +1435,7 @@ http.response.bytes:
   description: Total size in bytes of the response (body and headers).
   example: 1437
   flat_name: http.response.bytes
+  format: bytes
   level: extended
   name: response.bytes
   short: Total size in bytes of the response (body and headers).

--- a/generated/ecs/fields_flat.yml
+++ b/generated/ecs/fields_flat.yml
@@ -91,6 +91,7 @@ client.bytes:
   description: Bytes sent from the client to the server.
   example: 184
   flat_name: client.bytes
+  format: bytes
   level: core
   name: bytes
   short: Bytes sent from the client to the server.
@@ -421,6 +422,7 @@ destination.bytes:
   description: Bytes sent from the destination to the source.
   example: 184
   flat_name: destination.bytes
+  format: bytes
   level: core
   name: bytes
   short: Bytes sent from the destination to the source.
@@ -722,6 +724,8 @@ event.duration:
     If event.start and event.end are known this value should be the difference between
     the end and start time.'
   flat_name: event.duration
+  format: duration
+  input_format: nanoseconds
   level: core
   name: duration
   short: Duration of the event in nanoseconds.
@@ -1533,6 +1537,7 @@ network.bytes:
     sum.'
   example: 368
   flat_name: network.bytes
+  format: bytes
   level: core
   name: bytes
   short: Total bytes transferred in both directions.
@@ -2024,6 +2029,7 @@ server.bytes:
   description: Bytes sent from the server to the client.
   example: 184
   flat_name: server.bytes
+  format: bytes
   level: core
   name: bytes
   short: Bytes sent from the server to the client.
@@ -2319,6 +2325,7 @@ source.bytes:
   description: Bytes sent from the source to the destination.
   example: 184
   flat_name: source.bytes
+  format: bytes
   level: core
   name: bytes
   short: Bytes sent from the source to the destination.

--- a/generated/ecs/fields_nested.yml
+++ b/generated/ecs/fields_nested.yml
@@ -1609,6 +1609,7 @@ http:
       description: Size in bytes of the request body.
       example: 887
       flat_name: http.request.body.bytes
+      format: bytes
       level: extended
       name: request.body.bytes
       short: Size in bytes of the request body.
@@ -1626,6 +1627,7 @@ http:
       description: Total size in bytes of the request (body and headers).
       example: 1437
       flat_name: http.request.bytes
+      format: bytes
       level: extended
       name: request.bytes
       short: Total size in bytes of the request (body and headers).
@@ -1655,6 +1657,7 @@ http:
       description: Size in bytes of the response body.
       example: 887
       flat_name: http.response.body.bytes
+      format: bytes
       level: extended
       name: response.body.bytes
       short: Size in bytes of the response body.
@@ -1672,6 +1675,7 @@ http:
       description: Total size in bytes of the response (body and headers).
       example: 1437
       flat_name: http.response.bytes
+      format: bytes
       level: extended
       name: response.bytes
       short: Total size in bytes of the response (body and headers).

--- a/generated/ecs/fields_nested.yml
+++ b/generated/ecs/fields_nested.yml
@@ -178,6 +178,7 @@ client:
       description: Bytes sent from the client to the server.
       example: 184
       flat_name: client.bytes
+      format: bytes
       level: core
       name: bytes
       short: Bytes sent from the client to the server.
@@ -546,6 +547,7 @@ destination:
       description: Bytes sent from the destination to the source.
       example: 184
       flat_name: destination.bytes
+      format: bytes
       level: core
       name: bytes
       short: Bytes sent from the destination to the source.
@@ -886,6 +888,8 @@ event:
         If event.start and event.end are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
+      format: duration
+      input_format: nanoseconds
       level: core
       name: duration
       short: Duration of the event in nanoseconds.
@@ -1764,6 +1768,7 @@ network:
         sum.'
       example: 368
       flat_name: network.bytes
+      format: bytes
       level: core
       name: bytes
       short: Total bytes transferred in both directions.
@@ -2359,6 +2364,7 @@ server:
       description: Bytes sent from the server to the client.
       example: 184
       flat_name: server.bytes
+      format: bytes
       level: core
       name: bytes
       short: Bytes sent from the server to the client.
@@ -2677,6 +2683,7 @@ source:
       description: Bytes sent from the source to the destination.
       example: 184
       flat_name: source.bytes
+      format: bytes
       level: core
       name: bytes
       short: Bytes sent from the source to the destination.

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -53,6 +53,7 @@
 
     # Metrics
     - name: bytes
+      format: bytes
       level: core
       type: long
       example: 184

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -51,6 +51,7 @@
 
     # Metrics
     - name: bytes
+      format: bytes
       level: core
       type: long
       example: 184

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -143,6 +143,8 @@
     - name: duration
       level: core
       type: long
+      format: duration
+      input_format: nanoseconds
       short: Duration of the event in nanoseconds.
       description: >
         Duration of the event in nanoseconds.

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -58,6 +58,7 @@
     - name: request.bytes
       level: extended
       type: long
+      format: bytes
       description: >
         Total size in bytes of the request (body and headers).
       example: 1437
@@ -65,6 +66,7 @@
     - name: request.body.bytes
       level: extended
       type: long
+      format: bytes
       description: >
         Size in bytes of the request body.
       example: 887
@@ -72,6 +74,7 @@
     - name: response.bytes
       level: extended
       type: long
+      format: bytes
       description: >
         Total size in bytes of the response (body and headers).
       example: 1437
@@ -79,7 +82,7 @@
     - name: response.body.bytes
       level: extended
       type: long
+      format: bytes
       description: >
         Size in bytes of the response body.
       example: 887
-

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -121,6 +121,7 @@
     - name: bytes
       level: core
       type: long
+      format: bytes
       short: Total bytes transferred in both directions.
       description: >
         Total bytes transferred in both directions.

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -53,6 +53,7 @@
 
     # Metrics
     - name: bytes
+      format: bytes
       level: core
       type: long
       example: 184

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -51,6 +51,7 @@
 
     # Metrics
     - name: bytes
+      format: bytes
       level: core
       type: long
       example: 184

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -28,7 +28,7 @@ def generate(ecs_nested, ecs_version):
 
 def fieldset_field_array(source_fields):
     allowed_keys = ['name', 'level', 'required', 'type', 'object_type',
-                    'ignore_above', 'multi_fields', 'format',
+                    'ignore_above', 'multi_fields', 'format', 'input_format',
                     'description', 'example']
     fields = []
     for nested_field_name in source_fields:


### PR DESCRIPTION
The 1.0.0 field definitions generated by ECS (https://github.com/elastic/beats/pull/11150)
removed a few field formats that had previously been defined on the Beats side,
but were not yet part of ECS.

This adds all of the missing these fields formats to ECS, and generates a Beats
field definition file that includes them all.