### PR TITLE
A new take on adding missing Syslog fields to ECS.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -11,6 +11,8 @@ Thanks, you're awesome :-) -->
 
 ### Added
 
+* Added fields in `log.*` to allow for full Syslog mapping. #525
+
 ### Improvements
 
 ### Deprecated

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -98,9 +98,9 @@ type Event struct {
 	Provider string `ecs:"provider"`
 
 	// Severity describes the original severity of the event. What the
-	// different severity values mean can very different between sources and
-	// use cases. It's up to the implementer to make sure severities are
-	// consistent across events.
+	// different severity values mean can be different between sources and use
+	// cases. It's up to the implementer to make sure severities are consistent
+	// across events.
 	// This field corresponds to Syslog's severity. Note that the text-based
 	// severity for Syslog events is `log.level` in ECS.
 	Severity int64 `ecs:"severity"`

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -97,10 +97,10 @@ type Event struct {
 	// operating system (kernel, Microsoft-Windows-Security-Auditing).
 	Provider string `ecs:"provider"`
 
-	// Severity describes the severity of the event. What the different
-	// severity values mean can be different between sources and use cases.
-	// It's up to the implementer to make sure severities are consistent across
-	// events from the same source.
+	// The numeric severity of the event according to your event source.
+	// What the different severity values mean can be different between sources
+	// and use cases. It's up to the implementer to make sure severities are
+	// consistent across events from the same source.
 	// The Syslog severity belongs in `log.severity`. `event.severity` is meant
 	// to represent the severity according to the event source (e.g. firewall,
 	// IDS). If the event source does not publish its own severity, you may

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -101,10 +101,11 @@ type Event struct {
 	// What the different severity values mean can be different between sources
 	// and use cases. It's up to the implementer to make sure severities are
 	// consistent across events from the same source.
-	// The Syslog severity belongs in `log.severity`. `event.severity` is meant
-	// to represent the severity according to the event source (e.g. firewall,
-	// IDS). If the event source does not publish its own severity, you may
-	// copy the `log.severity` to `event.severity`.
+	// The Syslog severity belongs in `log.syslog.severity.code`.
+	// `event.severity` is meant to represent the severity according to the
+	// event source (e.g. firewall, IDS). If the event source does not publish
+	// its own severity, you may optionally copy the `log.syslog.severity.code`
+	// to `event.severity`.
 	Severity int64 `ecs:"severity"`
 
 	// Raw text message of entire event. Used to demonstrate log integrity.

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -98,9 +98,11 @@ type Event struct {
 	Provider string `ecs:"provider"`
 
 	// Severity describes the original severity of the event. What the
-	// different severity values mean can very different between use cases.
-	// It's up to the implementer to make sure severities are consistent across
-	// events.
+	// different severity values mean can very different between sources and
+	// use cases. It's up to the implementer to make sure severities are
+	// consistent across events.
+	// This field corresponds to Syslog's severity. Note that the text-based
+	// severity for Syslog events is `log.level` in ECS.
 	Severity int64 `ecs:"severity"`
 
 	// Raw text message of entire event. Used to demonstrate log integrity.

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -97,12 +97,14 @@ type Event struct {
 	// operating system (kernel, Microsoft-Windows-Security-Auditing).
 	Provider string `ecs:"provider"`
 
-	// Severity describes the original severity of the event. What the
-	// different severity values mean can be different between sources and use
-	// cases. It's up to the implementer to make sure severities are consistent
-	// across events.
-	// This field corresponds to Syslog's severity. Note that the text-based
-	// severity for Syslog events is `log.level` in ECS.
+	// Severity describes the severity of the event. What the different
+	// severity values mean can be different between sources and use cases.
+	// It's up to the implementer to make sure severities are consistent across
+	// events from the same source.
+	// The Syslog severity belongs in `log.severity`. `event.severity` is meant
+	// to represent the severity according to the event source (e.g. firewall,
+	// IDS). If the event source does not publish its own severity, you may
+	// copy the `log.severity` to `event.severity`.
 	Severity int64 `ecs:"severity"`
 
 	// Raw text message of entire event. Used to demonstrate log integrity.

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -28,17 +28,18 @@ type Log struct {
 	Level string `ecs:"level"`
 
 	// The Syslog text-based facility of the log event, if available. See RFCs
-	// 5324 or 3164.
+	// 5424 or 3164.
 	Facility string `ecs:"facility"`
 
 	// The Syslog numeric facility of the log event, if available.
-	// According to RFCs 5324 and 3164, this value should be an integer between
+	// According to RFCs 5424 and 3164, this value should be an integer between
 	// 0 and 23.
 	FacilityCode int64 `ecs:"facility_code"`
 
 	// Syslog numeric priority of the event, if available.
-	// According to RFCs 5324 and 3164, the priority is 8 * facility +
-	// severity. Accordingly, this number should be between 0 and 191.
+	// According to RFCs 5424 and 3164, the priority is 8 * facility +
+	// severity. This number is therefore expected to contain a value between 0
+	// and 191.
 	Priority int64 `ecs:"priority"`
 
 	// This is the original log message and contains the full log message

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -29,12 +29,12 @@ type Log struct {
 
 	// The Syslog text-based facility of the log event, if available. See RFCs
 	// 5424 or 3164.
-	Facility string `ecs:"facility"`
+	FacilityName string `ecs:"facility.name"`
 
 	// The Syslog numeric facility of the log event, if available.
 	// According to RFCs 5424 and 3164, this value should be an integer between
 	// 0 and 23.
-	FacilityCode int64 `ecs:"facility_code"`
+	FacilityCode int64 `ecs:"facility.code"`
 
 	// Syslog numeric priority of the event, if available.
 	// According to RFCs 5424 and 3164, the priority is 8 * facility +

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -21,8 +21,9 @@ package ecs
 
 // Fields which are specific to log events.
 type Log struct {
-	// Original log level of the log event. Syslog's severity label should be
-	// stored here.
+	// Original log level of the log event.
+	// Syslog's severity label should be stored here. Syslog's numeric severity
+	// is `event.severity` in ECS.
 	// Some examples are `warn`, `error`, `i`.
 	Level string `ecs:"level"`
 

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -21,9 +21,24 @@ package ecs
 
 // Fields which are specific to log events.
 type Log struct {
-	// Original log level of the log event.
+	// Original log level of the log event. Syslog's severity label should be
+	// stored here.
 	// Some examples are `warn`, `error`, `i`.
 	Level string `ecs:"level"`
+
+	// The Syslog text-based facility of the log event, if available. See RFCs
+	// 5324 or 3164.
+	Facility string `ecs:"facility"`
+
+	// The Syslog numeric facility of the log event, if available.
+	// According to RFCs 5324 and 3164, this value should be an integer between
+	// 0 and 23.
+	FacilityCode int64 `ecs:"facility_code"`
+
+	// Syslog numeric priority of the event, if available.
+	// According to RFCs 5324 and 3164, the priority is 8 * facility +
+	// severity. Accordingly, this number should be between 0 and 191.
+	Priority int64 `ecs:"priority"`
 
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -22,32 +22,12 @@ package ecs
 // Fields which are specific to log events.
 type Log struct {
 	// Original log level of the log event.
-	// Syslog's severity label should be stored here.
+	// If the source of the event provides a log level or textual severity,
+	// this is the one that goes in `log.level`. If your source doesn't specify
+	// one, you may put your event transport's severity here (e.g. Syslog
+	// severity).
 	// Some examples are `warn`, `err`, `i`, `informational`.
 	Level string `ecs:"level"`
-
-	// The Syslog numeric severity of the log event, if available. See RFCs
-	// 5424 or 3164.
-	// If the event source publishing via Syslog provides a different severity
-	// value (e.g. firewall, IDS), it should go to `event.severity`. If the
-	// event source does not specify a distinct severity, you may instead copy
-	// the Syslog severity to `event.severity`.
-	Severity int64 `ecs:"severity"`
-
-	// The Syslog text-based facility of the log event, if available. See RFCs
-	// 5424 or 3164.
-	FacilityName string `ecs:"facility.name"`
-
-	// The Syslog numeric facility of the log event, if available.
-	// According to RFCs 5424 and 3164, this value should be an integer between
-	// 0 and 23.
-	FacilityCode int64 `ecs:"facility.code"`
-
-	// Syslog numeric priority of the event, if available.
-	// According to RFCs 5424 and 3164, the priority is 8 * facility +
-	// severity. This number is therefore expected to contain a value between 0
-	// and 191.
-	Priority int64 `ecs:"priority"`
 
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.
@@ -73,4 +53,37 @@ type Log struct {
 
 	// The name of the function or method which originated the log event.
 	OriginFunction string `ecs:"origin.function"`
+
+	// The Syslog metadata of the event, if the event was transmitted via
+	// Syslog. Please see RFCs 5424 or 3164.
+	Syslog map[string]interface{} `ecs:"syslog"`
+
+	// The Syslog numeric severity of the log event, if available.
+	// If the event source publishing via Syslog provides a different numeric
+	// severity value (e.g. firewall, IDS), your source's numeric severity
+	// should go to `event.severity`. If the event source does not specify a
+	// distinct severity, you can optionally copy the Syslog severity to
+	// `event.severity`.
+	SyslogSeverityCode int64 `ecs:"syslog.severity.code"`
+
+	// The Syslog numeric severity of the log event, if available.
+	// If the event source publishing via Syslog provides a different severity
+	// value (e.g. firewall, IDS), your source's text severity should go to
+	// `log.level`. If the event source does not specify a distinct severity,
+	// you can optionally copy the Syslog severity to `log.level`.
+	SyslogSeverityName string `ecs:"syslog.severity.name"`
+
+	// The Syslog numeric facility of the log event, if available.
+	// According to RFCs 5424 and 3164, this value should be an integer between
+	// 0 and 23.
+	SyslogFacilityCode int64 `ecs:"syslog.facility.code"`
+
+	// The Syslog text-based facility of the log event, if available.
+	SyslogFacilityName string `ecs:"syslog.facility.name"`
+
+	// Syslog numeric priority of the event, if available.
+	// According to RFCs 5424 and 3164, the priority is 8 * facility +
+	// severity. This number is therefore expected to contain a value between 0
+	// and 191.
+	SyslogPriority int64 `ecs:"syslog.priority"`
 }

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -22,10 +22,17 @@ package ecs
 // Fields which are specific to log events.
 type Log struct {
 	// Original log level of the log event.
-	// Syslog's severity label should be stored here. Syslog's numeric severity
-	// is `event.severity` in ECS.
-	// Some examples are `warn`, `error`, `i`.
+	// Syslog's severity label should be stored here.
+	// Some examples are `warn`, `err`, `i`, `informational`.
 	Level string `ecs:"level"`
+
+	// The Syslog numeric severity of the log event, if available. See RFCs
+	// 5424 or 3164.
+	// If the event source publishing via Syslog provides a different severity
+	// value (e.g. firewall, IDS), it should go to `event.severity`. If the
+	// event source does not specify a distinct severity, you may instead copy
+	// the Syslog severity to `event.severity`.
+	Severity int64 `ecs:"severity"`
 
 	// The Syslog text-based facility of the log event, if available. See RFCs
 	// 5424 or 3164.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1225,7 +1225,9 @@ type: long
 // ===============================================================
 
 | event.severity
-| Severity describes the original severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.
+| Severity describes the original severity of the event. What the different severity values mean can very different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.
+
+This field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.
 
 type: long
 
@@ -2044,8 +2046,32 @@ Fields which are specific to log events.
 
 // ===============================================================
 
+| log.facility
+| The Syslog text-based facility of the log event, if available. See RFCs 5324 or 3164.
+
+type: keyword
+
+example: `local7`
+
+| extended
+
+// ===============================================================
+
+| log.facility_code
+| The Syslog numeric facility of the log event, if available.
+
+According to RFCs 5324 and 3164, this value should be an integer between 0 and 23.
+
+type: long
+
+example: `23`
+
+| extended
+
+// ===============================================================
+
 | log.level
-| Original log level of the log event.
+| Original log level of the log event. Syslog's severity label should be stored here.
 
 Some examples are `warn`, `error`, `i`.
 
@@ -2080,6 +2106,19 @@ type: keyword
 example: `Sep 19 08:26:10 localhost My log`
 
 | core
+
+// ===============================================================
+
+| log.priority
+| Syslog numeric priority of the event, if available.
+
+According to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly, this number should be between 0 and 191.
+
+type: long
+
+example: `135`
+
+| extended
 
 // ===============================================================
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1225,9 +1225,9 @@ type: long
 // ===============================================================
 
 | event.severity
-| Severity describes the original severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.
+| Severity describes the severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.
 
-This field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.
+The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.
 
 type: long
 
@@ -2073,13 +2073,13 @@ example: `local7`
 | log.level
 | Original log level of the log event.
 
-Syslog's severity label should be stored here. Syslog's numeric severity is `event.severity` in ECS.
+Syslog's severity label should be stored here.
 
-Some examples are `warn`, `error`, `i`.
+Some examples are `warn`, `err`, `i`, `informational`.
 
 type: keyword
 
-example: `err`
+example: `error`
 
 | core
 
@@ -2119,6 +2119,19 @@ According to RFCs 5424 and 3164, the priority is 8 * facility + severity. This n
 type: long
 
 example: `135`
+
+| extended
+
+// ===============================================================
+
+| log.severity
+| The Syslog numeric severity of the log event, if available. See RFCs 5424 or 3164.
+
+If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), it should go to `event.severity`. If the event source does not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.
+
+type: long
+
+example: `3`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2047,7 +2047,7 @@ Fields which are specific to log events.
 // ===============================================================
 
 | log.facility
-| The Syslog text-based facility of the log event, if available. See RFCs 5324 or 3164.
+| The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.
 
 type: keyword
 
@@ -2060,7 +2060,7 @@ example: `local7`
 | log.facility_code
 | The Syslog numeric facility of the log event, if available.
 
-According to RFCs 5324 and 3164, this value should be an integer between 0 and 23.
+According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
 
 type: long
 
@@ -2114,7 +2114,7 @@ example: `Sep 19 08:26:10 localhost My log`
 | log.priority
 | Syslog numeric priority of the event, if available.
 
-According to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly, this number should be between 0 and 191.
+According to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.
 
 type: long
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2046,18 +2046,7 @@ Fields which are specific to log events.
 
 // ===============================================================
 
-| log.facility
-| The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.
-
-type: keyword
-
-example: `local7`
-
-| extended
-
-// ===============================================================
-
-| log.facility_code
+| log.facility.code
 | The Syslog numeric facility of the log event, if available.
 
 According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
@@ -2065,6 +2054,17 @@ According to RFCs 5424 and 3164, this value should be an integer between 0 and 2
 type: long
 
 example: `23`
+
+| extended
+
+// ===============================================================
+
+| log.facility.name
+| The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.
+
+type: keyword
+
+example: `local7`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2071,7 +2071,9 @@ example: `23`
 // ===============================================================
 
 | log.level
-| Original log level of the log event. Syslog's severity label should be stored here.
+| Original log level of the log event.
+
+Syslog's severity label should be stored here. Syslog's numeric severity is `event.severity` in ECS.
 
 Some examples are `warn`, `error`, `i`.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1225,7 +1225,7 @@ type: long
 // ===============================================================
 
 | event.severity
-| Severity describes the original severity of the event. What the different severity values mean can very different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.
+| Severity describes the original severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.
 
 This field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1281,7 +1281,7 @@ type: long
 
 What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.
 
-The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.
+The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.
 
 type: long
 
@@ -2113,34 +2113,10 @@ Fields which are specific to log events.
 
 // ===============================================================
 
-| log.facility.code
-| The Syslog numeric facility of the log event, if available.
-
-According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
-
-type: long
-
-example: `23`
-
-| extended
-
-// ===============================================================
-
-| log.facility.name
-| The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.
-
-type: keyword
-
-example: `local7`
-
-| extended
-
-// ===============================================================
-
 | log.level
 | Original log level of the log event.
 
-Syslog's severity label should be stored here.
+If the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).
 
 Some examples are `warn`, `err`, `i`, `informational`.
 
@@ -2211,7 +2187,42 @@ example: `Sep 19 08:26:10 localhost My log`
 
 // ===============================================================
 
-| log.priority
+| log.syslog
+| The Syslog metadata of the event, if the event was transmitted via Syslog. Please see RFCs 5424 or 3164.
+
+type: object
+
+
+
+| extended
+
+// ===============================================================
+
+| log.syslog.facility.code
+| The Syslog numeric facility of the log event, if available.
+
+According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
+
+type: long
+
+example: `23`
+
+| extended
+
+// ===============================================================
+
+| log.syslog.facility.name
+| The Syslog text-based facility of the log event, if available.
+
+type: keyword
+
+example: `local7`
+
+| extended
+
+// ===============================================================
+
+| log.syslog.priority
 | Syslog numeric priority of the event, if available.
 
 According to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.
@@ -2224,14 +2235,27 @@ example: `135`
 
 // ===============================================================
 
-| log.severity
-| The Syslog numeric severity of the log event, if available. See RFCs 5424 or 3164.
+| log.syslog.severity.code
+| The Syslog numeric severity of the log event, if available.
 
-If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), it should go to `event.severity`. If the event source does not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.
+If the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.
 
 type: long
 
 example: `3`
+
+| extended
+
+// ===============================================================
+
+| log.syslog.severity.name
+| The Syslog numeric severity of the log event, if available.
+
+If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.
+
+type: keyword
+
+example: `Error`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1225,7 +1225,9 @@ type: long
 // ===============================================================
 
 | event.severity
-| Severity describes the severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.
+| The numeric severity of the event according to your event source.
+
+What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.
 
 The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -971,13 +971,15 @@
       level: core
       type: long
       format: string
-      description: 'Severity describes the original severity of the event. What the
-        different severity values mean can be different between sources and use cases.
-        It''s up to the implementer to make sure severities are consistent across
-        events.
+      description: 'Severity describes the severity of the event. What the different
+        severity values mean can be different between sources and use cases. It''s
+        up to the implementer to make sure severities are consistent across events
+        from the same source.
 
-        This field corresponds to Syslog''s severity. Note that the text-based severity
-        for Syslog events is `log.level` in ECS.'
+        The Syslog severity belongs in `log.severity`. `event.severity` is meant to
+        represent the severity according to the event source (e.g. firewall, IDS).
+        If the event source does not publish its own severity, you may copy the `log.severity`
+        to `event.severity`.'
       example: 7
     - name: start
       level: extended
@@ -1549,11 +1551,10 @@
       ignore_above: 1024
       description: 'Original log level of the log event.
 
-        Syslog''s severity label should be stored here. Syslog''s numeric severity
-        is `event.severity` in ECS.
+        Syslog''s severity label should be stored here.
 
-        Some examples are `warn`, `error`, `i`.'
-      example: err
+        Some examples are `warn`, `err`, `i`, `informational`.'
+      example: error
     - name: logger
       level: core
       type: keyword
@@ -1585,6 +1586,17 @@
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.'
       example: 135
+    - name: severity
+      level: extended
+      type: long
+      description: 'The Syslog numeric severity of the log event, if available. See
+        RFCs 5424 or 3164.
+
+        If the event source publishing via Syslog provides a different severity value
+        (e.g. firewall, IDS), it should go to `event.severity`. If the event source
+        does not specify a distinct severity, you may instead copy the Syslog severity
+        to `event.severity`.'
+      example: 3
   - name: network
     title: Network
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1026,10 +1026,10 @@
         use cases. It''s up to the implementer to make sure severities are consistent
         across events from the same source.
 
-        The Syslog severity belongs in `log.severity`. `event.severity` is meant to
-        represent the severity according to the event source (e.g. firewall, IDS).
-        If the event source does not publish its own severity, you may copy the `log.severity`
-        to `event.severity`.'
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity`
+        is meant to represent the severity according to the event source (e.g. firewall,
+        IDS). If the event source does not publish its own severity, you may optionally
+        copy the `log.syslog.severity.code` to `event.severity`.'
       example: 7
     - name: start
       level: extended
@@ -1593,29 +1593,15 @@
     description: Fields which are specific to log events.
     type: group
     fields:
-    - name: facility.code
-      level: extended
-      type: long
-      format: string
-      description: 'The Syslog numeric facility of the log event, if available.
-
-        According to RFCs 5424 and 3164, this value should be an integer between 0
-        and 23.'
-      example: 23
-    - name: facility.name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5424 or 3164.
-      example: local7
     - name: level
       level: core
       type: keyword
       ignore_above: 1024
       description: 'Original log level of the log event.
 
-        Syslog''s severity label should be stored here.
+        If the source of the event provides a log level or textual severity, this
+        is the one that goes in `log.level`. If your source doesn''t specify one,
+        you may put your event transport''s severity here (e.g. Syslog severity).
 
         Some examples are `warn`, `err`, `i`, `informational`.'
       example: error
@@ -1660,7 +1646,28 @@
         This field is not indexed and doc_values are disabled so it can''t be queried
         but the value can be retrieved from `_source`.'
       example: Sep 19 08:26:10 localhost My log
-    - name: priority
+    - name: syslog
+      level: extended
+      type: object
+      object_type: keyword
+      description: The Syslog metadata of the event, if the event was transmitted
+        via Syslog. Please see RFCs 5424 or 3164.
+    - name: syslog.facility.code
+      level: extended
+      type: long
+      format: string
+      description: 'The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5424 and 3164, this value should be an integer between 0
+        and 23.'
+      example: 23
+    - name: syslog.facility.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The Syslog text-based facility of the log event, if available.
+      example: local7
+    - name: syslog.priority
       level: extended
       type: long
       format: string
@@ -1669,17 +1676,27 @@
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.'
       example: 135
-    - name: severity
+    - name: syslog.severity.code
       level: extended
       type: long
-      description: 'The Syslog numeric severity of the log event, if available. See
-        RFCs 5424 or 3164.
+      description: 'The Syslog numeric severity of the log event, if available.
+
+        If the event source publishing via Syslog provides a different numeric severity
+        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
+        If the event source does not specify a distinct severity, you can optionally
+        copy the Syslog severity to `event.severity`.'
+      example: 3
+    - name: syslog.severity.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), it should go to `event.severity`. If the event source
-        does not specify a distinct severity, you may instead copy the Syslog severity
-        to `event.severity`.'
-      example: 3
+        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        If the event source does not specify a distinct severity, you can optionally
+        copy the Syslog severity to `log.level`.'
+      example: Error
   - name: network
     title: Network
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1527,14 +1527,7 @@
     description: Fields which are specific to log events.
     type: group
     fields:
-    - name: facility
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5424 or 3164.
-      example: local7
-    - name: facility_code
+    - name: facility.code
       level: extended
       type: long
       format: string
@@ -1543,6 +1536,13 @@
         According to RFCs 5424 and 3164, this value should be an integer between 0
         and 23.'
       example: 23
+    - name: facility.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The Syslog text-based facility of the log event, if available.
+        See RFCs 5424 or 3164.
+      example: local7
     - name: level
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -971,10 +971,11 @@
       level: core
       type: long
       format: string
-      description: 'Severity describes the severity of the event. What the different
-        severity values mean can be different between sources and use cases. It''s
-        up to the implementer to make sure severities are consistent across events
-        from the same source.
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and
+        use cases. It''s up to the implementer to make sure severities are consistent
+        across events from the same source.
 
         The Syslog severity belongs in `log.severity`. `event.severity` is meant to
         represent the severity according to the event source (e.g. firewall, IDS).

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1547,8 +1547,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Original log level of the log event. Syslog''s severity label
-        should be stored here.
+      description: 'Original log level of the log event.
+
+        Syslog''s severity label should be stored here. Syslog''s numeric severity
+        is `event.severity` in ECS.
 
         Some examples are `warn`, `error`, `i`.'
       example: err

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1532,7 +1532,7 @@
       type: keyword
       ignore_above: 1024
       description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5324 or 3164.
+        See RFCs 5424 or 3164.
       example: local7
     - name: facility_code
       level: extended
@@ -1540,7 +1540,7 @@
       format: string
       description: 'The Syslog numeric facility of the log event, if available.
 
-        According to RFCs 5324 and 3164, this value should be an integer between 0
+        According to RFCs 5424 and 3164, this value should be an integer between 0
         and 23.'
       example: 23
     - name: level
@@ -1582,8 +1582,8 @@
       format: string
       description: 'Syslog numeric priority of the event, if available.
 
-        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
-        Accordingly, this number should be between 0 and 191.'
+        According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
+        This number is therefore expected to contain a value between 0 and 191.'
       example: 135
   - name: network
     title: Network

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -971,10 +971,14 @@
       level: core
       type: long
       format: string
-      description: Severity describes the original severity of the event. What the
-        different severity values mean can very different between use cases. It's
-        up to the implementer to make sure severities are consistent across events.
-      example: '7'
+      description: 'Severity describes the original severity of the event. What the
+        different severity values mean can very different between sources and use
+        cases. It''s up to the implementer to make sure severities are consistent
+        across events.
+
+        This field corresponds to Syslog''s severity. Note that the text-based severity
+        for Syslog events is `log.level` in ECS.'
+      example: 7
     - name: start
       level: extended
       type: date
@@ -1523,11 +1527,28 @@
     description: Fields which are specific to log events.
     type: group
     fields:
+    - name: facility
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The Syslog text-based facility of the log event, if available.
+        See RFCs 5324 or 3164.
+      example: local7
+    - name: facility_code
+      level: extended
+      type: long
+      format: string
+      description: 'The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5324 and 3164, this value should be an integer between 0
+        and 23.'
+      example: 23
     - name: level
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Original log level of the log event.
+      description: 'Original log level of the log event. Syslog''s severity label
+        should be stored here.
 
         Some examples are `warn`, `error`, `i`.'
       example: err
@@ -1553,6 +1574,15 @@
         This field is not indexed and doc_values are disabled so it can''t be queried
         but the value can be retrieved from `_source`.'
       example: Sep 19 08:26:10 localhost My log
+    - name: priority
+      level: extended
+      type: long
+      format: string
+      description: 'Syslog numeric priority of the event, if available.
+
+        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
+        Accordingly, this number should be between 0 and 191.'
+      example: 135
   - name: network
     title: Network
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -972,9 +972,9 @@
       type: long
       format: string
       description: 'Severity describes the original severity of the event. What the
-        different severity values mean can very different between sources and use
-        cases. It''s up to the implementer to make sure severities are consistent
-        across events.
+        different severity values mean can be different between sources and use cases.
+        It''s up to the implementer to make sure severities are consistent across
+        events.
 
         This field corresponds to Syslog''s severity. Note that the text-based severity
         for Syslog events is `log.level` in ECS.'

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -196,10 +196,11 @@ http.response.status_code,long,extended,404,1.2.0-dev
 http.version,keyword,extended,1.1,1.2.0-dev
 log.facility.code,long,extended,23,1.2.0-dev
 log.facility.name,keyword,extended,local7,1.2.0-dev
-log.level,keyword,core,err,1.2.0-dev
+log.level,keyword,core,error,1.2.0-dev
 log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,1.2.0-dev
 log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.2.0-dev
 log.priority,long,extended,135,1.2.0-dev
+log.severity,long,extended,3,1.2.0-dev
 network.application,keyword,extended,aim,1.2.0-dev
 network.bytes,long,core,368,1.2.0-dev
 network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,1.2.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -194,9 +194,12 @@ http.response.body.content,keyword,extended,Hello world,1.2.0-dev
 http.response.bytes,long,extended,1437,1.2.0-dev
 http.response.status_code,long,extended,404,1.2.0-dev
 http.version,keyword,extended,1.1,1.2.0-dev
+log.facility,keyword,extended,local7,1.2.0-dev
+log.facility_code,long,extended,23,1.2.0-dev
 log.level,keyword,core,err,1.2.0-dev
 log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,1.2.0-dev
 log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.2.0-dev
+log.priority,long,extended,135,1.2.0-dev
 network.application,keyword,extended,aim,1.2.0-dev
 network.bytes,long,core,368,1.2.0-dev
 network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,1.2.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -194,8 +194,8 @@ http.response.body.content,keyword,extended,Hello world,1.2.0-dev
 http.response.bytes,long,extended,1437,1.2.0-dev
 http.response.status_code,long,extended,404,1.2.0-dev
 http.version,keyword,extended,1.1,1.2.0-dev
-log.facility,keyword,extended,local7,1.2.0-dev
-log.facility_code,long,extended,23,1.2.0-dev
+log.facility.code,long,extended,23,1.2.0-dev
+log.facility.name,keyword,extended,local7,1.2.0-dev
 log.level,keyword,core,err,1.2.0-dev
 log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,1.2.0-dev
 log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.2.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -202,16 +202,18 @@ http.response.body.content,keyword,extended,Hello world,1.2.0-dev
 http.response.bytes,long,extended,1437,1.2.0-dev
 http.response.status_code,long,extended,404,1.2.0-dev
 http.version,keyword,extended,1.1,1.2.0-dev
-log.facility.code,long,extended,23,1.2.0-dev
-log.facility.name,keyword,extended,local7,1.2.0-dev
 log.level,keyword,core,error,1.2.0-dev
 log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,1.2.0-dev
 log.origin.file.line,integer,extended,42,1.2.0-dev
 log.origin.file.name,keyword,extended,Bootstrap.java,1.2.0-dev
 log.origin.function,keyword,extended,init,1.2.0-dev
 log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.2.0-dev
-log.priority,long,extended,135,1.2.0-dev
-log.severity,long,extended,3,1.2.0-dev
+log.syslog,object,extended,,1.2.0-dev
+log.syslog.facility.code,long,extended,23,1.2.0-dev
+log.syslog.facility.name,keyword,extended,local7,1.2.0-dev
+log.syslog.priority,long,extended,135,1.2.0-dev
+log.syslog.severity.code,long,extended,3,1.2.0-dev
+log.syslog.severity.name,keyword,extended,Error,1.2.0-dev
 network.application,keyword,extended,aim,1.2.0-dev
 network.bytes,long,core,368,1.2.0-dev
 network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1389,9 +1389,10 @@ event.severity:
     cases. It''s up to the implementer to make sure severities are consistent across
     events from the same source.
 
-    The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent
-    the severity according to the event source (e.g. firewall, IDS). If the event
-    source does not publish its own severity, you may copy the `log.severity` to `event.severity`.'
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
   example: 7
   flat_name: event.severity
   format: string
@@ -2267,34 +2268,12 @@ labels:
   order: 2
   short: Custom key/value pairs.
   type: object
-log.facility.code:
-  description: 'The Syslog numeric facility of the log event, if available.
-
-    According to RFCs 5424 and 3164, this value should be an integer between 0 and
-    23.'
-  example: 23
-  flat_name: log.facility.code
-  format: string
-  level: extended
-  name: facility.code
-  order: 3
-  short: Syslog numeric facility of the event.
-  type: long
-log.facility.name:
-  description: The Syslog text-based facility of the log event, if available. See
-    RFCs 5424 or 3164.
-  example: local7
-  flat_name: log.facility.name
-  ignore_above: 1024
-  level: extended
-  name: facility.name
-  order: 2
-  short: Syslog text-based facility of the event.
-  type: keyword
 log.level:
   description: 'Original log level of the log event.
 
-    Syslog''s severity label should be stored here.
+    If the source of the event provides a log level or textual severity, this is the
+    one that goes in `log.level`. If your source doesn''t specify one, you may put
+    your event transport''s severity here (e.g. Syslog severity).
 
     Some examples are `warn`, `err`, `i`, `informational`.'
   example: error
@@ -2313,7 +2292,7 @@ log.logger:
   ignore_above: 1024
   level: core
   name: logger
-  order: 6
+  order: 2
   short: Name of the logger.
   type: keyword
 log.origin.file.line:
@@ -2365,36 +2344,84 @@ log.original:
   index: false
   level: core
   name: original
-  order: 5
+  order: 1
   short: Original log message with light interpretation only (encoding, newlines).
   type: keyword
-log.priority:
+log.syslog:
+  description: The Syslog metadata of the event, if the event was transmitted via
+    Syslog. Please see RFCs 5424 or 3164.
+  flat_name: log.syslog
+  level: extended
+  name: syslog
+  object_type: keyword
+  order: 6
+  short: Syslog metadata
+  type: object
+log.syslog.facility.code:
+  description: 'The Syslog numeric facility of the log event, if available.
+
+    According to RFCs 5424 and 3164, this value should be an integer between 0 and
+    23.'
+  example: 23
+  flat_name: log.syslog.facility.code
+  format: string
+  level: extended
+  name: syslog.facility.code
+  order: 9
+  short: Syslog numeric facility of the event.
+  type: long
+log.syslog.facility.name:
+  description: The Syslog text-based facility of the log event, if available.
+  example: local7
+  flat_name: log.syslog.facility.name
+  ignore_above: 1024
+  level: extended
+  name: syslog.facility.name
+  order: 10
+  short: Syslog text-based facility of the event.
+  type: keyword
+log.syslog.priority:
   description: 'Syslog numeric priority of the event, if available.
 
     According to RFCs 5424 and 3164, the priority is 8 * facility + severity. This
     number is therefore expected to contain a value between 0 and 191.'
   example: 135
-  flat_name: log.priority
+  flat_name: log.syslog.priority
   format: string
   level: extended
-  name: priority
-  order: 4
+  name: syslog.priority
+  order: 11
   short: Syslog priority of the event.
   type: long
-log.severity:
-  description: 'The Syslog numeric severity of the log event, if available. See RFCs
-    5424 or 3164.
+log.syslog.severity.code:
+  description: 'The Syslog numeric severity of the log event, if available.
 
-    If the event source publishing via Syslog provides a different severity value
-    (e.g. firewall, IDS), it should go to `event.severity`. If the event source does
-    not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.'
+    If the event source publishing via Syslog provides a different numeric severity
+    value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
+    If the event source does not specify a distinct severity, you can optionally copy
+    the Syslog severity to `event.severity`.'
   example: 3
-  flat_name: log.severity
+  flat_name: log.syslog.severity.code
   level: extended
-  name: severity
-  order: 1
+  name: syslog.severity.code
+  order: 7
   short: Syslog numeric severity of the event.
   type: long
+log.syslog.severity.name:
+  description: 'The Syslog numeric severity of the log event, if available.
+
+    If the event source publishing via Syslog provides a different severity value
+    (e.g. firewall, IDS), your source''s text severity should go to `log.level`. If
+    the event source does not specify a distinct severity, you can optionally copy
+    the Syslog severity to `log.level`.'
+  example: Error
+  flat_name: log.syslog.severity.name
+  ignore_above: 1024
+  level: extended
+  name: syslog.severity.name
+  order: 8
+  short: Syslog text-based severity of the event.
+  type: keyword
 message:
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1306,19 +1306,20 @@ event.sequence:
   short: Sequence number of the event.
   type: long
 event.severity:
-  description: 'Severity describes the original severity of the event. What the different
-    severity values mean can be different between sources and use cases. It''s up
-    to the implementer to make sure severities are consistent across events.
+  description: 'Severity describes the severity of the event. What the different severity
+    values mean can be different between sources and use cases. It''s up to the implementer
+    to make sure severities are consistent across events from the same source.
 
-    This field corresponds to Syslog''s severity. Note that the text-based severity
-    for Syslog events is `log.level` in ECS.'
+    The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent
+    the severity according to the event source (e.g. firewall, IDS). If the event
+    source does not publish its own severity, you may copy the `log.severity` to `event.severity`.'
   example: 7
   flat_name: event.severity
   format: string
   level: core
   name: severity
   order: 10
-  short: Original severity of the event.
+  short: Severity of the event.
   type: long
 event.start:
   description: event.start contains the date when the event started or when the activity
@@ -2174,7 +2175,7 @@ log.facility.code:
   format: string
   level: extended
   name: facility.code
-  order: 2
+  order: 3
   short: Syslog numeric facility of the event.
   type: long
 log.facility.name:
@@ -2185,17 +2186,16 @@ log.facility.name:
   ignore_above: 1024
   level: extended
   name: facility.name
-  order: 1
+  order: 2
   short: Syslog text-based facility of the event.
   type: keyword
 log.level:
   description: 'Original log level of the log event.
 
-    Syslog''s severity label should be stored here. Syslog''s numeric severity is
-    `event.severity` in ECS.
+    Syslog''s severity label should be stored here.
 
-    Some examples are `warn`, `error`, `i`.'
-  example: err
+    Some examples are `warn`, `err`, `i`, `informational`.'
+  example: error
   flat_name: log.level
   ignore_above: 1024
   level: core
@@ -2211,7 +2211,7 @@ log.logger:
   ignore_above: 1024
   level: core
   name: logger
-  order: 5
+  order: 6
   short: Name of the logger.
   type: keyword
 log.original:
@@ -2232,7 +2232,7 @@ log.original:
   index: false
   level: core
   name: original
-  order: 4
+  order: 5
   short: Original log message with light interpretation only (encoding, newlines).
   type: keyword
 log.priority:
@@ -2245,8 +2245,22 @@ log.priority:
   format: string
   level: extended
   name: priority
-  order: 3
+  order: 4
   short: Syslog priority of the event.
+  type: long
+log.severity:
+  description: 'The Syslog numeric severity of the log event, if available. See RFCs
+    5424 or 3164.
+
+    If the event source publishing via Syslog provides a different severity value
+    (e.g. firewall, IDS), it should go to `event.severity`. If the event source does
+    not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.'
+  example: 3
+  flat_name: log.severity
+  level: extended
+  name: severity
+  order: 1
+  short: Syslog numeric severity of the event.
   type: long
 message:
   description: 'For log events the message field contains the log message, optimized

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1306,9 +1306,11 @@ event.sequence:
   short: Sequence number of the event.
   type: long
 event.severity:
-  description: 'Severity describes the severity of the event. What the different severity
-    values mean can be different between sources and use cases. It''s up to the implementer
-    to make sure severities are consistent across events from the same source.
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
 
     The Syslog severity belongs in `log.severity`. `event.severity` is meant to represent
     the severity according to the event source (e.g. firewall, IDS). If the event
@@ -1319,7 +1321,7 @@ event.severity:
   level: core
   name: severity
   order: 10
-  short: Severity of the event.
+  short: Numeric severity of the event.
   type: long
 event.start:
   description: event.start contains the date when the event started or when the activity

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1307,7 +1307,7 @@ event.sequence:
   type: long
 event.severity:
   description: 'Severity describes the original severity of the event. What the different
-    severity values mean can very different between sources and use cases. It''s up
+    severity values mean can be different between sources and use cases. It''s up
     to the implementer to make sure severities are consistent across events.
 
     This field corresponds to Syslog''s severity. Note that the text-based severity

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2189,8 +2189,10 @@ log.facility_code:
   short: Syslog numeric facility of the event.
   type: long
 log.level:
-  description: 'Original log level of the log event. Syslog''s severity label should
-    be stored here.
+  description: 'Original log level of the log event.
+
+    Syslog''s severity label should be stored here. Syslog''s numeric severity is
+    `event.severity` in ECS.
 
     Some examples are `warn`, `error`, `i`.'
   example: err

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1306,10 +1306,13 @@ event.sequence:
   short: Sequence number of the event.
   type: long
 event.severity:
-  description: Severity describes the original severity of the event. What the different
-    severity values mean can very different between use cases. It's up to the implementer
-    to make sure severities are consistent across events.
-  example: '7'
+  description: 'Severity describes the original severity of the event. What the different
+    severity values mean can very different between sources and use cases. It''s up
+    to the implementer to make sure severities are consistent across events.
+
+    This field corresponds to Syslog''s severity. Note that the text-based severity
+    for Syslog events is `log.level` in ECS.'
+  example: 7
   flat_name: event.severity
   format: string
   level: core
@@ -2161,8 +2164,33 @@ labels:
   order: 2
   short: Custom key/value pairs.
   type: object
+log.facility:
+  description: The Syslog text-based facility of the log event, if available. See
+    RFCs 5324 or 3164.
+  example: local7
+  flat_name: log.facility
+  ignore_above: 1024
+  level: extended
+  name: facility
+  order: 1
+  short: Syslog text-based facility of the event.
+  type: keyword
+log.facility_code:
+  description: 'The Syslog numeric facility of the log event, if available.
+
+    According to RFCs 5324 and 3164, this value should be an integer between 0 and
+    23.'
+  example: 23
+  flat_name: log.facility_code
+  format: string
+  level: extended
+  name: facility_code
+  order: 2
+  short: Syslog numeric facility of the event.
+  type: long
 log.level:
-  description: 'Original log level of the log event.
+  description: 'Original log level of the log event. Syslog''s severity label should
+    be stored here.
 
     Some examples are `warn`, `error`, `i`.'
   example: err
@@ -2181,7 +2209,7 @@ log.logger:
   ignore_above: 1024
   level: core
   name: logger
-  order: 2
+  order: 5
   short: Name of the logger.
   type: keyword
 log.original:
@@ -2202,9 +2230,22 @@ log.original:
   index: false
   level: core
   name: original
-  order: 1
+  order: 4
   short: Original log message with light interpretation only (encoding, newlines).
   type: keyword
+log.priority:
+  description: 'Syslog numeric priority of the event, if available.
+
+    According to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly,
+    this number should be between 0 and 191.'
+  example: 135
+  flat_name: log.priority
+  format: string
+  level: extended
+  name: priority
+  order: 3
+  short: Syslog priority of the event.
+  type: long
 message:
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2164,30 +2164,30 @@ labels:
   order: 2
   short: Custom key/value pairs.
   type: object
-log.facility:
-  description: The Syslog text-based facility of the log event, if available. See
-    RFCs 5424 or 3164.
-  example: local7
-  flat_name: log.facility
-  ignore_above: 1024
-  level: extended
-  name: facility
-  order: 1
-  short: Syslog text-based facility of the event.
-  type: keyword
-log.facility_code:
+log.facility.code:
   description: 'The Syslog numeric facility of the log event, if available.
 
     According to RFCs 5424 and 3164, this value should be an integer between 0 and
     23.'
   example: 23
-  flat_name: log.facility_code
+  flat_name: log.facility.code
   format: string
   level: extended
-  name: facility_code
+  name: facility.code
   order: 2
   short: Syslog numeric facility of the event.
   type: long
+log.facility.name:
+  description: The Syslog text-based facility of the log event, if available. See
+    RFCs 5424 or 3164.
+  example: local7
+  flat_name: log.facility.name
+  ignore_above: 1024
+  level: extended
+  name: facility.name
+  order: 1
+  short: Syslog text-based facility of the event.
+  type: keyword
 log.level:
   description: 'Original log level of the log event.
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2166,7 +2166,7 @@ labels:
   type: object
 log.facility:
   description: The Syslog text-based facility of the log event, if available. See
-    RFCs 5324 or 3164.
+    RFCs 5424 or 3164.
   example: local7
   flat_name: log.facility
   ignore_above: 1024
@@ -2178,7 +2178,7 @@ log.facility:
 log.facility_code:
   description: 'The Syslog numeric facility of the log event, if available.
 
-    According to RFCs 5324 and 3164, this value should be an integer between 0 and
+    According to RFCs 5424 and 3164, this value should be an integer between 0 and
     23.'
   example: 23
   flat_name: log.facility_code
@@ -2238,8 +2238,8 @@ log.original:
 log.priority:
   description: 'Syslog numeric priority of the event, if available.
 
-    According to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly,
-    this number should be between 0 and 191.'
+    According to RFCs 5424 and 3164, the priority is 8 * facility + severity. This
+    number is therefore expected to contain a value between 0 and 191.'
   example: 135
   flat_name: log.priority
   format: string

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1602,10 +1602,10 @@ event:
         use cases. It''s up to the implementer to make sure severities are consistent
         across events from the same source.
 
-        The Syslog severity belongs in `log.severity`. `event.severity` is meant to
-        represent the severity according to the event source (e.g. firewall, IDS).
-        If the event source does not publish its own severity, you may copy the `log.severity`
-        to `event.severity`.'
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity`
+        is meant to represent the severity according to the event source (e.g. firewall,
+        IDS). If the event source does not publish its own severity, you may optionally
+        copy the `log.syslog.severity.code` to `event.severity`.'
       example: 7
       flat_name: event.severity
       format: string
@@ -2573,34 +2573,12 @@ http:
 log:
   description: Fields which are specific to log events.
   fields:
-    facility.code:
-      description: 'The Syslog numeric facility of the log event, if available.
-
-        According to RFCs 5424 and 3164, this value should be an integer between 0
-        and 23.'
-      example: 23
-      flat_name: log.facility.code
-      format: string
-      level: extended
-      name: facility.code
-      order: 3
-      short: Syslog numeric facility of the event.
-      type: long
-    facility.name:
-      description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5424 or 3164.
-      example: local7
-      flat_name: log.facility.name
-      ignore_above: 1024
-      level: extended
-      name: facility.name
-      order: 2
-      short: Syslog text-based facility of the event.
-      type: keyword
     level:
       description: 'Original log level of the log event.
 
-        Syslog''s severity label should be stored here.
+        If the source of the event provides a log level or textual severity, this
+        is the one that goes in `log.level`. If your source doesn''t specify one,
+        you may put your event transport''s severity here (e.g. Syslog severity).
 
         Some examples are `warn`, `err`, `i`, `informational`.'
       example: error
@@ -2619,7 +2597,7 @@ log:
       ignore_above: 1024
       level: core
       name: logger
-      order: 6
+      order: 2
       short: Name of the logger.
       type: keyword
     origin.file.line:
@@ -2671,37 +2649,84 @@ log:
       index: false
       level: core
       name: original
-      order: 5
+      order: 1
       short: Original log message with light interpretation only (encoding, newlines).
       type: keyword
-    priority:
+    syslog:
+      description: The Syslog metadata of the event, if the event was transmitted
+        via Syslog. Please see RFCs 5424 or 3164.
+      flat_name: log.syslog
+      level: extended
+      name: syslog
+      object_type: keyword
+      order: 6
+      short: Syslog metadata
+      type: object
+    syslog.facility.code:
+      description: 'The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5424 and 3164, this value should be an integer between 0
+        and 23.'
+      example: 23
+      flat_name: log.syslog.facility.code
+      format: string
+      level: extended
+      name: syslog.facility.code
+      order: 9
+      short: Syslog numeric facility of the event.
+      type: long
+    syslog.facility.name:
+      description: The Syslog text-based facility of the log event, if available.
+      example: local7
+      flat_name: log.syslog.facility.name
+      ignore_above: 1024
+      level: extended
+      name: syslog.facility.name
+      order: 10
+      short: Syslog text-based facility of the event.
+      type: keyword
+    syslog.priority:
       description: 'Syslog numeric priority of the event, if available.
 
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.'
       example: 135
-      flat_name: log.priority
+      flat_name: log.syslog.priority
       format: string
       level: extended
-      name: priority
-      order: 4
+      name: syslog.priority
+      order: 11
       short: Syslog priority of the event.
       type: long
-    severity:
-      description: 'The Syslog numeric severity of the log event, if available. See
-        RFCs 5424 or 3164.
+    syslog.severity.code:
+      description: 'The Syslog numeric severity of the log event, if available.
 
-        If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), it should go to `event.severity`. If the event source
-        does not specify a distinct severity, you may instead copy the Syslog severity
-        to `event.severity`.'
+        If the event source publishing via Syslog provides a different numeric severity
+        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
+        If the event source does not specify a distinct severity, you can optionally
+        copy the Syslog severity to `event.severity`.'
       example: 3
-      flat_name: log.severity
+      flat_name: log.syslog.severity.code
       level: extended
-      name: severity
-      order: 1
+      name: syslog.severity.code
+      order: 7
       short: Syslog numeric severity of the event.
       type: long
+    syslog.severity.name:
+      description: 'The Syslog numeric severity of the log event, if available.
+
+        If the event source publishing via Syslog provides a different severity value
+        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        If the event source does not specify a distinct severity, you can optionally
+        copy the Syslog severity to `log.level`.'
+      example: Error
+      flat_name: log.syslog.severity.name
+      ignore_above: 1024
+      level: extended
+      name: syslog.severity.name
+      order: 8
+      short: Syslog text-based severity of the event.
+      type: keyword
   group: 2
   name: log
   prefix: log.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1519,10 +1519,11 @@ event:
       short: Sequence number of the event.
       type: long
     severity:
-      description: 'Severity describes the severity of the event. What the different
-        severity values mean can be different between sources and use cases. It''s
-        up to the implementer to make sure severities are consistent across events
-        from the same source.
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and
+        use cases. It''s up to the implementer to make sure severities are consistent
+        across events from the same source.
 
         The Syslog severity belongs in `log.severity`. `event.severity` is meant to
         represent the severity according to the event source (e.g. firewall, IDS).
@@ -1534,7 +1535,7 @@ event:
       level: core
       name: severity
       order: 10
-      short: Severity of the event.
+      short: Numeric severity of the event.
       type: long
     start:
       description: event.start contains the date when the event started or when the

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2472,7 +2472,7 @@ log:
   fields:
     facility:
       description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5324 or 3164.
+        See RFCs 5424 or 3164.
       example: local7
       flat_name: log.facility
       ignore_above: 1024
@@ -2484,7 +2484,7 @@ log:
     facility_code:
       description: 'The Syslog numeric facility of the log event, if available.
 
-        According to RFCs 5324 and 3164, this value should be an integer between 0
+        According to RFCs 5424 and 3164, this value should be an integer between 0
         and 23.'
       example: 23
       flat_name: log.facility_code
@@ -2544,8 +2544,8 @@ log:
     priority:
       description: 'Syslog numeric priority of the event, if available.
 
-        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
-        Accordingly, this number should be between 0 and 191.'
+        According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
+        This number is therefore expected to contain a value between 0 and 191.'
       example: 135
       flat_name: log.priority
       format: string

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1520,9 +1520,9 @@ event:
       type: long
     severity:
       description: 'Severity describes the original severity of the event. What the
-        different severity values mean can very different between sources and use
-        cases. It''s up to the implementer to make sure severities are consistent
-        across events.
+        different severity values mean can be different between sources and use cases.
+        It''s up to the implementer to make sure severities are consistent across
+        events.
 
         This field corresponds to Syslog''s severity. Note that the text-based severity
         for Syslog events is `log.level` in ECS.'

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1519,10 +1519,14 @@ event:
       short: Sequence number of the event.
       type: long
     severity:
-      description: Severity describes the original severity of the event. What the
-        different severity values mean can very different between use cases. It's
-        up to the implementer to make sure severities are consistent across events.
-      example: '7'
+      description: 'Severity describes the original severity of the event. What the
+        different severity values mean can very different between sources and use
+        cases. It''s up to the implementer to make sure severities are consistent
+        across events.
+
+        This field corresponds to Syslog''s severity. Note that the text-based severity
+        for Syslog events is `log.level` in ECS.'
+      example: 7
       flat_name: event.severity
       format: string
       level: core
@@ -2466,8 +2470,33 @@ http:
 log:
   description: Fields which are specific to log events.
   fields:
+    facility:
+      description: The Syslog text-based facility of the log event, if available.
+        See RFCs 5324 or 3164.
+      example: local7
+      flat_name: log.facility
+      ignore_above: 1024
+      level: extended
+      name: facility
+      order: 1
+      short: Syslog text-based facility of the event.
+      type: keyword
+    facility_code:
+      description: 'The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5324 and 3164, this value should be an integer between 0
+        and 23.'
+      example: 23
+      flat_name: log.facility_code
+      format: string
+      level: extended
+      name: facility_code
+      order: 2
+      short: Syslog numeric facility of the event.
+      type: long
     level:
-      description: 'Original log level of the log event.
+      description: 'Original log level of the log event. Syslog''s severity label
+        should be stored here.
 
         Some examples are `warn`, `error`, `i`.'
       example: err
@@ -2486,7 +2515,7 @@ log:
       ignore_above: 1024
       level: core
       name: logger
-      order: 2
+      order: 5
       short: Name of the logger.
       type: keyword
     original:
@@ -2507,9 +2536,22 @@ log:
       index: false
       level: core
       name: original
-      order: 1
+      order: 4
       short: Original log message with light interpretation only (encoding, newlines).
       type: keyword
+    priority:
+      description: 'Syslog numeric priority of the event, if available.
+
+        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
+        Accordingly, this number should be between 0 and 191.'
+      example: 135
+      flat_name: log.priority
+      format: string
+      level: extended
+      name: priority
+      order: 3
+      short: Syslog priority of the event.
+      type: long
   group: 2
   name: log
   prefix: log.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1519,20 +1519,22 @@ event:
       short: Sequence number of the event.
       type: long
     severity:
-      description: 'Severity describes the original severity of the event. What the
-        different severity values mean can be different between sources and use cases.
-        It''s up to the implementer to make sure severities are consistent across
-        events.
+      description: 'Severity describes the severity of the event. What the different
+        severity values mean can be different between sources and use cases. It''s
+        up to the implementer to make sure severities are consistent across events
+        from the same source.
 
-        This field corresponds to Syslog''s severity. Note that the text-based severity
-        for Syslog events is `log.level` in ECS.'
+        The Syslog severity belongs in `log.severity`. `event.severity` is meant to
+        represent the severity according to the event source (e.g. firewall, IDS).
+        If the event source does not publish its own severity, you may copy the `log.severity`
+        to `event.severity`.'
       example: 7
       flat_name: event.severity
       format: string
       level: core
       name: severity
       order: 10
-      short: Original severity of the event.
+      short: Severity of the event.
       type: long
     start:
       description: event.start contains the date when the event started or when the
@@ -2480,7 +2482,7 @@ log:
       format: string
       level: extended
       name: facility.code
-      order: 2
+      order: 3
       short: Syslog numeric facility of the event.
       type: long
     facility.name:
@@ -2491,17 +2493,16 @@ log:
       ignore_above: 1024
       level: extended
       name: facility.name
-      order: 1
+      order: 2
       short: Syslog text-based facility of the event.
       type: keyword
     level:
       description: 'Original log level of the log event.
 
-        Syslog''s severity label should be stored here. Syslog''s numeric severity
-        is `event.severity` in ECS.
+        Syslog''s severity label should be stored here.
 
-        Some examples are `warn`, `error`, `i`.'
-      example: err
+        Some examples are `warn`, `err`, `i`, `informational`.'
+      example: error
       flat_name: log.level
       ignore_above: 1024
       level: core
@@ -2517,7 +2518,7 @@ log:
       ignore_above: 1024
       level: core
       name: logger
-      order: 5
+      order: 6
       short: Name of the logger.
       type: keyword
     original:
@@ -2538,7 +2539,7 @@ log:
       index: false
       level: core
       name: original
-      order: 4
+      order: 5
       short: Original log message with light interpretation only (encoding, newlines).
       type: keyword
     priority:
@@ -2551,8 +2552,23 @@ log:
       format: string
       level: extended
       name: priority
-      order: 3
+      order: 4
       short: Syslog priority of the event.
+      type: long
+    severity:
+      description: 'The Syslog numeric severity of the log event, if available. See
+        RFCs 5424 or 3164.
+
+        If the event source publishing via Syslog provides a different severity value
+        (e.g. firewall, IDS), it should go to `event.severity`. If the event source
+        does not specify a distinct severity, you may instead copy the Syslog severity
+        to `event.severity`.'
+      example: 3
+      flat_name: log.severity
+      level: extended
+      name: severity
+      order: 1
+      short: Syslog numeric severity of the event.
       type: long
   group: 2
   name: log

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2495,8 +2495,10 @@ log:
       short: Syslog numeric facility of the event.
       type: long
     level:
-      description: 'Original log level of the log event. Syslog''s severity label
-        should be stored here.
+      description: 'Original log level of the log event.
+
+        Syslog''s severity label should be stored here. Syslog''s numeric severity
+        is `event.severity` in ECS.
 
         Some examples are `warn`, `error`, `i`.'
       example: err

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2470,30 +2470,30 @@ http:
 log:
   description: Fields which are specific to log events.
   fields:
-    facility:
-      description: The Syslog text-based facility of the log event, if available.
-        See RFCs 5424 or 3164.
-      example: local7
-      flat_name: log.facility
-      ignore_above: 1024
-      level: extended
-      name: facility
-      order: 1
-      short: Syslog text-based facility of the event.
-      type: keyword
-    facility_code:
+    facility.code:
       description: 'The Syslog numeric facility of the log event, if available.
 
         According to RFCs 5424 and 3164, this value should be an integer between 0
         and 23.'
       example: 23
-      flat_name: log.facility_code
+      flat_name: log.facility.code
       format: string
       level: extended
-      name: facility_code
+      name: facility.code
       order: 2
       short: Syslog numeric facility of the event.
       type: long
+    facility.name:
+      description: The Syslog text-based facility of the log event, if available.
+        See RFCs 5424 or 3164.
+      example: local7
+      flat_name: log.facility.name
+      ignore_above: 1024
+      level: extended
+      name: facility.name
+      order: 1
+      short: Syslog text-based facility of the event.
+      type: keyword
     level:
       description: 'Original log level of the log event.
 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -951,6 +951,9 @@
             }, 
             "priority": {
               "type": "long"
+            }, 
+            "severity": {
+              "type": "long"
             }
           }
         }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -958,17 +958,6 @@
         }, 
         "log": {
           "properties": {
-            "facility": {
-              "properties": {
-                "code": {
-                  "type": "long"
-                }, 
-                "name": {
-                  "ignore_above": 1024, 
-                  "type": "keyword"
-                }
-              }
-            }, 
             "level": {
               "ignore_above": 1024, 
               "type": "keyword"
@@ -1002,11 +991,34 @@
               "index": false, 
               "type": "keyword"
             }, 
-            "priority": {
-              "type": "long"
-            }, 
-            "severity": {
-              "type": "long"
+            "syslog": {
+              "properties": {
+                "facility": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    }, 
+                    "name": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }
+                  }
+                }, 
+                "priority": {
+                  "type": "long"
+                }, 
+                "severity": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    }, 
+                    "name": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
             }
           }
         }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -924,6 +924,13 @@
         }, 
         "log": {
           "properties": {
+            "facility": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
+            "facility_code": {
+              "type": "long"
+            }, 
             "level": {
               "ignore_above": 1024, 
               "type": "keyword"
@@ -937,6 +944,9 @@
               "ignore_above": 1024, 
               "index": false, 
               "type": "keyword"
+            }, 
+            "priority": {
+              "type": "long"
             }
           }
         }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -925,11 +925,15 @@
         "log": {
           "properties": {
             "facility": {
-              "ignore_above": 1024, 
-              "type": "keyword"
-            }, 
-            "facility_code": {
-              "type": "long"
+              "properties": {
+                "code": {
+                  "type": "long"
+                }, 
+                "name": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }
+              }
             }, 
             "level": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -923,6 +923,13 @@
       }, 
       "log": {
         "properties": {
+          "facility": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
+          "facility_code": {
+            "type": "long"
+          }, 
           "level": {
             "ignore_above": 1024, 
             "type": "keyword"
@@ -936,6 +943,9 @@
             "ignore_above": 1024, 
             "index": false, 
             "type": "keyword"
+          }, 
+          "priority": {
+            "type": "long"
           }
         }
       }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -957,17 +957,6 @@
       }, 
       "log": {
         "properties": {
-          "facility": {
-            "properties": {
-              "code": {
-                "type": "long"
-              }, 
-              "name": {
-                "ignore_above": 1024, 
-                "type": "keyword"
-              }
-            }
-          }, 
           "level": {
             "ignore_above": 1024, 
             "type": "keyword"
@@ -1001,11 +990,34 @@
             "index": false, 
             "type": "keyword"
           }, 
-          "priority": {
-            "type": "long"
-          }, 
-          "severity": {
-            "type": "long"
+          "syslog": {
+            "properties": {
+              "facility": {
+                "properties": {
+                  "code": {
+                    "type": "long"
+                  }, 
+                  "name": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }
+                }
+              }, 
+              "priority": {
+                "type": "long"
+              }, 
+              "severity": {
+                "properties": {
+                  "code": {
+                    "type": "long"
+                  }, 
+                  "name": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
           }
         }
       }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -950,6 +950,9 @@
           }, 
           "priority": {
             "type": "long"
+          }, 
+          "severity": {
+            "type": "long"
           }
         }
       }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -924,11 +924,15 @@
       "log": {
         "properties": {
           "facility": {
-            "ignore_above": 1024, 
-            "type": "keyword"
-          }, 
-          "facility_code": {
-            "type": "long"
+            "properties": {
+              "code": {
+                "type": "long"
+              }, 
+              "name": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }
+            }
           }, 
           "level": {
             "ignore_above": 1024, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -649,6 +649,9 @@
             },
             "priority": {
               "type": "long"
+            },
+            "severity": {
+              "type": "long"
             }
           }
         },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -622,6 +622,13 @@
         },
         "log": {
           "properties": {
+            "facility": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "facility_code": {
+              "type": "long"
+            },
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -635,6 +642,9 @@
               "ignore_above": 1024,
               "index": false,
               "type": "keyword"
+            },
+            "priority": {
+              "type": "long"
             }
           }
         },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -643,17 +643,6 @@
         },
         "log": {
           "properties": {
-            "facility": {
-              "properties": {
-                "code": {
-                  "type": "long"
-                },
-                "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            },
             "level": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -687,11 +676,35 @@
               "index": false,
               "type": "keyword"
             },
-            "priority": {
-              "type": "long"
-            },
-            "severity": {
-              "type": "long"
+            "syslog": {
+              "properties": {
+                "facility": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "priority": {
+                  "type": "long"
+                },
+                "severity": {
+                  "properties": {
+                    "code": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "object"
             }
           }
         },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -623,11 +623,15 @@
         "log": {
           "properties": {
             "facility": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "facility_code": {
-              "type": "long"
+              "properties": {
+                "code": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "level": {
               "ignore_above": 1024,

--- a/schema.json
+++ b/schema.json
@@ -883,7 +883,7 @@
         "type": "long"
       }, 
       "event.severity": {
-        "description": "Severity describes the severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.", 
+        "description": "The numeric severity of the event according to your event source.\nWhat the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -883,7 +883,7 @@
         "type": "long"
       }, 
       "event.severity": {
-        "description": "Severity describes the original severity of the event. What the different severity values mean can very different between use cases. It's up to the implementer to make sure severities are consistent across events.", 
+        "description": "Severity describes the original severity of the event. What the different severity values mean can very different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.\nThis field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 
@@ -1485,8 +1485,28 @@
   "log": {
     "description": "Fields which are specific to log events.\n", 
     "fields": {
+      "log.facility": {
+        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5324 or 3164.", 
+        "example": "local7", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.facility", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "log.facility_code": {
+        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5324 and 3164, this value should be an integer between 0 and 23.", 
+        "example": "23", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.facility_code", 
+        "required": false, 
+        "type": "long"
+      }, 
       "log.level": {
-        "description": "Original log level of the log event.\nSome examples are `warn`, `error`, `i`.", 
+        "description": "Original log level of the log event. Syslog's severity label should be stored here.\nSome examples are `warn`, `error`, `i`.", 
         "example": "err", 
         "footnote": "", 
         "group": 2, 
@@ -1514,6 +1534,16 @@
         "name": "log.original", 
         "required": false, 
         "type": "(not indexed)"
+      }, 
+      "log.priority": {
+        "description": "Syslog numeric priority of the event, if available.\nAccording to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly, this number should be between 0 and 191.", 
+        "example": "135", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.priority", 
+        "required": false, 
+        "type": "long"
       }
     }, 
     "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -883,7 +883,7 @@
         "type": "long"
       }, 
       "event.severity": {
-        "description": "Severity describes the original severity of the event. What the different severity values mean can very different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.\nThis field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.", 
+        "description": "Severity describes the original severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.\nThis field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1506,7 +1506,7 @@
         "type": "long"
       }, 
       "log.level": {
-        "description": "Original log level of the log event. Syslog's severity label should be stored here.\nSome examples are `warn`, `error`, `i`.", 
+        "description": "Original log level of the log event.\nSyslog's severity label should be stored here. Syslog's numeric severity is `event.severity` in ECS.\nSome examples are `warn`, `error`, `i`.", 
         "example": "err", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -923,7 +923,7 @@
         "type": "long"
       }, 
       "event.severity": {
-        "description": "The numeric severity of the event according to your event source.\nWhat the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.", 
+        "description": "The numeric severity of the event according to your event source.\nWhat the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 
@@ -1535,28 +1535,8 @@
   "log": {
     "description": "Fields which are specific to log events.\n", 
     "fields": {
-      "log.facility.code": {
-        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.", 
-        "example": "23", 
-        "footnote": "", 
-        "group": 2, 
-        "level": "extended", 
-        "name": "log.facility.code", 
-        "required": false, 
-        "type": "long"
-      }, 
-      "log.facility.name": {
-        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.", 
-        "example": "local7", 
-        "footnote": "", 
-        "group": 2, 
-        "level": "extended", 
-        "name": "log.facility.name", 
-        "required": false, 
-        "type": "keyword"
-      }, 
       "log.level": {
-        "description": "Original log level of the log event.\nSyslog's severity label should be stored here.\nSome examples are `warn`, `err`, `i`, `informational`.", 
+        "description": "Original log level of the log event.\nIf the source of the event provides a log level or textual severity, this is the one that goes in `log.level`. If your source doesn't specify one, you may put your event transport's severity here (e.g. Syslog severity).\nSome examples are `warn`, `err`, `i`, `informational`.", 
         "example": "error", 
         "footnote": "", 
         "group": 2, 
@@ -1615,25 +1595,65 @@
         "required": false, 
         "type": "(not indexed)"
       }, 
-      "log.priority": {
+      "log.syslog": {
+        "description": "The Syslog metadata of the event, if the event was transmitted via Syslog. Please see RFCs 5424 or 3164.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.syslog", 
+        "required": false, 
+        "type": "object"
+      }, 
+      "log.syslog.facility.code": {
+        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.", 
+        "example": "23", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.syslog.facility.code", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "log.syslog.facility.name": {
+        "description": "The Syslog text-based facility of the log event, if available.", 
+        "example": "local7", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.syslog.facility.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "log.syslog.priority": {
         "description": "Syslog numeric priority of the event, if available.\nAccording to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.", 
         "example": "135", 
         "footnote": "", 
         "group": 2, 
         "level": "extended", 
-        "name": "log.priority", 
+        "name": "log.syslog.priority", 
         "required": false, 
         "type": "long"
       }, 
-      "log.severity": {
-        "description": "The Syslog numeric severity of the log event, if available. See RFCs 5424 or 3164.\nIf the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), it should go to `event.severity`. If the event source does not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.", 
+      "log.syslog.severity.code": {
+        "description": "The Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.", 
         "example": "3", 
         "footnote": "", 
         "group": 2, 
         "level": "extended", 
-        "name": "log.severity", 
+        "name": "log.syslog.severity.code", 
         "required": false, 
         "type": "long"
+      }, 
+      "log.syslog.severity.name": {
+        "description": "The Syslog numeric severity of the log event, if available.\nIf the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.", 
+        "example": "Error", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.syslog.severity.name", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1486,7 +1486,7 @@
     "description": "Fields which are specific to log events.\n", 
     "fields": {
       "log.facility": {
-        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5324 or 3164.", 
+        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.", 
         "example": "local7", 
         "footnote": "", 
         "group": 2, 
@@ -1496,7 +1496,7 @@
         "type": "keyword"
       }, 
       "log.facility_code": {
-        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5324 and 3164, this value should be an integer between 0 and 23.", 
+        "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.", 
         "example": "23", 
         "footnote": "", 
         "group": 2, 
@@ -1536,7 +1536,7 @@
         "type": "(not indexed)"
       }, 
       "log.priority": {
-        "description": "Syslog numeric priority of the event, if available.\nAccording to RFCs 5324 and 3164, the priority is 8 * facility + severity. Accordingly, this number should be between 0 and 191.", 
+        "description": "Syslog numeric priority of the event, if available.\nAccording to RFCs 5424 and 3164, the priority is 8 * facility + severity. This number is therefore expected to contain a value between 0 and 191.", 
         "example": "135", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1485,25 +1485,25 @@
   "log": {
     "description": "Fields which are specific to log events.\n", 
     "fields": {
-      "log.facility": {
-        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.", 
-        "example": "local7", 
-        "footnote": "", 
-        "group": 2, 
-        "level": "extended", 
-        "name": "log.facility", 
-        "required": false, 
-        "type": "keyword"
-      }, 
-      "log.facility_code": {
+      "log.facility.code": {
         "description": "The Syslog numeric facility of the log event, if available.\nAccording to RFCs 5424 and 3164, this value should be an integer between 0 and 23.", 
         "example": "23", 
         "footnote": "", 
         "group": 2, 
         "level": "extended", 
-        "name": "log.facility_code", 
+        "name": "log.facility.code", 
         "required": false, 
         "type": "long"
+      }, 
+      "log.facility.name": {
+        "description": "The Syslog text-based facility of the log event, if available. See RFCs 5424 or 3164.", 
+        "example": "local7", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.facility.name", 
+        "required": false, 
+        "type": "keyword"
       }, 
       "log.level": {
         "description": "Original log level of the log event.\nSyslog's severity label should be stored here. Syslog's numeric severity is `event.severity` in ECS.\nSome examples are `warn`, `error`, `i`.", 

--- a/schema.json
+++ b/schema.json
@@ -883,7 +883,7 @@
         "type": "long"
       }, 
       "event.severity": {
-        "description": "Severity describes the original severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events.\nThis field corresponds to Syslog's severity. Note that the text-based severity for Syslog events is `log.level` in ECS.", 
+        "description": "Severity describes the severity of the event. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source.\nThe Syslog severity belongs in `log.severity`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may copy the `log.severity` to `event.severity`.", 
         "example": "7", 
         "footnote": "", 
         "group": 2, 
@@ -1506,8 +1506,8 @@
         "type": "keyword"
       }, 
       "log.level": {
-        "description": "Original log level of the log event.\nSyslog's severity label should be stored here. Syslog's numeric severity is `event.severity` in ECS.\nSome examples are `warn`, `error`, `i`.", 
-        "example": "err", 
+        "description": "Original log level of the log event.\nSyslog's severity label should be stored here.\nSome examples are `warn`, `err`, `i`, `informational`.", 
+        "example": "error", 
         "footnote": "", 
         "group": 2, 
         "level": "core", 
@@ -1542,6 +1542,16 @@
         "group": 2, 
         "level": "extended", 
         "name": "log.priority", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "log.severity": {
+        "description": "The Syslog numeric severity of the log event, if available. See RFCs 5424 or 3164.\nIf the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), it should go to `event.severity`. If the event source does not specify a distinct severity, you may instead copy the Syslog severity to `event.severity`.", 
+        "example": "3", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "log.severity", 
         "required": false, 
         "type": "long"
       }

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -156,10 +156,11 @@
         It's up to the implementer to make sure severities are consistent across
         events from the same source.
 
-        The Syslog severity belongs in `log.severity`. `event.severity` is meant
-        to represent the severity according to the event source (e.g. firewall,
-        IDS). If the event source does not publish its own severity, you may copy
-        the `log.severity` to `event.severity`.
+        The Syslog severity belongs in `log.syslog.severity.code`.
+        `event.severity` is meant to represent the severity according to
+        the event source (e.g. firewall, IDS).
+        If the event source does not publish its own severity,
+        you may optionally copy the `log.syslog.severity.code` to `event.severity`.
 
     - name: original
       level: core

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -150,7 +150,7 @@
       short: Original severity of the event.
       description: >
         Severity describes the original severity of the event. What the different
-        severity values mean can very different between sources and use cases.
+        severity values mean can be different between sources and use cases.
         It's up to the implementer to make sure severities are consistent across events.
 
         This field corresponds to Syslog's severity. Note that the text-based

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -147,14 +147,19 @@
       level: core
       format: string
       example: 7
-      short: Original severity of the event.
+      short: Numeric severity of the event.
       description: >
-        Severity describes the original severity of the event. What the different
-        severity values mean can be different between sources and use cases.
-        It's up to the implementer to make sure severities are consistent across events.
+        The numeric severity of the event according to your event source.
 
-        This field corresponds to Syslog's severity. Note that the text-based
-        severity for Syslog events is `log.level` in ECS.
+        What the different severity values mean can be different between sources
+        and use cases.
+        It's up to the implementer to make sure severities are consistent across
+        events from the same source.
+
+        The Syslog severity belongs in `log.severity`. `event.severity` is meant
+        to represent the severity according to the event source (e.g. firewall,
+        IDS). If the event source does not publish its own severity, you may copy
+        the `log.severity` to `event.severity`.
 
     - name: original
       level: core

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -143,15 +143,18 @@
       example: kernel
 
     - name: severity
-      format: string
-      level: core
       type: long
-      example: "7"
+      level: core
+      format: string
+      example: 7
       short: Original severity of the event.
       description: >
         Severity describes the original severity of the event. What the different
-        severity values mean can very different between use cases. It's up to
-        the implementer to make sure severities are consistent across events.
+        severity values mean can very different between sources and use cases.
+        It's up to the implementer to make sure severities are consistent across events.
+
+        This field corresponds to Syslog's severity. Note that the text-based
+        severity for Syslog events is `log.level` in ECS.
 
     - name: original
       level: core

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -27,7 +27,7 @@
       short: Syslog text-based facility of the event.
       description: >
         The Syslog text-based facility of the log event, if available. See RFCs
-        5324 or 3164.
+        5424 or 3164.
 
     - name: facility_code
       format: string
@@ -38,7 +38,7 @@
       description: >
         The Syslog numeric facility of the log event, if available.
 
-        According to RFCs 5324 and 3164, this value should be an integer between 0 and 23.
+        According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
 
     - name: priority
       format: string
@@ -49,8 +49,8 @@
       description: >
         Syslog numeric priority of the event, if available.
 
-        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
-        Accordingly, this number should be between 0 and 191.
+        According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
+        This number is therefore expected to contain a value between 0 and 191.
 
     - name: original
       level: core

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -12,10 +12,43 @@
       type: keyword
       short: Log level of the log event.
       description: >
-        Original log level of the log event.
+        Original log level of the log event. Syslog's severity label should be
+        stored here.
 
         Some examples are `warn`, `error`, `i`.
       example: err
+
+    - name: facility
+      level: extended
+      type: keyword
+      example: local7
+      short: Syslog text-based facility of the event.
+      description: >
+        The Syslog text-based facility of the log event, if available. See RFCs
+        5324 or 3164.
+
+    - name: facility_code
+      format: string
+      level: extended
+      type: long
+      example: 23
+      short: Syslog numeric facility of the event.
+      description: >
+        The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5324 and 3164, this value should be an integer between 0 and 23.
+
+    - name: priority
+      format: string
+      level: extended
+      type: long
+      example: 135
+      short: Syslog priority of the event.
+      description: >
+        Syslog numeric priority of the event, if available.
+
+        According to RFCs 5324 and 3164, the priority is 8 * facility + severity.
+        Accordingly, this number should be between 0 and 191.
 
     - name: original
       level: core
@@ -42,4 +75,4 @@
       example: org.elasticsearch.bootstrap.Bootstrap
       short: Name of the logger.
       description: >
-        The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. 
+        The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -14,11 +14,24 @@
       description: >
         Original log level of the log event.
 
-        Syslog's severity label should be stored here. Syslog's numeric severity
-        is `event.severity` in ECS.
+        Syslog's severity label should be stored here.
 
-        Some examples are `warn`, `error`, `i`.
-      example: err
+        Some examples are `warn`, `err`, `i`, `informational`.
+      example: error
+
+    - name: severity
+      level: extended
+      type: long
+      example: 3
+      short: Syslog numeric severity of the event.
+      description: >
+        The Syslog numeric severity of the log event, if available. See RFCs
+        5424 or 3164.
+
+        If the event source publishing via Syslog provides a different severity
+        value (e.g. firewall, IDS), it should go to `event.severity`. If the
+        event source does not specify a distinct severity, you may instead copy
+        the Syslog severity to `event.severity`.
 
     - name: facility.name
       level: extended

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -12,8 +12,10 @@
       type: keyword
       short: Log level of the log event.
       description: >
-        Original log level of the log event. Syslog's severity label should be
-        stored here.
+        Original log level of the log event.
+
+        Syslog's severity label should be stored here. Syslog's numeric severity
+        is `event.severity` in ECS.
 
         Some examples are `warn`, `error`, `i`.
       example: err

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -14,56 +14,12 @@
       description: >
         Original log level of the log event.
 
-        Syslog's severity label should be stored here.
+        If the source of the event provides a log level or textual severity,
+        this is the one that goes in `log.level`. If your source doesn't specify
+        one, you may put your event transport's severity here (e.g. Syslog severity).
 
         Some examples are `warn`, `err`, `i`, `informational`.
       example: error
-
-    - name: severity
-      level: extended
-      type: long
-      example: 3
-      short: Syslog numeric severity of the event.
-      description: >
-        The Syslog numeric severity of the log event, if available. See RFCs
-        5424 or 3164.
-
-        If the event source publishing via Syslog provides a different severity
-        value (e.g. firewall, IDS), it should go to `event.severity`. If the
-        event source does not specify a distinct severity, you may instead copy
-        the Syslog severity to `event.severity`.
-
-    - name: facility.name
-      level: extended
-      type: keyword
-      example: local7
-      short: Syslog text-based facility of the event.
-      description: >
-        The Syslog text-based facility of the log event, if available. See RFCs
-        5424 or 3164.
-
-    - name: facility.code
-      format: string
-      level: extended
-      type: long
-      example: 23
-      short: Syslog numeric facility of the event.
-      description: >
-        The Syslog numeric facility of the log event, if available.
-
-        According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
-
-    - name: priority
-      format: string
-      level: extended
-      type: long
-      example: 135
-      short: Syslog priority of the event.
-      description: >
-        Syslog numeric priority of the event, if available.
-
-        According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
-        This number is therefore expected to contain a value between 0 and 191.
 
     - name: original
       level: core
@@ -83,6 +39,7 @@
 
         This field is not indexed and doc_values are disabled so it can't be
         queried but the value can be retrieved from `_source`.
+
 
     - name: logger
       level: core
@@ -116,3 +73,69 @@
       short: The function which originated the log event.
       description: >
         The name of the function or method which originated the log event.
+
+
+    - name: syslog
+      level: extended
+      type: object
+      short: Syslog metadata
+      description: >
+        The Syslog metadata of the event, if the event was transmitted via Syslog.
+        Please see RFCs 5424 or 3164.
+
+    - name: syslog.severity.code
+      level: extended
+      type: long
+      example: 3
+      short: Syslog numeric severity of the event.
+      description: >
+        The Syslog numeric severity of the log event, if available.
+
+        If the event source publishing via Syslog provides a different numeric severity
+        value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`.
+        If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `event.severity`.
+
+    - name: syslog.severity.name
+      level: extended
+      type: keyword
+      example: Error
+      short: Syslog text-based severity of the event.
+      description: >
+        The Syslog numeric severity of the log event, if available.
+
+        If the event source publishing via Syslog provides a different severity
+        value (e.g. firewall, IDS), your source's text severity should go to `log.level`.
+        If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `log.level`.
+
+    - name: syslog.facility.code
+      format: string
+      level: extended
+      type: long
+      example: 23
+      short: Syslog numeric facility of the event.
+      description: >
+        The Syslog numeric facility of the log event, if available.
+
+        According to RFCs 5424 and 3164, this value should be an integer between 0 and 23.
+
+    - name: syslog.facility.name
+      level: extended
+      type: keyword
+      example: local7
+      short: Syslog text-based facility of the event.
+      description: >
+        The Syslog text-based facility of the log event, if available.
+
+    - name: syslog.priority
+      format: string
+      level: extended
+      type: long
+      example: 135
+      short: Syslog priority of the event.
+      description: >
+        Syslog numeric priority of the event, if available.
+
+        According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
+        This number is therefore expected to contain a value between 0 and 191.

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -20,7 +20,7 @@
         Some examples are `warn`, `error`, `i`.
       example: err
 
-    - name: facility
+    - name: facility.name
       level: extended
       type: keyword
       example: local7
@@ -29,7 +29,7 @@
         The Syslog text-based facility of the log event, if available. See RFCs
         5424 or 3164.
 
-    - name: facility_code
+    - name: facility.code
       format: string
       level: extended
       type: long


### PR DESCRIPTION
This PR is meant to replace and close #301.

Unfortunately #301 is too old to be brought up to date with the current state
of the ECS repo.

While bringing the discussion we had in the original PR to present day ECS,
I'm proposing a few changes to what we had there. Comments welcome, if you
agree/disagree.

In this PR:

- Modify description of `log.level` and associate it with Syslog's severity label.
- Modify description of `event.severity` and associate it with Syslog's severity numeric code.
- Add field `log.facility` as the text-based representation.
- Add field `log.facility_code` as the numeric representation.
- Add field `log.priority` (numeric only: 8 * facility + severity)

Differences with #301:

- I'm nesting under `log.*` instead of `event.*`, because I feel like these very
  Syslog-specific fields work better there than in the already crowded `event.*`.
- I'm not adding a text field for the priority label. There's no such thing as a priority label in Syslog.
- I'm specifically calling out the Syslog mapping in the existing field `log.level` and `event.severity`.