### PR TITLE
Backport #502 to 1.0: Clarify `service.id` description.

### DIFF
--- a/code/go/ecs/service.go
+++ b/code/go/ecs/service.go
@@ -24,11 +24,13 @@ package ecs
 // These fields help you find and correlate logs for a specific service and
 // version.
 type Service struct {
-	// Unique identifier of the running service.
-	// This id should uniquely identify this service. This makes it possible to
-	// correlate logs and metrics for one specific service.
-	// Example: If you are experiencing issues with one redis instance, you can
-	// filter on that id to see metrics and logs for that single instance.
+	// Unique identifier of the running service. If the service is comprised of
+	// many nodes, the `service.id` should be the same for all nodes.
+	// This id should uniquely identify the service. This makes it possible to
+	// correlate logs and metrics for one specific service, no matter which
+	// particular node emitted the event.
+	// Note that if you need to see the events from one specific host of the
+	// service, you should filter on that `host.name` or `host.id` instead.
 	ID string `ecs:"id"`
 
 	// Name of the service data is collected from.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2288,11 +2288,11 @@ example: `8a4f500f`
 // ===============================================================
 
 | service.id
-| Unique identifier of the running service.
+| Unique identifier of the running service. If the service is comprised of many nodes, the `service.id` should be the same for all nodes.
 
-This id should uniquely identify this service. This makes it possible to correlate logs and metrics for one specific service.
+This id should uniquely identify the service. This makes it possible to correlate logs and metrics for one specific service, no matter which particular node emitted the event.
 
-Example: If you are experiencing issues with one redis instance, you can filter on that id to see metrics and logs for that single instance.
+Note that if you need to see the events from one specific host of the service, you should filter on that `host.name` or `host.id` instead.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1750,13 +1750,15 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Unique identifier of the running service.
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible to correlate
-        logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you can filter
-        on that id to see metrics and logs for that single instance.'
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
     - name: name
       level: core

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2469,13 +2469,15 @@ service.ephemeral_id:
   short: Ephemeral identifier of this service.
   type: keyword
 service.id:
-  description: 'Unique identifier of the running service.
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
 
-    This id should uniquely identify this service. This makes it possible to correlate
-    logs and metrics for one specific service.
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
 
-    Example: If you are experiencing issues with one redis instance, you can filter
-    on that id to see metrics and logs for that single instance.'
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
   example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
   flat_name: service.id
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2835,13 +2835,15 @@ service:
       short: Ephemeral identifier of this service.
       type: keyword
     id:
-      description: 'Unique identifier of the running service.
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible to correlate
-        logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you can filter
-        on that id to see metrics and logs for that single instance.'
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
       flat_name: service.id
       ignore_above: 1024

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -16,13 +16,15 @@
       type: keyword
       short: Unique identifier of the running service.
       description: >
-        Unique identifier of the running service.
+        Unique identifier of the running service. If the service is comprised of
+        many nodes, the `service.id` should be the same for all nodes.
 
-        This id should uniquely identify this service. This makes it possible
-        to correlate logs and metrics for one specific service.
+        This id should uniquely identify the service. This makes it possible
+        to correlate logs and metrics for one specific service, no matter which
+        particular node emitted the event.
 
-        Example: If you are experiencing issues with one redis instance, you
-        can filter on that id to see metrics and logs for that single instance.
+        Note that if you need to see the events from one specific host of the
+        service, you should filter on that `host.name` or `host.id` instead.
 
       example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
 


### PR DESCRIPTION
Backport of PR #502 to 1.0 branch. Original message:

This removes an example that went contrary to the purpose of a `service.id`.
If someone needs to focus on the events emitted by one host of a
service, they should filter on `host.id` or `host.name`.

`service.id` is meant to identify a service as a whole.