### PR TITLE
Backport #470 to 1.0: Fix/add examples for the pid fields

### DIFF
--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -35,7 +35,7 @@ type Process struct {
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
-	// Process parent id.
+	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 
 	// Array of process arguments.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2035,18 +2035,18 @@ example: `ssh`
 
 type: long
 
-example: `ssh`
+example: `4242`
 
 | core
 
 // ===============================================================
 
 | process.ppid
-| Process parent id.
+| Parent process' pid.
 
 type: long
 
-
+example: `4241`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1522,12 +1522,13 @@
       type: long
       format: string
       description: Process id.
-      example: ssh
+      example: 4242
     - name: ppid
       level: extended
       type: long
       format: string
-      description: Process parent id.
+      description: Parent process' pid.
+      example: 4241
     - name: start
       level: extended
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -194,8 +194,8 @@ os.version,keyword,extended,10.14.1,1.0.1
 process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",1.0.1
 process.executable,keyword,extended,/usr/bin/ssh,1.0.1
 process.name,keyword,extended,ssh,1.0.1
-process.pid,long,core,ssh,1.0.1
-process.ppid,long,extended,,1.0.1
+process.pid,long,core,4242,1.0.1
+process.ppid,long,extended,4241,1.0.1
 process.start,date,extended,2016-05-23T08:05:34.853Z,1.0.1
 process.thread.id,long,extended,4242,1.0.1
 process.title,keyword,extended,,1.0.1

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2151,7 +2151,7 @@ process.name:
   type: keyword
 process.pid:
   description: Process id.
-  example: ssh
+  example: 4242
   flat_name: process.pid
   format: string
   level: core
@@ -2160,13 +2160,14 @@ process.pid:
   short: Process id.
   type: long
 process.ppid:
-  description: Process parent id.
+  description: Parent process' pid.
+  example: 4241
   flat_name: process.ppid
   format: string
   level: extended
   name: ppid
   order: 2
-  short: Process parent id.
+  short: Parent process' pid.
   type: long
 process.start:
   description: The time the process started.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2461,7 +2461,7 @@ process:
       type: keyword
     pid:
       description: Process id.
-      example: ssh
+      example: 4242
       flat_name: process.pid
       format: string
       level: core
@@ -2470,13 +2470,14 @@ process:
       short: Process id.
       type: long
     ppid:
-      description: Process parent id.
+      description: Parent process' pid.
+      example: 4241
       flat_name: process.ppid
       format: string
       level: extended
       name: ppid
       order: 2
-      short: Process parent id.
+      short: Parent process' pid.
       type: long
     start:
       description: The time the process started.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -18,7 +18,7 @@
       type: long
       description: >
         Process id.
-      example: ssh
+      example: 4242
 
     - name: name
       level: extended
@@ -35,7 +35,8 @@
       level: extended
       type: long
       description: >
-        Process parent id.
+        Parent process' pid.
+      example: 4241
 
     - name: args
       level: extended


### PR DESCRIPTION
Backport of PR #470 to 1.0 branch. Original message:

* Fix the example for `process.pid`
* Add example for ppid as well, and tweak its description a bit.