### PR TITLE
Implement field list all on one page

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1,4 +1,5 @@
 
+[float]
 [[ecs-base]]
 === Base Fields
 
@@ -72,6 +73,7 @@ example: `["production", "env2"]`
 
 |=====
 
+[float]
 [[ecs-agent]]
 === Agent Fields
 
@@ -154,6 +156,7 @@ example: `6.0.0-rc2`
 
 |=====
 
+[float]
 [[ecs-client]]
 === Client Fields
 
@@ -283,6 +286,7 @@ type: long
 
 |=====
 
+[float]
 [[ecs-cloud]]
 === Cloud Fields
 
@@ -377,6 +381,7 @@ example: `us-east-1`
 
 |=====
 
+[float]
 [[ecs-container]]
 === Container Fields
 
@@ -460,6 +465,7 @@ example: `docker`
 
 |=====
 
+[float]
 [[ecs-destination]]
 === Destination Fields
 
@@ -587,6 +593,7 @@ type: long
 
 |=====
 
+[float]
 [[ecs-ecs]]
 === ECS Fields
 
@@ -615,6 +622,7 @@ example: `1.0.0`
 
 |=====
 
+[float]
 [[ecs-error]]
 === Error Fields
 
@@ -665,6 +673,7 @@ type: text
 
 |=====
 
+[float]
 [[ecs-event]]
 === Event Fields
 
@@ -949,6 +958,7 @@ type: keyword
 
 |=====
 
+[float]
 [[ecs-file]]
 === File Fields
 
@@ -1195,6 +1205,7 @@ example: `1001`
 
 |=====
 
+[float]
 [[ecs-geo]]
 === Geo Fields
 
@@ -1313,6 +1324,7 @@ Note also that the `geo` fields are not expected to be used directly at the top 
 
 
 
+[float]
 [[ecs-group]]
 === Group Fields
 
@@ -1359,6 +1371,7 @@ Note also that the `group` fields may be used directly at the top level.
 
 
 
+[float]
 [[ecs-hash]]
 === Group Fields
 
@@ -1429,6 +1442,7 @@ Note also that the `hash` fields are not expected to be used directly at the top
 
 
 
+[float]
 [[ecs-host]]
 === Host Fields
 
@@ -1579,6 +1593,7 @@ example: `1325`
 
 |=====
 
+[float]
 [[ecs-http]]
 === HTTP Fields
 
@@ -1706,6 +1721,7 @@ example: `1.1`
 
 |=====
 
+[float]
 [[ecs-log]]
 === Log Fields
 
@@ -1749,6 +1765,7 @@ example: `Sep 19 08:26:10 localhost My log`
 
 |=====
 
+[float]
 [[ecs-network]]
 === Network Fields
 
@@ -1919,6 +1936,7 @@ example: `ipv4`
 
 |=====
 
+[float]
 [[ecs-observer]]
 === Observer Fields
 
@@ -2044,6 +2062,7 @@ type: keyword
 
 |=====
 
+[float]
 [[ecs-organization]]
 === Organization Fields
 
@@ -2083,6 +2102,7 @@ type: keyword
 
 |=====
 
+[float]
 [[ecs-os]]
 === Operating System Fields
 
@@ -2173,6 +2193,7 @@ Note also that the `os` fields are not expected to be used directly at the top l
 
 
 
+[float]
 [[ecs-process]]
 === Process Fields
 
@@ -2340,6 +2361,7 @@ example: `/home/alice`
 
 |=====
 
+[float]
 [[ecs-related]]
 === Related Fields
 
@@ -2370,6 +2392,7 @@ type: ip
 
 |=====
 
+[float]
 [[ecs-server]]
 === Server Fields
 
@@ -2499,6 +2522,7 @@ type: long
 
 |=====
 
+[float]
 [[ecs-service]]
 === Service Fields
 
@@ -2600,6 +2624,7 @@ example: `3.2.4`
 
 |=====
 
+[float]
 [[ecs-source]]
 === Source Fields
 
@@ -2727,6 +2752,7 @@ type: long
 
 |=====
 
+[float]
 [[ecs-url]]
 === URL Fields
 
@@ -2864,6 +2890,7 @@ type: keyword
 
 |=====
 
+[float]
 [[ecs-user]]
 === User Fields
 
@@ -2965,6 +2992,7 @@ Note also that the `user` fields may be used directly at the top level.
 
 |=====
 
+[float]
 [[ecs-user_agent]]
 === User agent Fields
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -76,4 +76,7 @@ all fields are defined.
 
 |=====
 
+
+=== Fields
+
 include::field-details.asciidoc[]

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -183,6 +183,9 @@ def index_row():
 
 def index_footer():
     return '''
+
+=== Fields
+
 include::field-details.asciidoc[]
 '''
 
@@ -194,6 +197,7 @@ include::field-details.asciidoc[]
 
 def field_details_table_header():
     return '''
+[float]
 [[ecs-{fieldset_name}]]
 === {fieldset_title} Fields
 


### PR DESCRIPTION
I personally prefer to have all field definitions on one page to have it Cmd-F friendly and make browsing between fields efficient. This implements this mostly.

Screenshot below on how it looks at the moment:

![Screenshot 2019-06-25 at 16 08 02](https://user-images.githubusercontent.com/244900/60105349-757a0c00-9763-11e9-99af-d1d330ce1983.png)
