### PR TITLE
Split user-agent original into text and keyword

### DIFF
--- a/code/go/ecs/user_agent.go
+++ b/code/go/ecs/user_agent.go
@@ -23,8 +23,11 @@ package ecs
 // They often show up in web service logs coming from the parsed user agent
 // string.
 type UserAgent struct {
-	// Unparsed version of the user_agent.
+	// Unparsed keyword version of the user_agent.
 	Original string `ecs:"original"`
+
+	// Unparsed text version of the user_agent.
+	OriginalText string `ecs:"original.text"`
 
 	// Name of the user agent.
 	Name string `ecs:"name"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3543,9 +3543,20 @@ example: `Safari`
 // ===============================================================
 
 | user_agent.original
-| Unparsed version of the user_agent.
+| Unparsed keyword version of the user_agent.
 
 type: keyword
+
+example: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1`
+
+| extended
+
+// ===============================================================
+
+| user_agent.original.text
+| Unparsed text version of the user_agent.
+
+type: text
 
 example: `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1`
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2689,7 +2689,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Unparsed version of the user_agent.
+      description: Unparsed keyword version of the user_agent.
+      example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+    - name: original.text
+      level: extended
+      type: text
+      description: Unparsed text version of the user_agent.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
     - name: os.family

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -342,6 +342,7 @@ user.name,keyword,core,albert,1.2.0-dev
 user_agent.device.name,keyword,extended,iPhone,1.2.0-dev
 user_agent.name,keyword,extended,Safari,1.2.0-dev
 user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",1.2.0-dev
+user_agent.original.text,text,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",1.2.0-dev
 user_agent.os.family,keyword,extended,debian,1.2.0-dev
 user_agent.os.full,keyword,extended,Mac OS Mojave,1.2.0-dev
 user_agent.os.kernel,keyword,extended,4.4.0-112-generic,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3841,7 +3841,7 @@ user_agent.device.name:
   ignore_above: 1024
   level: extended
   name: device.name
-  order: 3
+  order: 4
   short: Name of the device.
   type: keyword
 user_agent.name:
@@ -3851,11 +3851,11 @@ user_agent.name:
   ignore_above: 1024
   level: extended
   name: name
-  order: 1
+  order: 2
   short: Name of the user agent.
   type: keyword
 user_agent.original:
-  description: Unparsed version of the user_agent.
+  description: Unparsed keyword version of the user_agent.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
     (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
   flat_name: user_agent.original
@@ -3863,8 +3863,19 @@ user_agent.original:
   level: extended
   name: original
   order: 0
-  short: Unparsed version of the user_agent.
+  short: Unparsed keyword version of the user_agent.
   type: keyword
+user_agent.original.text:
+  description: Unparsed text version of the user_agent.
+  example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
+    (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+  flat_name: user_agent.original.text
+  level: extended
+  name: original.text
+  norms: false
+  order: 1
+  short: Unparsed text version of the user_agent.
+  type: text
 user_agent.os.family:
   description: OS family (such as redhat, debian, freebsd, windows).
   example: debian
@@ -3938,6 +3949,6 @@ user_agent.version:
   ignore_above: 1024
   level: extended
   name: version
-  order: 2
+  order: 3
   short: Version of the user agent.
   type: keyword

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4332,7 +4332,7 @@ user_agent:
       ignore_above: 1024
       level: extended
       name: device.name
-      order: 3
+      order: 4
       short: Name of the device.
       type: keyword
     name:
@@ -4342,11 +4342,11 @@ user_agent:
       ignore_above: 1024
       level: extended
       name: name
-      order: 1
+      order: 2
       short: Name of the user agent.
       type: keyword
     original:
-      description: Unparsed version of the user_agent.
+      description: Unparsed keyword version of the user_agent.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
       flat_name: user_agent.original
@@ -4354,8 +4354,19 @@ user_agent:
       level: extended
       name: original
       order: 0
-      short: Unparsed version of the user_agent.
+      short: Unparsed keyword version of the user_agent.
       type: keyword
+    original.text:
+      description: Unparsed text version of the user_agent.
+      example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+      flat_name: user_agent.original.text
+      level: extended
+      name: original.text
+      norms: false
+      order: 1
+      short: Unparsed text version of the user_agent.
+      type: text
     os.family:
       description: OS family (such as redhat, debian, freebsd, windows).
       example: debian
@@ -4429,7 +4440,7 @@ user_agent:
       ignore_above: 1024
       level: extended
       name: version
-      order: 2
+      order: 3
       short: Version of the user agent.
       type: keyword
   group: 2

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -1050,6 +1050,12 @@
             },
             "original": {
               "ignore_above": 1024,
+              "properties": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
               "type": "keyword"
             },
             "version": {

--- a/schema.json
+++ b/schema.json
@@ -2513,7 +2513,7 @@
         "type": "keyword"
       }, 
       "user_agent.original": {
-        "description": "Unparsed version of the user_agent.", 
+        "description": "Unparsed keyword version of the user_agent.", 
         "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1", 
         "footnote": "", 
         "group": 2, 
@@ -2521,6 +2521,16 @@
         "name": "user_agent.original", 
         "required": false, 
         "type": "keyword"
+      }, 
+      "user_agent.original.text": {
+        "description": "Unparsed text version of the user_agent.", 
+        "example": "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "user_agent.original.text", 
+        "required": false, 
+        "type": "text"
       }, 
       "user_agent.version": {
         "description": "Version of the user agent.", 

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -14,7 +14,14 @@
       level: extended
       type: keyword
       description: >
-        Unparsed version of the user_agent.
+        Unparsed keyword version of the user_agent.
+      example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
+
+    - name: original.text
+      level: extended
+      type: text
+      description: >
+        Unparsed text version of the user_agent.
       example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
 
     - name: name


### PR DESCRIPTION
Added an original user-agent text field so users can do wildcard searches. Security analysts will find this useful if they want to search for user-agents containing terms like powershell - *powershell*. This is in case an attacker or pentester runs a command to download a file but forgets to set the user-agent to something common.