### PR TITLE
Backport #464 to 1.0: Fix exmple typo in process.yml

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2035,7 +2035,7 @@ example: `ssh`
 
 type: long
 
-
+example: `ssh`
 
 | core
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1517,6 +1517,7 @@
       level: core
       type: long
       description: Process id.
+      example: ssh
     - name: ppid
       level: extended
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -194,7 +194,7 @@ os.version,keyword,extended,10.14.1,1.0.1
 process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",1.0.1
 process.executable,keyword,extended,/usr/bin/ssh,1.0.1
 process.name,keyword,extended,ssh,1.0.1
-process.pid,long,core,,1.0.1
+process.pid,long,core,ssh,1.0.1
 process.ppid,long,extended,,1.0.1
 process.start,date,extended,2016-05-23T08:05:34.853Z,1.0.1
 process.thread.id,long,extended,4242,1.0.1

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2147,7 +2147,7 @@ process.name:
   type: keyword
 process.pid:
   description: Process id.
-  exmple: ssh
+  example: ssh
   flat_name: process.pid
   level: core
   name: pid

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2457,7 +2457,7 @@ process:
       type: keyword
     pid:
       description: Process id.
-      exmple: ssh
+      example: ssh
       flat_name: process.pid
       level: core
       name: pid

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -17,7 +17,7 @@
       type: long
       description: >
         Process id.
-      exmple: ssh
+      example: ssh
 
     - name: name
       level: extended


### PR DESCRIPTION
Backport of PR #464 to 1.0 branch. Original message:

This closes #461, which was submitted by @codebrain, who use Windows --
ECS tooling doesn't currently run on Windows. Thanks Stuart!