### PR TITLE
Backport #430 to 1.0: Docs: Fix a table start to align with the stop (#430)

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -15,7 +15,7 @@ all fields are defined.
 [[ecs-fieldsets]]
 === Field Sets
 [cols="<,<",options="header",]
-|=======================================================================
+|=====
 | Field Set  | Description
 
 | <<ecs-base,Base>> | All fields defined directly at the top level

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -170,7 +170,7 @@ all fields are defined.
 [[ecs-fieldsets]]
 === Field Sets
 [cols="<,<",options="header",]
-|=======================================================================
+|=====
 | Field Set  | Description
 '''
 


### PR DESCRIPTION
Backport of PR #430 to 1.0 branch. Original message:

Asciidoctor is a bit pickier about start and end delimiter and complains
about this table because the start line has more `=`s than the end line.

This removes `=`s from the table start, so it lines up with the table end.