### PR TITLE
Add object_type to fields

### DIFF
--- a/schemas/README.md
+++ b/schemas/README.md
@@ -35,6 +35,7 @@ Supported keys to describe fields
 - multi\_fields (optional):
 - reusable (optional):
 - index (optional): If `False`, means field is not indexed (overrides type)
+- object_type
 
 ### Multi\_fields
 


### PR DESCRIPTION
`base.yml` contains object_type, but this is missing from the documentation.
https://github.com/elastic/ecs/blob/652f7250f9c3acfec9538b00ad60053b7042ba20/schemas/base.yml#L39