### PR TITLE
Added parent domain field to source, destination and url.

### DIFF
--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -42,6 +42,14 @@ type Destination struct {
 	// Destination domain.
 	Domain string `ecs:"domain"`
 
+	// Destination parent domain domain stripped of any subdomain.
+	// For example, the registered domain for "foo.google.com" is "google.com".
+	// This value can be determined precisely with a list like the public
+	// suffix list (http://publicsuffix.org). Trying to approximate this by
+	// simply taking the last two labels will not work well for TLDs such as
+	// "co.uk".
+	DomainParent string `ecs:"domain.parent"`
+
 	// Bytes sent from the destination to the source.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -42,6 +42,14 @@ type Source struct {
 	// Source domain.
 	Domain string `ecs:"domain"`
 
+	// Source parent domain domain stripped of any subdomain.
+	// For example, the registered domain for "foo.google.com" is "google.com".
+	// This value can be determined precisely with a list like the public
+	// suffix list (http://publicsuffix.org). Trying to approximate this by
+	// simply taking the last two labels will not work well for TLDs such as
+	// "co.uk".
+	DomainParent string `ecs:"domain.parent"`
+
 	// Bytes sent from the source to the destination.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -44,6 +44,14 @@ type Url struct {
 	// field.
 	Domain string `ecs:"domain"`
 
+	// Parent domain of a url stripped of any subdomain.
+	// For example, the registered domain for "foo.google.com" is "google.com".
+	// This value can be determined precisely with a list like the public
+	// suffix list (http://publicsuffix.org). Trying to approximate this by
+	// simply taking the last two labels will not work well for TLDs such as
+	// "co.uk".
+	DomainParent string `ecs:"domain.parent"`
+
 	// Port of the request, such as 443.
 	Port int64 `ecs:"port"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -588,6 +588,21 @@ type: keyword
 
 // ===============================================================
 
+| destination.domain.parent
+| Destination parent domain domain stripped of any subdomain.
+
+For example, the registered domain for "foo.google.com" is "google.com".
+
+This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | destination.ip
 | IP address of the destination.
 
@@ -3029,6 +3044,21 @@ type: keyword
 
 // ===============================================================
 
+| source.domain.parent
+| Source parent domain domain stripped of any subdomain.
+
+For example, the registered domain for "foo.google.com" is "google.com".
+
+This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | source.ip
 | IP address of the source.
 
@@ -3200,6 +3230,21 @@ In some cases a URL may refer to an IP and/or port directly, without a domain na
 type: keyword
 
 example: `www.elastic.co`
+
+| extended
+
+// ===============================================================
+
+| url.domain.parent
+| Parent domain of a url stripped of any subdomain.
+
+For example, the registered domain for "foo.google.com" is "google.com".
+
+This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
+
+type: keyword
+
+
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -459,6 +459,17 @@
       type: keyword
       ignore_above: 1024
       description: Destination domain.
+    - name: domain.parent
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Destination parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
     - name: geo.city_name
       level: core
       type: keyword
@@ -2301,6 +2312,17 @@
       type: keyword
       ignore_above: 1024
       description: Source domain.
+    - name: domain.parent
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
     - name: geo.city_name
       level: core
       type: keyword
@@ -2481,6 +2503,17 @@
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.'
       example: www.elastic.co
+    - name: domain.parent
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Parent domain of a url stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
     - name: fragment
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -55,6 +55,7 @@ destination.as.number,long,extended,15169,1.2.0-dev
 destination.as.organization.name,keyword,extended,Google LLC,1.2.0-dev
 destination.bytes,long,core,184,1.2.0-dev
 destination.domain,keyword,core,,1.2.0-dev
+destination.domain.parent,keyword,extended,,1.2.0-dev
 destination.geo.city_name,keyword,core,Montreal,1.2.0-dev
 destination.geo.continent_name,keyword,core,North America,1.2.0-dev
 destination.geo.country_iso_code,keyword,core,CA,1.2.0-dev
@@ -292,6 +293,7 @@ source.as.number,long,extended,15169,1.2.0-dev
 source.as.organization.name,keyword,extended,Google LLC,1.2.0-dev
 source.bytes,long,core,184,1.2.0-dev
 source.domain,keyword,core,,1.2.0-dev
+source.domain.parent,keyword,extended,,1.2.0-dev
 source.geo.city_name,keyword,core,Montreal,1.2.0-dev
 source.geo.continent_name,keyword,core,North America,1.2.0-dev
 source.geo.country_iso_code,keyword,core,CA,1.2.0-dev
@@ -317,6 +319,7 @@ source.user.name,keyword,core,albert,1.2.0-dev
 trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,1.2.0-dev
 transaction.id,keyword,extended,00f067aa0ba902b7,1.2.0-dev
 url.domain,keyword,extended,www.elastic.co,1.2.0-dev
+url.domain.parent,keyword,extended,,1.2.0-dev
 url.fragment,keyword,extended,,1.2.0-dev
 url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,1.2.0-dev
 url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -570,7 +570,7 @@ destination.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the destination to the source.
   type: long
 destination.domain:
@@ -581,6 +581,21 @@ destination.domain:
   name: domain
   order: 4
   short: Destination domain.
+  type: keyword
+destination.domain.parent:
+  description: 'Destination parent domain domain stripped of any subdomain.
+
+    For example, the registered domain for "foo.google.com" is "google.com".
+
+    This value can be determined precisely with a list like the public suffix list
+    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    two labels will not work well for TLDs such as "co.uk".'
+  flat_name: destination.domain.parent
+  ignore_above: 1024
+  level: extended
+  name: domain.parent
+  order: 5
+  short: Destination parent domain stripped of any subdomain.
   type: keyword
 destination.geo.city_name:
   description: City name.
@@ -702,7 +717,7 @@ destination.nat.ip:
   flat_name: destination.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Destination NAT ip
   type: ip
 destination.nat.port:
@@ -713,7 +728,7 @@ destination.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Destination NAT Port
   type: long
 destination.packets:
@@ -722,7 +737,7 @@ destination.packets:
   flat_name: destination.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the destination to the source.
   type: long
 destination.port:
@@ -3269,7 +3284,7 @@ source.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the source to the destination.
   type: long
 source.domain:
@@ -3280,6 +3295,21 @@ source.domain:
   name: domain
   order: 4
   short: Source domain.
+  type: keyword
+source.domain.parent:
+  description: 'Source parent domain domain stripped of any subdomain.
+
+    For example, the registered domain for "foo.google.com" is "google.com".
+
+    This value can be determined precisely with a list like the public suffix list
+    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    two labels will not work well for TLDs such as "co.uk".'
+  flat_name: source.domain.parent
+  ignore_above: 1024
+  level: extended
+  name: domain.parent
+  order: 5
+  short: Source parent domain stripped of any subdomain.
   type: keyword
 source.geo.city_name:
   description: City name.
@@ -3401,7 +3431,7 @@ source.nat.ip:
   flat_name: source.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Source NAT ip
   type: ip
 source.nat.port:
@@ -3413,7 +3443,7 @@ source.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Source NAT port
   type: long
 source.packets:
@@ -3422,7 +3452,7 @@ source.packets:
   flat_name: source.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the source to the destination.
   type: long
 source.port:
@@ -3571,6 +3601,21 @@ url.domain:
   order: 3
   short: Domain of the url.
   type: keyword
+url.domain.parent:
+  description: 'Parent domain of a url stripped of any subdomain.
+
+    For example, the registered domain for "foo.google.com" is "google.com".
+
+    This value can be determined precisely with a list like the public suffix list
+    (http://publicsuffix.org). Trying to approximate this by simply taking the last
+    two labels will not work well for TLDs such as "co.uk".'
+  flat_name: url.domain.parent
+  ignore_above: 1024
+  level: extended
+  name: domain.parent
+  order: 4
+  short: Parent domain of a url stripped of any subdomain.
+  type: keyword
 url.fragment:
   description: 'Portion of the url after the `#`, such as "top".
 
@@ -3579,7 +3624,7 @@ url.fragment:
   ignore_above: 1024
   level: extended
   name: fragment
-  order: 7
+  order: 8
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
@@ -3614,7 +3659,7 @@ url.password:
   ignore_above: 1024
   level: extended
   name: password
-  order: 9
+  order: 10
   short: Password of the request.
   type: keyword
 url.path:
@@ -3623,7 +3668,7 @@ url.path:
   ignore_above: 1024
   level: extended
   name: path
-  order: 5
+  order: 6
   short: Path of the request, such as "/search".
   type: keyword
 url.port:
@@ -3633,7 +3678,7 @@ url.port:
   format: string
   level: extended
   name: port
-  order: 4
+  order: 5
   short: Port of the request, such as 443.
   type: long
 url.query:
@@ -3648,7 +3693,7 @@ url.query:
   ignore_above: 1024
   level: extended
   name: query
-  order: 6
+  order: 7
   short: Query string of the request.
   type: keyword
 url.scheme:
@@ -3669,7 +3714,7 @@ url.username:
   ignore_above: 1024
   level: extended
   name: username
-  order: 8
+  order: 9
   short: Username of the request.
   type: keyword
 user.domain:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -721,7 +721,7 @@ destination:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the destination to the source.
       type: long
     domain:
@@ -732,6 +732,21 @@ destination:
       name: domain
       order: 4
       short: Destination domain.
+      type: keyword
+    domain.parent:
+      description: 'Destination parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
+      flat_name: destination.domain.parent
+      ignore_above: 1024
+      level: extended
+      name: domain.parent
+      order: 5
+      short: Destination parent domain stripped of any subdomain.
       type: keyword
     geo.city_name:
       description: City name.
@@ -853,7 +868,7 @@ destination:
       flat_name: destination.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Destination NAT ip
       type: ip
     nat.port:
@@ -864,7 +879,7 @@ destination:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Destination NAT Port
       type: long
     packets:
@@ -873,7 +888,7 @@ destination:
       flat_name: destination.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the destination to the source.
       type: long
     port:
@@ -3708,7 +3723,7 @@ source:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the source to the destination.
       type: long
     domain:
@@ -3719,6 +3734,21 @@ source:
       name: domain
       order: 4
       short: Source domain.
+      type: keyword
+    domain.parent:
+      description: 'Source parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
+      flat_name: source.domain.parent
+      ignore_above: 1024
+      level: extended
+      name: domain.parent
+      order: 5
+      short: Source parent domain stripped of any subdomain.
       type: keyword
     geo.city_name:
       description: City name.
@@ -3840,7 +3870,7 @@ source:
       flat_name: source.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Source NAT ip
       type: ip
     nat.port:
@@ -3852,7 +3882,7 @@ source:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Source NAT port
       type: long
     packets:
@@ -3861,7 +3891,7 @@ source:
       flat_name: source.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the source to the destination.
       type: long
     port:
@@ -4027,6 +4057,21 @@ url:
       order: 3
       short: Domain of the url.
       type: keyword
+    domain.parent:
+      description: 'Parent domain of a url stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public suffix
+        list (http://publicsuffix.org). Trying to approximate this by simply taking
+        the last two labels will not work well for TLDs such as "co.uk".'
+      flat_name: url.domain.parent
+      ignore_above: 1024
+      level: extended
+      name: domain.parent
+      order: 4
+      short: Parent domain of a url stripped of any subdomain.
+      type: keyword
     fragment:
       description: 'Portion of the url after the `#`, such as "top".
 
@@ -4035,7 +4080,7 @@ url:
       ignore_above: 1024
       level: extended
       name: fragment
-      order: 7
+      order: 8
       short: Portion of the url after the `#`.
       type: keyword
     full:
@@ -4071,7 +4116,7 @@ url:
       ignore_above: 1024
       level: extended
       name: password
-      order: 9
+      order: 10
       short: Password of the request.
       type: keyword
     path:
@@ -4080,7 +4125,7 @@ url:
       ignore_above: 1024
       level: extended
       name: path
-      order: 5
+      order: 6
       short: Path of the request, such as "/search".
       type: keyword
     port:
@@ -4090,7 +4135,7 @@ url:
       format: string
       level: extended
       name: port
-      order: 4
+      order: 5
       short: Port of the request, such as 443.
       type: long
     query:
@@ -4105,7 +4150,7 @@ url:
       ignore_above: 1024
       level: extended
       name: query
-      order: 6
+      order: 7
       short: Query string of the request.
       type: keyword
     scheme:
@@ -4126,7 +4171,7 @@ url:
       ignore_above: 1024
       level: extended
       name: username
-      order: 8
+      order: 9
       short: Username of the request.
       type: keyword
   group: 2

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -186,6 +186,12 @@
             },
             "domain": {
               "ignore_above": 1024,
+              "properties": {
+                "parent": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "type": "keyword"
             },
             "ip": {
@@ -892,6 +898,12 @@
             },
             "domain": {
               "ignore_above": 1024,
+              "properties": {
+                "parent": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "type": "keyword"
             },
             "ip": {
@@ -947,6 +959,12 @@
           "properties": {
             "domain": {
               "ignore_above": 1024,
+              "properties": {
+                "parent": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
               "type": "keyword"
             },
             "fragment": {

--- a/schema.json
+++ b/schema.json
@@ -416,6 +416,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "destination.domain.parent": {
+        "description": "Destination parent domain domain stripped of any subdomain.\nFor example, the registered domain for \"foo.google.com\" is \"google.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "destination.domain.parent", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "destination.ip": {
         "description": "IP address of the destination.\nCan be one or multiple IPv4 or IPv6 addresses.", 
         "example": "", 
@@ -2166,6 +2176,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "source.domain.parent": {
+        "description": "Source parent domain domain stripped of any subdomain.\nFor example, the registered domain for \"foo.google.com\" is \"google.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "source.domain.parent", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "source.ip": {
         "description": "IP address of the source.\nCan be one or multiple IPv4 or IPv6 addresses.", 
         "example": "", 
@@ -2271,6 +2291,16 @@
         "group": 2, 
         "level": "extended", 
         "name": "url.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.domain.parent": {
+        "description": "Parent domain of a url stripped of any subdomain.\nFor example, the registered domain for \"foo.google.com\" is \"google.com\".\nThis value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as \"co.uk\".", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.domain.parent", 
         "required": false, 
         "type": "keyword"
       }, 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -50,6 +50,19 @@
       description: >
         Destination domain.
 
+    - name: domain.parent
+      level: extended
+      type: keyword
+      short: Destination parent domain stripped of any subdomain.
+      description: >
+        Destination parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public
+        suffix list (http://publicsuffix.org). Trying to approximate this by
+        simply taking the last two labels will not work well for TLDs such as "co.uk".
+
     # Metrics
     - name: bytes
       format: bytes

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -50,6 +50,19 @@
       description: >
         Source domain.
 
+    - name: domain.parent
+      level: extended
+      type: keyword
+      short: Source parent domain stripped of any subdomain.
+      description: >
+        Source parent domain domain stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public
+        suffix list (http://publicsuffix.org). Trying to approximate this by
+        simply taking the last two labels will not work well for TLDs such as "co.uk".
+
     # Metrics
     - name: bytes
       format: bytes

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -54,6 +54,19 @@
         domain name. In this case, the IP address would go to the `domain` field.
       example: www.elastic.co
 
+    - name: domain.parent
+      level: extended
+      type: keyword
+      short: Parent domain of a url stripped of any subdomain.
+      description: >
+        Parent domain of a url stripped of any subdomain.
+
+        For example, the registered domain for "foo.google.com" is "google.com".
+
+        This value can be determined precisely with a list like the public
+        suffix list (http://publicsuffix.org). Trying to approximate this by
+        simply taking the last two labels will not work well for TLDs such as "co.uk".
+
     - name: port
       format: string
       level: extended


### PR DESCRIPTION
The parent domain field is the domain without any sub-domain. The domain field is a exact-match keyword field, which means it is not possible to search for all connections to a domain when a sub-domain is involved. The parent domain field will allow users to store normalized domains using the public suffix list.

For example, the registered domain for "foo.malware.com" is "malware.com".

This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". If the parent domain normalization process fails, users should store with original domain with the sub-domain in the parent-domain field. Punny-code domains are more likely to fail when using common TLD extract libraries which using the public suffix list to get the parent domain, hence using a best-effort approach means users can still search one field to more accurately find network connections. 

This is important in SIEM and log management functions, as users need to be able to find all logs when they are searching for a known bad IOC domain. Users could index domains into an extra text field in their schema, but this is slow and expensive when searching many TB's of data in Elasticsearch.