### PR TITLE
Add ability to include external directory of schemas when running generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ generate: template legacy_use_cases codegen generator
 # Run the new generator
 .PHONY: generator
 generator:
-	$(PYTHON) scripts/generator.py
+	$(PYTHON) scripts/generator.py --include "${INCLUDE}"
 
 # Generate Go code from the schema.
 .PHONY: gocodegen

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -1,5 +1,5 @@
 import argparse
-
+import glob
 import schema_reader
 from generators import intermediate_files
 from generators import csv_generator
@@ -14,7 +14,8 @@ def main():
     ecs_version = read_version()
     print "Running generator. ECS version " + ecs_version
 
-    (ecs_nested, ecs_flat) = schema_reader.load_ecs()
+    # Load the default schemas
+    (ecs_nested, ecs_flat) = schema_reader.load_ecs(sorted(glob.glob("schemas/*.yml")))
 
     intermediate_files.generate(ecs_nested, ecs_flat)
     if args.intermediate_only:

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -14,17 +14,17 @@ def main():
     args = argument_parser()
 
     ecs_version = read_version()
-    print "Running generator. ECS version " + ecs_version
+    print 'Running generator. ECS version ' + ecs_version
 
     # Load the default schemas
-    print "Loading default schemas"
-    (ecs_nested, ecs_flat) = schema_reader.load_ecs(sorted(glob.glob("schemas/*.yml")))
+    print 'Loading default schemas'
+    (ecs_nested, ecs_flat) = schema_reader.load_ecs(sorted(glob.glob('schemas/*.yml')))
 
     # Maybe load user specified directory of schemas
     if args.include:
-        include_glob = os.path.join(args.include + "/*.yml")
+        include_glob = os.path.join(args.include + '/*.yml')
 
-        print "Loading user defined schemas: {0}".format(include_glob)
+        print 'Loading user defined schemas: {0}'.format(include_glob)
 
         (user_ecs_nested, user_ecs_flat) = schema_reader.load_ecs(sorted(glob.glob(include_glob)))
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -1,11 +1,13 @@
 import argparse
 import glob
+import os
 import schema_reader
 from generators import intermediate_files
 from generators import csv_generator
 from generators import es_template
 from generators import beats
 from generators import asciidoc_fields
+from generators import ecs_helpers
 
 
 def main():
@@ -15,7 +17,20 @@ def main():
     print "Running generator. ECS version " + ecs_version
 
     # Load the default schemas
+    print "Loading default schemas"
     (ecs_nested, ecs_flat) = schema_reader.load_ecs(sorted(glob.glob("schemas/*.yml")))
+
+    # Maybe load user specified directory of schemas
+    if args.include:
+        include_glob = os.path.join(args.include + "/*.yml")
+
+        print "Loading user defined schemas: {0}".format(include_glob)
+
+        (user_ecs_nested, user_ecs_flat) = schema_reader.load_ecs(sorted(glob.glob(include_glob)))
+
+        # Merge without allowing user schemas to overwrite default schemas
+        ecs_nested = ecs_helpers.safe_merge_dicts(ecs_nested, user_ecs_nested)
+        ecs_flat = ecs_helpers.safe_merge_dicts(ecs_flat, user_ecs_flat)
 
     intermediate_files.generate(ecs_nested, ecs_flat)
     if args.intermediate_only:
@@ -31,7 +46,8 @@ def argument_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--intermediate-only', action='store_true',
                         help='generate intermediary files only')
-
+    parser.add_argument('--include', action='store',
+                        help='include user specified directory of (custom) ecs schemas')
     return parser.parse_args()
 
 

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -1,6 +1,7 @@
 import yaml
 
 from collections import OrderedDict
+from copy import deepcopy
 
 # Dictionary helpers
 
@@ -33,6 +34,17 @@ def dict_sorted_by_keys(dict, sort_keys):
         tuples.append(sort_criteria)
 
     return list(map(lambda t: t[-1], sorted(tuples)))
+
+
+def safe_merge_dicts(a, b):
+    """Merges two dictionaries into one. If duplicate keys are detected a ValueError is raised."""
+    c = deepcopy(a)
+    for key in b:
+        if key not in c:
+            c[key] = b[key]
+        else:
+            raise ValueError("Duplicate key found when merging dictionaries: {0}".format(key))
+    return c
 
 
 def yaml_ordereddict(dumper, data):

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -43,7 +43,7 @@ def safe_merge_dicts(a, b):
         if key not in c:
             c[key] = b[key]
         else:
-            raise ValueError("Duplicate key found when merging dictionaries: {0}".format(key))
+            raise ValueError('Duplicate key found when merging dictionaries: {0}'.format(key))
     return c
 
 

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -4,11 +4,6 @@ import yaml
 # File loading stuff
 
 
-def schema_files():
-    """Return the schema file list to load"""
-    return sorted(glob.glob("schemas/*.yml"))
-
-
 def read_schema_file(file):
     """Read a raw schema yml into a map, removing the wrapping array in each file"""
     with open(file) as f:
@@ -19,7 +14,7 @@ def read_schema_file(file):
     return fields
 
 
-def load_schema_files(files=schema_files()):
+def load_schema_files(files):
     fields_nested = {}
     for f in files:
         new_fields = read_schema_file(f)
@@ -169,8 +164,9 @@ def finalize_schemas(fields_nested, fields_flat):
         duplicate_reusable_fieldsets(schema, fields_flat, fields_nested)
 
 
-def load_ecs():
-    fields_nested = load_schema_files()
+def load_ecs(files):
+    """Loads the given list of files"""
+    fields_nested = load_schema_files(files)
     fields_flat = {}
     finalize_schemas(fields_nested, fields_flat)
     return (fields_nested, fields_flat)

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -66,11 +66,11 @@ class TestECSHelpers(unittest.TestCase):
         result = ecs_helpers.safe_merge_dicts(a, b)
 
         self.assertEquals(result,
-            {
-                'cloud': {'group': 2, 'name': 'cloud'},
-                'agent': {'group': 2, 'name': 'agent'},
-                'base': {'group': 1, 'name': 'base'}
-            })
+                          {
+                              'cloud': {'group': 2, 'name': 'cloud'},
+                              'agent': {'group': 2, 'name': 'agent'},
+                              'base': {'group': 1, 'name': 'base'}
+                          })
 
     def test_merge_dicts_raises_if_duplicate_key_added(self):
         a = {'cloud': {'group': 2, 'name': 'cloud'}}

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -56,6 +56,29 @@ class TestECSHelpers(unittest.TestCase):
         result = ecs_helpers.dict_sorted_by_keys(dict, ['group', 'name'])
         self.assertEqual(result, expected)
 
+    def test_merge_dicts(self):
+        a = {
+            'cloud': {'group': 2, 'name': 'cloud'},
+            'agent': {'group': 2, 'name': 'agent'},
+        }
+        b = {'base': {'group': 1, 'name': 'base'}}
+
+        result = ecs_helpers.safe_merge_dicts(a, b)
+
+        self.assertEquals(result,
+            {
+                'cloud': {'group': 2, 'name': 'cloud'},
+                'agent': {'group': 2, 'name': 'agent'},
+                'base': {'group': 1, 'name': 'base'}
+            })
+
+    def test_merge_dicts_raises_if_duplicate_key_added(self):
+        a = {'cloud': {'group': 2, 'name': 'cloud'}}
+        b = {'cloud': {'group': 9, 'name': 'bazbar'}}
+
+        with self.assertRaises(ValueError):
+            ecs_helpers.safe_merge_dicts(a, b)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -8,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts import schema_reader
 
 
-(nested, flat) = schema_reader.load_ecs(sorted(glob.glob('../../schemas/*.yml')))
+(nested, flat) = schema_reader.load_ecs(sorted(glob.glob('schemas/*.yml')))
 
 
 class TestEcsSpec(unittest.TestCase):

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import glob
 import unittest
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -7,7 +8,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts import schema_reader
 
 
-(nested, flat) = schema_reader.load_ecs()
+(nested, flat) = schema_reader.load_ecs(sorted(glob.glob('../../schemas/*.yml')))
 
 
 class TestEcsSpec(unittest.TestCase):

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -101,6 +101,10 @@ class TestSchemaReader(unittest.TestCase):
         }
         self.assertEqual(field, expected)
 
+    def test_load_ecs_with_empty_list_loads_nothing(self):
+        result = schema_reader.load_ecs([])
+        self.assertEqual(result, ({}, {}))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds the ability to pass a path to `make` (which is used by the `generator` target) to a directory where users might have their own schemas defined. 

The use case this is solving for is when a user has custom schemas that are required due to being unable to map fields directly to ECS Core/Extended fields. This change allows them to run the following to have their schemas included in the output of `make` or `make generate`:
```
$> make INCLUDE=/path/to/dir/of/yml/files
or 
$> make generator INCLUDE=/path/to/dir/of/yml/files
```

If `INCLUDE` does not exist, everything works as per usual. If `INCLUDE` does not contain any yml files everything works as per usual. If `INCLUDE` contains yml files the keys/values are merged with those found in the `schemas` directory and the output is for both sets of values. If the user tries to include a yml file that will overwrite a key from the `schemas` directory, an exception is raised.

As mentioned above, the `generator` target was the focus here. Should this PR add this functionality to any other targets/scripts?