### PR TITLE
Fix links to reused fields at the bottom of field set detail pages.

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -269,13 +269,13 @@ type: long
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[client.geo.*]
+| <<ecs-geo,client.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-user.html[client.user.*]
+| <<ecs-user,client.user.*>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -573,13 +573,13 @@ type: long
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[destination.geo.*]
+| <<ecs-geo,destination.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-user.html[destination.user.*]
+| <<ecs-user,destination.user.*>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1364,19 +1364,19 @@ type: keyword
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[host.geo.*]
+| <<ecs-geo,host.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-os.html[host.os.*]
+| <<ecs-os,host.os.*>>
 | OS fields contain information about the operating system.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-user.html[host.user.*]
+| <<ecs-user,host.user.*>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1835,13 +1835,13 @@ type: keyword
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[observer.geo.*]
+| <<ecs-geo,observer.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-os.html[observer.os.*]
+| <<ecs-os,observer.os.*>>
 | OS fields contain information about the operating system.
 
 // ===============================================================
@@ -2245,13 +2245,13 @@ type: long
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[server.geo.*]
+| <<ecs-geo,server.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-user.html[server.user.*]
+| <<ecs-user,server.user.*>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -2473,13 +2473,13 @@ type: long
 // ===============================================================
 
 
-| http://localhost:8000/ecs-geo.html[source.geo.*]
+| <<ecs-geo,source.geo.*>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| http://localhost:8000/ecs-user.html[source.user.*]
+| <<ecs-user,source.user.*>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -2717,7 +2717,7 @@ Note also that the `user` fields may be used directly at the top level.
 // ===============================================================
 
 
-| http://localhost:8000/ecs-group.html[user.group.*]
+| <<ecs-group,user.group.*>>
 | User's group relevant to the event.
 
 // ===============================================================
@@ -2801,7 +2801,7 @@ example: `12.0`
 // ===============================================================
 
 
-| http://localhost:8000/ecs-os.html[user_agent.os.*]
+| <<ecs-os,user_agent.os.*>>
 | OS fields contain information about the operating system.
 
 // ===============================================================

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -253,7 +253,7 @@ def nestings_table_header():
 
 def nestings_row():
     return '''
-| http://localhost:8000/ecs-{nesting_name}.html[{flat_nesting}]
+| <<ecs-{nesting_name},{flat_nesting}>>
 | {nesting_short}
 
 // ===============================================================


### PR DESCRIPTION
They didn't use asciidoc link helpers, so incorrectly pointed to to localhost:8000.