### PR TITLE
Create new cloud field to hold account alias

### DIFF
--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -68,3 +68,13 @@
 
         Examples: AWS account id, Google Cloud ORG Id, or other unique
         identifier.
+    - name: account.alias
+      level: extended
+      type: keyword
+      example: 
+      short: The cloud account alias that is supplied by the cloud customer.
+      description: >
+        The user-supplied name of a cloud account. This is a logical name
+        given to an account for easy identification.
+
+        Examples: AWS Account Alias used for console login


### PR DESCRIPTION
As I was upgrading our proprietary schema to ECS, I could not find a proper place for an AWS Account Alias - https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html#AboutAccountAlias

This is an important field for us because AWS Account IDs are not great for humans.  Since this is user-supplied and volatile, I kept the AWS "alias" jargon instead of "name".