### PR TITLE
(#475) Add support for server and process uptime fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -6,6 +6,7 @@
 
 ### Added
 
+* Added `process.uptime` and `host.uptime` fields. #475
 * Added field formats to all `.bytes` fields and `event.duration`. #385, #425
 * Added `hash.*` field set. #426
 * Added `event.code`, `event.sequence` and `event.provider`. #439

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -53,6 +53,9 @@ type Host struct {
 	// meaningful in your environment.
 	Type string `ecs:"type"`
 
+	// Seconds the host has been up.
+	Uptime int64 `ecs:"uptime"`
+
 	// Operating system architecture.
 	Architecture string `ecs:"architecture"`
 }

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -60,6 +60,9 @@ type Process struct {
 	// The time the process started.
 	Start time.Time `ecs:"start"`
 
+	// Seconds the process has been up.
+	Uptime int64 `ecs:"uptime"`
+
 	// The working directory of the process.
 	WorkingDirectory string `ecs:"working_directory"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1531,6 +1531,17 @@ type: keyword
 
 // ===============================================================
 
+| host.uptime
+| Seconds the host has been up.
+
+type: long
+
+example: `1325`
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -2277,6 +2288,17 @@ The proctitle, some times the same as process name. Can also be different: for e
 type: keyword
 
 
+
+| extended
+
+// ===============================================================
+
+| process.uptime
+| Seconds the process has been up.
+
+type: long
+
+example: `1325`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1153,6 +1153,11 @@
         For Cloud providers this can be the machine type like `t2.medium`. If vm,
         this could be the container, for example, or other information meaningful
         in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
     - name: user.email
       level: extended
       type: keyword
@@ -1700,6 +1705,11 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
     - name: working_directory
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -147,6 +147,7 @@ host.os.name,keyword,extended,Mac OS X,1.1.0-dev
 host.os.platform,keyword,extended,darwin,1.1.0-dev
 host.os.version,keyword,extended,10.14.1,1.1.0-dev
 host.type,keyword,core,,1.1.0-dev
+host.uptime,long,extended,1325,1.1.0-dev
 host.user.email,keyword,extended,,1.1.0-dev
 host.user.full_name,keyword,extended,Albert Einstein,1.1.0-dev
 host.user.group.id,keyword,extended,,1.1.0-dev
@@ -219,6 +220,7 @@ process.ppid,long,extended,4241,1.1.0-dev
 process.start,date,extended,2016-05-23T08:05:34.853Z,1.1.0-dev
 process.thread.id,long,extended,4242,1.1.0-dev
 process.title,keyword,extended,,1.1.0-dev
+process.uptime,long,extended,1325,1.1.0-dev
 process.working_directory,keyword,extended,/home/alice,1.1.0-dev
 related.ip,ip,extended,,1.1.0-dev
 server.address,keyword,extended,,1.1.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1374,7 +1374,7 @@ host.architecture:
   ignore_above: 1024
   level: core
   name: architecture
-  order: 6
+  order: 7
   short: Operating system architecture.
   type: keyword
 host.geo.city_name:
@@ -1601,6 +1601,15 @@ host.type:
   order: 5
   short: Type of host.
   type: keyword
+host.uptime:
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  order: 6
+  short: Seconds the host has been up.
+  type: long
 host.user.email:
   description: User email address.
   flat_name: host.user.email
@@ -2428,6 +2437,15 @@ process.title:
   order: 6
   short: Process title.
   type: keyword
+process.uptime:
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.uptime
+  level: extended
+  name: uptime
+  order: 9
+  short: Seconds the process has been up.
+  type: long
 process.working_directory:
   description: The working directory of the process.
   example: /home/alice
@@ -2435,7 +2453,7 @@ process.working_directory:
   ignore_above: 1024
   level: extended
   name: working_directory
-  order: 9
+  order: 10
   short: The working directory of the process.
   type: keyword
 related.ip:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1634,7 +1634,7 @@ host:
       ignore_above: 1024
       level: core
       name: architecture
-      order: 6
+      order: 7
       short: Operating system architecture.
       type: keyword
     geo.city_name:
@@ -1863,6 +1863,15 @@ host:
       order: 5
       short: Type of host.
       type: keyword
+    uptime:
+      description: Seconds the host has been up.
+      example: 1325
+      flat_name: host.uptime
+      level: extended
+      name: uptime
+      order: 6
+      short: Seconds the host has been up.
+      type: long
     user.email:
       description: User email address.
       flat_name: host.user.email
@@ -2760,6 +2769,15 @@ process:
       order: 6
       short: Process title.
       type: keyword
+    uptime:
+      description: Seconds the process has been up.
+      example: 1325
+      flat_name: process.uptime
+      level: extended
+      name: uptime
+      order: 9
+      short: Seconds the process has been up.
+      type: long
     working_directory:
       description: The working directory of the process.
       example: /home/alice
@@ -2767,7 +2785,7 @@ process:
       ignore_above: 1024
       level: extended
       name: working_directory
-      order: 9
+      order: 10
       short: The working directory of the process.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -676,6 +676,9 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "uptime": {
+              "type": "long"
+            }, 
             "user": {
               "properties": {
                 "email": {
@@ -1025,6 +1028,9 @@
             "title": {
               "ignore_above": 1024, 
               "type": "keyword"
+            }, 
+            "uptime": {
+              "type": "long"
             }, 
             "working_directory": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -675,6 +675,9 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "uptime": {
+            "type": "long"
+          }, 
           "user": {
             "properties": {
               "email": {
@@ -1024,6 +1027,9 @@
           "title": {
             "ignore_above": 1024, 
             "type": "keyword"
+          }, 
+          "uptime": {
+            "type": "long"
           }, 
           "working_directory": {
             "ignore_above": 1024, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -450,6 +450,9 @@
             "type": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
             }
           }
         },
@@ -681,6 +684,9 @@
             "title": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "uptime": {
+              "type": "long"
             },
             "working_directory": {
               "ignore_above": 1024,

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -66,6 +66,13 @@
         If vm, this could be the container, for example, or other information
         meaningful in your environment.
 
+    - name: uptime
+      level: extended
+      type: long
+      example: 1325
+      description: >
+        Seconds the host has been up.
+
     - name: architecture
       level: core
       type: keyword

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -87,6 +87,13 @@
       description: >
         The time the process started.
 
+    - name: uptime
+      level: extended
+      type: long
+      example: 1325
+      description: >
+        Seconds the process has been up.
+
     - name: working_directory
       level: extended
       type: keyword


### PR DESCRIPTION
Closes #475

## What does this PR do?
This PR adds fields for `process.uptime` and `server.uptime`. As suggested by @webmat, the uptime field will be measured in **seconds**.