### PR TITLE
Backport #454 to 1.0: Format port numbers and numeric IDs as strings

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -8,6 +8,8 @@
 
 ### Improvements
 
+* Format port numbers and numeric IDs as strings. #454
+
 ### Deprecated
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -222,6 +222,7 @@
     - name: port
       level: core
       type: long
+      format: string
       description: Port of the client.
     - name: user.email
       level: extended
@@ -461,6 +462,7 @@
     - name: port
       level: core
       type: long
+      format: string
       description: Port of the destination.
     - name: user.email
       level: extended
@@ -691,6 +693,7 @@
     - name: severity
       level: core
       type: long
+      format: string
       description: Severity describes the original severity of the event. What the
         different severity values mean can very different between use cases. It's
         up to the implementer to make sure severities are consistent across events.
@@ -1126,6 +1129,7 @@
     - name: response.status_code
       level: extended
       type: long
+      format: string
       description: HTTP response status code.
       example: 404
     - name: version
@@ -1516,10 +1520,12 @@
     - name: pid
       level: core
       type: long
+      format: string
       description: Process id.
     - name: ppid
       level: extended
       type: long
+      format: string
       description: Process parent id.
     - name: start
       level: extended
@@ -1529,6 +1535,7 @@
     - name: thread.id
       level: extended
       type: long
+      format: string
       description: Thread ID.
       example: 4242
     - name: title
@@ -1677,6 +1684,7 @@
     - name: port
       level: core
       type: long
+      format: string
       description: Port of the server.
     - name: user.email
       level: extended
@@ -1890,6 +1898,7 @@
     - name: port
       level: core
       type: long
+      format: string
       description: Port of the source.
     - name: user.email
       level: extended
@@ -1987,6 +1996,7 @@
     - name: port
       level: extended
       type: long
+      format: string
       description: Port of the request, such as 443.
       example: 443
     - name: query

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -236,6 +236,7 @@ client.packets:
 client.port:
   description: Port of the client.
   flat_name: client.port
+  format: string
   level: core
   name: port
   order: 2
@@ -601,6 +602,7 @@ destination.packets:
 destination.port:
   description: Port of the destination.
   flat_name: destination.port
+  format: string
   level: core
   name: port
   order: 2
@@ -920,6 +922,7 @@ event.severity:
     to make sure severities are consistent across events.
   example: '7'
   flat_name: event.severity
+  format: string
   level: core
   name: severity
   order: 8
@@ -1583,6 +1586,7 @@ http.response.status_code:
   description: HTTP response status code.
   example: 404
   flat_name: http.response.status_code
+  format: string
   level: extended
   name: response.status_code
   order: 3
@@ -2149,6 +2153,7 @@ process.pid:
   description: Process id.
   exmple: ssh
   flat_name: process.pid
+  format: string
   level: core
   name: pid
   order: 0
@@ -2157,6 +2162,7 @@ process.pid:
 process.ppid:
   description: Process parent id.
   flat_name: process.ppid
+  format: string
   level: extended
   name: ppid
   order: 2
@@ -2175,6 +2181,7 @@ process.thread.id:
   description: Thread ID.
   example: 4242
   flat_name: process.thread.id
+  format: string
   level: extended
   name: thread.id
   order: 6
@@ -2366,6 +2373,7 @@ server.packets:
 server.port:
   description: Port of the server.
   flat_name: server.port
+  format: string
   level: core
   name: port
   order: 2
@@ -2689,6 +2697,7 @@ source.packets:
 source.port:
   description: Port of the source.
   flat_name: source.port
+  format: string
   level: core
   name: port
   order: 2
@@ -2852,6 +2861,7 @@ url.port:
   description: Port of the request, such as 443.
   example: 443
   flat_name: url.port
+  format: string
   level: extended
   name: port
   order: 4

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -326,6 +326,7 @@ client:
     port:
       description: Port of the client.
       flat_name: client.port
+      format: string
       level: core
       name: port
       order: 2
@@ -732,6 +733,7 @@ destination:
     port:
       description: Port of the destination.
       flat_name: destination.port
+      format: string
       level: core
       name: port
       order: 2
@@ -1094,6 +1096,7 @@ event:
         up to the implementer to make sure severities are consistent across events.
       example: '7'
       flat_name: event.severity
+      format: string
       level: core
       name: severity
       order: 8
@@ -1837,6 +1840,7 @@ http:
       description: HTTP response status code.
       example: 404
       flat_name: http.response.status_code
+      format: string
       level: extended
       name: response.status_code
       order: 3
@@ -2459,6 +2463,7 @@ process:
       description: Process id.
       exmple: ssh
       flat_name: process.pid
+      format: string
       level: core
       name: pid
       order: 0
@@ -2467,6 +2472,7 @@ process:
     ppid:
       description: Process parent id.
       flat_name: process.ppid
+      format: string
       level: extended
       name: ppid
       order: 2
@@ -2485,6 +2491,7 @@ process:
       description: Thread ID.
       example: 4242
       flat_name: process.thread.id
+      format: string
       level: extended
       name: thread.id
       order: 6
@@ -2717,6 +2724,7 @@ server:
     port:
       description: Port of the server.
       flat_name: server.port
+      format: string
       level: core
       name: port
       order: 2
@@ -3066,6 +3074,7 @@ source:
     port:
       description: Port of the source.
       flat_name: source.port
+      format: string
       level: core
       name: port
       order: 2
@@ -3233,6 +3242,7 @@ url:
       description: Port of the request, such as 443.
       example: 443
       flat_name: url.port
+      format: string
       level: extended
       name: port
       order: 4

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -41,6 +41,7 @@
         Can be one or multiple IPv4 or IPv6 addresses.
 
     - name: port
+      format: string
       level: core
       type: long
       description: >

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -32,6 +32,7 @@
         Can be one or multiple IPv4 or IPv6 addresses.
 
     - name: port
+      format: string
       level: core
       type: long
       description: >

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -112,6 +112,7 @@
       example: stats
 
     - name: severity
+      format: string
       level: core
       type: long
       example: "7"

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -34,6 +34,7 @@
       example: https://blog.example.com/
 
     - name: response.status_code
+      format: string
       level: extended
       type: long
       description: >

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -13,6 +13,7 @@
   fields:
 
     - name: pid
+      format: string
       level: core
       type: long
       description: >
@@ -30,6 +31,7 @@
       example: ssh
 
     - name: ppid
+      format: string
       level: extended
       type: long
       description: >
@@ -63,6 +65,7 @@
         for example a browser setting its title to the web page currently opened.
 
     - name: thread.id
+      format: string
       level: extended
       type: long
       example: 4242

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -41,6 +41,7 @@
         Can be one or multiple IPv4 or IPv6 addresses.
 
     - name: port
+      format: string
       level: core
       type: long
       description: >

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -32,6 +32,7 @@
         Can be one or multiple IPv4 or IPv6 addresses.
 
     - name: port
+      format: string
       level: core
       type: long
       description: >

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -55,6 +55,7 @@
       example: www.elastic.co
 
     - name: port
+      format: string
       level: extended
       type: long
       description: >


### PR DESCRIPTION
Backport of PR #454 to 1.0 branch. Original message:

Changes the display format of things like port numbers and PIDs to string where appropriate. Changed fields are:

client.port
destination.port
event.severity
event.sequence (backport note: not in 1.0)
http.response.status_code
process.pid
process.ppid
process.pgid (backport note: not in 1.0)
process.thread.id
server.port
source.port
url.port