### PR TITLE
Added top_level_domain field

### DIFF
--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -53,6 +53,17 @@ type Client struct {
 	// Client domain.
 	Domain string `ecs:"domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	TopLevelDomain string `ecs:"top_level_domain"`
+
 	// Bytes sent from the client to the server.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -42,6 +42,17 @@ type Destination struct {
 	// Destination domain.
 	Domain string `ecs:"domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	TopLevelDomain string `ecs:"top_level_domain"`
+
 	// Bytes sent from the destination to the source.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -72,6 +72,17 @@ type Dns struct {
 	// "co.uk".
 	QuestionRegisteredDomain string `ecs:"question.registered_domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	QuestionTopLevelDomain string `ecs:"question.top_level_domain"`
+
 	// An array containing an object for each answer section returned by the
 	// server.
 	// The main keys that should be present in these objects are defined by

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -53,6 +53,17 @@ type Server struct {
 	// Server domain.
 	Domain string `ecs:"domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	TopLevelDomain string `ecs:"top_level_domain"`
+
 	// Bytes sent from the server to the client.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -42,6 +42,17 @@ type Source struct {
 	// Source domain.
 	Domain string `ecs:"domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	TopLevelDomain string `ecs:"top_level_domain"`
+
 	// Bytes sent from the source to the destination.
 	Bytes int64 `ecs:"bytes"`
 

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -44,6 +44,17 @@ type Url struct {
 	// field.
 	Domain string `ecs:"domain"`
 
+	// The top level domain (TLD) also known as the domain suffix is the last
+	// part of the domain name. For example, the top level domain for
+	// google.com is "com".
+	// The following groups of top level domain are maintained by the Internet
+	// Assigned Numbers Authority (IANA).
+	// Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD)
+	// Restricted generic top-level domains (grTLD) Sponsored top-level domains
+	// (sTLD) Country code top-level domains (ccTLD) Internationalized country
+	// code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+	TopLevelDomain string `ecs:"top_level_domain"`
+
 	// Port of the request, such as 443.
 	Port int64 `ecs:"port"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -324,6 +324,21 @@ type: long
 
 // ===============================================================
 
+| client.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -660,6 +675,21 @@ type: long
 
 // ===============================================================
 
+| destination.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -855,6 +885,21 @@ This value can be determined precisely with a list like the public suffix list (
 type: keyword
 
 example: `google.com`
+
+| extended
+
+// ===============================================================
+
+| dns.question.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
 
 | extended
 
@@ -2841,6 +2886,21 @@ type: long
 
 // ===============================================================
 
+| server.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -3101,6 +3161,21 @@ type: long
 
 // ===============================================================
 
+| source.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -3298,6 +3373,21 @@ Note: The `:` is not part of the scheme.
 type: keyword
 
 example: `https`
+
+| extended
+
+// ===============================================================
+
+| url.top_level_domain
+| The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is "com".
+
+The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)
+
+type: keyword
+
+
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -273,6 +273,21 @@
       type: long
       format: string
       description: Port of the client.
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: user.domain
       level: extended
       type: keyword
@@ -547,6 +562,21 @@
       type: long
       format: string
       description: Port of the destination.
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: user.domain
       level: extended
       type: keyword
@@ -711,6 +741,21 @@
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: google.com
+    - name: question.top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: question.type
       level: extended
       type: keyword
@@ -2139,6 +2184,21 @@
       type: long
       format: string
       description: Port of the server.
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: user.domain
       level: extended
       type: keyword
@@ -2390,6 +2450,21 @@
       type: long
       format: string
       description: Port of the source.
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: user.domain
       level: extended
       type: keyword
@@ -2542,6 +2617,21 @@
 
         Note: The `:` is not part of the scheme.'
       example: https
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
     - name: username
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -29,6 +29,7 @@ client.nat.ip,ip,extended,,1.2.0-dev
 client.nat.port,long,extended,,1.2.0-dev
 client.packets,long,core,12,1.2.0-dev
 client.port,long,core,,1.2.0-dev
+client.top_level_domain,keyword,extended,,1.2.0-dev
 client.user.domain,keyword,extended,,1.2.0-dev
 client.user.email,keyword,extended,,1.2.0-dev
 client.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
@@ -69,6 +70,7 @@ destination.nat.ip,ip,extended,,1.2.0-dev
 destination.nat.port,long,extended,,1.2.0-dev
 destination.packets,long,core,12,1.2.0-dev
 destination.port,long,core,,1.2.0-dev
+destination.top_level_domain,keyword,extended,,1.2.0-dev
 destination.user.domain,keyword,extended,,1.2.0-dev
 destination.user.email,keyword,extended,,1.2.0-dev
 destination.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
@@ -89,6 +91,7 @@ dns.op_code,keyword,extended,QUERY,1.2.0-dev
 dns.question.class,keyword,extended,IN,1.2.0-dev
 dns.question.name,keyword,extended,www.google.com,1.2.0-dev
 dns.question.registered_domain,keyword,extended,google.com,1.2.0-dev
+dns.question.top_level_domain,keyword,extended,,1.2.0-dev
 dns.question.type,keyword,extended,AAAA,1.2.0-dev
 dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",1.2.0-dev
 dns.response_code,keyword,extended,NOERROR,1.2.0-dev
@@ -273,6 +276,7 @@ server.nat.ip,ip,extended,,1.2.0-dev
 server.nat.port,long,extended,,1.2.0-dev
 server.packets,long,core,12,1.2.0-dev
 server.port,long,core,,1.2.0-dev
+server.top_level_domain,keyword,extended,,1.2.0-dev
 server.user.domain,keyword,extended,,1.2.0-dev
 server.user.email,keyword,extended,,1.2.0-dev
 server.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
@@ -306,6 +310,7 @@ source.nat.ip,ip,extended,,1.2.0-dev
 source.nat.port,long,extended,,1.2.0-dev
 source.packets,long,core,12,1.2.0-dev
 source.port,long,core,,1.2.0-dev
+source.top_level_domain,keyword,extended,,1.2.0-dev
 source.user.domain,keyword,extended,,1.2.0-dev
 source.user.email,keyword,extended,,1.2.0-dev
 source.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
@@ -325,6 +330,7 @@ url.path,keyword,extended,,1.2.0-dev
 url.port,long,extended,443,1.2.0-dev
 url.query,keyword,extended,,1.2.0-dev
 url.scheme,keyword,extended,https,1.2.0-dev
+url.top_level_domain,keyword,extended,,1.2.0-dev
 url.username,keyword,extended,,1.2.0-dev
 user.domain,keyword,extended,,1.2.0-dev
 user.email,keyword,extended,,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -145,7 +145,7 @@ client.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the client to the server.
   type: long
 client.domain:
@@ -277,7 +277,7 @@ client.nat.ip:
   flat_name: client.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Client NAT ip address
   type: ip
 client.nat.port:
@@ -289,7 +289,7 @@ client.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Client NAT port
   type: long
 client.packets:
@@ -298,7 +298,7 @@ client.packets:
   flat_name: client.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the client to the server.
   type: long
 client.port:
@@ -310,6 +310,25 @@ client.port:
   order: 2
   short: Port of the client.
   type: long
+client.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: client.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: top_level_domain
+  order: 5
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 client.user.domain:
   description: 'Name of the directory the user is a member of.
 
@@ -570,7 +589,7 @@ destination.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the destination to the source.
   type: long
 destination.domain:
@@ -702,7 +721,7 @@ destination.nat.ip:
   flat_name: destination.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Destination NAT ip
   type: ip
 destination.nat.port:
@@ -713,7 +732,7 @@ destination.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Destination NAT Port
   type: long
 destination.packets:
@@ -722,7 +741,7 @@ destination.packets:
   flat_name: destination.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the destination to the source.
   type: long
 destination.port:
@@ -734,6 +753,25 @@ destination.port:
   order: 2
   short: Port of the destination.
   type: long
+destination.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: destination.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: top_level_domain
+  order: 5
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 destination.user.domain:
   description: 'Name of the directory the user is a member of.
 
@@ -837,7 +875,7 @@ dns.answers:
   level: extended
   name: answers
   object_type: keyword
-  order: 9
+  order: 10
   short: Array of DNS answers.
   type: object
 dns.answers.class:
@@ -847,7 +885,7 @@ dns.answers.class:
   ignore_above: 1024
   level: extended
   name: answers.class
-  order: 12
+  order: 13
   short: The class of DNS data contained in this resource record.
   type: keyword
 dns.answers.data:
@@ -859,7 +897,7 @@ dns.answers.data:
   ignore_above: 1024
   level: extended
   name: answers.data
-  order: 14
+  order: 15
   short: The data describing the resource.
   type: keyword
 dns.answers.name:
@@ -873,7 +911,7 @@ dns.answers.name:
   ignore_above: 1024
   level: extended
   name: answers.name
-  order: 10
+  order: 11
   short: The domain name to which this resource record pertains.
   type: keyword
 dns.answers.ttl:
@@ -883,7 +921,7 @@ dns.answers.ttl:
   flat_name: dns.answers.ttl
   level: extended
   name: answers.ttl
-  order: 13
+  order: 14
   short: The time interval in seconds that this resource record may be cached before
     it should be discarded. Zero values mean that the data should not be cached.
   type: long
@@ -894,7 +932,7 @@ dns.answers.type:
   ignore_above: 1024
   level: extended
   name: answers.type
-  order: 11
+  order: 12
   short: The type of data contained in this resource record.
   type: keyword
 dns.header_flags:
@@ -976,6 +1014,25 @@ dns.question.registered_domain:
   order: 8
   short: The highest registered domain, stripped of the subdomain.
   type: keyword
+dns.question.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: dns.question.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: question.top_level_domain
+  order: 9
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 dns.question.type:
   description: The type of record being queried.
   example: AAAA
@@ -999,7 +1056,7 @@ dns.resolved_ip:
   flat_name: dns.resolved_ip
   level: extended
   name: resolved_ip
-  order: 15
+  order: 16
   short: Array containing all IPs seen in answers.data
   type: ip
 dns.response_code:
@@ -2884,7 +2941,7 @@ server.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the server to the client.
   type: long
 server.domain:
@@ -3016,7 +3073,7 @@ server.nat.ip:
   flat_name: server.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Server NAT ip
   type: ip
 server.nat.port:
@@ -3028,7 +3085,7 @@ server.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Server NAT port
   type: long
 server.packets:
@@ -3037,7 +3094,7 @@ server.packets:
   flat_name: server.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the server to the client.
   type: long
 server.port:
@@ -3049,6 +3106,25 @@ server.port:
   order: 2
   short: Port of the server.
   type: long
+server.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: server.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: top_level_domain
+  order: 5
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 server.user.domain:
   description: 'Name of the directory the user is a member of.
 
@@ -3269,7 +3345,7 @@ source.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 5
+  order: 6
   short: Bytes sent from the source to the destination.
   type: long
 source.domain:
@@ -3401,7 +3477,7 @@ source.nat.ip:
   flat_name: source.nat.ip
   level: extended
   name: nat.ip
-  order: 7
+  order: 8
   short: Source NAT ip
   type: ip
 source.nat.port:
@@ -3413,7 +3489,7 @@ source.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 8
+  order: 9
   short: Source NAT port
   type: long
 source.packets:
@@ -3422,7 +3498,7 @@ source.packets:
   flat_name: source.packets
   level: core
   name: packets
-  order: 6
+  order: 7
   short: Packets sent from the source to the destination.
   type: long
 source.port:
@@ -3434,6 +3510,25 @@ source.port:
   order: 2
   short: Port of the source.
   type: long
+source.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: source.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: top_level_domain
+  order: 5
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 source.user.domain:
   description: 'Name of the directory the user is a member of.
 
@@ -3579,7 +3674,7 @@ url.fragment:
   ignore_above: 1024
   level: extended
   name: fragment
-  order: 7
+  order: 8
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
@@ -3614,7 +3709,7 @@ url.password:
   ignore_above: 1024
   level: extended
   name: password
-  order: 9
+  order: 10
   short: Password of the request.
   type: keyword
 url.path:
@@ -3623,7 +3718,7 @@ url.path:
   ignore_above: 1024
   level: extended
   name: path
-  order: 5
+  order: 6
   short: Path of the request, such as "/search".
   type: keyword
 url.port:
@@ -3633,7 +3728,7 @@ url.port:
   format: string
   level: extended
   name: port
-  order: 4
+  order: 5
   short: Port of the request, such as 443.
   type: long
 url.query:
@@ -3648,7 +3743,7 @@ url.query:
   ignore_above: 1024
   level: extended
   name: query
-  order: 6
+  order: 7
   short: Query string of the request.
   type: keyword
 url.scheme:
@@ -3663,13 +3758,32 @@ url.scheme:
   order: 2
   short: Scheme of the url.
   type: keyword
+url.top_level_domain:
+  description: 'The top level domain (TLD) also known as the domain suffix is the
+    last part of the domain name. For example, the top level domain for google.com
+    is "com".
+
+    The following groups of top level domain are maintained by the Internet Assigned
+    Numbers Authority (IANA).
+
+    Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+    generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code
+    top-level domains (ccTLD) Internationalized country code top-level domains (IDN
+    ccTLDs) Test top-level domains (tTLD)'
+  flat_name: url.top_level_domain
+  ignore_above: 1024
+  level: extended
+  name: top_level_domain
+  order: 4
+  short: The top level domain is the last part of the domain (com, net, org).
+  type: keyword
 url.username:
   description: Username of the request.
   flat_name: url.username
   ignore_above: 1024
   level: extended
   name: username
-  order: 8
+  order: 9
   short: Username of the request.
   type: keyword
 user.domain:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -254,7 +254,7 @@ client:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the client to the server.
       type: long
     domain:
@@ -386,7 +386,7 @@ client:
       flat_name: client.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Client NAT ip address
       type: ip
     nat.port:
@@ -398,7 +398,7 @@ client:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Client NAT port
       type: long
     packets:
@@ -407,7 +407,7 @@ client:
       flat_name: client.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the client to the server.
       type: long
     port:
@@ -419,6 +419,25 @@ client:
       order: 2
       short: Port of the client.
       type: long
+    top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: client.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: top_level_domain
+      order: 5
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     user.domain:
       description: 'Name of the directory the user is a member of.
 
@@ -721,7 +740,7 @@ destination:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the destination to the source.
       type: long
     domain:
@@ -853,7 +872,7 @@ destination:
       flat_name: destination.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Destination NAT ip
       type: ip
     nat.port:
@@ -864,7 +883,7 @@ destination:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Destination NAT Port
       type: long
     packets:
@@ -873,7 +892,7 @@ destination:
       flat_name: destination.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the destination to the source.
       type: long
     port:
@@ -885,6 +904,25 @@ destination:
       order: 2
       short: Port of the destination.
       type: long
+    top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: destination.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: top_level_domain
+      order: 5
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     user.domain:
       description: 'Name of the directory the user is a member of.
 
@@ -1005,7 +1043,7 @@ dns:
       level: extended
       name: answers
       object_type: keyword
-      order: 9
+      order: 10
       short: Array of DNS answers.
       type: object
     answers.class:
@@ -1015,7 +1053,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.class
-      order: 12
+      order: 13
       short: The class of DNS data contained in this resource record.
       type: keyword
     answers.data:
@@ -1027,7 +1065,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.data
-      order: 14
+      order: 15
       short: The data describing the resource.
       type: keyword
     answers.name:
@@ -1041,7 +1079,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.name
-      order: 10
+      order: 11
       short: The domain name to which this resource record pertains.
       type: keyword
     answers.ttl:
@@ -1052,7 +1090,7 @@ dns:
       flat_name: dns.answers.ttl
       level: extended
       name: answers.ttl
-      order: 13
+      order: 14
       short: The time interval in seconds that this resource record may be cached
         before it should be discarded. Zero values mean that the data should not be
         cached.
@@ -1064,7 +1102,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.type
-      order: 11
+      order: 12
       short: The type of data contained in this resource record.
       type: keyword
     header_flags:
@@ -1147,6 +1185,25 @@ dns:
       order: 8
       short: The highest registered domain, stripped of the subdomain.
       type: keyword
+    question.top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: dns.question.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: question.top_level_domain
+      order: 9
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     question.type:
       description: The type of record being queried.
       example: AAAA
@@ -1170,7 +1227,7 @@ dns:
       flat_name: dns.resolved_ip
       level: extended
       name: resolved_ip
-      order: 15
+      order: 16
       short: Array containing all IPs seen in answers.data
       type: ip
     response_code:
@@ -3296,7 +3353,7 @@ server:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the server to the client.
       type: long
     domain:
@@ -3428,7 +3485,7 @@ server:
       flat_name: server.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Server NAT ip
       type: ip
     nat.port:
@@ -3440,7 +3497,7 @@ server:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Server NAT port
       type: long
     packets:
@@ -3449,7 +3506,7 @@ server:
       flat_name: server.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the server to the client.
       type: long
     port:
@@ -3461,6 +3518,25 @@ server:
       order: 2
       short: Port of the server.
       type: long
+    top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: server.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: top_level_domain
+      order: 5
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     user.domain:
       description: 'Name of the directory the user is a member of.
 
@@ -3708,7 +3784,7 @@ source:
       format: bytes
       level: core
       name: bytes
-      order: 5
+      order: 6
       short: Bytes sent from the source to the destination.
       type: long
     domain:
@@ -3840,7 +3916,7 @@ source:
       flat_name: source.nat.ip
       level: extended
       name: nat.ip
-      order: 7
+      order: 8
       short: Source NAT ip
       type: ip
     nat.port:
@@ -3852,7 +3928,7 @@ source:
       format: string
       level: extended
       name: nat.port
-      order: 8
+      order: 9
       short: Source NAT port
       type: long
     packets:
@@ -3861,7 +3937,7 @@ source:
       flat_name: source.packets
       level: core
       name: packets
-      order: 6
+      order: 7
       short: Packets sent from the source to the destination.
       type: long
     port:
@@ -3873,6 +3949,25 @@ source:
       order: 2
       short: Port of the source.
       type: long
+    top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: source.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: top_level_domain
+      order: 5
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     user.domain:
       description: 'Name of the directory the user is a member of.
 
@@ -4035,7 +4130,7 @@ url:
       ignore_above: 1024
       level: extended
       name: fragment
-      order: 7
+      order: 8
       short: Portion of the url after the `#`.
       type: keyword
     full:
@@ -4071,7 +4166,7 @@ url:
       ignore_above: 1024
       level: extended
       name: password
-      order: 9
+      order: 10
       short: Password of the request.
       type: keyword
     path:
@@ -4080,7 +4175,7 @@ url:
       ignore_above: 1024
       level: extended
       name: path
-      order: 5
+      order: 6
       short: Path of the request, such as "/search".
       type: keyword
     port:
@@ -4090,7 +4185,7 @@ url:
       format: string
       level: extended
       name: port
-      order: 4
+      order: 5
       short: Port of the request, such as 443.
       type: long
     query:
@@ -4105,7 +4200,7 @@ url:
       ignore_above: 1024
       level: extended
       name: query
-      order: 6
+      order: 7
       short: Query string of the request.
       type: keyword
     scheme:
@@ -4120,13 +4215,32 @@ url:
       order: 2
       short: Scheme of the url.
       type: keyword
+    top_level_domain:
+      description: 'The top level domain (TLD) also known as the domain suffix is
+        the last part of the domain name. For example, the top level domain for google.com
+        is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned
+        Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted
+        generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country
+        code top-level domains (ccTLD) Internationalized country code top-level domains
+        (IDN ccTLDs) Test top-level domains (tTLD)'
+      flat_name: url.top_level_domain
+      ignore_above: 1024
+      level: extended
+      name: top_level_domain
+      order: 4
+      short: The top level domain is the last part of the domain (com, net, org).
+      type: keyword
     username:
       description: Username of the request.
       flat_name: url.username
       ignore_above: 1024
       level: extended
       name: username
-      order: 8
+      order: 9
       short: Username of the request.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -148,6 +148,10 @@
             "port": {
               "type": "long"
             }, 
+            "top_level_domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "user": {
               "properties": {
                 "domain": {
@@ -351,6 +355,10 @@
             "port": {
               "type": "long"
             }, 
+            "top_level_domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "user": {
               "properties": {
                 "domain": {
@@ -441,6 +449,10 @@
                   "type": "keyword"
                 }, 
                 "registered_domain": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
+                "top_level_domain": {
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1286,6 +1298,10 @@
             "port": {
               "type": "long"
             }, 
+            "top_level_domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "user": {
               "properties": {
                 "domain": {
@@ -1442,6 +1458,10 @@
             "port": {
               "type": "long"
             }, 
+            "top_level_domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "user": {
               "properties": {
                 "domain": {
@@ -1538,6 +1558,10 @@
               "type": "keyword"
             }, 
             "scheme": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
+            "top_level_domain": {
               "ignore_above": 1024, 
               "type": "keyword"
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -147,6 +147,10 @@
           "port": {
             "type": "long"
           }, 
+          "top_level_domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "user": {
             "properties": {
               "domain": {
@@ -350,6 +354,10 @@
           "port": {
             "type": "long"
           }, 
+          "top_level_domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "user": {
             "properties": {
               "domain": {
@@ -440,6 +448,10 @@
                 "type": "keyword"
               }, 
               "registered_domain": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
+              "top_level_domain": {
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1285,6 +1297,10 @@
           "port": {
             "type": "long"
           }, 
+          "top_level_domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "user": {
             "properties": {
               "domain": {
@@ -1441,6 +1457,10 @@
           "port": {
             "type": "long"
           }, 
+          "top_level_domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "user": {
             "properties": {
               "domain": {
@@ -1537,6 +1557,10 @@
             "type": "keyword"
           }, 
           "scheme": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
+          "top_level_domain": {
             "ignore_above": 1024, 
             "type": "keyword"
           }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -97,6 +97,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -210,6 +214,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -262,6 +270,10 @@
                   "type": "keyword"
                 },
                 "registered_domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "top_level_domain": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -850,6 +862,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -916,6 +932,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "top_level_domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -977,6 +997,10 @@
               "type": "keyword"
             },
             "scheme": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "top_level_domain": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/schema.json
+++ b/schema.json
@@ -228,6 +228,16 @@
         "name": "client.port", 
         "required": false, 
         "type": "long"
+      }, 
+      "client.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "client.top_level_domain", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 
@@ -475,6 +485,16 @@
         "name": "destination.port", 
         "required": false, 
         "type": "long"
+      }, 
+      "destination.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "destination.top_level_domain", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 
@@ -602,6 +622,16 @@
         "group": 2, 
         "level": "extended", 
         "name": "dns.question.registered_domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "dns.question.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "dns.question.top_level_domain", 
         "required": false, 
         "type": "keyword"
       }, 
@@ -2057,6 +2087,16 @@
         "name": "server.port", 
         "required": false, 
         "type": "long"
+      }, 
+      "server.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "server.top_level_domain", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 
@@ -2225,6 +2265,16 @@
         "name": "source.port", 
         "required": false, 
         "type": "long"
+      }, 
+      "source.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "source.top_level_domain", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 
@@ -2351,6 +2401,16 @@
         "group": 2, 
         "level": "extended", 
         "name": "url.scheme", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "url.top_level_domain": {
+        "description": "The top level domain (TLD) also known as the domain suffix is the last part of the domain name. For example, the top level domain for google.com is \"com\".\nThe following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).\nInfrastructure top-level domain (ARPA) Generic top-level domains (gTLD) Restricted generic top-level domains (grTLD) Sponsored top-level domains (sTLD) Country code top-level domains (ccTLD) Internationalized country code top-level domains (IDN ccTLDs) Test top-level domains (tTLD)", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.top_level_domain", 
         "required": false, 
         "type": "keyword"
       }, 

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -59,6 +59,24 @@
       description: >
         Client domain.
 
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     # Metrics
     - name: bytes
       format: bytes

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -50,6 +50,24 @@
       description: >
         Destination domain.
 
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     # Metrics
     - name: bytes
       format: bytes

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -101,6 +101,24 @@
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: google.com
 
+    - name: question.top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     - name: answers
       level: extended
       type: object

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -59,6 +59,24 @@
       description: >
         Server domain.
 
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     # Metrics
     - name: bytes
       format: bytes
@@ -93,4 +111,3 @@
         Translated port of destination based NAT sessions (e.g. internet to private DMZ)
 
         Typically used with load balancers, firewalls, or routers.
-        

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -50,6 +50,24 @@
       description: >
         Source domain.
 
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     # Metrics
     - name: bytes
       format: bytes
@@ -84,4 +102,3 @@
         Translated port of source based NAT sessions. (e.g. internal client to internet)
 
         Typically used with load balancers, firewalls, or routers.
-        

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -54,6 +54,24 @@
         domain name. In this case, the IP address would go to the `domain` field.
       example: www.elastic.co
 
+    - name: top_level_domain
+      level: extended
+      type: keyword
+      short: The top level domain is the last part of the domain (com, net, org).
+      description: >
+        The top level domain (TLD) also known as the domain suffix is the last part of the domain name.
+        For example, the top level domain for google.com is "com".
+
+        The following groups of top level domain are maintained by the Internet Assigned Numbers Authority (IANA).
+
+        Infrastructure top-level domain (ARPA)
+        Generic top-level domains (gTLD)
+        Restricted generic top-level domains (grTLD)
+        Sponsored top-level domains (sTLD)
+        Country code top-level domains (ccTLD)
+        Internationalized country code top-level domains (IDN ccTLDs)
+        Test top-level domains (tTLD)
+
     - name: port
       format: string
       level: extended


### PR DESCRIPTION
Added top_level_domain field so Elasticsearch users with security use cases, can identify logs where the domain has a particular suffix. For example, if a company is experiencing a spear-phishing campaign, they may want to identify all connections to .xyz or .ru domains if the attackers using these domains in their links. 

Having a top_level_domain suffix will allow users to find these connections without having to index domains in text fields, so they won't need to do expensive wildcard queries - "*.ru". Instead they can just do a fast keyword search in their analytics.

Users will be able to create a unique list of top_level_domains by using if statements in Logstash pipelines/filters.