### PR TITLE
Add group.domain field to the group schema

### DIFF
--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -26,3 +26,12 @@
       type: keyword
       description: >
         Name of the group.
+   
+    - name: domain
+      level: extended
+      type: keyword
+      short: Name of the directory the group is a member of. 
+      description: >
+          Name of the directory the group is a member of.
+
+          For example, an LDAP or Active Directory domain name.


### PR DESCRIPTION
Added group.domain field in the group schema.
I've been working with Window's Security Groups Events  and the group domain needs to be mapped into ECS in order to be able to correlate with others events
(Example events 4731,4732,4733,... where the  SubjectDomainName is the domain of the group created/modified/deteled, etc)
Another use case I found to justified the existence of the group,domain was several Fortigate Logs where group="DOMAIN\GROUP" appears as field (for example log_id=0315093008)