### PR TITLE
Docs: Fix a table start to align with the stop

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -15,7 +15,7 @@ all fields are defined.
 [[ecs-fieldsets]]
 === Field Sets
 [cols="<,<",options="header",]
-|=======================================================================
+|=====
 | Field Set  | Description
 
 | <<ecs-base,Base>> | All fields defined directly at the top level

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -170,7 +170,7 @@ all fields are defined.
 [[ecs-fieldsets]]
 === Field Sets
 [cols="<,<",options="header",]
-|=======================================================================
+|=====
 | Field Set  | Description
 '''
 


### PR DESCRIPTION
Asciidoctor is a bit pickier about start and end delimiter and complains
about this table because the start line has more `=`s than the end line.
This removes `=`s from the start until it lines up with the end.