### PR TITLE
added nat.ip and nat.port to source and destination fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -13,6 +13,8 @@
 * Added `file.name` and `file.directory`. #441
 * Added `file.created`, and `file.accessed`. #445
 * Added `domain` field to user. #486
+* Added `.nat.ip` and `.nat.port` to `source`, `destination`, `client` and `server`. #491 
+
 
 ### Improvements
 

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -58,4 +58,14 @@ type Client struct {
 
 	// Packets sent from the client to the server.
 	Packets int64 `ecs:"packets"`
+
+	// Translated IP of source based NAT sessions (e.g. internal client to
+	// internet).
+	// Typically connections traversing load balancers, firewalls, or routers.
+	NatIP string `ecs:"nat.ip"`
+
+	// Translated port of source based NAT sessions (e.g. internal client to
+	// internet).
+	// Typically connections traversing load balancers, firewalls, or routers.
+	NatPort int64 `ecs:"nat.port"`
 }

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -47,4 +47,13 @@ type Destination struct {
 
 	// Packets sent from the destination to the source.
 	Packets int64 `ecs:"packets"`
+
+	// Translated ip of destination based NAT sessions (e.g. internet to
+	// private DMZ)
+	// Typically used with load balancers, firewalls, or routers.
+	NatIP string `ecs:"nat.ip"`
+
+	// Port the source session is translated to by NAT Device.
+	// Typically used with load balancers, firewalls, or routers.
+	NatPort int64 `ecs:"nat.port"`
 }

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -58,4 +58,14 @@ type Server struct {
 
 	// Packets sent from the server to the client.
 	Packets int64 `ecs:"packets"`
+
+	// Translated ip of destination based NAT sessions (e.g. internet to
+	// private DMZ)
+	// Typically used with load balancers, firewalls, or routers.
+	NatIP string `ecs:"nat.ip"`
+
+	// Translated port of destination based NAT sessions (e.g. internet to
+	// private DMZ)
+	// Typically used with load balancers, firewalls, or routers.
+	NatPort int64 `ecs:"nat.port"`
 }

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -47,4 +47,14 @@ type Source struct {
 
 	// Packets sent from the source to the destination.
 	Packets int64 `ecs:"packets"`
+
+	// Translated ip of source based NAT sessions (e.g. internal client to
+	// internet)
+	// Typically connections traversing load balancers, firewalls, or routers.
+	NatIP string `ecs:"nat.ip"`
+
+	// Translated port of source based NAT sessions. (e.g. internal client to
+	// internet)
+	// Typically used with load balancers, firewalls, or routers.
+	NatPort int64 `ecs:"nat.port"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -230,6 +230,32 @@ type: keyword
 
 // ===============================================================
 
+| client.nat.ip
+| Translated IP of source based NAT sessions (e.g. internal client to internet).
+
+Typically connections traversing load balancers, firewalls, or routers.
+
+type: ip
+
+
+
+| extended
+
+// ===============================================================
+
+| client.nat.port
+| Translated port of source based NAT sessions (e.g. internal client to internet).
+
+Typically connections traversing load balancers, firewalls, or routers.
+
+type: long
+
+
+
+| extended
+
+// ===============================================================
+
 | client.packets
 | Packets sent from the client to the server.
 
@@ -531,6 +557,32 @@ type: keyword
 
 
 | core
+
+// ===============================================================
+
+| destination.nat.ip
+| Translated ip of destination based NAT sessions (e.g. internet to private DMZ)
+
+Typically used with load balancers, firewalls, or routers.
+
+type: ip
+
+
+
+| extended
+
+// ===============================================================
+
+| destination.nat.port
+| Port the source session is translated to by NAT Device.
+
+Typically used with load balancers, firewalls, or routers.
+
+type: long
+
+
+
+| extended
 
 // ===============================================================
 
@@ -2446,6 +2498,32 @@ type: keyword
 
 // ===============================================================
 
+| server.nat.ip
+| Translated ip of destination based NAT sessions (e.g. internet to private DMZ)
+
+Typically used with load balancers, firewalls, or routers.
+
+type: ip
+
+
+
+| extended
+
+// ===============================================================
+
+| server.nat.port
+| Translated port of destination based NAT sessions (e.g. internet to private DMZ)
+
+Typically used with load balancers, firewalls, or routers.
+
+type: long
+
+
+
+| extended
+
+// ===============================================================
+
 | server.packets
 | Packets sent from the server to the client.
 
@@ -2671,6 +2749,32 @@ type: keyword
 
 
 | core
+
+// ===============================================================
+
+| source.nat.ip
+| Translated ip of source based NAT sessions (e.g. internal client to internet)
+
+Typically connections traversing load balancers, firewalls, or routers.
+
+type: ip
+
+
+
+| extended
+
+// ===============================================================
+
+| source.nat.port
+| Translated port of source based NAT sessions. (e.g. internal client to internet)
+
+Typically used with load balancers, firewalls, or routers.
+
+type: long
+
+
+
+| extended
 
 // ===============================================================
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -215,6 +215,21 @@
       type: keyword
       ignore_above: 1024
       description: MAC address of the client.
+    - name: nat.ip
+      level: extended
+      type: ip
+      description: 'Translated IP of source based NAT sessions (e.g. internal client
+        to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.'
+    - name: nat.port
+      level: extended
+      type: long
+      format: string
+      description: 'Translated port of source based NAT sessions (e.g. internal client
+        to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.'
     - name: packets
       level: core
       type: long
@@ -463,6 +478,20 @@
       type: keyword
       ignore_above: 1024
       description: MAC address of the destination.
+    - name: nat.ip
+      level: extended
+      type: ip
+      description: 'Translated ip of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
+    - name: nat.port
+      level: extended
+      type: long
+      format: string
+      description: 'Port the source session is translated to by NAT Device.
+
+        Typically used with load balancers, firewalls, or routers.'
     - name: packets
       level: core
       type: long
@@ -1862,6 +1891,21 @@
       type: keyword
       ignore_above: 1024
       description: MAC address of the server.
+    - name: nat.ip
+      level: extended
+      type: ip
+      description: 'Translated ip of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
+    - name: nat.port
+      level: extended
+      type: long
+      format: string
+      description: 'Translated port of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
     - name: packets
       level: core
       type: long
@@ -2084,6 +2128,21 @@
       type: keyword
       ignore_above: 1024
       description: MAC address of the source.
+    - name: nat.ip
+      level: extended
+      type: ip
+      description: 'Translated ip of source based NAT sessions (e.g. internal client
+        to internet)
+
+        Typically connections traversing load balancers, firewalls, or routers.'
+    - name: nat.port
+      level: extended
+      type: long
+      format: string
+      description: 'Translated port of source based NAT sessions. (e.g. internal client
+        to internet)
+
+        Typically used with load balancers, firewalls, or routers.'
     - name: packets
       level: core
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -21,6 +21,8 @@ client.geo.region_iso_code,keyword,core,CA-QC,1.1.0-dev
 client.geo.region_name,keyword,core,Quebec,1.1.0-dev
 client.ip,ip,core,,1.1.0-dev
 client.mac,keyword,core,,1.1.0-dev
+client.nat.ip,ip,extended,,1.1.0-dev
+client.nat.port,long,extended,,1.1.0-dev
 client.packets,long,core,12,1.1.0-dev
 client.port,long,core,,1.1.0-dev
 client.user.domain,keyword,extended,,1.1.0-dev
@@ -57,6 +59,8 @@ destination.geo.region_iso_code,keyword,core,CA-QC,1.1.0-dev
 destination.geo.region_name,keyword,core,Quebec,1.1.0-dev
 destination.ip,ip,core,,1.1.0-dev
 destination.mac,keyword,core,,1.1.0-dev
+destination.nat.ip,ip,extended,,1.1.0-dev
+destination.nat.port,long,extended,,1.1.0-dev
 destination.packets,long,core,12,1.1.0-dev
 destination.port,long,core,,1.1.0-dev
 destination.user.domain,keyword,extended,,1.1.0-dev
@@ -239,6 +243,8 @@ server.geo.region_iso_code,keyword,core,CA-QC,1.1.0-dev
 server.geo.region_name,keyword,core,Quebec,1.1.0-dev
 server.ip,ip,core,,1.1.0-dev
 server.mac,keyword,core,,1.1.0-dev
+server.nat.ip,ip,extended,,1.1.0-dev
+server.nat.port,long,extended,,1.1.0-dev
 server.packets,long,core,12,1.1.0-dev
 server.port,long,core,,1.1.0-dev
 server.user.domain,keyword,extended,,1.1.0-dev
@@ -268,6 +274,8 @@ source.geo.region_iso_code,keyword,core,CA-QC,1.1.0-dev
 source.geo.region_name,keyword,core,Quebec,1.1.0-dev
 source.ip,ip,core,,1.1.0-dev
 source.mac,keyword,core,,1.1.0-dev
+source.nat.ip,ip,extended,,1.1.0-dev
+source.nat.port,long,extended,,1.1.0-dev
 source.packets,long,core,12,1.1.0-dev
 source.port,long,core,,1.1.0-dev
 source.user.domain,keyword,extended,,1.1.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -225,6 +225,29 @@ client.mac:
   order: 3
   short: MAC address of the client.
   type: keyword
+client.nat.ip:
+  description: 'Translated IP of source based NAT sessions (e.g. internal client to
+    internet).
+
+    Typically connections traversing load balancers, firewalls, or routers.'
+  flat_name: client.nat.ip
+  level: extended
+  name: nat.ip
+  order: 7
+  short: Client NAT ip address
+  type: ip
+client.nat.port:
+  description: 'Translated port of source based NAT sessions (e.g. internal client
+    to internet).
+
+    Typically connections traversing load balancers, firewalls, or routers.'
+  flat_name: client.nat.port
+  format: string
+  level: extended
+  name: nat.port
+  order: 8
+  short: Client NAT port
+  type: long
 client.packets:
   description: Packets sent from the client to the server.
   example: 12
@@ -604,6 +627,28 @@ destination.mac:
   order: 3
   short: MAC address of the destination.
   type: keyword
+destination.nat.ip:
+  description: 'Translated ip of destination based NAT sessions (e.g. internet to
+    private DMZ)
+
+    Typically used with load balancers, firewalls, or routers.'
+  flat_name: destination.nat.ip
+  level: extended
+  name: nat.ip
+  order: 7
+  short: Destination NAT ip
+  type: ip
+destination.nat.port:
+  description: 'Port the source session is translated to by NAT Device.
+
+    Typically used with load balancers, firewalls, or routers.'
+  flat_name: destination.nat.port
+  format: string
+  level: extended
+  name: nat.port
+  order: 8
+  short: Destination NAT Port
+  type: long
 destination.packets:
   description: Packets sent from the destination to the source.
   example: 12
@@ -2645,6 +2690,29 @@ server.mac:
   order: 3
   short: MAC address of the server.
   type: keyword
+server.nat.ip:
+  description: 'Translated ip of destination based NAT sessions (e.g. internet to
+    private DMZ)
+
+    Typically used with load balancers, firewalls, or routers.'
+  flat_name: server.nat.ip
+  level: extended
+  name: nat.ip
+  order: 7
+  short: Server NAT ip
+  type: ip
+server.nat.port:
+  description: 'Translated port of destination based NAT sessions (e.g. internet to
+    private DMZ)
+
+    Typically used with load balancers, firewalls, or routers.'
+  flat_name: server.nat.port
+  format: string
+  level: extended
+  name: nat.port
+  order: 8
+  short: Server NAT port
+  type: long
 server.packets:
   description: Packets sent from the server to the client.
   example: 12
@@ -2982,6 +3050,29 @@ source.mac:
   order: 3
   short: MAC address of the source.
   type: keyword
+source.nat.ip:
+  description: 'Translated ip of source based NAT sessions (e.g. internal client to
+    internet)
+
+    Typically connections traversing load balancers, firewalls, or routers.'
+  flat_name: source.nat.ip
+  level: extended
+  name: nat.ip
+  order: 7
+  short: Source NAT ip
+  type: ip
+source.nat.port:
+  description: 'Translated port of source based NAT sessions. (e.g. internal client
+    to internet)
+
+    Typically used with load balancers, firewalls, or routers.'
+  flat_name: source.nat.port
+  format: string
+  level: extended
+  name: nat.port
+  order: 8
+  short: Source NAT port
+  type: long
 source.packets:
   description: Packets sent from the source to the destination.
   example: 12

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -315,6 +315,29 @@ client:
       order: 3
       short: MAC address of the client.
       type: keyword
+    nat.ip:
+      description: 'Translated IP of source based NAT sessions (e.g. internal client
+        to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.'
+      flat_name: client.nat.ip
+      level: extended
+      name: nat.ip
+      order: 7
+      short: Client NAT ip address
+      type: ip
+    nat.port:
+      description: 'Translated port of source based NAT sessions (e.g. internal client
+        to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.'
+      flat_name: client.nat.port
+      format: string
+      level: extended
+      name: nat.port
+      order: 8
+      short: Client NAT port
+      type: long
     packets:
       description: Packets sent from the client to the server.
       example: 12
@@ -735,6 +758,28 @@ destination:
       order: 3
       short: MAC address of the destination.
       type: keyword
+    nat.ip:
+      description: 'Translated ip of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
+      flat_name: destination.nat.ip
+      level: extended
+      name: nat.ip
+      order: 7
+      short: Destination NAT ip
+      type: ip
+    nat.port:
+      description: 'Port the source session is translated to by NAT Device.
+
+        Typically used with load balancers, firewalls, or routers.'
+      flat_name: destination.nat.port
+      format: string
+      level: extended
+      name: nat.port
+      order: 8
+      short: Destination NAT Port
+      type: long
     packets:
       description: Packets sent from the destination to the source.
       example: 12
@@ -3020,6 +3065,29 @@ server:
       order: 3
       short: MAC address of the server.
       type: keyword
+    nat.ip:
+      description: 'Translated ip of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
+      flat_name: server.nat.ip
+      level: extended
+      name: nat.ip
+      order: 7
+      short: Server NAT ip
+      type: ip
+    nat.port:
+      description: 'Translated port of destination based NAT sessions (e.g. internet
+        to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.'
+      flat_name: server.nat.port
+      format: string
+      level: extended
+      name: nat.port
+      order: 8
+      short: Server NAT port
+      type: long
     packets:
       description: Packets sent from the server to the client.
       example: 12
@@ -3383,6 +3451,29 @@ source:
       order: 3
       short: MAC address of the source.
       type: keyword
+    nat.ip:
+      description: 'Translated ip of source based NAT sessions (e.g. internal client
+        to internet)
+
+        Typically connections traversing load balancers, firewalls, or routers.'
+      flat_name: source.nat.ip
+      level: extended
+      name: nat.ip
+      order: 7
+      short: Source NAT ip
+      type: ip
+    nat.port:
+      description: 'Translated port of source based NAT sessions. (e.g. internal client
+        to internet)
+
+        Typically used with load balancers, firewalls, or routers.'
+      flat_name: source.nat.port
+      format: string
+      level: extended
+      name: nat.port
+      order: 8
+      short: Source NAT port
+      type: long
     packets:
       description: Packets sent from the source to the destination.
       example: 12

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -102,6 +102,16 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                }, 
+                "port": {
+                  "type": "long"
+                }
+              }
+            }, 
             "packets": {
               "type": "long"
             }, 
@@ -279,6 +289,16 @@
             "mac": {
               "ignore_above": 1024, 
               "type": "keyword"
+            }, 
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                }, 
+                "port": {
+                  "type": "long"
+                }
+              }
             }, 
             "packets": {
               "type": "long"
@@ -1112,6 +1132,16 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                }, 
+                "port": {
+                  "type": "long"
+                }
+              }
+            }, 
             "packets": {
               "type": "long"
             }, 
@@ -1242,6 +1272,16 @@
             "mac": {
               "ignore_above": 1024, 
               "type": "keyword"
+            }, 
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                }, 
+                "port": {
+                  "type": "long"
+                }
+              }
             }, 
             "packets": {
               "type": "long"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -101,6 +101,16 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "nat": {
+            "properties": {
+              "ip": {
+                "type": "ip"
+              }, 
+              "port": {
+                "type": "long"
+              }
+            }
+          }, 
           "packets": {
             "type": "long"
           }, 
@@ -278,6 +288,16 @@
           "mac": {
             "ignore_above": 1024, 
             "type": "keyword"
+          }, 
+          "nat": {
+            "properties": {
+              "ip": {
+                "type": "ip"
+              }, 
+              "port": {
+                "type": "long"
+              }
+            }
           }, 
           "packets": {
             "type": "long"
@@ -1111,6 +1131,16 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "nat": {
+            "properties": {
+              "ip": {
+                "type": "ip"
+              }, 
+              "port": {
+                "type": "long"
+              }
+            }
+          }, 
           "packets": {
             "type": "long"
           }, 
@@ -1241,6 +1271,16 @@
           "mac": {
             "ignore_above": 1024, 
             "type": "keyword"
+          }, 
+          "nat": {
+            "properties": {
+              "ip": {
+                "type": "ip"
+              }, 
+              "port": {
+                "type": "long"
+              }
+            }
           }, 
           "packets": {
             "type": "long"

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -67,6 +67,16 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
             "packets": {
               "type": "long"
             },
@@ -169,6 +179,16 @@
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
             },
             "packets": {
               "type": "long"
@@ -721,6 +741,16 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
+            },
             "packets": {
               "type": "long"
             },
@@ -776,6 +806,16 @@
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "nat": {
+              "properties": {
+                "ip": {
+                  "type": "ip"
+                },
+                "port": {
+                  "type": "long"
+                }
+              }
             },
             "packets": {
               "type": "long"

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -74,3 +74,22 @@
       example: 12
       description: >
         Packets sent from the client to the server.
+
+    - name: nat.ip
+      level: extended
+      type: ip
+      short: Client NAT ip address
+      description: >
+        Translated IP of source based NAT sessions (e.g. internal client to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.
+
+    - name: nat.port
+      format: string
+      level: extended
+      type: long
+      short: Client NAT port
+      description: >
+        Translated port of source based NAT sessions (e.g. internal client to internet).
+
+        Typically connections traversing load balancers, firewalls, or routers.

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -65,3 +65,21 @@
       example: 12
       description: >
         Packets sent from the destination to the source.
+
+    - name: nat.ip
+      level: extended
+      type: ip
+      short: NAT IP address of the destination.
+      description: >
+        IP address used for destination Network Address Translation
+
+        Typically used with load balancers, firewalls, or routers.
+
+    - name: nat.port
+      format: string
+      level: core
+      type: long
+      description: >
+        Port used for destination based Port & Network Address Translation. 
+
+        Typically used with load balancers, firewalls, or routers.

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -69,17 +69,18 @@
     - name: nat.ip
       level: extended
       type: ip
-      short: NAT IP address of the destination.
+      short: Destination NAT ip
       description: >
-        IP address used for destination Network Address Translation
+        Translated ip of destination based NAT sessions (e.g. internet to private DMZ)
 
         Typically used with load balancers, firewalls, or routers.
 
     - name: nat.port
       format: string
-      level: core
+      level: extended
       type: long
+      short: Destination NAT Port
       description: >
-        Port used for destination based Port & Network Address Translation. 
+        Port the source session is translated to by NAT Device.
 
         Typically used with load balancers, firewalls, or routers.

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -74,3 +74,23 @@
       example: 12
       description: >
         Packets sent from the server to the client.
+
+    - name: nat.ip
+      level: extended
+      type: ip
+      short: Server NAT ip
+      description: >
+        Translated ip of destination based NAT sessions (e.g. internet to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.
+
+    - name: nat.port
+      format: string
+      level: extended
+      type: long
+      short: Server NAT port
+      description: >
+        Translated port of destination based NAT sessions (e.g. internet to private DMZ)
+
+        Typically used with load balancers, firewalls, or routers.
+        

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -69,17 +69,19 @@
     - name: nat.ip
       level: extended
       type: ip
-      short: NAT IP address of the source.
+      short: Source NAT ip
       description: >
-        IP address used for destination Network Address Translation
+        Translated ip of source based NAT sessions (e.g. internal client to internet)
 
-        Typically used with load balancers, firewalls, or routers.
-
+        Typically connections traversing load balancers, firewalls, or routers.
+    
     - name: nat.port
       format: string
-      level: core
+      level: extended
       type: long
+      short: Source NAT port
       description: >
-        Port used for source based Port & Network Address Translation. 
+        Translated port of source based NAT sessions. (e.g. internal client to internet)
 
         Typically used with load balancers, firewalls, or routers.
+        

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -65,3 +65,21 @@
       example: 12
       description: >
         Packets sent from the source to the destination.
+
+    - name: nat.ip
+      level: extended
+      type: ip
+      short: NAT IP address of the source.
+      description: >
+        IP address used for destination Network Address Translation
+
+        Typically used with load balancers, firewalls, or routers.
+
+    - name: nat.port
+      format: string
+      level: core
+      type: long
+      description: >
+        Port used for source based Port & Network Address Translation. 
+
+        Typically used with load balancers, firewalls, or routers.


### PR DESCRIPTION
To better support Port/Address translation in flow/fw type network events added source.nat.ip, source.nat.port, destination.nat.ip, destination.nat.port.

If, in the case of e.g. 1:1 nat, the observer doesn't report nat ports, the original port should be copied to the nat.port field for ease of searching all fields of the connection (e.g. searching nat ips/ports for threat hunting etc)

To - do: 
If there is telemetry provided across devices implementing NAT (e.g. internally load balanced source nat sessions being reported across multiple devices before and after S/NAT) we may want to also include:
  - nat.session_id
     - copy native session id at NAT gateway to stitch together pre/post NAT sessions
