### PR TITLE
Added url.extension field

### DIFF
--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -66,6 +66,11 @@ type Url struct {
 	// differentiate between the two cases.
 	Query string `ecs:"query"`
 
+	// The field contains the file extension from the original request url. The
+	// file extension is only set if it exists, as not every url has a file
+	// extension.
+	Extension string `ecs:"extension"`
+
 	// Portion of the url after the `#`, such as "top".
 	// The `#` is not part of the fragment.
 	Fragment string `ecs:"fragment"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3265,6 +3265,17 @@ example: `www.elastic.co`
 
 // ===============================================================
 
+| url.extension
+| The field contains the file extension from the original request url. The file extension is only set if it exists, as not every url has a file extension.
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | url.fragment
 | Portion of the url after the `#`, such as "top".
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2529,6 +2529,13 @@
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.'
       example: www.elastic.co
+    - name: extension
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The field contains the file extension from the original request
+        url. The file extension is only set if it exists, as not every url has a file
+        extension.
     - name: fragment
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -321,6 +321,7 @@ source.user.name,keyword,core,albert,1.2.0-dev
 trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,1.2.0-dev
 transaction.id,keyword,extended,00f067aa0ba902b7,1.2.0-dev
 url.domain,keyword,extended,www.elastic.co,1.2.0-dev
+url.extension,keyword,extended,,1.2.0-dev
 url.fragment,keyword,extended,,1.2.0-dev
 url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,1.2.0-dev
 url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3635,6 +3635,16 @@ url.domain:
   order: 3
   short: Domain of the url.
   type: keyword
+url.extension:
+  description: The field contains the file extension from the original request url.
+    The file extension is only set if it exists, as not every url has a file extension.
+  flat_name: url.extension
+  ignore_above: 1024
+  level: extended
+  name: extension
+  order: 8
+  short: File extension from the original request url.
+  type: keyword
 url.fragment:
   description: 'Portion of the url after the `#`, such as "top".
 
@@ -3643,7 +3653,7 @@ url.fragment:
   ignore_above: 1024
   level: extended
   name: fragment
-  order: 8
+  order: 9
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
@@ -3678,7 +3688,7 @@ url.password:
   ignore_above: 1024
   level: extended
   name: password
-  order: 10
+  order: 11
   short: Password of the request.
   type: keyword
 url.path:
@@ -3749,7 +3759,7 @@ url.username:
   ignore_above: 1024
   level: extended
   name: username
-  order: 9
+  order: 10
   short: Username of the request.
   type: keyword
 user.domain:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4091,6 +4091,17 @@ url:
       order: 3
       short: Domain of the url.
       type: keyword
+    extension:
+      description: The field contains the file extension from the original request
+        url. The file extension is only set if it exists, as not every url has a file
+        extension.
+      flat_name: url.extension
+      ignore_above: 1024
+      level: extended
+      name: extension
+      order: 8
+      short: File extension from the original request url.
+      type: keyword
     fragment:
       description: 'Portion of the url after the `#`, such as "top".
 
@@ -4099,7 +4110,7 @@ url:
       ignore_above: 1024
       level: extended
       name: fragment
-      order: 8
+      order: 9
       short: Portion of the url after the `#`.
       type: keyword
     full:
@@ -4135,7 +4146,7 @@ url:
       ignore_above: 1024
       level: extended
       name: password
-      order: 10
+      order: 11
       short: Password of the request.
       type: keyword
     path:
@@ -4206,7 +4217,7 @@ url:
       ignore_above: 1024
       level: extended
       name: username
-      order: 9
+      order: 10
       short: Username of the request.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1526,6 +1526,10 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "extension": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "fragment": {
               "ignore_above": 1024, 
               "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1525,6 +1525,10 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "extension": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "fragment": {
             "ignore_above": 1024, 
             "type": "keyword"

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -965,6 +965,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "extension": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "fragment": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/schema.json
+++ b/schema.json
@@ -2314,6 +2314,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "url.extension": {
+        "description": "The field contains the file extension from the original request url. The file extension is only set if it exists, as not every url has a file extension.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "url.extension", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "url.fragment": {
         "description": "Portion of the url after the `#`, such as \"top\".\nThe `#` is not part of the fragment.", 
         "example": "", 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -95,6 +95,14 @@
         the query field exists with an empty string. The `exists`
         query can be used to differentiate between the two cases.
 
+    - name: extension
+      level: extended
+      type: keyword
+      short: File extension from the original request url.
+      description: >
+        The field contains the file extension from the original request url.
+        The file extension is only set if it exists, as not every url has a file extension.
+
     - name: fragment
       level: extended
       type: keyword


### PR DESCRIPTION
Added a url extension field as using the file.extension field to store this could confuse security analysts. It should be easier for security analysts to associate extension and url if it's in the url object. We want to avoid them thinking the file exists on the computer straight away.

Proxy logs provide the file extension in a uri extension field, along with 
uri schema
uri domain
uri query
uri path etc..

Security analysts will want to look for file types like exe, js, swf, hda, vb, vbs, jar, bat coming from suspicious sites/locations.