### PR TITLE
Added location and name field to observer.

### DIFF
--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -24,12 +24,13 @@ package ecs
 // events and metrics.
 // This could be a custom hardware appliance or a server that has been
 // configured to run special network, security, or application software.
-// Examples include firewalls, intrusion detection/prevention systems, network
-// monitoring sensors, web application firewalls, data loss prevention systems,
-// and APM servers. The observer.* fields shall be populated with details of
-// the system, if any, that detects, observes and/or creates a network,
-// security, or application event or metric. Message queues and ETL components
-// used in processing events or metrics are not considered observers in ECS.
+// Examples include firewalls, web proxies, intrusion detection/prevention
+// systems, network monitoring sensors, web application firewalls, data loss
+// prevention systems, and APM servers. The observer.* fields shall be
+// populated with details of the system, if any, that detects, observes and/or
+// creates a network, security, or application event or metric. Message queues
+// and ETL components used in processing events or metrics are not considered
+// observers in ECS.
 type Observer struct {
 	// MAC address of the observer
 	MAC string `ecs:"mac"`
@@ -39,6 +40,12 @@ type Observer struct {
 
 	// Hostname of the observer.
 	Hostname string `ecs:"hostname"`
+
+	// Name of the observer.
+	Name string `ecs:"name"`
+
+	// Location of the observer.
+	Location string `ecs:"location"`
 
 	// observer vendor information.
 	Vendor string `ecs:"vendor"`

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -44,8 +44,8 @@ type Observer struct {
 	// Name of the observer.
 	Name string `ecs:"name"`
 
-	// Location of the observer.
-	Location string `ecs:"location"`
+	// The observers product name.
+	Product string `ecs:"product"`
 
 	// observer vendor information.
 	Vendor string `ecs:"vendor"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2290,7 +2290,7 @@ example: `ipv4`
 
 An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.
 
-This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
+This could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, web proxies, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.
 
 ==== Observer Field Details
 
@@ -2322,8 +2322,30 @@ type: ip
 
 // ===============================================================
 
+| observer.location
+| Location of the observer.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
 | observer.mac
 | MAC address of the observer
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| observer.name
+| Name of the observer.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2322,17 +2322,6 @@ type: ip
 
 // ===============================================================
 
-| observer.location
-| Location of the observer.
-
-type: keyword
-
-
-
-| core
-
-// ===============================================================
-
 | observer.mac
 | MAC address of the observer
 
@@ -2349,7 +2338,18 @@ type: keyword
 
 type: keyword
 
+example: `1_proxySG`
 
+| core
+
+// ===============================================================
+
+| observer.product
+| The observers product name.
+
+type: keyword
+
+example: `s200`
 
 | core
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1765,11 +1765,6 @@
       level: core
       type: ip
       description: IP address of the observer.
-    - name: location
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Location of the observer.
     - name: mac
       level: core
       type: keyword
@@ -1780,6 +1775,7 @@
       type: keyword
       ignore_above: 1024
       description: Name of the observer.
+      example: 1_proxySG
     - name: os.family
       level: extended
       type: keyword
@@ -1816,6 +1812,12 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: product
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The observers product name.
+      example: s200
     - name: serial_number
       level: extended
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1695,11 +1695,11 @@
 
       This could be a custom hardware appliance or a server that has been configured
       to run special network, security, or application software. Examples include
-      firewalls, intrusion detection/prevention systems, network monitoring sensors,
-      web application firewalls, data loss prevention systems, and APM servers. The
-      observer.* fields shall be populated with details of the system, if any, that
-      detects, observes and/or creates a network, security, or application event or
-      metric. Message queues and ETL components used in processing events or metrics
+      firewalls, web proxies, intrusion detection/prevention systems, network monitoring
+      sensors, web application firewalls, data loss prevention systems, and APM servers.
+      The observer.* fields shall be populated with details of the system, if any,
+      that detects, observes and/or creates a network, security, or application event
+      or metric. Message queues and ETL components used in processing events or metrics
       are not considered observers in ECS.'
     type: group
     fields:
@@ -1765,11 +1765,21 @@
       level: core
       type: ip
       description: IP address of the observer.
+    - name: location
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Location of the observer.
     - name: mac
       level: core
       type: keyword
       ignore_above: 1024
       description: MAC address of the observer
+    - name: name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Name of the observer.
     - name: os.family
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -220,7 +220,9 @@ observer.geo.region_iso_code,keyword,core,CA-QC,1.2.0-dev
 observer.geo.region_name,keyword,core,Quebec,1.2.0-dev
 observer.hostname,keyword,core,,1.2.0-dev
 observer.ip,ip,core,,1.2.0-dev
+observer.location,keyword,core,,1.2.0-dev
 observer.mac,keyword,core,,1.2.0-dev
+observer.name,keyword,core,,1.2.0-dev
 observer.os.family,keyword,extended,debian,1.2.0-dev
 observer.os.full,keyword,extended,Mac OS Mojave,1.2.0-dev
 observer.os.kernel,keyword,extended,4.4.0-112-generic,1.2.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -220,15 +220,15 @@ observer.geo.region_iso_code,keyword,core,CA-QC,1.2.0-dev
 observer.geo.region_name,keyword,core,Quebec,1.2.0-dev
 observer.hostname,keyword,core,,1.2.0-dev
 observer.ip,ip,core,,1.2.0-dev
-observer.location,keyword,core,,1.2.0-dev
 observer.mac,keyword,core,,1.2.0-dev
-observer.name,keyword,core,,1.2.0-dev
+observer.name,keyword,core,1_proxySG,1.2.0-dev
 observer.os.family,keyword,extended,debian,1.2.0-dev
 observer.os.full,keyword,extended,Mac OS Mojave,1.2.0-dev
 observer.os.kernel,keyword,extended,4.4.0-112-generic,1.2.0-dev
 observer.os.name,keyword,extended,Mac OS X,1.2.0-dev
 observer.os.platform,keyword,extended,darwin,1.2.0-dev
 observer.os.version,keyword,extended,10.14.1,1.2.0-dev
+observer.product,keyword,core,s200,1.2.0-dev
 observer.serial_number,keyword,extended,,1.2.0-dev
 observer.type,keyword,core,firewall,1.2.0-dev
 observer.vendor,keyword,core,,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2504,6 +2504,15 @@ observer.ip:
   order: 1
   short: IP address of the observer.
   type: ip
+observer.location:
+  description: Location of the observer.
+  flat_name: observer.location
+  ignore_above: 1024
+  level: core
+  name: location
+  order: 4
+  short: Location of the observer.
+  type: keyword
 observer.mac:
   description: MAC address of the observer
   flat_name: observer.mac
@@ -2512,6 +2521,15 @@ observer.mac:
   name: mac
   order: 0
   short: MAC address of the observer
+  type: keyword
+observer.name:
+  description: Name of the observer.
+  flat_name: observer.name
+  ignore_above: 1024
+  level: core
+  name: name
+  order: 3
+  short: Name of the observer.
   type: keyword
 observer.os.family:
   description: OS family (such as redhat, debian, freebsd, windows).
@@ -2585,7 +2603,7 @@ observer.serial_number:
   ignore_above: 1024
   level: extended
   name: serial_number
-  order: 5
+  order: 7
   short: Observer serial number.
   type: keyword
 observer.type:
@@ -2598,7 +2616,7 @@ observer.type:
   ignore_above: 1024
   level: core
   name: type
-  order: 6
+  order: 8
   short: The type of the observer the data is coming from.
   type: keyword
 observer.vendor:
@@ -2607,7 +2625,7 @@ observer.vendor:
   ignore_above: 1024
   level: core
   name: vendor
-  order: 3
+  order: 5
   short: observer vendor information.
   type: keyword
 observer.version:
@@ -2616,7 +2634,7 @@ observer.version:
   ignore_above: 1024
   level: core
   name: version
-  order: 4
+  order: 6
   short: Observer version.
   type: keyword
 organization.id:

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2504,15 +2504,6 @@ observer.ip:
   order: 1
   short: IP address of the observer.
   type: ip
-observer.location:
-  description: Location of the observer.
-  flat_name: observer.location
-  ignore_above: 1024
-  level: core
-  name: location
-  order: 4
-  short: Location of the observer.
-  type: keyword
 observer.mac:
   description: MAC address of the observer
   flat_name: observer.mac
@@ -2524,6 +2515,7 @@ observer.mac:
   type: keyword
 observer.name:
   description: Name of the observer.
+  example: 1_proxySG
   flat_name: observer.name
   ignore_above: 1024
   level: core
@@ -2596,6 +2588,16 @@ observer.os.version:
   order: 4
   original_fieldset: os
   short: Operating system version as a raw string.
+  type: keyword
+observer.product:
+  description: The observers product name.
+  example: s200
+  flat_name: observer.product
+  ignore_above: 1024
+  level: core
+  name: product
+  order: 4
+  short: The observers product name.
   type: keyword
 observer.serial_number:
   description: Observer serial number.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2829,15 +2829,6 @@ observer:
       order: 1
       short: IP address of the observer.
       type: ip
-    location:
-      description: Location of the observer.
-      flat_name: observer.location
-      ignore_above: 1024
-      level: core
-      name: location
-      order: 4
-      short: Location of the observer.
-      type: keyword
     mac:
       description: MAC address of the observer
       flat_name: observer.mac
@@ -2849,6 +2840,7 @@ observer:
       type: keyword
     name:
       description: Name of the observer.
+      example: 1_proxySG
       flat_name: observer.name
       ignore_above: 1024
       level: core
@@ -2921,6 +2913,16 @@ observer:
       order: 4
       original_fieldset: os
       short: Operating system version as a raw string.
+      type: keyword
+    product:
+      description: The observers product name.
+      example: s200
+      flat_name: observer.product
+      ignore_above: 1024
+      level: core
+      name: product
+      order: 4
+      short: The observers product name.
       type: keyword
     serial_number:
       description: Observer serial number.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2712,12 +2712,12 @@ observer:
 
     This could be a custom hardware appliance or a server that has been configured
     to run special network, security, or application software. Examples include firewalls,
-    intrusion detection/prevention systems, network monitoring sensors, web application
-    firewalls, data loss prevention systems, and APM servers. The observer.* fields
-    shall be populated with details of the system, if any, that detects, observes
-    and/or creates a network, security, or application event or metric. Message queues
-    and ETL components used in processing events or metrics are not considered observers
-    in ECS.'
+    web proxies, intrusion detection/prevention systems, network monitoring sensors,
+    web application firewalls, data loss prevention systems, and APM servers. The
+    observer.* fields shall be populated with details of the system, if any, that
+    detects, observes and/or creates a network, security, or application event or
+    metric. Message queues and ETL components used in processing events or metrics
+    are not considered observers in ECS.'
   fields:
     geo.city_name:
       description: City name.
@@ -2829,6 +2829,15 @@ observer:
       order: 1
       short: IP address of the observer.
       type: ip
+    location:
+      description: Location of the observer.
+      flat_name: observer.location
+      ignore_above: 1024
+      level: core
+      name: location
+      order: 4
+      short: Location of the observer.
+      type: keyword
     mac:
       description: MAC address of the observer
       flat_name: observer.mac
@@ -2837,6 +2846,15 @@ observer:
       name: mac
       order: 0
       short: MAC address of the observer
+      type: keyword
+    name:
+      description: Name of the observer.
+      flat_name: observer.name
+      ignore_above: 1024
+      level: core
+      name: name
+      order: 3
+      short: Name of the observer.
       type: keyword
     os.family:
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -2910,7 +2928,7 @@ observer:
       ignore_above: 1024
       level: extended
       name: serial_number
-      order: 5
+      order: 7
       short: Observer serial number.
       type: keyword
     type:
@@ -2923,7 +2941,7 @@ observer:
       ignore_above: 1024
       level: core
       name: type
-      order: 6
+      order: 8
       short: The type of the observer the data is coming from.
       type: keyword
     vendor:
@@ -2932,7 +2950,7 @@ observer:
       ignore_above: 1024
       level: core
       name: vendor
-      order: 3
+      order: 5
       short: observer vendor information.
       type: keyword
     version:
@@ -2941,7 +2959,7 @@ observer:
       ignore_above: 1024
       level: core
       name: version
-      order: 4
+      order: 6
       short: Observer version.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1041,7 +1041,15 @@
             "ip": {
               "type": "ip"
             }, 
+            "location": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "mac": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
+            "name": {
               "ignore_above": 1024, 
               "type": "keyword"
             }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1041,10 +1041,6 @@
             "ip": {
               "type": "ip"
             }, 
-            "location": {
-              "ignore_above": 1024, 
-              "type": "keyword"
-            }, 
             "mac": {
               "ignore_above": 1024, 
               "type": "keyword"
@@ -1080,6 +1076,10 @@
                   "type": "keyword"
                 }
               }
+            }, 
+            "product": {
+              "ignore_above": 1024, 
+              "type": "keyword"
             }, 
             "serial_number": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1040,7 +1040,15 @@
           "ip": {
             "type": "ip"
           }, 
+          "location": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "mac": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
+          "name": {
             "ignore_above": 1024, 
             "type": "keyword"
           }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1040,10 +1040,6 @@
           "ip": {
             "type": "ip"
           }, 
-          "location": {
-            "ignore_above": 1024, 
-            "type": "keyword"
-          }, 
           "mac": {
             "ignore_above": 1024, 
             "type": "keyword"
@@ -1079,6 +1075,10 @@
                 "type": "keyword"
               }
             }
+          }, 
+          "product": {
+            "ignore_above": 1024, 
+            "type": "keyword"
           }, 
           "serial_number": {
             "ignore_above": 1024, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -704,7 +704,15 @@
             "ip": {
               "type": "ip"
             },
+            "location": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "mac": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -704,15 +704,15 @@
             "ip": {
               "type": "ip"
             },
-            "location": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "mac": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "product": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/schema.json
+++ b/schema.json
@@ -1683,16 +1683,6 @@
         "required": false, 
         "type": "ip"
       }, 
-      "observer.location": {
-        "description": "Location of the observer.", 
-        "example": "", 
-        "footnote": "", 
-        "group": 2, 
-        "level": "core", 
-        "name": "observer.location", 
-        "required": false, 
-        "type": "keyword"
-      }, 
       "observer.mac": {
         "description": "MAC address of the observer", 
         "example": "", 
@@ -1705,11 +1695,21 @@
       }, 
       "observer.name": {
         "description": "Name of the observer.", 
-        "example": "", 
+        "example": "1_proxySG", 
         "footnote": "", 
         "group": 2, 
         "level": "core", 
         "name": "observer.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.product": {
+        "description": "The observers product name.", 
+        "example": "s200", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.product", 
         "required": false, 
         "type": "keyword"
       }, 

--- a/schema.json
+++ b/schema.json
@@ -1661,7 +1661,7 @@
     "type": "group"
   }, 
   "observer": {
-    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.\nThis could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.\n", 
+    "description": "An observer is defined as a special network, security, or application device used to detect, observe, or create network, security, or application-related events and metrics.\nThis could be a custom hardware appliance or a server that has been configured to run special network, security, or application software. Examples include firewalls, web proxies, intrusion detection/prevention systems, network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers. The observer.* fields shall be populated with details of the system, if any, that detects, observes and/or creates a network, security, or application event or metric. Message queues and ETL components used in processing events or metrics are not considered observers in ECS.\n", 
     "fields": {
       "observer.hostname": {
         "description": "Hostname of the observer.", 
@@ -1683,6 +1683,16 @@
         "required": false, 
         "type": "ip"
       }, 
+      "observer.location": {
+        "description": "Location of the observer.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.location", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "observer.mac": {
         "description": "MAC address of the observer", 
         "example": "", 
@@ -1690,6 +1700,16 @@
         "group": 2, 
         "level": "core", 
         "name": "observer.mac", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "observer.name": {
+        "description": "Name of the observer.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "observer.name", 
         "required": false, 
         "type": "keyword"
       }, 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -36,11 +36,13 @@
       type: keyword
       description: >
         Name of the observer.
-    - name: location
+      example: 1_proxySG
+    - name: product
       level: core
       type: keyword
       description: >
-        Location of the observer.
+        The observers product name.
+      example: s200
     - name: vendor
       level: core
       type: keyword

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -9,7 +9,7 @@
 
     This could be a custom hardware appliance or a server that has been configured
     to run special network, security, or application software.
-    Examples include firewalls, intrusion detection/prevention systems,
+    Examples include firewalls, web proxies, intrusion detection/prevention systems,
     network monitoring sensors, web application firewalls, data loss prevention systems, and APM servers.
     The observer.* fields shall be populated with details of the system, if any,
     that detects, observes and/or creates a network, security, or application event or metric.
@@ -31,6 +31,16 @@
       type: keyword
       description: >
         Hostname of the observer.
+    - name: name
+      level: core
+      type: keyword
+      description: >
+        Name of the observer.
+    - name: location
+      level: core
+      type: keyword
+      description: >
+        Location of the observer.
     - name: vendor
       level: core
       type: keyword


### PR DESCRIPTION
Web proxies can block traffic in the same way as an Intrusion Prevention System which is listed as a type of Observer. Added a location and name field so observer can also store fields use to describe web proxy appliances found in web proxy logs. 