### PR TITLE
Remove the 'docs' task from TravisCI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,3 @@ jobs:
     - stage: check
       script:
       - make check
-    - stage: docs
-      script:
-      - OPEN_DOCS="" make docs


### PR DESCRIPTION
With the recent addition of the more authoritative 'elasticsearch-ci/docs' CI job, the TravisCI job for docs is redundant.