### PR TITLE
Specify static output format for event.duration

### DIFF
--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -613,6 +613,8 @@
       type: long
       format: duration
       input_format: nanoseconds
+      output_format: asMilliseconds
+      output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
         If event.start and event.end are known this value should be the difference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -800,6 +800,8 @@ event.duration:
   level: core
   name: duration
   order: 11
+  output_format: asMilliseconds
+  output_precision: 1
   short: Duration of the event in nanoseconds.
   type: long
 event.end:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -974,6 +974,8 @@ event:
       level: core
       name: duration
       order: 11
+      output_format: asMilliseconds
+      output_precision: 1
       short: Duration of the event in nanoseconds.
       type: long
     end:

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -154,6 +154,8 @@
       type: long
       format: duration
       input_format: nanoseconds
+      output_format: asMilliseconds
+      output_precision: 1
       short: Duration of the event in nanoseconds.
       description: >
         Duration of the event in nanoseconds.

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -31,7 +31,7 @@ def generate(ecs_nested, ecs_version):
 def fieldset_field_array(source_fields):
     allowed_keys = ['name', 'level', 'required', 'type', 'object_type',
                     'ignore_above', 'multi_fields', 'format', 'input_format',
-                    'description', 'example']
+                    'output_format', 'output_precision', 'description', 'example']
     fields = []
     for nested_field_name in source_fields:
         ecs_field = source_fields[nested_field_name]


### PR DESCRIPTION
We fixed it Beats in https://github.com/elastic/beats/pull/11675. This brings
back the change in ECS, so the next version of ECS doesn't overwrite the fix.

Static ms output format isn't great, it's just the least bad option :-\