### PR TITLE
Added http request and response content-type field

### DIFF
--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -48,9 +48,15 @@ type Http struct {
 	// Size in bytes of the request body.
 	RequestBodyBytes int64 `ecs:"request.body.bytes"`
 
+	// The MIME type set in the request content-type field.
+	RequestContentType string `ecs:"request.content_type"`
+
 	// Total size in bytes of the response (body and headers).
 	ResponseBytes int64 `ecs:"response.bytes"`
 
 	// Size in bytes of the response body.
 	ResponseBodyBytes int64 `ecs:"response.body.bytes"`
+
+	// The MIME type set in the response content-type field.
+	ResponseContentType string `ecs:"response.content_type"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1980,6 +1980,17 @@ example: `1437`
 
 // ===============================================================
 
+| http.request.content_type
+| The MIME type set in the request content-type field.
+
+type: keyword
+
+example: `application/zip text/html application/octet-stream text/javascript application/x-www-form-urlencoded`
+
+| extended
+
+// ===============================================================
+
 | http.request.method
 | HTTP request method.
 
@@ -2032,6 +2043,17 @@ example: `Hello world`
 type: long
 
 example: `1437`
+
+| extended
+
+// ===============================================================
+
+| http.response.content_type
+| The MIME type set in the response content-type field.
+
+type: keyword
+
+example: `application/zip text/html application/octet-stream text/javascript`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1496,6 +1496,13 @@
       format: bytes
       description: Total size in bytes of the request (body and headers).
       example: 1437
+    - name: request.content_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The MIME type set in the request content-type field.
+      example: application/zip text/html application/octet-stream text/javascript
+        application/x-www-form-urlencoded
     - name: request.method
       level: extended
       type: keyword
@@ -1529,6 +1536,12 @@
       format: bytes
       description: Total size in bytes of the response (body and headers).
       example: 1437
+    - name: response.content_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The MIME type set in the response content-type field.
+      example: application/zip text/html application/octet-stream text/javascript
     - name: response.status_code
       level: extended
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -189,11 +189,13 @@ host.user.name,keyword,core,albert,1.2.0-dev
 http.request.body.bytes,long,extended,887,1.2.0-dev
 http.request.body.content,keyword,extended,Hello world,1.2.0-dev
 http.request.bytes,long,extended,1437,1.2.0-dev
+http.request.content_type,keyword,extended,application/zip text/html application/octet-stream text/javascript application/x-www-form-urlencoded,1.2.0-dev
 http.request.method,keyword,extended,"get, post, put",1.2.0-dev
 http.request.referrer,keyword,extended,https://blog.example.com/,1.2.0-dev
 http.response.body.bytes,long,extended,887,1.2.0-dev
 http.response.body.content,keyword,extended,Hello world,1.2.0-dev
 http.response.bytes,long,extended,1437,1.2.0-dev
+http.response.content_type,keyword,extended,application/zip text/html application/octet-stream text/javascript,1.2.0-dev
 http.response.status_code,long,extended,404,1.2.0-dev
 http.version,keyword,extended,1.1,1.2.0-dev
 log.level,keyword,core,err,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2103,6 +2103,16 @@ http.request.bytes:
   order: 6
   short: Total size in bytes of the request (body and headers).
   type: long
+http.request.content_type:
+  description: The MIME type set in the request content-type field.
+  example: application/zip text/html application/octet-stream text/javascript application/x-www-form-urlencoded
+  flat_name: http.request.content_type
+  ignore_above: 1024
+  level: extended
+  name: request.content_type
+  order: 8
+  short: The MIME type set in the request content-type field.
+  type: keyword
 http.request.method:
   description: 'HTTP request method.
 
@@ -2133,7 +2143,7 @@ http.response.body.bytes:
   format: bytes
   level: extended
   name: response.body.bytes
-  order: 9
+  order: 10
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
@@ -2153,9 +2163,19 @@ http.response.bytes:
   format: bytes
   level: extended
   name: response.bytes
-  order: 8
+  order: 9
   short: Total size in bytes of the response (body and headers).
   type: long
+http.response.content_type:
+  description: The MIME type set in the response content-type field.
+  example: application/zip text/html application/octet-stream text/javascript
+  flat_name: http.response.content_type
+  ignore_above: 1024
+  level: extended
+  name: response.content_type
+  order: 11
+  short: The MIME type set in the response content-type field.
+  type: keyword
 http.response.status_code:
   description: HTTP response status code.
   example: 404

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2416,6 +2416,17 @@ http:
       order: 6
       short: Total size in bytes of the request (body and headers).
       type: long
+    request.content_type:
+      description: The MIME type set in the request content-type field.
+      example: application/zip text/html application/octet-stream text/javascript
+        application/x-www-form-urlencoded
+      flat_name: http.request.content_type
+      ignore_above: 1024
+      level: extended
+      name: request.content_type
+      order: 8
+      short: The MIME type set in the request content-type field.
+      type: keyword
     request.method:
       description: 'HTTP request method.
 
@@ -2446,7 +2457,7 @@ http:
       format: bytes
       level: extended
       name: response.body.bytes
-      order: 9
+      order: 10
       short: Size in bytes of the response body.
       type: long
     response.body.content:
@@ -2466,9 +2477,19 @@ http:
       format: bytes
       level: extended
       name: response.bytes
-      order: 8
+      order: 9
       short: Total size in bytes of the response (body and headers).
       type: long
+    response.content_type:
+      description: The MIME type set in the response content-type field.
+      example: application/zip text/html application/octet-stream text/javascript
+      flat_name: http.response.content_type
+      ignore_above: 1024
+      level: extended
+      name: response.content_type
+      order: 11
+      short: The MIME type set in the response content-type field.
+      type: keyword
     response.status_code:
       description: HTTP response status code.
       example: 404

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -890,6 +890,10 @@
                 "bytes": {
                   "type": "long"
                 }, 
+                "content_type": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
                 "method": {
                   "ignore_above": 1024, 
                   "type": "keyword"
@@ -915,6 +919,10 @@
                 }, 
                 "bytes": {
                   "type": "long"
+                }, 
+                "content_type": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
                 }, 
                 "status_code": {
                   "type": "long"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -889,6 +889,10 @@
               "bytes": {
                 "type": "long"
               }, 
+              "content_type": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
               "method": {
                 "ignore_above": 1024, 
                 "type": "keyword"
@@ -914,6 +918,10 @@
               }, 
               "bytes": {
                 "type": "long"
+              }, 
+              "content_type": {
+                "ignore_above": 1024, 
+                "type": "keyword"
               }, 
               "status_code": {
                 "type": "long"

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -588,6 +588,10 @@
                 "bytes": {
                   "type": "long"
                 },
+                "content_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -613,6 +617,10 @@
                 },
                 "bytes": {
                   "type": "long"
+                },
+                "content_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "status_code": {
                   "type": "long"

--- a/schema.json
+++ b/schema.json
@@ -1426,6 +1426,16 @@
         "required": false, 
         "type": "long"
       }, 
+      "http.request.content_type": {
+        "description": "The MIME type set in the request content-type field.", 
+        "example": "application/zip text/html application/octet-stream text/javascript application/x-www-form-urlencoded", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.request.content_type", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "http.request.method": {
         "description": "HTTP request method.\nThe field value must be normalized to lowercase for querying. See the documentation section \"Implementing ECS\".", 
         "example": "get, post, put", 
@@ -1475,6 +1485,16 @@
         "name": "http.response.bytes", 
         "required": false, 
         "type": "long"
+      }, 
+      "http.response.content_type": {
+        "description": "The MIME type set in the response content-type field.", 
+        "example": "application/zip text/html application/octet-stream text/javascript", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "http.response.content_type", 
+        "required": false, 
+        "type": "keyword"
       }, 
       "http.response.status_code": {
         "description": "HTTP response status code.", 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -72,6 +72,18 @@
         Size in bytes of the request body.
       example: 887
 
+    - name: request.content_type
+      level: extended
+      type: keyword
+      description: >
+        The MIME type set in the request content-type field.
+      example:
+        application/zip
+        text/html
+        application/octet-stream
+        text/javascript
+        application/x-www-form-urlencoded
+
     - name: response.bytes
       level: extended
       type: long
@@ -87,3 +99,14 @@
       description: >
         Size in bytes of the response body.
       example: 887
+
+    - name: response.content_type
+      level: extended
+      type: keyword
+      description: >
+        The MIME type set in the response content-type field.
+      example:
+        application/zip
+        text/html
+        application/octet-stream
+        text/javascript


### PR DESCRIPTION
The content-type field can be useful to identify what type of data is being transferred over http. The value isn't always accurate as a web-server can set the content-type to any value.

For example, security analysts might want to look at http requests to uncommon domains with the following content-type
application/x-www-form-urlencoded

Sometimes generic malware sets this content-type to application/x-www-form-urlencoded
Or the request accepts text and the proxy detects an executable being returned.