### PR TITLE
Forward port #459 to master: Update log.yml

### DIFF
--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -1,6 +1,7 @@
 ---
 - name: log
   title: Log
+  group: 2
   description: >
     Fields which are specific to log events.
   type: group


### PR DESCRIPTION
Accidentally merged #459 to 1.0, so forward-porting to master. Original message:

YAML file is missing the `group` parameter as defined as required by the documentation, default value set to 2.