### PR TITLE
Clarify `service.id` description.

### DIFF
--- a/code/go/ecs/service.go
+++ b/code/go/ecs/service.go
@@ -24,11 +24,13 @@ package ecs
 // These fields help you find and correlate logs for a specific service and
 // version.
 type Service struct {
-	// Unique identifier of the running service.
-	// This id should uniquely identify this service. This makes it possible to
-	// correlate logs and metrics for one specific service.
-	// Example: If you are experiencing issues with one redis instance, you can
-	// filter on that id to see metrics and logs for that single instance.
+	// Unique identifier of the running service. If the service is comprised of
+	// many nodes, the `service.id` should be the same for all nodes.
+	// This id should uniquely identify the service. This makes it possible to
+	// correlate logs and metrics for one specific service, no matter which
+	// particular node emitted the event.
+	// Note that if you need to see the events from one specific host of the
+	// service, you should filter on that `host.name` or `host.id` instead.
 	ID string `ecs:"id"`
 
 	// Name of the service data is collected from.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2670,11 +2670,11 @@ example: `8a4f500f`
 // ===============================================================
 
 | service.id
-| Unique identifier of the running service.
+| Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes.
 
-This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service.
+This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event.
 
-Example: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.
+Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2042,13 +2042,15 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique identifier of the running service.
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible to correlate
-        logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you can filter
-        on that id to see metrics and logs for that single instance.'
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
     - name: name
       level: core

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2922,13 +2922,15 @@ service.ephemeral_id:
   short: Ephemeral identifier of this service.
   type: keyword
 service.id:
-  description: 'Unique identifier of the running service.
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
 
-    This id should uniquely identify this service. This makes it possible to correlate
-    logs and metrics for one specific service.
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
 
-    Example: If you are experiencing issues with one redis instance, you can filter
-    on that id to see metrics and logs for that single instance.'
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
   example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
   flat_name: service.id
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3334,13 +3334,15 @@ service:
       short: Ephemeral identifier of this service.
       type: keyword
     id:
-      description: 'Unique identifier of the running service.
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible to correlate
-        logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you can filter
-        on that id to see metrics and logs for that single instance.'
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
       flat_name: service.id
       ignore_above: 1024

--- a/schema.json
+++ b/schema.json
@@ -1889,7 +1889,7 @@
         "type": "keyword"
       }, 
       "service.id": {
-        "description": "Unique identifier of the running service.\nThis id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service.\nExample: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.", 
+        "description": "Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes.\nThis id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event.\nNote that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead.", 
         "example": "d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6", 
         "footnote": "", 
         "group": 2, 

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -16,13 +16,15 @@
       type: keyword
       short: Unique identifier of the running service.
       description: >
-        Unique identifier of the running service.
+        Unique identifier of the running service. If the service is comprised of
+        many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible
-        to correlate logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible
+        to correlate logs and metrics for one specific service, no matter which
+        particular node emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you
-        can filter on that id to see metrics and logs for that single instance.
+        Note that if you need to see the events from one specific host of the
+        service, you should filter on that `host.name` or `host.id` instead.
 
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
 


### PR DESCRIPTION
This removes an example that went contrary to the purpose of a `service.id`.
If someone needs to focus on the events emitted by one host of a
service, they should filter on `host.id` or `host.name`.

`service.id` is meant to identify a service as a whole.