### PR TITLE
Added question.subdomain field

### DIFF
--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -72,6 +72,9 @@ type Dns struct {
 	// "co.uk".
 	QuestionRegisteredDomain string `ecs:"question.registered_domain"`
 
+	// A subdomain is a hostname under it's parent domain.
+	QuestionSubdomain string `ecs:"question.subdomain"`
+
 	// An array containing an object for each answer section returned by the
 	// server.
 	// The main keys that should be present in these objects are defined by

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -890,6 +890,17 @@ example: `google.com`
 
 // ===============================================================
 
+| dns.question.subdomain
+| A subdomain is a hostname under it's parent domain.
+
+type: keyword
+
+example: `www`
+
+| extended
+
+// ===============================================================
+
 | dns.question.type
 | The type of record being queried.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -735,6 +735,12 @@
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
       example: google.com
+    - name: question.subdomain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A subdomain is a hostname under it's parent domain.
+      example: www
     - name: question.type
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -91,6 +91,7 @@ dns.op_code,keyword,extended,QUERY,1.2.0-dev
 dns.question.class,keyword,extended,IN,1.2.0-dev
 dns.question.name,keyword,extended,www.google.com,1.2.0-dev
 dns.question.registered_domain,keyword,extended,google.com,1.2.0-dev
+dns.question.subdomain,keyword,extended,www,1.2.0-dev
 dns.question.type,keyword,extended,AAAA,1.2.0-dev
 dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",1.2.0-dev
 dns.response_code,keyword,extended,NOERROR,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -869,7 +869,7 @@ dns.answers:
   level: extended
   name: answers
   object_type: keyword
-  order: 9
+  order: 10
   short: Array of DNS answers.
   type: object
 dns.answers.class:
@@ -879,7 +879,7 @@ dns.answers.class:
   ignore_above: 1024
   level: extended
   name: answers.class
-  order: 12
+  order: 13
   short: The class of DNS data contained in this resource record.
   type: keyword
 dns.answers.data:
@@ -891,7 +891,7 @@ dns.answers.data:
   ignore_above: 1024
   level: extended
   name: answers.data
-  order: 14
+  order: 15
   short: The data describing the resource.
   type: keyword
 dns.answers.name:
@@ -905,7 +905,7 @@ dns.answers.name:
   ignore_above: 1024
   level: extended
   name: answers.name
-  order: 10
+  order: 11
   short: The domain name to which this resource record pertains.
   type: keyword
 dns.answers.ttl:
@@ -915,7 +915,7 @@ dns.answers.ttl:
   flat_name: dns.answers.ttl
   level: extended
   name: answers.ttl
-  order: 13
+  order: 14
   short: The time interval in seconds that this resource record may be cached before
     it should be discarded. Zero values mean that the data should not be cached.
   type: long
@@ -926,7 +926,7 @@ dns.answers.type:
   ignore_above: 1024
   level: extended
   name: answers.type
-  order: 11
+  order: 12
   short: The type of data contained in this resource record.
   type: keyword
 dns.header_flags:
@@ -1008,6 +1008,16 @@ dns.question.registered_domain:
   order: 8
   short: The highest registered domain, stripped of the subdomain.
   type: keyword
+dns.question.subdomain:
+  description: A subdomain is a hostname under it's parent domain.
+  example: www
+  flat_name: dns.question.subdomain
+  ignore_above: 1024
+  level: extended
+  name: question.subdomain
+  order: 9
+  short: The subdomain of the domain.
+  type: keyword
 dns.question.type:
   description: The type of record being queried.
   example: AAAA
@@ -1031,7 +1041,7 @@ dns.resolved_ip:
   flat_name: dns.resolved_ip
   level: extended
   name: resolved_ip
-  order: 15
+  order: 16
   short: Array containing all IPs seen in answers.data
   type: ip
 dns.response_code:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1037,7 +1037,7 @@ dns:
       level: extended
       name: answers
       object_type: keyword
-      order: 9
+      order: 10
       short: Array of DNS answers.
       type: object
     answers.class:
@@ -1047,7 +1047,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.class
-      order: 12
+      order: 13
       short: The class of DNS data contained in this resource record.
       type: keyword
     answers.data:
@@ -1059,7 +1059,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.data
-      order: 14
+      order: 15
       short: The data describing the resource.
       type: keyword
     answers.name:
@@ -1073,7 +1073,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.name
-      order: 10
+      order: 11
       short: The domain name to which this resource record pertains.
       type: keyword
     answers.ttl:
@@ -1084,7 +1084,7 @@ dns:
       flat_name: dns.answers.ttl
       level: extended
       name: answers.ttl
-      order: 13
+      order: 14
       short: The time interval in seconds that this resource record may be cached
         before it should be discarded. Zero values mean that the data should not be
         cached.
@@ -1096,7 +1096,7 @@ dns:
       ignore_above: 1024
       level: extended
       name: answers.type
-      order: 11
+      order: 12
       short: The type of data contained in this resource record.
       type: keyword
     header_flags:
@@ -1179,6 +1179,16 @@ dns:
       order: 8
       short: The highest registered domain, stripped of the subdomain.
       type: keyword
+    question.subdomain:
+      description: A subdomain is a hostname under it's parent domain.
+      example: www
+      flat_name: dns.question.subdomain
+      ignore_above: 1024
+      level: extended
+      name: question.subdomain
+      order: 9
+      short: The subdomain of the domain.
+      type: keyword
     question.type:
       description: The type of record being queried.
       example: AAAA
@@ -1202,7 +1212,7 @@ dns:
       flat_name: dns.resolved_ip
       level: extended
       name: resolved_ip
-      order: 15
+      order: 16
       short: Array containing all IPs seen in answers.data
       type: ip
     response_code:

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -452,6 +452,10 @@
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
+                "subdomain": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
                 "type": {
                   "ignore_above": 1024, 
                   "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -451,6 +451,10 @@
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
+              "subdomain": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
               "type": {
                 "ignore_above": 1024, 
                 "type": "keyword"

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -273,6 +273,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "subdomain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "type": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/schema.json
+++ b/schema.json
@@ -625,6 +625,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "dns.question.subdomain": {
+        "description": "A subdomain is a hostname under it's parent domain.", 
+        "example": "www", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "dns.question.subdomain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "dns.question.type": {
         "description": "The type of record being queried.", 
         "example": "AAAA", 

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -101,6 +101,14 @@
         simply taking the last two labels will not work well for TLDs such as "co.uk".
       example: google.com
 
+    - name: question.subdomain
+      level: extended
+      type: keyword
+      short: The subdomain of the domain.
+      description: >
+        A subdomain is a hostname under it's parent domain.
+      example: www
+
     - name: answers
       level: extended
       type: object


### PR DESCRIPTION
Added to question.subdomain field for security use cases such as looking for dns-exfil.

Currently domains are only indexed as domain, top_level_domain and registered_domain.

The subdomain field will allow users to find parent domains with a abnormally high number of sub-domains.