### PR TITLE
Cut changelog for ECS 1.0.1...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [1.0.1](https://github.com/elastic/ecs/compare/v1.0.0...v1.0.1)
+
+### Added
+
+* Add generated source code for Go. #249
+* Translate the documentation from README.md, to the main website. #266, #334
+* New generator that supports reusable fields, for files based on ECS.
+  It generates schema.csv, Elasticsearch 6 and 7 templates, and field documentation
+  for the main website. #336
+* Generator for the asciidoc rendering of field definitions. #347
+* Generator for the Beats fields.ecs.yml file. #379
+
 ## [1.0.0](https://github.com/elastic/ecs/compare/v1.0.0-beta2...v1.0.0)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ All notable changes to this project will be documented in this file based on the
 ### Added
 
 * Add generated source code for Go. #249
-* Translate the documentation from README.md, to the main website. #266, #334
+* Translate the documentation from README.md, to the main website. #266, #334, #400, #430, #437
 * New generator that supports reusable fields, for files based on ECS.
   It generates schema.csv, Elasticsearch 6 and 7 templates, and field documentation
   for the main website. #336
 * Generator for the asciidoc rendering of field definitions. #347
 * Generator for the Beats fields.ecs.yml file. #379
+* Remove many legacy generated files. #399
+* Specify static output format for event.duration. #432
 
 ## [1.0.0](https://github.com/elastic/ecs/compare/v1.0.0-beta2...v1.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file based on the
 * Generator for the asciidoc rendering of field definitions. #347
 * Generator for the Beats fields.ecs.yml file. #379
 * Remove many legacy generated files. #399
-* Specify static output format for event.duration. #432
+* Specify static output format for event.duration. #425
 
 ## [1.0.0](https://github.com/elastic/ecs/compare/v1.0.0-beta2...v1.0.0)
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -6,14 +6,6 @@
 
 ### Added
 
-* Add generated source code for Go. #249
-* Translate the documentation from README.md, to the main website. #266, #334
-* New generator that supports reusable fields, for files based on ECS.
-  It generates schema.csv, Elasticsearch 6 and 7 templates, and field documentation
-  for the main website. #336
-* Generator for the asciidoc rendering of field definitions. #347
-* Generator for the Beats fields.ecs.yml file. #379
-
 ### Improvements
 
 ### Deprecated


### PR DESCRIPTION
1.0.1 should have been cut a few weeks ago, after migrating the docs to the main site, and a few related tweaks 🤦‍♂ 