### PR TITLE
Additions to event

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -13,6 +13,7 @@
 * Generator for the asciidoc rendering of field definitions. #347
 * Generator for the Beats fields.ecs.yml file. #379
 * Added field formats to all `.bytes` fields and `event.duration`. #385
+* Added `event.code`, `event.sequence` and `event.provider`. #439
 
 ### Improvements
 

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -77,13 +77,17 @@ type Event struct {
 	Type string `ecs:"type"`
 
 	// Name of the module this data is coming from.
-	// This information is coming from the modules used in Beats or Logstash.
+	// If your monitoring agent supports the concept of modules or plugins to
+	// parse events of a given source (e.g. Apache logs), `event.module` should
+	// contain the name of this module.
 	Module string `ecs:"module"`
 
 	// Name of the dataset.
-	// The concept of a `dataset` (fileset / metricset) is used in Beats as a
-	// subset of modules. It contains the information which is currently stored
-	// in metricset.name and metricset.module or fileset.name.
+	// If an event source publishes more than one type of log or events (e.g.
+	// access log, error log), the dataset is used to specify which dataset
+	// this comes from.
+	// It's recommended but not required to start the dataset name with the
+	// module name, followed by a dot, then the dataset name.
 	Dataset string `ecs:"dataset"`
 
 	// Source of the event.

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -86,6 +86,14 @@ type Event struct {
 	// in metricset.name and metricset.module or fileset.name.
 	Dataset string `ecs:"dataset"`
 
+	// Source of the event.
+	// Event transports such as Syslog or the Windows Event Log typically have
+	// a single field about the source of an event. It can be the name of the
+	// software that generated the event (e.g. Sysmon, httpd), or of a
+	// subsystem of the operating system (kernel,
+	// Microsoft-Windows-Security-Auditing).
+	Provider string `ecs:"provider"`
+
 	// Severity describes the original severity of the event. What the
 	// different severity values mean can very different between use cases.
 	// It's up to the implementer to make sure severities are consistent across

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -37,6 +37,12 @@ type Event struct {
 	// Unique ID to describe the event.
 	ID string `ecs:"id"`
 
+	// Identification code for this event, if one exists.
+	// Some event sources use event codes to identify messages unambiguously,
+	// regardless of message language or wording adjustments over time. An
+	// example of this is the Windows Event ID.
+	Code string `ecs:"code"`
+
 	// The kind of the event.
 	// This gives information about what type of information the event
 	// contains, without being specific to the contents of the event.  Examples

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -78,8 +78,8 @@ type Event struct {
 
 	// Name of the module this data is coming from.
 	// If your monitoring agent supports the concept of modules or plugins to
-	// parse events of a given source (e.g. Apache logs), `event.module` should
-	// contain the name of this module.
+	// process events of a given source (e.g. Apache logs), `event.module`
+	// should contain the name of this module.
 	Module string `ecs:"module"`
 
 	// Name of the dataset.
@@ -91,11 +91,10 @@ type Event struct {
 	Dataset string `ecs:"dataset"`
 
 	// Source of the event.
-	// Event transports such as Syslog or the Windows Event Log typically have
-	// a single field about the source of an event. It can be the name of the
-	// software that generated the event (e.g. Sysmon, httpd), or of a
-	// subsystem of the operating system (kernel,
-	// Microsoft-Windows-Security-Auditing).
+	// Event transports such as Syslog or the Windows Event Log typically
+	// mention the source of an event. It can be the name of the software that
+	// generated the event (e.g. Sysmon, httpd), or of a subsystem of the
+	// operating system (kernel, Microsoft-Windows-Security-Auditing).
 	Provider string `ecs:"provider"`
 
 	// Severity describes the original severity of the event. What the

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -118,6 +118,12 @@ type Event struct {
 	// difference between the end and start time.
 	Duration time.Duration `ecs:"duration"`
 
+	// Sequence number of the event.
+	// The sequence number is a value published by some event sources, to make
+	// the exact ordering of events unambiguous, regarless of the timestamp
+	// precision.
+	Sequence int64 `ecs:"sequence"`
+
 	// This field should be populated when the event's timestamp does not
 	// include timezone information already (e.g. default Syslog timestamps).
 	// It's optional otherwise.

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -84,8 +84,8 @@ type Event struct {
 
 	// Name of the dataset.
 	// If an event source publishes more than one type of log or events (e.g.
-	// access log, error log), the dataset is used to specify which dataset
-	// this comes from.
+	// access log, error log), the dataset is used to specify which one the
+	// event comes from.
 	// It's recommended but not required to start the dataset name with the
 	// module name, followed by a dot, then the dataset name.
 	Dataset string `ecs:"dataset"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -847,6 +847,19 @@ example: `success`
 
 // ===============================================================
 
+| event.provider
+| Source of the event.
+
+Event transports such as Syslog or the Windows Event Log typically have a single field about the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).
+
+type: keyword
+
+example: `kernel`
+
+| extended
+
+// ===============================================================
+
 | event.risk_score
 | Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -813,7 +813,7 @@ example: `state`
 | event.module
 | Name of the module this data is coming from.
 
-If your monitoring agent supports the concept of modules or plugins to parse events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.
+If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.
 
 type: keyword
 
@@ -852,7 +852,7 @@ example: `success`
 | event.provider
 | Source of the event.
 
-Event transports such as Syslog or the Windows Event Log typically have a single field about the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).
+Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -739,7 +739,7 @@ type: date
 | event.dataset
 | Name of the dataset.
 
-If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which dataset this comes from.
+If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from.
 
 It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -706,6 +706,19 @@ example: `user-management`
 
 // ===============================================================
 
+| event.code
+| Identification code for this event, if one exists.
+
+Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.
+
+type: keyword
+
+example: `4648`
+
+| extended
+
+// ===============================================================
+
 | event.created
 | event.created contains the date/time when the event was first read by an agent, or by your pipeline.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -886,6 +886,19 @@ type: float
 
 // ===============================================================
 
+| event.sequence
+| Sequence number of the event.
+
+The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regarless of the timestamp precision.
+
+type: long
+
+
+
+| extended
+
+// ===============================================================
+
 | event.severity
 | Severity describes the original severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -739,11 +739,13 @@ type: date
 | event.dataset
 | Name of the dataset.
 
-The concept of a `dataset` (fileset / metricset) is used in Beats as a subset of modules. It contains the information which is currently stored in metricset.name and metricset.module or fileset.name.
+If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which dataset this comes from.
+
+It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.
 
 type: keyword
 
-example: `stats`
+example: `apache.access`
 
 | core
 
@@ -811,11 +813,11 @@ example: `state`
 | event.module
 | Name of the module this data is coming from.
 
-This information is coming from the modules used in Beats or Logstash.
+If your monitoring agent supports the concept of modules or plugins to parse events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.
 
 type: keyword
 
-example: `mysql`
+example: `apache`
 
 | core
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -615,7 +615,8 @@
       description: 'Name of the dataset.
 
         If an event source publishes more than one type of log or events (e.g. access
-        log, error log), the dataset is used to specify which dataset this comes from.
+        log, error log), the dataset is used to specify which one the event comes
+        from.
 
         It''s recommended but not required to start the dataset name with the module
         name, followed by a dot, then the dataset name.'

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -666,7 +666,7 @@
       ignore_above: 1024
       description: 'Name of the module this data is coming from.
 
-        If your monitoring agent supports the concept of modules or plugins to parse
+        If your monitoring agent supports the concept of modules or plugins to process
         events of a given source (e.g. Apache logs), `event.module` should contain
         the name of this module.'
       example: apache
@@ -697,10 +697,10 @@
       ignore_above: 1024
       description: 'Source of the event.
 
-        Event transports such as Syslog or the Windows Event Log typically have a
-        single field about the source of an event. It can be the name of the software
-        that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating
-        system (kernel, Microsoft-Windows-Security-Auditing).'
+        Event transports such as Syslog or the Windows Event Log typically mention
+        the source of an event. It can be the name of the software that generated
+        the event (e.g. Sysmon, httpd), or of a subsystem of the operating system
+        (kernel, Microsoft-Windows-Security-Auditing).'
       example: kernel
     - name: risk_score
       level: core

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -687,6 +687,17 @@
         versions of ECS, we plan to provide a list of acceptable values for this field,
         please use with caution.'
       example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically have a
+        single field about the source of an event. It can be the name of the software
+        that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating
+        system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: risk_score
       level: core
       type: float

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -715,6 +715,13 @@
 
         This is mainly useful if you use more than one system that assigns risk scores,
         and you want to see a normalized value across all systems.'
+    - name: sequence
+      level: extended
+      type: long
+      description: 'Sequence number of the event.
+
+        The sequence number is a value published by some event sources, to make the
+        exact ordering of events unambiguous, regarless of the timestamp precision.'
     - name: severity
       level: core
       type: long

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -614,10 +614,12 @@
       ignore_above: 1024
       description: 'Name of the dataset.
 
-        The concept of a `dataset` (fileset / metricset) is used in Beats as a subset
-        of modules. It contains the information which is currently stored in metricset.name
-        and metricset.module or fileset.name.'
-      example: stats
+        If an event source publishes more than one type of log or events (e.g. access
+        log, error log), the dataset is used to specify which dataset this comes from.
+
+        It''s recommended but not required to start the dataset name with the module
+        name, followed by a dot, then the dataset name.'
+      example: apache.access
     - name: duration
       level: core
       type: long
@@ -664,8 +666,10 @@
       ignore_above: 1024
       description: 'Name of the module this data is coming from.
 
-        This information is coming from the modules used in Beats or Logstash.'
-      example: mysql
+        If your monitoring agent supports the concept of modules or plugins to parse
+        events of a given source (e.g. Apache logs), `event.module` should contain
+        the name of this module.'
+      example: apache
     - name: original
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -583,6 +583,16 @@
         multiple actions. Warning: In future versions of ECS, we plan to provide a
         list of acceptable values for this field, please use with caution.'
       example: user-management
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless
+        of message language or wording adjustments over time. An example of this is
+        the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -85,6 +85,7 @@ event.outcome,keyword,extended,success,1.1.0-dev
 event.provider,keyword,extended,kernel,1.1.0-dev
 event.risk_score,float,core,,1.1.0-dev
 event.risk_score_norm,float,extended,,1.1.0-dev
+event.sequence,long,extended,,1.1.0-dev
 event.severity,long,core,7,1.1.0-dev
 event.start,date,extended,,1.1.0-dev
 event.timezone,keyword,extended,,1.1.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -73,13 +73,13 @@ event.action,keyword,core,user-password-change,1.1.0-dev
 event.category,keyword,core,user-management,1.1.0-dev
 event.code,keyword,extended,4648,1.1.0-dev
 event.created,date,core,,1.1.0-dev
-event.dataset,keyword,core,stats,1.1.0-dev
+event.dataset,keyword,core,apache.access,1.1.0-dev
 event.duration,long,core,,1.1.0-dev
 event.end,date,extended,,1.1.0-dev
 event.hash,keyword,extended,123456789012345678901234567890ABCD,1.1.0-dev
 event.id,keyword,core,8a4f500d,1.1.0-dev
 event.kind,keyword,extended,state,1.1.0-dev
-event.module,keyword,core,mysql,1.1.0-dev
+event.module,keyword,core,apache,1.1.0-dev
 event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,1.1.0-dev
 event.outcome,keyword,extended,success,1.1.0-dev
 event.provider,keyword,extended,kernel,1.1.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -82,6 +82,7 @@ event.kind,keyword,extended,state,1.1.0-dev
 event.module,keyword,core,mysql,1.1.0-dev
 event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,1.1.0-dev
 event.outcome,keyword,extended,success,1.1.0-dev
+event.provider,keyword,extended,kernel,1.1.0-dev
 event.risk_score,float,core,,1.1.0-dev
 event.risk_score_norm,float,extended,,1.1.0-dev
 event.severity,long,core,7,1.1.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -71,6 +71,7 @@ error.id,keyword,core,,1.1.0-dev
 error.message,text,core,,1.1.0-dev
 event.action,keyword,core,user-password-change,1.1.0-dev
 event.category,keyword,core,user-management,1.1.0-dev
+event.code,keyword,extended,4648,1.1.0-dev
 event.created,date,core,,1.1.0-dev
 event.dataset,keyword,core,stats,1.1.0-dev
 event.duration,long,core,,1.1.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -793,7 +793,7 @@ event.dataset:
   description: 'Name of the dataset.
 
     If an event source publishes more than one type of log or events (e.g. access
-    log, error log), the dataset is used to specify which dataset this comes from.
+    log, error log), the dataset is used to specify which one the event comes from.
 
     It''s recommended but not required to start the dataset name with the module name,
     followed by a dot, then the dataset name.'

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -870,9 +870,9 @@ event.kind:
 event.module:
   description: 'Name of the module this data is coming from.
 
-    If your monitoring agent supports the concept of modules or plugins to parse events
-    of a given source (e.g. Apache logs), `event.module` should contain the name of
-    this module.'
+    If your monitoring agent supports the concept of modules or plugins to process
+    events of a given source (e.g. Apache logs), `event.module` should contain the
+    name of this module.'
   example: apache
   flat_name: event.module
   ignore_above: 1024
@@ -915,10 +915,9 @@ event.outcome:
 event.provider:
   description: 'Source of the event.
 
-    Event transports such as Syslog or the Windows Event Log typically have a single
-    field about the source of an event. It can be the name of the software that generated
-    the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel,
-    Microsoft-Windows-Security-Auditing).'
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
   example: kernel
   flat_name: event.provider
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -786,7 +786,7 @@ event.created:
   flat_name: event.created
   level: core
   name: created
-  order: 15
+  order: 16
   short: Time when the event was first read by an agent or by your pipeline.
   type: date
 event.dataset:
@@ -826,7 +826,7 @@ event.end:
   flat_name: event.end
   level: extended
   name: end
-  order: 17
+  order: 18
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
@@ -933,7 +933,7 @@ event.risk_score:
   flat_name: event.risk_score
   level: core
   name: risk_score
-  order: 18
+  order: 19
   short: Risk score or priority of the event (e.g. security solutions). Use your system's
     original value here.
   type: float
@@ -946,9 +946,20 @@ event.risk_score_norm:
   flat_name: event.risk_score_norm
   level: extended
   name: risk_score_norm
-  order: 19
+  order: 20
   short: Normalized risk score or priority of the event (0-100).
   type: float
+event.sequence:
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regarless of the timestamp precision.'
+  flat_name: event.sequence
+  level: extended
+  name: sequence
+  order: 14
+  short: Sequence number of the event.
+  type: long
 event.severity:
   description: Severity describes the original severity of the event. What the different
     severity values mean can very different between use cases. It's up to the implementer
@@ -966,7 +977,7 @@ event.start:
   flat_name: event.start
   level: extended
   name: start
-  order: 16
+  order: 17
   short: event.start contains the date when the event started or when the activity
     was first observed.
   type: date
@@ -981,7 +992,7 @@ event.timezone:
   ignore_above: 1024
   level: extended
   name: timezone
-  order: 14
+  order: 15
   short: Event time zone.
   type: keyword
 event.type:

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -786,7 +786,7 @@ event.created:
   flat_name: event.created
   level: core
   name: created
-  order: 14
+  order: 15
   short: Time when the event was first read by an agent or by your pipeline.
   type: date
 event.dataset:
@@ -813,7 +813,7 @@ event.duration:
   input_format: nanoseconds
   level: core
   name: duration
-  order: 12
+  order: 13
   output_format: asMilliseconds
   output_precision: 1
   short: Duration of the event in nanoseconds.
@@ -824,7 +824,7 @@ event.end:
   flat_name: event.end
   level: extended
   name: end
-  order: 16
+  order: 17
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
@@ -836,7 +836,7 @@ event.hash:
   ignore_above: 1024
   level: extended
   name: hash
-  order: 11
+  order: 12
   short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
     log integrity.
   type: keyword
@@ -890,7 +890,7 @@ event.original:
   index: false
   level: core
   name: original
-  order: 10
+  order: 11
   short: Raw text message of entire event.
   type: keyword
 event.outcome:
@@ -908,13 +908,28 @@ event.outcome:
   order: 5
   short: The outcome of the event.
   type: keyword
+event.provider:
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically have a single
+    field about the source of an event. It can be the name of the software that generated
+    the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel,
+    Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  order: 9
+  short: Source of the event.
+  type: keyword
 event.risk_score:
   description: Risk score or priority of the event (e.g. security solutions). Use
     your system's original value here.
   flat_name: event.risk_score
   level: core
   name: risk_score
-  order: 17
+  order: 18
   short: Risk score or priority of the event (e.g. security solutions). Use your system's
     original value here.
   type: float
@@ -927,7 +942,7 @@ event.risk_score_norm:
   flat_name: event.risk_score_norm
   level: extended
   name: risk_score_norm
-  order: 18
+  order: 19
   short: Normalized risk score or priority of the event (0-100).
   type: float
 event.severity:
@@ -938,7 +953,7 @@ event.severity:
   flat_name: event.severity
   level: core
   name: severity
-  order: 9
+  order: 10
   short: Original severity of the event.
   type: long
 event.start:
@@ -947,7 +962,7 @@ event.start:
   flat_name: event.start
   level: extended
   name: start
-  order: 15
+  order: 16
   short: event.start contains the date when the event started or when the activity
     was first observed.
   type: date
@@ -962,7 +977,7 @@ event.timezone:
   ignore_above: 1024
   level: extended
   name: timezone
-  order: 13
+  order: 14
   short: Event time zone.
   type: keyword
 event.type:

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -792,10 +792,12 @@ event.created:
 event.dataset:
   description: 'Name of the dataset.
 
-    The concept of a `dataset` (fileset / metricset) is used in Beats as a subset
-    of modules. It contains the information which is currently stored in metricset.name
-    and metricset.module or fileset.name.'
-  example: stats
+    If an event source publishes more than one type of log or events (e.g. access
+    log, error log), the dataset is used to specify which dataset this comes from.
+
+    It''s recommended but not required to start the dataset name with the module name,
+    followed by a dot, then the dataset name.'
+  example: apache.access
   flat_name: event.dataset
   ignore_above: 1024
   level: core
@@ -868,8 +870,10 @@ event.kind:
 event.module:
   description: 'Name of the module this data is coming from.
 
-    This information is coming from the modules used in Beats or Logstash.'
-  example: mysql
+    If your monitoring agent supports the concept of modules or plugins to parse events
+    of a given source (e.g. Apache logs), `event.module` should contain the name of
+    this module.'
+  example: apache
   flat_name: event.module
   ignore_above: 1024
   level: core

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -738,7 +738,7 @@ event.action:
   ignore_above: 1024
   level: core
   name: action
-  order: 3
+  order: 4
   short: The action captured by the event.
   type: keyword
 event.category:
@@ -753,8 +753,22 @@ event.category:
   ignore_above: 1024
   level: core
   name: category
-  order: 2
+  order: 3
   short: Event category.
+  type: keyword
+event.code:
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  order: 1
+  short: Identification code for this event.
   type: keyword
 event.created:
   description: 'event.created contains the date/time when the event was first read
@@ -772,7 +786,7 @@ event.created:
   flat_name: event.created
   level: core
   name: created
-  order: 13
+  order: 14
   short: Time when the event was first read by an agent or by your pipeline.
   type: date
 event.dataset:
@@ -786,7 +800,7 @@ event.dataset:
   ignore_above: 1024
   level: core
   name: dataset
-  order: 7
+  order: 8
   short: Name of the dataset.
   type: keyword
 event.duration:
@@ -799,7 +813,7 @@ event.duration:
   input_format: nanoseconds
   level: core
   name: duration
-  order: 11
+  order: 12
   output_format: asMilliseconds
   output_precision: 1
   short: Duration of the event in nanoseconds.
@@ -810,7 +824,7 @@ event.end:
   flat_name: event.end
   level: extended
   name: end
-  order: 15
+  order: 16
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
@@ -822,7 +836,7 @@ event.hash:
   ignore_above: 1024
   level: extended
   name: hash
-  order: 10
+  order: 11
   short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
     log integrity.
   type: keyword
@@ -848,7 +862,7 @@ event.kind:
   ignore_above: 1024
   level: extended
   name: kind
-  order: 1
+  order: 2
   short: The kind of the event.
   type: keyword
 event.module:
@@ -860,7 +874,7 @@ event.module:
   ignore_above: 1024
   level: core
   name: module
-  order: 6
+  order: 7
   short: Name of the module this data is coming from.
   type: keyword
 event.original:
@@ -876,7 +890,7 @@ event.original:
   index: false
   level: core
   name: original
-  order: 9
+  order: 10
   short: Raw text message of entire event.
   type: keyword
 event.outcome:
@@ -891,7 +905,7 @@ event.outcome:
   ignore_above: 1024
   level: extended
   name: outcome
-  order: 4
+  order: 5
   short: The outcome of the event.
   type: keyword
 event.risk_score:
@@ -900,7 +914,7 @@ event.risk_score:
   flat_name: event.risk_score
   level: core
   name: risk_score
-  order: 16
+  order: 17
   short: Risk score or priority of the event (e.g. security solutions). Use your system's
     original value here.
   type: float
@@ -913,7 +927,7 @@ event.risk_score_norm:
   flat_name: event.risk_score_norm
   level: extended
   name: risk_score_norm
-  order: 17
+  order: 18
   short: Normalized risk score or priority of the event (0-100).
   type: float
 event.severity:
@@ -924,7 +938,7 @@ event.severity:
   flat_name: event.severity
   level: core
   name: severity
-  order: 8
+  order: 9
   short: Original severity of the event.
   type: long
 event.start:
@@ -933,7 +947,7 @@ event.start:
   flat_name: event.start
   level: extended
   name: start
-  order: 14
+  order: 15
   short: event.start contains the date when the event started or when the activity
     was first observed.
   type: date
@@ -948,7 +962,7 @@ event.timezone:
   ignore_above: 1024
   level: extended
   name: timezone
-  order: 12
+  order: 13
   short: Event time zone.
   type: keyword
 event.type:
@@ -959,7 +973,7 @@ event.type:
   ignore_above: 1024
   level: core
   name: type
-  order: 5
+  order: 6
   short: Reserved for future usage.
   type: keyword
 file.ctime:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -960,7 +960,7 @@ event:
       flat_name: event.created
       level: core
       name: created
-      order: 15
+      order: 16
       short: Time when the event was first read by an agent or by your pipeline.
       type: date
     dataset:
@@ -1000,7 +1000,7 @@ event:
       flat_name: event.end
       level: extended
       name: end
-      order: 17
+      order: 18
       short: event.end contains the date when the event ended or when the activity
         was last observed.
       type: date
@@ -1107,7 +1107,7 @@ event:
       flat_name: event.risk_score
       level: core
       name: risk_score
-      order: 18
+      order: 19
       short: Risk score or priority of the event (e.g. security solutions). Use your
         system's original value here.
       type: float
@@ -1120,9 +1120,20 @@ event:
       flat_name: event.risk_score_norm
       level: extended
       name: risk_score_norm
-      order: 19
+      order: 20
       short: Normalized risk score or priority of the event (0-100).
       type: float
+    sequence:
+      description: 'Sequence number of the event.
+
+        The sequence number is a value published by some event sources, to make the
+        exact ordering of events unambiguous, regarless of the timestamp precision.'
+      flat_name: event.sequence
+      level: extended
+      name: sequence
+      order: 14
+      short: Sequence number of the event.
+      type: long
     severity:
       description: Severity describes the original severity of the event. What the
         different severity values mean can very different between use cases. It's
@@ -1140,7 +1151,7 @@ event:
       flat_name: event.start
       level: extended
       name: start
-      order: 16
+      order: 17
       short: event.start contains the date when the event started or when the activity
         was first observed.
       type: date
@@ -1155,7 +1166,7 @@ event:
       ignore_above: 1024
       level: extended
       name: timezone
-      order: 14
+      order: 15
       short: Event time zone.
       type: keyword
     type:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1044,7 +1044,7 @@ event:
     module:
       description: 'Name of the module this data is coming from.
 
-        If your monitoring agent supports the concept of modules or plugins to parse
+        If your monitoring agent supports the concept of modules or plugins to process
         events of a given source (e.g. Apache logs), `event.module` should contain
         the name of this module.'
       example: apache
@@ -1089,10 +1089,10 @@ event:
     provider:
       description: 'Source of the event.
 
-        Event transports such as Syslog or the Windows Event Log typically have a
-        single field about the source of an event. It can be the name of the software
-        that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating
-        system (kernel, Microsoft-Windows-Security-Auditing).'
+        Event transports such as Syslog or the Windows Event Log typically mention
+        the source of an event. It can be the name of the software that generated
+        the event (e.g. Sysmon, httpd), or of a subsystem of the operating system
+        (kernel, Microsoft-Windows-Security-Auditing).'
       example: kernel
       flat_name: event.provider
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -960,7 +960,7 @@ event:
       flat_name: event.created
       level: core
       name: created
-      order: 14
+      order: 15
       short: Time when the event was first read by an agent or by your pipeline.
       type: date
     dataset:
@@ -987,7 +987,7 @@ event:
       input_format: nanoseconds
       level: core
       name: duration
-      order: 12
+      order: 13
       output_format: asMilliseconds
       output_precision: 1
       short: Duration of the event in nanoseconds.
@@ -998,7 +998,7 @@ event:
       flat_name: event.end
       level: extended
       name: end
-      order: 16
+      order: 17
       short: event.end contains the date when the event ended or when the activity
         was last observed.
       type: date
@@ -1010,7 +1010,7 @@ event:
       ignore_above: 1024
       level: extended
       name: hash
-      order: 11
+      order: 12
       short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
         log integrity.
       type: keyword
@@ -1064,7 +1064,7 @@ event:
       index: false
       level: core
       name: original
-      order: 10
+      order: 11
       short: Raw text message of entire event.
       type: keyword
     outcome:
@@ -1082,13 +1082,28 @@ event:
       order: 5
       short: The outcome of the event.
       type: keyword
+    provider:
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically have a
+        single field about the source of an event. It can be the name of the software
+        that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating
+        system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
+      flat_name: event.provider
+      ignore_above: 1024
+      level: extended
+      name: provider
+      order: 9
+      short: Source of the event.
+      type: keyword
     risk_score:
       description: Risk score or priority of the event (e.g. security solutions).
         Use your system's original value here.
       flat_name: event.risk_score
       level: core
       name: risk_score
-      order: 17
+      order: 18
       short: Risk score or priority of the event (e.g. security solutions). Use your
         system's original value here.
       type: float
@@ -1101,7 +1116,7 @@ event:
       flat_name: event.risk_score_norm
       level: extended
       name: risk_score_norm
-      order: 18
+      order: 19
       short: Normalized risk score or priority of the event (0-100).
       type: float
     severity:
@@ -1112,7 +1127,7 @@ event:
       flat_name: event.severity
       level: core
       name: severity
-      order: 9
+      order: 10
       short: Original severity of the event.
       type: long
     start:
@@ -1121,7 +1136,7 @@ event:
       flat_name: event.start
       level: extended
       name: start
-      order: 15
+      order: 16
       short: event.start contains the date when the event started or when the activity
         was first observed.
       type: date
@@ -1136,7 +1151,7 @@ event:
       ignore_above: 1024
       level: extended
       name: timezone
-      order: 13
+      order: 14
       short: Event time zone.
       type: keyword
     type:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -912,7 +912,7 @@ event:
       ignore_above: 1024
       level: core
       name: action
-      order: 3
+      order: 4
       short: The action captured by the event.
       type: keyword
     category:
@@ -927,8 +927,22 @@ event:
       ignore_above: 1024
       level: core
       name: category
-      order: 2
+      order: 3
       short: Event category.
+      type: keyword
+    code:
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless
+        of message language or wording adjustments over time. An example of this is
+        the Windows Event ID.'
+      example: 4648
+      flat_name: event.code
+      ignore_above: 1024
+      level: extended
+      name: code
+      order: 1
+      short: Identification code for this event.
       type: keyword
     created:
       description: 'event.created contains the date/time when the event was first
@@ -946,7 +960,7 @@ event:
       flat_name: event.created
       level: core
       name: created
-      order: 13
+      order: 14
       short: Time when the event was first read by an agent or by your pipeline.
       type: date
     dataset:
@@ -960,7 +974,7 @@ event:
       ignore_above: 1024
       level: core
       name: dataset
-      order: 7
+      order: 8
       short: Name of the dataset.
       type: keyword
     duration:
@@ -973,7 +987,7 @@ event:
       input_format: nanoseconds
       level: core
       name: duration
-      order: 11
+      order: 12
       output_format: asMilliseconds
       output_precision: 1
       short: Duration of the event in nanoseconds.
@@ -984,7 +998,7 @@ event:
       flat_name: event.end
       level: extended
       name: end
-      order: 15
+      order: 16
       short: event.end contains the date when the event ended or when the activity
         was last observed.
       type: date
@@ -996,7 +1010,7 @@ event:
       ignore_above: 1024
       level: extended
       name: hash
-      order: 10
+      order: 11
       short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
         log integrity.
       type: keyword
@@ -1022,7 +1036,7 @@ event:
       ignore_above: 1024
       level: extended
       name: kind
-      order: 1
+      order: 2
       short: The kind of the event.
       type: keyword
     module:
@@ -1034,7 +1048,7 @@ event:
       ignore_above: 1024
       level: core
       name: module
-      order: 6
+      order: 7
       short: Name of the module this data is coming from.
       type: keyword
     original:
@@ -1050,7 +1064,7 @@ event:
       index: false
       level: core
       name: original
-      order: 9
+      order: 10
       short: Raw text message of entire event.
       type: keyword
     outcome:
@@ -1065,7 +1079,7 @@ event:
       ignore_above: 1024
       level: extended
       name: outcome
-      order: 4
+      order: 5
       short: The outcome of the event.
       type: keyword
     risk_score:
@@ -1074,7 +1088,7 @@ event:
       flat_name: event.risk_score
       level: core
       name: risk_score
-      order: 16
+      order: 17
       short: Risk score or priority of the event (e.g. security solutions). Use your
         system's original value here.
       type: float
@@ -1087,7 +1101,7 @@ event:
       flat_name: event.risk_score_norm
       level: extended
       name: risk_score_norm
-      order: 17
+      order: 18
       short: Normalized risk score or priority of the event (0-100).
       type: float
     severity:
@@ -1098,7 +1112,7 @@ event:
       flat_name: event.severity
       level: core
       name: severity
-      order: 8
+      order: 9
       short: Original severity of the event.
       type: long
     start:
@@ -1107,7 +1121,7 @@ event:
       flat_name: event.start
       level: extended
       name: start
-      order: 14
+      order: 15
       short: event.start contains the date when the event started or when the activity
         was first observed.
       type: date
@@ -1122,7 +1136,7 @@ event:
       ignore_above: 1024
       level: extended
       name: timezone
-      order: 12
+      order: 13
       short: Event time zone.
       type: keyword
     type:
@@ -1133,7 +1147,7 @@ event:
       ignore_above: 1024
       level: core
       name: type
-      order: 5
+      order: 6
       short: Reserved for future usage.
       type: keyword
   group: 2

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -966,10 +966,12 @@ event:
     dataset:
       description: 'Name of the dataset.
 
-        The concept of a `dataset` (fileset / metricset) is used in Beats as a subset
-        of modules. It contains the information which is currently stored in metricset.name
-        and metricset.module or fileset.name.'
-      example: stats
+        If an event source publishes more than one type of log or events (e.g. access
+        log, error log), the dataset is used to specify which dataset this comes from.
+
+        It''s recommended but not required to start the dataset name with the module
+        name, followed by a dot, then the dataset name.'
+      example: apache.access
       flat_name: event.dataset
       ignore_above: 1024
       level: core
@@ -1042,8 +1044,10 @@ event:
     module:
       description: 'Name of the module this data is coming from.
 
-        This information is coming from the modules used in Beats or Logstash.'
-      example: mysql
+        If your monitoring agent supports the concept of modules or plugins to parse
+        events of a given source (e.g. Apache logs), `event.module` should contain
+        the name of this module.'
+      example: apache
       flat_name: event.module
       ignore_above: 1024
       level: core

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -967,7 +967,8 @@ event:
       description: 'Name of the dataset.
 
         If an event source publishes more than one type of log or events (e.g. access
-        log, error log), the dataset is used to specify which dataset this comes from.
+        log, error log), the dataset is used to specify which one the event comes
+        from.
 
         It''s recommended but not required to start the dataset name with the module
         name, followed by a dot, then the dataset name.'

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -407,6 +407,9 @@
             "risk_score_norm": {
               "type": "float"
             }, 
+            "sequence": {
+              "type": "long"
+            }, 
             "severity": {
               "type": "long"
             }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -354,6 +354,10 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "code": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "created": {
               "type": "date"
             }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -397,6 +397,10 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "provider": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "risk_score": {
               "type": "float"
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -406,6 +406,9 @@
           "risk_score_norm": {
             "type": "float"
           }, 
+          "sequence": {
+            "type": "long"
+          }, 
           "severity": {
             "type": "long"
           }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -353,6 +353,10 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "code": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "created": {
             "type": "date"
           }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -396,6 +396,10 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "provider": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "risk_score": {
             "type": "float"
           }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -265,6 +265,9 @@
             "risk_score_norm": {
               "type": "float"
             },
+            "sequence": {
+              "type": "long"
+            },
             "severity": {
               "type": "long"
             },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -255,6 +255,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "provider": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "risk_score": {
               "type": "float"
             },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -212,6 +212,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "created": {
               "type": "date"
             },

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -123,6 +123,20 @@
         stored in metricset.name and metricset.module or fileset.name.
       example: stats
 
+    - name: provider
+      level: extended
+      type: keyword
+      short: Source of the event.
+      description: >
+        Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically have
+        a single field about the source of an event. It can be the name of the
+        software that generated the event (e.g. Sysmon, httpd),
+        or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).
+
+      example: kernel
+
     - name: severity
       level: core
       type: long

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -108,8 +108,10 @@
       description: >
         Name of the module this data is coming from.
 
-        This information is coming from the modules used in Beats or Logstash.
-      example: mysql
+        If your monitoring agent supports the concept of modules or plugins to parse events
+        of a given source (e.g. Apache logs), `event.module` should contain the name
+        of this module.
+      example: apache
 
     - name: dataset
       level: core
@@ -118,10 +120,13 @@
       description: >
         Name of the dataset.
 
-        The concept of a `dataset` (fileset / metricset) is used in Beats as a
-        subset of modules. It contains the information which is currently
-        stored in metricset.name and metricset.module or fileset.name.
-      example: stats
+        If an event source publishes more than one type of log or events
+        (e.g. access log, error log), the dataset is used to specify which
+        dataset this comes from.
+
+        It's recommended but not required to start the dataset name with
+        the module name, followed by a dot, then the dataset name.
+      example: apache.access
 
     - name: provider
       level: extended

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -194,6 +194,16 @@
         If event.start and event.end are known this value should be the
         difference between the end and start time.
 
+    - name: sequence
+      level: extended
+      type: long
+      short: Sequence number of the event.
+      description: >
+        Sequence number of the event.
+
+        The sequence number is a value published by some event sources, to make the
+        exact ordering of events unambiguous, regarless of the timestamp precision.
+
     - name: timezone
       level: extended
       type: keyword

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -25,6 +25,18 @@
         Unique ID to describe the event.
       example: 8a4f500d
 
+    - name: code
+      level: extended
+      type: keyword
+      short: Identification code for this event.
+      description: >
+        Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously,
+        regardless of message language or wording adjustments over time.
+        An example of this is the Windows Event ID.
+      example: 4648
+
     - name: kind
       level: extended
       type: keyword

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -122,7 +122,7 @@
 
         If an event source publishes more than one type of log or events
         (e.g. access log, error log), the dataset is used to specify which
-        dataset this comes from.
+        one the event comes from.
 
         It's recommended but not required to start the dataset name with
         the module name, followed by a dot, then the dataset name.

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -108,9 +108,9 @@
       description: >
         Name of the module this data is coming from.
 
-        If your monitoring agent supports the concept of modules or plugins to parse events
-        of a given source (e.g. Apache logs), `event.module` should contain the name
-        of this module.
+        If your monitoring agent supports the concept of modules or plugins to
+        process events of a given source (e.g. Apache logs),
+        `event.module` should contain the name of this module.
       example: apache
 
     - name: dataset
@@ -135,8 +135,8 @@
       description: >
         Source of the event.
 
-        Event transports such as Syslog or the Windows Event Log typically have
-        a single field about the source of an event. It can be the name of the
+        Event transports such as Syslog or the Windows Event Log typically
+        mention the source of an event. It can be the name of the
         software that generated the event (e.g. Sysmon, httpd),
         or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).
 

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -7,7 +7,7 @@ ECS usage in Auditbeat.
 
 | Field  | Description  | Level  | Type  | Example  |
 |---|---|---|---|---|
-| [event.module](../README.md#event.module)  | Auditbeat module name. | core | keyword | `mysql` |
+| [event.module](../README.md#event.module)  | Auditbeat module name. | core | keyword | `apache` |
 | <a name="file.&ast;"></a>*file.&ast;* | *File attributes.<br/>* |  |  |  |
 | [file.path](../README.md#file.path)  | The path to the file. | extended | keyword |  |
 | [file.target_path](../README.md#file.target_path)  | The target path for symlinks. | extended | keyword |  |


### PR DESCRIPTION
This PR addresses/improves a few things in the the "event" field set.

If any of these turns out controversial / complicated, I'll be happy to extract them to a separate PR. The goal here is to get the simple things in.

- Added `event.code` (See https://github.com/elastic/beats/pull/10333)
- Added `event.sequence` (See https://github.com/elastic/ecs/issues/129, https://github.com/elastic/beats/pull/10760)
- Added `event.provider` (See https://github.com/elastic/ecs/issues/321)
  - Note: Beats modules currently put the Syslog "programname" in `process.name` which is sometimes accurate, sometimes not (e.g. "kernel"). event.provider would be a better field for this.
- Explain event.module and event.dataset without mentioning Beats

Closes #321
Addresses part of #129