### PR TITLE
Fix/add examples for the pid fields

### DIFF
--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -35,7 +35,7 @@ type Process struct {
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
-	// Process parent id.
+	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 
 	// Identifier of the group of processes the process belongs to.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2230,7 +2230,7 @@ type: long
 
 type: long
 
-example: `ssh`
+example: `4242`
 
 | core
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2237,11 +2237,11 @@ example: `4242`
 // ===============================================================
 
 | process.ppid
-| Process parent id.
+| Parent process' pid.
 
 type: long
 
-
+example: `4241`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1674,7 +1674,7 @@
       type: long
       format: string
       description: Process id.
-      example: ssh
+      example: 4242
     - name: ppid
       level: extended
       type: long

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1679,7 +1679,8 @@
       level: extended
       type: long
       format: string
-      description: Process parent id.
+      description: Parent process' pid.
+      example: 4241
     - name: start
       level: extended
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -215,7 +215,7 @@ process.hash.sha512,keyword,extended,,1.1.0-dev
 process.name,keyword,extended,ssh,1.1.0-dev
 process.pgid,long,extended,,1.1.0-dev
 process.pid,long,core,4242,1.1.0-dev
-process.ppid,long,extended,,1.1.0-dev
+process.ppid,long,extended,4241,1.1.0-dev
 process.start,date,extended,2016-05-23T08:05:34.853Z,1.1.0-dev
 process.thread.id,long,extended,4242,1.1.0-dev
 process.title,keyword,extended,,1.1.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -214,7 +214,7 @@ process.hash.sha256,keyword,extended,,1.1.0-dev
 process.hash.sha512,keyword,extended,,1.1.0-dev
 process.name,keyword,extended,ssh,1.1.0-dev
 process.pgid,long,extended,,1.1.0-dev
-process.pid,long,core,ssh,1.1.0-dev
+process.pid,long,core,4242,1.1.0-dev
 process.ppid,long,extended,,1.1.0-dev
 process.start,date,extended,2016-05-23T08:05:34.853Z,1.1.0-dev
 process.thread.id,long,extended,4242,1.1.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2388,13 +2388,14 @@ process.pid:
   short: Process id.
   type: long
 process.ppid:
-  description: Process parent id.
+  description: Parent process' pid.
+  example: 4241
   flat_name: process.ppid
   format: string
   level: extended
   name: ppid
   order: 2
-  short: Process parent id.
+  short: Parent process' pid.
   type: long
 process.start:
   description: The time the process started.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2379,7 +2379,7 @@ process.pgid:
   type: long
 process.pid:
   description: Process id.
-  example: ssh
+  example: 4242
   flat_name: process.pid
   format: string
   level: core

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2720,13 +2720,14 @@ process:
       short: Process id.
       type: long
     ppid:
-      description: Process parent id.
+      description: Parent process' pid.
+      example: 4241
       flat_name: process.ppid
       format: string
       level: extended
       name: ppid
       order: 2
-      short: Process parent id.
+      short: Parent process' pid.
       type: long
     start:
       description: The time the process started.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2711,7 +2711,7 @@ process:
       type: long
     pid:
       description: Process id.
-      example: ssh
+      example: 4242
       flat_name: process.pid
       format: string
       level: core

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -18,7 +18,7 @@
       type: long
       description: >
         Process id.
-      example: ssh
+      example: 4242
 
     - name: name
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -35,7 +35,8 @@
       level: extended
       type: long
       description: >
-        Process parent id.
+        Parent process' pid.
+      example: 4241
 
     - name: pgid
       format: string


### PR DESCRIPTION
PR #464 fixed a typo that prevented the example value for `process.pid`
from being picked up. But I guess we all missed the fact that the example
value for the field was "ssh", which is wrong :-)