### PR TITLE
Add 2 missing timestamps to `file`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,7 @@
 * Added field formats to all `.bytes` fields and `event.duration`. #385
 * Added `event.code`, `event.sequence` and `event.provider`. #439
 * Added `file.name` and `file.directory`. #441
+* Added `file.created`, and `file.accessed`. #445
 
 ### Improvements
 

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -81,4 +81,10 @@ type File struct {
 	// `ctime` will be adjusted at the same time, since `mtime` is an attribute
 	// of the file.
 	Ctime time.Time `ecs:"ctime"`
+
+	// File creation time.
+	Created time.Time `ecs:"created"`
+
+	// Last time file content accessed.
+	Accessed time.Time `ecs:"accessed"`
 }

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -85,6 +85,6 @@ type File struct {
 	// File creation time.
 	Created time.Time `ecs:"created"`
 
-	// Last time file content accessed.
+	// Last time the file was accessed.
 	Accessed time.Time `ecs:"accessed"`
 }

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -83,8 +83,10 @@ type File struct {
 	Ctime time.Time `ecs:"ctime"`
 
 	// File creation time.
+	// Note that not all filesystems store the creation time.
 	Created time.Time `ecs:"created"`
 
 	// Last time the file was accessed.
+	// Note that not all filesystems keep track of access time.
 	Accessed time.Time `ecs:"accessed"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -967,6 +967,8 @@ File objects can be associated with host events, network events, and/or file eve
 | file.accessed
 | Last time the file was accessed.
 
+Note that not all filesystems keep track of access time.
+
 type: date
 
 
@@ -977,6 +979,8 @@ type: date
 
 | file.created
 | File creation time.
+
+Note that not all filesystems store the creation time.
 
 type: date
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -964,6 +964,28 @@ File objects can be associated with host events, network events, and/or file eve
 
 // ===============================================================
 
+| file.accessed
+| Last time file content accessed.
+
+type: date
+
+
+
+| extended
+
+// ===============================================================
+
+| file.created
+| File creation time.
+
+type: date
+
+
+
+| extended
+
+// ===============================================================
+
 | file.ctime
 | Last time the file attributes or metadata changed.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -965,7 +965,7 @@ File objects can be associated with host events, network events, and/or file eve
 // ===============================================================
 
 | file.accessed
-| Last time file content accessed.
+| Last time the file was accessed.
 
 type: date
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -767,7 +767,7 @@
     - name: accessed
       level: extended
       type: date
-      description: Last time file content accessed.
+      description: Last time the file was accessed.
     - name: created
       level: extended
       type: date

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -767,11 +767,15 @@
     - name: accessed
       level: extended
       type: date
-      description: Last time the file was accessed.
+      description: 'Last time the file was accessed.
+
+        Note that not all filesystems keep track of access time.'
     - name: created
       level: extended
       type: date
-      description: File creation time.
+      description: 'File creation time.
+
+        Note that not all filesystems store the creation time.'
     - name: ctime
       level: extended
       type: date

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -764,6 +764,14 @@
       the event or metric.'
     type: group
     fields:
+    - name: accessed
+      level: extended
+      type: date
+      description: Last time file content accessed.
+    - name: created
+      level: extended
+      type: date
+      description: File creation time.
     - name: ctime
       level: extended
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -90,6 +90,8 @@ event.severity,long,core,7,1.1.0-dev
 event.start,date,extended,,1.1.0-dev
 event.timezone,keyword,extended,,1.1.0-dev
 event.type,keyword,core,,1.1.0-dev
+file.accessed,date,extended,,1.1.0-dev
+file.created,date,extended,,1.1.0-dev
 file.ctime,date,extended,,1.1.0-dev
 file.device,keyword,extended,sda,1.1.0-dev
 file.directory,keyword,extended,/home/alice,1.1.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1006,7 +1006,9 @@ event.type:
   short: Reserved for future usage.
   type: keyword
 file.accessed:
-  description: Last time the file was accessed.
+  description: 'Last time the file was accessed.
+
+    Note that not all filesystems keep track of access time.'
   flat_name: file.accessed
   level: extended
   name: accessed
@@ -1014,7 +1016,9 @@ file.accessed:
   short: Last time the file was accessed.
   type: date
 file.created:
-  description: File creation time.
+  description: 'File creation time.
+
+    Note that not all filesystems store the creation time.'
   flat_name: file.created
   level: extended
   name: created

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1005,6 +1005,22 @@ event.type:
   order: 6
   short: Reserved for future usage.
   type: keyword
+file.accessed:
+  description: Last time file content accessed.
+  flat_name: file.accessed
+  level: extended
+  name: accessed
+  order: 17
+  short: Last time file content accessed.
+  type: date
+file.created:
+  description: File creation time.
+  flat_name: file.created
+  level: extended
+  name: created
+  order: 16
+  short: File creation time.
+  type: date
 file.ctime:
   description: 'Last time the file attributes or metadata changed.
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1006,12 +1006,12 @@ event.type:
   short: Reserved for future usage.
   type: keyword
 file.accessed:
-  description: Last time file content accessed.
+  description: Last time the file was accessed.
   flat_name: file.accessed
   level: extended
   name: accessed
   order: 17
-  short: Last time file content accessed.
+  short: Last time the file was accessed.
   type: date
 file.created:
   description: File creation time.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1197,7 +1197,9 @@ file:
     or metric.'
   fields:
     accessed:
-      description: Last time the file was accessed.
+      description: 'Last time the file was accessed.
+
+        Note that not all filesystems keep track of access time.'
       flat_name: file.accessed
       level: extended
       name: accessed
@@ -1205,7 +1207,9 @@ file:
       short: Last time the file was accessed.
       type: date
     created:
-      description: File creation time.
+      description: 'File creation time.
+
+        Note that not all filesystems store the creation time.'
       flat_name: file.created
       level: extended
       name: created

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1197,12 +1197,12 @@ file:
     or metric.'
   fields:
     accessed:
-      description: Last time file content accessed.
+      description: Last time the file was accessed.
       flat_name: file.accessed
       level: extended
       name: accessed
       order: 17
-      short: Last time file content accessed.
+      short: Last time the file was accessed.
       type: date
     created:
       description: File creation time.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1196,6 +1196,22 @@ file:
     File fields provide details about the affected file associated with the event
     or metric.'
   fields:
+    accessed:
+      description: Last time file content accessed.
+      flat_name: file.accessed
+      level: extended
+      name: accessed
+      order: 17
+      short: Last time file content accessed.
+      type: date
+    created:
+      description: File creation time.
+      flat_name: file.created
+      level: extended
+      name: created
+      order: 16
+      short: File creation time.
+      type: date
     ctime:
       description: 'Last time the file attributes or metadata changed.
 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -428,6 +428,12 @@
         }, 
         "file": {
           "properties": {
+            "accessed": {
+              "type": "date"
+            }, 
+            "created": {
+              "type": "date"
+            }, 
             "ctime": {
               "type": "date"
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -427,6 +427,12 @@
       }, 
       "file": {
         "properties": {
+          "accessed": {
+            "type": "date"
+          }, 
+          "created": {
+            "type": "date"
+          }, 
           "ctime": {
             "type": "date"
           }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -286,6 +286,12 @@
         },
         "file": {
           "properties": {
+            "accessed": {
+              "type": "date"
+            },
+            "created": {
+              "type": "date"
+            },
             "ctime": {
               "type": "date"
             },

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -124,4 +124,4 @@
   - name: accessed
     level: extended
     type: date
-    description: Last time file content accessed.
+    description: Last time the file was accessed.

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -115,3 +115,13 @@
       Note that changes to the file content will update `mtime`. This implies
       `ctime` will be adjusted at the same time, since `mtime` is an attribute
       of the file.
+
+  - name: created
+    level: extended
+    type: date
+    description: File creation time.
+
+  - name: accessed
+    level: extended
+    type: date
+    description: Last time file content accessed.

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -119,9 +119,17 @@
   - name: created
     level: extended
     type: date
-    description: File creation time.
+    short: File creation time.
+    description: >
+      File creation time.
+
+      Note that not all filesystems store the creation time.
 
   - name: accessed
     level: extended
     type: date
-    description: Last time the file was accessed.
+    short: Last time the file was accessed.
+    description: >
+      Last time the file was accessed.
+
+      Note that not all filesystems keep track of access time.


### PR DESCRIPTION
This is take 2 of something started in #441. We're departing from the internal
 consistency of the 4 Linux file timestamp names (atime, ctime, crtime, mtime),
 and going for clear and readable names.

 Right now this is only introducing the 2 missing fields, `created` and `accessed`.

I think it would make sense to rename the other two eventually. But since this would be a breaking
 change, we'd have to deprecate them for a while & document how to handle deprecations in ECS, and so on. This can be done as a separate PR.

 Adding these 2 fields unapologetically should be straightforward, though :-)

Closes #422