### PR TITLE
Added event.detection to identify suspicious activity or files

### DIFF
--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -76,6 +76,15 @@ type Event struct {
 	// Please avoid using this field for user data.
 	Type string `ecs:"type"`
 
+	// The detection which triggered the event or was observed during
+	// processing of the event.
+	// An example of a detection which triggered an event is an anti-virus
+	// alert caused by malware. An example of a detection observed during
+	// processing of an event, is a web-proxy identifying a suspicious file
+	// while processing http requests between an internal host and external
+	// web-server.
+	Detection string `ecs:"detection"`
+
 	// Name of the module this data is coming from.
 	// If your monitoring agent supports the concept of modules or plugins to
 	// process events of a given source (e.g. Apache logs), `event.module`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1106,6 +1106,19 @@ example: `apache.access`
 
 // ===============================================================
 
+| event.detection
+| The detection which triggered the event or was observed during processing of the event.
+
+An example of a detection which triggered an event is an anti-virus alert caused by malware. An example of a detection observed during processing of an event, is a web-proxy identifying a suspicious file while processing http requests between an internal host and external web-server.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
 | event.duration
 | Duration of the event in nanoseconds.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -888,6 +888,17 @@
         It''s recommended but not required to start the dataset name with the module
         name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: detection
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The detection which triggered the event or was observed during
+        processing of the event.
+
+        An example of a detection which triggered an event is an anti-virus alert
+        caused by malware. An example of a detection observed during processing of
+        an event, is a web-proxy identifying a suspicious file while processing http
+        requests between an internal host and external web-server.'
     - name: duration
       level: core
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -104,6 +104,7 @@ event.category,keyword,core,user-management,1.2.0-dev
 event.code,keyword,extended,4648,1.2.0-dev
 event.created,date,core,,1.2.0-dev
 event.dataset,keyword,core,apache.access,1.2.0-dev
+event.detection,keyword,core,,1.2.0-dev
 event.duration,long,core,,1.2.0-dev
 event.end,date,extended,,1.2.0-dev
 event.hash,keyword,extended,123456789012345678901234567890ABCD,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1163,7 +1163,7 @@ event.created:
   flat_name: event.created
   level: core
   name: created
-  order: 16
+  order: 17
   short: Time when the event was first read by an agent or by your pipeline.
   type: date
 event.dataset:
@@ -1179,8 +1179,24 @@ event.dataset:
   ignore_above: 1024
   level: core
   name: dataset
-  order: 8
+  order: 9
   short: Name of the dataset.
+  type: keyword
+event.detection:
+  description: 'The detection which triggered the event or was observed during processing
+    of the event.
+
+    An example of a detection which triggered an event is an anti-virus alert caused
+    by malware. An example of a detection observed during processing of an event,
+    is a web-proxy identifying a suspicious file while processing http requests between
+    an internal host and external web-server.'
+  flat_name: event.detection
+  ignore_above: 1024
+  level: core
+  name: detection
+  order: 7
+  short: The detection which triggered the event or was observed during processing
+    of the event.
   type: keyword
 event.duration:
   description: 'Duration of the event in nanoseconds.
@@ -1192,7 +1208,7 @@ event.duration:
   input_format: nanoseconds
   level: core
   name: duration
-  order: 13
+  order: 14
   output_format: asMilliseconds
   output_precision: 1
   short: Duration of the event in nanoseconds.
@@ -1203,7 +1219,7 @@ event.end:
   flat_name: event.end
   level: extended
   name: end
-  order: 18
+  order: 19
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
@@ -1215,7 +1231,7 @@ event.hash:
   ignore_above: 1024
   level: extended
   name: hash
-  order: 12
+  order: 13
   short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
     log integrity.
   type: keyword
@@ -1255,7 +1271,7 @@ event.module:
   ignore_above: 1024
   level: core
   name: module
-  order: 7
+  order: 8
   short: Name of the module this data is coming from.
   type: keyword
 event.original:
@@ -1271,7 +1287,7 @@ event.original:
   index: false
   level: core
   name: original
-  order: 11
+  order: 12
   short: Raw text message of entire event.
   type: keyword
 event.outcome:
@@ -1300,7 +1316,7 @@ event.provider:
   ignore_above: 1024
   level: extended
   name: provider
-  order: 9
+  order: 10
   short: Source of the event.
   type: keyword
 event.risk_score:
@@ -1309,7 +1325,7 @@ event.risk_score:
   flat_name: event.risk_score
   level: core
   name: risk_score
-  order: 19
+  order: 20
   short: Risk score or priority of the event (e.g. security solutions). Use your system's
     original value here.
   type: float
@@ -1322,7 +1338,7 @@ event.risk_score_norm:
   flat_name: event.risk_score_norm
   level: extended
   name: risk_score_norm
-  order: 20
+  order: 21
   short: Normalized risk score or priority of the event (0-100).
   type: float
 event.sequence:
@@ -1334,7 +1350,7 @@ event.sequence:
   format: string
   level: extended
   name: sequence
-  order: 14
+  order: 15
   short: Sequence number of the event.
   type: long
 event.severity:
@@ -1346,7 +1362,7 @@ event.severity:
   format: string
   level: core
   name: severity
-  order: 10
+  order: 11
   short: Original severity of the event.
   type: long
 event.start:
@@ -1355,7 +1371,7 @@ event.start:
   flat_name: event.start
   level: extended
   name: start
-  order: 17
+  order: 18
   short: event.start contains the date when the event started or when the activity
     was first observed.
   type: date
@@ -1370,7 +1386,7 @@ event.timezone:
   ignore_above: 1024
   level: extended
   name: timezone
-  order: 15
+  order: 16
   short: Event time zone.
   type: keyword
 event.type:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1374,7 +1374,7 @@ event:
       flat_name: event.created
       level: core
       name: created
-      order: 16
+      order: 17
       short: Time when the event was first read by an agent or by your pipeline.
       type: date
     dataset:
@@ -1391,8 +1391,24 @@ event:
       ignore_above: 1024
       level: core
       name: dataset
-      order: 8
+      order: 9
       short: Name of the dataset.
+      type: keyword
+    detection:
+      description: 'The detection which triggered the event or was observed during
+        processing of the event.
+
+        An example of a detection which triggered an event is an anti-virus alert
+        caused by malware. An example of a detection observed during processing of
+        an event, is a web-proxy identifying a suspicious file while processing http
+        requests between an internal host and external web-server.'
+      flat_name: event.detection
+      ignore_above: 1024
+      level: core
+      name: detection
+      order: 7
+      short: The detection which triggered the event or was observed during processing
+        of the event.
       type: keyword
     duration:
       description: 'Duration of the event in nanoseconds.
@@ -1404,7 +1420,7 @@ event:
       input_format: nanoseconds
       level: core
       name: duration
-      order: 13
+      order: 14
       output_format: asMilliseconds
       output_precision: 1
       short: Duration of the event in nanoseconds.
@@ -1415,7 +1431,7 @@ event:
       flat_name: event.end
       level: extended
       name: end
-      order: 18
+      order: 19
       short: event.end contains the date when the event ended or when the activity
         was last observed.
       type: date
@@ -1427,7 +1443,7 @@ event:
       ignore_above: 1024
       level: extended
       name: hash
-      order: 12
+      order: 13
       short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
         log integrity.
       type: keyword
@@ -1467,7 +1483,7 @@ event:
       ignore_above: 1024
       level: core
       name: module
-      order: 7
+      order: 8
       short: Name of the module this data is coming from.
       type: keyword
     original:
@@ -1483,7 +1499,7 @@ event:
       index: false
       level: core
       name: original
-      order: 11
+      order: 12
       short: Raw text message of entire event.
       type: keyword
     outcome:
@@ -1513,7 +1529,7 @@ event:
       ignore_above: 1024
       level: extended
       name: provider
-      order: 9
+      order: 10
       short: Source of the event.
       type: keyword
     risk_score:
@@ -1522,7 +1538,7 @@ event:
       flat_name: event.risk_score
       level: core
       name: risk_score
-      order: 19
+      order: 20
       short: Risk score or priority of the event (e.g. security solutions). Use your
         system's original value here.
       type: float
@@ -1535,7 +1551,7 @@ event:
       flat_name: event.risk_score_norm
       level: extended
       name: risk_score_norm
-      order: 20
+      order: 21
       short: Normalized risk score or priority of the event (0-100).
       type: float
     sequence:
@@ -1547,7 +1563,7 @@ event:
       format: string
       level: extended
       name: sequence
-      order: 14
+      order: 15
       short: Sequence number of the event.
       type: long
     severity:
@@ -1559,7 +1575,7 @@ event:
       format: string
       level: core
       name: severity
-      order: 10
+      order: 11
       short: Original severity of the event.
       type: long
     start:
@@ -1568,7 +1584,7 @@ event:
       flat_name: event.start
       level: extended
       name: start
-      order: 17
+      order: 18
       short: event.start contains the date when the event started or when the activity
         was first observed.
       type: date
@@ -1583,7 +1599,7 @@ event:
       ignore_above: 1024
       level: extended
       name: timezone
-      order: 15
+      order: 16
       short: Event time zone.
       type: keyword
     type:

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -516,6 +516,10 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "detection": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "duration": {
               "type": "long"
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -515,6 +515,10 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "detection": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "duration": {
             "type": "long"
           }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -337,6 +337,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "detection": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "duration": {
               "type": "long"
             },

--- a/schema.json
+++ b/schema.json
@@ -782,6 +782,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "event.detection": {
+        "description": "The detection which triggered the event or was observed during processing of the event.\nAn example of a detection which triggered an event is an anti-virus alert caused by malware. An example of a detection observed during processing of an event, is a web-proxy identifying a suspicious file while processing http requests between an internal host and external web-server.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "event.detection", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "event.duration": {
         "description": "Duration of the event in nanoseconds.\nIf event.start and event.end are known this value should be the difference between the end and start time.", 
         "example": "", 

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -101,6 +101,17 @@
 
         Please avoid using this field for user data.
 
+    - name: detection
+      level: core
+      type: keyword
+      short: The detection which triggered the event or was observed during processing of the event.
+      description: >
+        The detection which triggered the event or was observed during processing of the event.
+
+        An example of a detection which triggered an event is an anti-virus alert caused by malware.
+        An example of a detection observed during processing of an event, is a web-proxy identifying a suspicious file
+        while processing http requests between an internal host and external web-server.
+
     - name: module
       level: core
       type: keyword


### PR DESCRIPTION
Added a field to store a detection which triggered the event or was observed during processing of the event.

An example of a detection which triggered an event is an anti-virus alert caused by malware.
An example of a detection observed during processing of an event, is a web-proxy identifying a suspicious file while processing http requests between an internal host and external web-server.

Detection's could come from the following sources
Anti-virus logs
Intrusion Detection Systems
Intrusion Prevention Systems
Endpoint Agent logs
Web-Proxy logs 
Email solution providers 
Cloud platforms 