### PR TITLE
Add error.type field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -12,6 +12,7 @@ Thanks, you're awesome :-) -->
 ### Added
 * Added `error.stack_trace` field. #562
 * Added `log.origin.file.name`, `log.origin.function` and `log.origin.file.line` fields. #563
+* Added `error.type` field. #TODO
 
 ### Improvements
 

--- a/code/go/ecs/error.go
+++ b/code/go/ecs/error.go
@@ -32,6 +32,9 @@ type Error struct {
 	// Error code describing the error.
 	Code string `ecs:"code"`
 
+	// The type of the error, for example the class name of the exception.
+	Type string `ecs:"type"`
+
 	// The stack trace of this error in plain text.
 	StackTrace string `ecs:"stack_trace"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1029,6 +1029,17 @@ type: keyword
 
 // ===============================================================
 
+| error.type
+| The type of the error, for example the class name of the exception.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
 |=====
 
 [[ecs-event]]

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -818,6 +818,11 @@
       type: keyword
       ignore_above: 1024
       description: The stack trace of this error in plain text.
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The type of the error, for example the class name of the exception.
   - name: event
     title: Event
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -100,6 +100,7 @@ error.code,keyword,core,,1.2.0-dev
 error.id,keyword,core,,1.2.0-dev
 error.message,text,core,,1.2.0-dev
 error.stack_trace,keyword,extended,,1.2.0-dev
+error.type,keyword,core,,1.2.0-dev
 event.action,keyword,core,user-password-change,1.2.0-dev
 event.category,keyword,core,user-management,1.2.0-dev
 event.code,keyword,extended,4648,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1112,8 +1112,17 @@ error.stack_trace:
   index: false
   level: extended
   name: stack_trace
-  order: 3
+  order: 4
   short: The stack trace of this error in plain text.
+  type: keyword
+error.type:
+  description: The type of the error, for example the class name of the exception.
+  flat_name: error.type
+  ignore_above: 1024
+  level: core
+  name: type
+  order: 3
+  short: The type of the error, for example the class name of the exception.
   type: keyword
 event.action:
   description: 'The action captured by the event.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1304,8 +1304,17 @@ error:
       index: false
       level: extended
       name: stack_trace
-      order: 3
+      order: 4
       short: The stack trace of this error in plain text.
+      type: keyword
+    type:
+      description: The type of the error, for example the class name of the exception.
+      flat_name: error.type
+      ignore_above: 1024
+      level: core
+      name: type
+      order: 3
+      short: The type of the error, for example the class name of the exception.
       type: keyword
   group: 2
   name: error

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -498,6 +498,10 @@
               "ignore_above": 1024, 
               "index": false, 
               "type": "keyword"
+            }, 
+            "type": {
+              "ignore_above": 1024, 
+              "type": "keyword"
             }
           }
         }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -497,6 +497,10 @@
             "ignore_above": 1024, 
             "index": false, 
             "type": "keyword"
+          }, 
+          "type": {
+            "ignore_above": 1024, 
+            "type": "keyword"
           }
         }
       }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -318,6 +318,10 @@
               "ignore_above": 1024,
               "index": false,
               "type": "keyword"
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },

--- a/schema.json
+++ b/schema.json
@@ -732,6 +732,16 @@
         "name": "error.stack_trace", 
         "required": false, 
         "type": "(not indexed)"
+      }, 
+      "error.type": {
+        "description": "The type of the error, for example the class name of the exception.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "error.type", 
+        "required": false, 
+        "type": "keyword"
       }
     }, 
     "group": 2, 

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -29,6 +29,12 @@
       description: >
         Error code describing the error.
 
+    - name: type
+      level: core
+      type: keyword
+      description: >
+        The type of the error, for example the class name of the exception.
+
     - name: stack_trace
       level: extended
       type: keyword


### PR DESCRIPTION
At first I tried to map the exception class name to error.code.
But I don't think that's the best place for that.
In APM we also have both a code and a type for an exception.