### PR TITLE
Backport #425 to 1.0: Specify static output format for event.duration

### DIFF
--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -609,6 +609,10 @@
     - name: duration
       level: core
       type: long
+      format: duration
+      input_format: nanoseconds
+      output_format: asMilliseconds
+      output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
         If event.start and event.end are known this value should be the difference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -793,9 +793,13 @@ event.duration:
     If event.start and event.end are known this value should be the difference between
     the end and start time.'
   flat_name: event.duration
+  format: duration
+  input_format: nanoseconds
   level: core
   name: duration
   order: 11
+  output_format: asMilliseconds
+  output_precision: 1
   short: Duration of the event in nanoseconds.
   type: long
 event.end:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -967,9 +967,13 @@ event:
         If event.start and event.end are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
+      format: duration
+      input_format: nanoseconds
       level: core
       name: duration
       order: 11
+      output_format: asMilliseconds
+      output_precision: 1
       short: Duration of the event in nanoseconds.
       type: long
     end:

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -152,6 +152,10 @@
     - name: duration
       level: core
       type: long
+      format: duration
+      input_format: nanoseconds
+      output_format: asMilliseconds
+      output_precision: 1
       short: Duration of the event in nanoseconds.
       description: >
         Duration of the event in nanoseconds.

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -30,8 +30,8 @@ def generate(ecs_nested, ecs_version):
 
 def fieldset_field_array(source_fields):
     allowed_keys = ['name', 'level', 'required', 'type', 'object_type',
-                    'ignore_above', 'multi_fields', 'format',
-                    'description', 'example']
+                    'ignore_above', 'multi_fields', 'format', 'input_format',
+                    'output_format', 'output_precision', 'description', 'example']
     fields = []
     for nested_field_name in source_fields:
         ecs_field = source_fields[nested_field_name]


### PR DESCRIPTION
Backport of PR #425 to 1.0 branch. Original message:

Static ms output format isn't great, it's just the least bad option