### PR TITLE
Add domain field to Group Schema

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -10,6 +10,7 @@ Thanks, you're awesome :-) -->
 ### Bugfixes
 
 ### Added
+- Add group.domain field #547 
 
 ### Improvements
 

--- a/code/go/ecs/group.go
+++ b/code/go/ecs/group.go
@@ -28,7 +28,7 @@ type Group struct {
 	// Name of the group.
 	Name string `ecs:"name"`
 
-	// Name of the directory the group is a member of. For example, an LDAP or
-	// Active Directory domain name.
+	// Name of the directory the group is a member of.
+	// For example, an LDAP or Active Directory domain name.
 	Domain string `ecs:"domain"`
 }

--- a/code/go/ecs/group.go
+++ b/code/go/ecs/group.go
@@ -27,4 +27,8 @@ type Group struct {
 
 	// Name of the group.
 	Name string `ecs:"name"`
+
+	// Name of the directory the group is a member of. For example, an LDAP or
+	// Active Directory domain name.
+	Domain string `ecs:"domain"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1682,7 +1682,9 @@ The group fields are meant to represent groups that are relevant to the event.
 // ===============================================================
 
 | group.domain
-| Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name.
+| Name of the directory the group is a member of.
+
+For example, an LDAP or Active Directory domain name.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1681,6 +1681,17 @@ The group fields are meant to represent groups that are relevant to the event.
 
 // ===============================================================
 
+| group.domain
+| Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name.
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | group.id
 | Unique identifier for the group on the system/platform.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -307,8 +307,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: user.group.id
       level: extended
       type: keyword
@@ -599,8 +600,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: user.group.id
       level: extended
       type: keyword
@@ -1246,8 +1248,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -1463,8 +1466,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: user.group.id
       level: extended
       type: keyword
@@ -2221,8 +2225,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: user.group.id
       level: extended
       type: keyword
@@ -2490,8 +2495,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: user.group.id
       level: extended
       type: keyword
@@ -2675,8 +2681,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: group.id
       level: extended
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -303,6 +303,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: user.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: user.group.id
       level: extended
       type: keyword
@@ -589,6 +595,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: user.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: user.group.id
       level: extended
       type: keyword
@@ -1230,6 +1242,12 @@
       to the event.
     type: group
     fields:
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: id
       level: extended
       type: keyword
@@ -1441,6 +1459,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: user.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: user.group.id
       level: extended
       type: keyword
@@ -2193,6 +2217,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: user.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: user.group.id
       level: extended
       type: keyword
@@ -2456,6 +2486,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: user.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: user.group.id
       level: extended
       type: keyword
@@ -2635,6 +2671,12 @@
       ignore_above: 1024
       description: User's full name, if available.
       example: Albert Einstein
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
     - name: group.id
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -33,6 +33,7 @@ client.registered_domain,keyword,extended,google.com,1.2.0-dev
 client.user.domain,keyword,extended,,1.2.0-dev
 client.user.email,keyword,extended,,1.2.0-dev
 client.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+client.user.group.domain,keyword,extended,,1.2.0-dev
 client.user.group.id,keyword,extended,,1.2.0-dev
 client.user.group.name,keyword,extended,,1.2.0-dev
 client.user.hash,keyword,extended,,1.2.0-dev
@@ -74,6 +75,7 @@ destination.registered_domain,keyword,extended,google.com,1.2.0-dev
 destination.user.domain,keyword,extended,,1.2.0-dev
 destination.user.email,keyword,extended,,1.2.0-dev
 destination.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+destination.user.group.domain,keyword,extended,,1.2.0-dev
 destination.user.group.id,keyword,extended,,1.2.0-dev
 destination.user.group.name,keyword,extended,,1.2.0-dev
 destination.user.hash,keyword,extended,,1.2.0-dev
@@ -150,6 +152,7 @@ geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.2.0-
 geo.name,keyword,extended,boston-dc,1.2.0-dev
 geo.region_iso_code,keyword,core,CA-QC,1.2.0-dev
 geo.region_name,keyword,core,Quebec,1.2.0-dev
+group.domain,keyword,extended,,1.2.0-dev
 group.id,keyword,extended,,1.2.0-dev
 group.name,keyword,extended,,1.2.0-dev
 hash.md5,keyword,extended,,1.2.0-dev
@@ -181,6 +184,7 @@ host.uptime,long,extended,1325,1.2.0-dev
 host.user.domain,keyword,extended,,1.2.0-dev
 host.user.email,keyword,extended,,1.2.0-dev
 host.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+host.user.group.domain,keyword,extended,,1.2.0-dev
 host.user.group.id,keyword,extended,,1.2.0-dev
 host.user.group.name,keyword,extended,,1.2.0-dev
 host.user.hash,keyword,extended,,1.2.0-dev
@@ -279,6 +283,7 @@ server.registered_domain,keyword,extended,google.com,1.2.0-dev
 server.user.domain,keyword,extended,,1.2.0-dev
 server.user.email,keyword,extended,,1.2.0-dev
 server.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+server.user.group.domain,keyword,extended,,1.2.0-dev
 server.user.group.id,keyword,extended,,1.2.0-dev
 server.user.group.name,keyword,extended,,1.2.0-dev
 server.user.hash,keyword,extended,,1.2.0-dev
@@ -313,6 +318,7 @@ source.registered_domain,keyword,extended,google.com,1.2.0-dev
 source.user.domain,keyword,extended,,1.2.0-dev
 source.user.email,keyword,extended,,1.2.0-dev
 source.user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+source.user.group.domain,keyword,extended,,1.2.0-dev
 source.user.group.id,keyword,extended,,1.2.0-dev
 source.user.group.name,keyword,extended,,1.2.0-dev
 source.user.hash,keyword,extended,,1.2.0-dev
@@ -334,6 +340,7 @@ url.username,keyword,extended,,1.2.0-dev
 user.domain,keyword,extended,,1.2.0-dev
 user.email,keyword,extended,,1.2.0-dev
 user.full_name,keyword,extended,Albert Einstein,1.2.0-dev
+user.group.domain,keyword,extended,,1.2.0-dev
 user.group.id,keyword,extended,,1.2.0-dev
 user.group.name,keyword,extended,,1.2.0-dev
 user.hash,keyword,extended,,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -368,8 +368,7 @@ client.user.group.domain:
   name: domain
   order: 2
   original_fieldset: user
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 client.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -820,8 +819,7 @@ destination.user.group.domain:
   name: domain
   order: 2
   original_fieldset: user
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 destination.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -1720,8 +1718,7 @@ group.domain:
   level: extended
   name: domain
   order: 2
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 group.id:
   description: Unique identifier for the group on the system/platform.
@@ -2062,8 +2059,7 @@ host.user.group.domain:
   name: domain
   order: 2
   original_fieldset: user
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 host.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -3186,8 +3182,7 @@ server.user.group.domain:
   name: domain
   order: 2
   original_fieldset: user
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 server.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -3599,8 +3594,7 @@ source.user.group.domain:
   name: domain
   order: 2
   original_fieldset: user
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 source.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -3862,8 +3856,7 @@ user.group.domain:
   name: domain
   order: 2
   original_fieldset: group
-  short: Name of the directory the group is a member of. For example, an LDAP or Active
-    Directory domain name.
+  short: Name of the directory the group is a member of.
   type: keyword
 user.group.id:
   description: Unique identifier for the group on the system/platform.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -359,6 +359,18 @@ client.user.full_name:
   original_fieldset: user
   short: User's full name, if available.
   type: keyword
+client.user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: client.user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: user
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
+  type: keyword
 client.user.group.id:
   description: Unique identifier for the group on the system/platform.
   flat_name: client.user.group.id
@@ -798,6 +810,18 @@ destination.user.full_name:
   order: 2
   original_fieldset: user
   short: User's full name, if available.
+  type: keyword
+destination.user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: destination.user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: user
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
   type: keyword
 destination.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -1688,6 +1712,17 @@ geo.region_name:
   order: 3
   short: Region name.
   type: keyword
+group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
+  type: keyword
 group.id:
   description: Unique identifier for the group on the system/platform.
   flat_name: group.id
@@ -2017,6 +2052,18 @@ host.user.full_name:
   order: 2
   original_fieldset: user
   short: User's full name, if available.
+  type: keyword
+host.user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: host.user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: user
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
   type: keyword
 host.user.group.id:
   description: Unique identifier for the group on the system/platform.
@@ -3130,6 +3177,18 @@ server.user.full_name:
   original_fieldset: user
   short: User's full name, if available.
   type: keyword
+server.user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: server.user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: user
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
+  type: keyword
 server.user.group.id:
   description: Unique identifier for the group on the system/platform.
   flat_name: server.user.group.id
@@ -3531,6 +3590,18 @@ source.user.full_name:
   original_fieldset: user
   short: User's full name, if available.
   type: keyword
+source.user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: source.user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: user
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
+  type: keyword
 source.user.group.id:
   description: Unique identifier for the group on the system/platform.
   flat_name: source.user.group.id
@@ -3781,6 +3852,18 @@ user.full_name:
   name: full_name
   order: 2
   short: User's full name, if available.
+  type: keyword
+user.group.domain:
+  description: Name of the directory the group is a member of. For example, an LDAP
+    or Active Directory domain name.
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 2
+  original_fieldset: group
+  short: Name of the directory the group is a member of. For example, an LDAP or Active
+    Directory domain name.
   type: keyword
 user.group.id:
   description: Unique identifier for the group on the system/platform.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -360,8 +360,9 @@ client.user.full_name:
   short: User's full name, if available.
   type: keyword
 client.user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: client.user.group.domain
   ignore_above: 1024
   level: extended
@@ -811,8 +812,9 @@ destination.user.full_name:
   short: User's full name, if available.
   type: keyword
 destination.user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: destination.user.group.domain
   ignore_above: 1024
   level: extended
@@ -1711,8 +1713,9 @@ geo.region_name:
   short: Region name.
   type: keyword
 group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: group.domain
   ignore_above: 1024
   level: extended
@@ -2051,8 +2054,9 @@ host.user.full_name:
   short: User's full name, if available.
   type: keyword
 host.user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: host.user.group.domain
   ignore_above: 1024
   level: extended
@@ -3174,8 +3178,9 @@ server.user.full_name:
   short: User's full name, if available.
   type: keyword
 server.user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: server.user.group.domain
   ignore_above: 1024
   level: extended
@@ -3586,8 +3591,9 @@ source.user.full_name:
   short: User's full name, if available.
   type: keyword
 source.user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: source.user.group.domain
   ignore_above: 1024
   level: extended
@@ -3848,8 +3854,9 @@ user.full_name:
   short: User's full name, if available.
   type: keyword
 user.group.domain:
-  description: Name of the directory the group is a member of. For example, an LDAP
-    or Active Directory domain name.
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
   flat_name: user.group.domain
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -477,8 +477,7 @@ client:
       name: domain
       order: 2
       original_fieldset: user
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -971,8 +970,7 @@ destination:
       name: domain
       order: 2
       original_fieldset: user
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -1982,8 +1980,7 @@ group:
       level: extended
       name: domain
       order: 2
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     id:
       description: Unique identifier for the group on the system/platform.
@@ -2361,8 +2358,7 @@ host:
       name: domain
       order: 2
       original_fieldset: user
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -3598,8 +3594,7 @@ server:
       name: domain
       order: 2
       original_fieldset: user
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -4038,8 +4033,7 @@ source:
       name: domain
       order: 2
       original_fieldset: user
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -4332,8 +4326,7 @@ user:
       name: domain
       order: 2
       original_fieldset: group
-      short: Name of the directory the group is a member of. For example, an LDAP
-        or Active Directory domain name.
+      short: Name of the directory the group is a member of.
       type: keyword
     group.id:
       description: Unique identifier for the group on the system/platform.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -468,6 +468,18 @@ client:
       original_fieldset: user
       short: User's full name, if available.
       type: keyword
+    user.group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: client.user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: user
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
+      type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
       flat_name: client.user.group.id
@@ -949,6 +961,18 @@ destination:
       order: 2
       original_fieldset: user
       short: User's full name, if available.
+      type: keyword
+    user.group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: destination.user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: user
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -1950,6 +1974,17 @@ group:
   description: The group fields are meant to represent groups that are relevant to
     the event.
   fields:
+    domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
+      type: keyword
     id:
       description: Unique identifier for the group on the system/platform.
       flat_name: group.id
@@ -2316,6 +2351,18 @@ host:
       order: 2
       original_fieldset: user
       short: User's full name, if available.
+      type: keyword
+    user.group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: host.user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: user
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
       type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
@@ -3542,6 +3589,18 @@ server:
       original_fieldset: user
       short: User's full name, if available.
       type: keyword
+    user.group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: server.user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: user
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
+      type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
       flat_name: server.user.group.id
@@ -3970,6 +4029,18 @@ source:
       original_fieldset: user
       short: User's full name, if available.
       type: keyword
+    user.group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: source.user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: user
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
+      type: keyword
     user.group.id:
       description: Unique identifier for the group on the system/platform.
       flat_name: source.user.group.id
@@ -4251,6 +4322,18 @@ user:
       name: full_name
       order: 2
       short: User's full name, if available.
+      type: keyword
+    group.domain:
+      description: Name of the directory the group is a member of. For example, an
+        LDAP or Active Directory domain name.
+      flat_name: user.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 2
+      original_fieldset: group
+      short: Name of the directory the group is a member of. For example, an LDAP
+        or Active Directory domain name.
       type: keyword
     group.id:
       description: Unique identifier for the group on the system/platform.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -469,8 +469,9 @@ client:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: client.user.group.domain
       ignore_above: 1024
       level: extended
@@ -962,8 +963,9 @@ destination:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: destination.user.group.domain
       ignore_above: 1024
       level: extended
@@ -1973,8 +1975,9 @@ group:
     the event.
   fields:
     domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: group.domain
       ignore_above: 1024
       level: extended
@@ -2350,8 +2353,9 @@ host:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: host.user.group.domain
       ignore_above: 1024
       level: extended
@@ -3586,8 +3590,9 @@ server:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: server.user.group.domain
       ignore_above: 1024
       level: extended
@@ -4025,8 +4030,9 @@ source:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: source.user.group.domain
       ignore_above: 1024
       level: extended
@@ -4318,8 +4324,9 @@ user:
       short: User's full name, if available.
       type: keyword
     group.domain:
-      description: Name of the directory the group is a member of. For example, an
-        LDAP or Active Directory domain name.
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
       flat_name: user.group.domain
       ignore_above: 1024
       level: extended

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -168,6 +168,10 @@
                 }, 
                 "group": {
                   "properties": {
+                    "domain": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }, 
                     "id": {
                       "ignore_above": 1024, 
                       "type": "keyword"
@@ -375,6 +379,10 @@
                 }, 
                 "group": {
                   "properties": {
+                    "domain": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }, 
                     "id": {
                       "ignore_above": 1024, 
                       "type": "keyword"
@@ -705,6 +713,10 @@
         }, 
         "group": {
           "properties": {
+            "domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "id": {
               "ignore_above": 1024, 
               "type": "keyword"
@@ -846,6 +858,10 @@
                 }, 
                 "group": {
                   "properties": {
+                    "domain": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }, 
                     "id": {
                       "ignore_above": 1024, 
                       "type": "keyword"
@@ -1314,6 +1330,10 @@
                 }, 
                 "group": {
                   "properties": {
+                    "domain": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }, 
                     "id": {
                       "ignore_above": 1024, 
                       "type": "keyword"
@@ -1474,6 +1494,10 @@
                 }, 
                 "group": {
                   "properties": {
+                    "domain": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }, 
                     "id": {
                       "ignore_above": 1024, 
                       "type": "keyword"
@@ -1583,6 +1607,10 @@
             }, 
             "group": {
               "properties": {
+                "domain": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
                 "id": {
                   "ignore_above": 1024, 
                   "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -167,6 +167,10 @@
               }, 
               "group": {
                 "properties": {
+                  "domain": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }, 
                   "id": {
                     "ignore_above": 1024, 
                     "type": "keyword"
@@ -374,6 +378,10 @@
               }, 
               "group": {
                 "properties": {
+                  "domain": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }, 
                   "id": {
                     "ignore_above": 1024, 
                     "type": "keyword"
@@ -704,6 +712,10 @@
       }, 
       "group": {
         "properties": {
+          "domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "id": {
             "ignore_above": 1024, 
             "type": "keyword"
@@ -845,6 +857,10 @@
               }, 
               "group": {
                 "properties": {
+                  "domain": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }, 
                   "id": {
                     "ignore_above": 1024, 
                     "type": "keyword"
@@ -1313,6 +1329,10 @@
               }, 
               "group": {
                 "properties": {
+                  "domain": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }, 
                   "id": {
                     "ignore_above": 1024, 
                     "type": "keyword"
@@ -1473,6 +1493,10 @@
               }, 
               "group": {
                 "properties": {
+                  "domain": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }, 
                   "id": {
                     "ignore_above": 1024, 
                     "type": "keyword"
@@ -1582,6 +1606,10 @@
           }, 
           "group": {
             "properties": {
+              "domain": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
               "id": {
                 "ignore_above": 1024, 
                 "type": "keyword"

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -506,6 +506,10 @@
         },
         "group": {
           "properties": {
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/schema.json
+++ b/schema.json
@@ -1230,7 +1230,7 @@
     "description": "The group fields are meant to represent groups that are relevant to the event.\n", 
     "fields": {
       "group.domain": {
-        "description": "Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name.", 
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.", 
         "example": "", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1229,6 +1229,16 @@
   "group": {
     "description": "The group fields are meant to represent groups that are relevant to the event.\n", 
     "fields": {
+      "group.domain": {
+        "description": "Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "group.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "group.id": {
         "description": "Unique identifier for the group on the system/platform.", 
         "example": "", 

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -33,5 +33,6 @@
       short: Name of the directory the group is a member of.
       description: >
         Name of the directory the group is a member of.
+
         For example, an LDAP or Active Directory domain name.
 

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -26,3 +26,11 @@
       type: keyword
       description: >
         Name of the group.
+
+    - name: domain
+      level: extended
+      type: keyword
+      description: >
+        Name of the directory the group is a member of.
+        For example, an LDAP or Active Directory domain name.
+

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -30,6 +30,7 @@
     - name: domain
       level: extended
       type: keyword
+      short: Name of the directory the group is a member of.
       description: >
         Name of the directory the group is a member of.
         For example, an LDAP or Active Directory domain name.


### PR DESCRIPTION
Added group.domain field in the group schema.
I've been working with Window's Security Groups Events and the group domain needs to be mapped into ECS in order to be able to correlate with others events
(Example events 4731,4732,4733,... where the SubjectDomainName is the domain of the group created/modified/deteled, etc)
Another use case I found to justified the existence of the group,domain was several Fortigate Logs where group="DOMAIN\GROUP" appears as field (for example log_id=0315093008)