### PR TITLE
Beef up the description of the `log` field set.

### DIFF
--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -20,10 +20,11 @@
 package ecs
 
 // Low level details specific to log events.
-// `log.*` typically contains lower level details about the logging mechanism
-// than `event.*`. For example, The Syslog transport details belongs under
-// `log.*`, whereas the message payloads transmitted via Syslog will likely be
-// parsed out into `event.*` or elsewhere in ECS.
+// The log.* fields are typically populated with details about the logging
+// mechanism used to create and/or transport the event. For example, syslog
+// details belong under `log.syslog.*`.
+// The details specific to your event source are typically not logged under
+// `log.*`, but rather in `event.*` or in other ECS fields.
 type Log struct {
 	// Original log level of the log event.
 	// Some examples are `warn`, `error`, `i`.

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -19,7 +19,11 @@
 
 package ecs
 
-// Fields which are specific to log events.
+// Low level details specific to log events.
+// `log.*` typically contains lower level details about the logging mechanism
+// than `event.*`. For example, The Syslog transport details belongs under
+// `log.*`, whereas the message payloads transmitted via Syslog will likely be
+// parsed out into `event.*` or elsewhere in ECS.
 type Log struct {
 	// Original log level of the log event.
 	// Some examples are `warn`, `error`, `i`.

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -19,7 +19,7 @@
 
 package ecs
 
-// Low level details specific to log events.
+// Details about the event's logging mechanism or logging transport.
 // The log.* fields are typically populated with details about the logging
 // mechanism used to create and/or transport the event. For example, syslog
 // details belong under `log.syslog.*`.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2099,7 +2099,7 @@ example: `1.1`
 [[ecs-log]]
 === Log Fields
 
-Low level details specific to log events.
+Details about the event's logging mechanism or logging transport.
 
 The log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2101,7 +2101,9 @@ example: `1.1`
 
 Low level details specific to log events.
 
-`log.*` typically contains lower level details about the logging mechanism than `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas the message payloads transmitted via Syslog will likely be parsed out into `event.*` or elsewhere in ECS.
+The log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.
+
+The details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields.
 
 ==== Log Field Details
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2099,7 +2099,9 @@ example: `1.1`
 [[ecs-log]]
 === Log Fields
 
-Fields which are specific to log events.
+Low level details specific to log events.
+
+`log.*` typically contains lower level details about the logging mechanism than `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas the message payloads transmitted via Syslog will likely be parsed out into `event.*` or elsewhere in ECS.
 
 ==== Log Field Details
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -52,7 +52,7 @@ all fields are defined.
 
 | <<ecs-http,HTTP>> | Fields describing an HTTP request.
 
-| <<ecs-log,Log>> | Low level details specific to log events.
+| <<ecs-log,Log>> | Details about the event's logging mechanism.
 
 | <<ecs-network,Network>> | Fields describing the communication path over which the event happened.
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -52,7 +52,7 @@ all fields are defined.
 
 | <<ecs-http,HTTP>> | Fields describing an HTTP request.
 
-| <<ecs-log,Log>> | Fields which are specific to log events.
+| <<ecs-log,Log>> | Low level details specific to log events.
 
 | <<ecs-network,Network>> | Fields describing the communication path over which the event happened.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1585,10 +1585,12 @@
     group: 2
     description: 'Low level details specific to log events.
 
-      `log.*` typically contains lower level details about the logging mechanism than
-      `event.*`. For example, The Syslog transport details belongs under `log.*`,
-      whereas the message payloads transmitted via Syslog will likely be parsed out
-      into `event.*` or elsewhere in ECS.'
+      The log.* fields are typically populated with details about the logging mechanism
+      used to create and/or transport the event. For example, syslog details belong
+      under `log.syslog.*`.
+
+      The details specific to your event source are typically not logged under `log.*`,
+      but rather in `event.*` or in other ECS fields.'
     type: group
     fields:
     - name: level

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1583,7 +1583,12 @@
   - name: log
     title: Log
     group: 2
-    description: Fields which are specific to log events.
+    description: 'Low level details specific to log events.
+
+      `log.*` typically contains lower level details about the logging mechanism than
+      `event.*`. For example, The Syslog transport details belongs under `log.*`,
+      whereas the message payloads transmitted via Syslog will likely be parsed out
+      into `event.*` or elsewhere in ECS.'
     type: group
     fields:
     - name: level

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1583,7 +1583,7 @@
   - name: log
     title: Log
     group: 2
-    description: 'Low level details specific to log events.
+    description: 'Details about the event''s logging mechanism or logging transport.
 
       The log.* fields are typically populated with details about the logging mechanism
       used to create and/or transport the event. For example, syslog details belong

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2564,7 +2564,7 @@ http:
   title: HTTP
   type: group
 log:
-  description: 'Low level details specific to log events.
+  description: 'Details about the event''s logging mechanism or logging transport.
 
     The log.* fields are typically populated with details about the logging mechanism
     used to create and/or transport the event. For example, syslog details belong

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2566,10 +2566,12 @@ http:
 log:
   description: 'Low level details specific to log events.
 
-    `log.*` typically contains lower level details about the logging mechanism than
-    `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas
-    the message payloads transmitted via Syslog will likely be parsed out into `event.*`
-    or elsewhere in ECS.'
+    The log.* fields are typically populated with details about the logging mechanism
+    used to create and/or transport the event. For example, syslog details belong
+    under `log.syslog.*`.
+
+    The details specific to your event source are typically not logged under `log.*`,
+    but rather in `event.*` or in other ECS fields.'
   fields:
     level:
       description: 'Original log level of the log event.
@@ -2649,7 +2651,7 @@ log:
   group: 2
   name: log
   prefix: log.
-  short: Low level details specific to log events.
+  short: Details about the event's logging mechanism.
   title: Log
   type: group
 network:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2564,7 +2564,12 @@ http:
   title: HTTP
   type: group
 log:
-  description: Fields which are specific to log events.
+  description: 'Low level details specific to log events.
+
+    `log.*` typically contains lower level details about the logging mechanism than
+    `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas
+    the message payloads transmitted via Syslog will likely be parsed out into `event.*`
+    or elsewhere in ECS.'
   fields:
     level:
       description: 'Original log level of the log event.
@@ -2644,7 +2649,7 @@ log:
   group: 2
   name: log
   prefix: log.
-  short: Fields which are specific to log events.
+  short: Low level details specific to log events.
   title: Log
   type: group
 network:

--- a/schema.json
+++ b/schema.json
@@ -1533,7 +1533,7 @@
     "type": "group"
   }, 
   "log": {
-    "description": "Low level details specific to log events.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields.\n", 
+    "description": "Details about the event's logging mechanism or logging transport.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields.\n", 
     "fields": {
       "log.level": {
         "description": "Original log level of the log event.\nSome examples are `warn`, `error`, `i`.", 

--- a/schema.json
+++ b/schema.json
@@ -1533,7 +1533,7 @@
     "type": "group"
   }, 
   "log": {
-    "description": "Fields which are specific to log events.\n", 
+    "description": "Low level details specific to log events.\n`log.*` typically contains lower level details about the logging mechanism than `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas the message payloads transmitted via Syslog will likely be parsed out into `event.*` or elsewhere in ECS.\n", 
     "fields": {
       "log.level": {
         "description": "Original log level of the log event.\nSome examples are `warn`, `error`, `i`.", 

--- a/schema.json
+++ b/schema.json
@@ -1533,7 +1533,7 @@
     "type": "group"
   }, 
   "log": {
-    "description": "Low level details specific to log events.\n`log.*` typically contains lower level details about the logging mechanism than `event.*`. For example, The Syslog transport details belongs under `log.*`, whereas the message payloads transmitted via Syslog will likely be parsed out into `event.*` or elsewhere in ECS.\n", 
+    "description": "Low level details specific to log events.\nThe log.* fields are typically populated with details about the logging mechanism used to create and/or transport the event. For example, syslog details belong under `log.syslog.*`.\nThe details specific to your event source are typically not logged under `log.*`, but rather in `event.*` or in other ECS fields.\n", 
     "fields": {
       "log.level": {
         "description": "Original log level of the log event.\nSome examples are `warn`, `error`, `i`.", 

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -2,14 +2,16 @@
 - name: log
   title: Log
   group: 2
-  short: Low level details specific to log events.
+  short: Details about the event's logging mechanism.
   description: >
     Low level details specific to log events.
 
-    `log.*` typically contains lower level details about the logging mechanism
-    than `event.*`. For example, The Syslog transport details belongs under `log.*`,
-    whereas the message payloads transmitted via Syslog will likely be parsed out
-    into `event.*` or elsewhere in ECS.
+    The log.* fields are typically populated with details about the logging
+    mechanism used to create and/or transport the event.
+    For example, syslog details belong under `log.syslog.*`.
+
+    The details specific to your event source are typically not logged under `log.*`,
+    but rather in `event.*` or in other ECS fields.
   type: group
   fields:
 

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -2,8 +2,14 @@
 - name: log
   title: Log
   group: 2
+  short: Low level details specific to log events.
   description: >
-    Fields which are specific to log events.
+    Low level details specific to log events.
+
+    `log.*` typically contains lower level details about the logging mechanism
+    than `event.*`. For example, The Syslog transport details belongs under `log.*`,
+    whereas the message payloads transmitted via Syslog will likely be parsed out
+    into `event.*` or elsewhere in ECS.
   type: group
   fields:
 
@@ -42,7 +48,7 @@
       example: org.elasticsearch.bootstrap.Bootstrap
       short: Name of the logger.
       description: >
-        The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name. 
+        The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.
 
     - name: origin.file.name
       level: extended
@@ -60,7 +66,7 @@
       short: The line number of the file which originated the log event.
       description: >
         The line number of the file containing the source code which originated the log event.
- 
+
     - name: origin.function
       level: extended
       type: keyword
@@ -68,4 +74,3 @@
       short: The function which originated the log event.
       description: >
         The name of the function or method which originated the log event.
-

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -4,7 +4,7 @@
   group: 2
   short: Details about the event's logging mechanism.
   description: >
-    Low level details specific to log events.
+    Details about the event's logging mechanism or logging transport.
 
     The log.* fields are typically populated with details about the logging
     mechanism used to create and/or transport the event.


### PR DESCRIPTION
This is meant to help clarify the difference between `log` and `event`.

Relates to #525 and address some concerns voiced in #516.