### PR TITLE
add JSON + omitempty tags to generated Go code

### DIFF
--- a/code/go/ecs/agent.go
+++ b/code/go/ecs/agent.go
@@ -27,7 +27,7 @@ package ecs
 // where the event happened or the measurement was taken.
 type Agent struct {
 	// Version of the agent.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Custom name of the agent.
 	// This is a name that can be given to an agent. This can be helpful if for
@@ -35,19 +35,19 @@ type Agent struct {
 	// readable separation is needed on which Filebeat instance data is coming
 	// from.
 	// If no name is given, the name is often left empty.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Type of the agent.
 	// The agent type stays always the same and should be given by the agent
 	// used. In case of Filebeat the agent would always be Filebeat also if two
 	// Filebeat instances are run on the same machine.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// Unique identifier of this agent (if one exists).
 	// Example: For Beats this would be beat.id.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Ephemeral identifier of this agent (if one exists).
 	// This id normally changes across restarts, but `agent.id` does not.
-	EphemeralID string `ecs:"ephemeral_id"`
+	EphemeralID string `ecs:"ephemeral_id" json:"ephemeral_id,omitempty"`
 }

--- a/code/go/ecs/as.go
+++ b/code/go/ecs/as.go
@@ -26,8 +26,8 @@ package ecs
 type AS struct {
 	// Unique number allocated to the autonomous system. The autonomous system
 	// number (ASN) uniquely identifies each network on the Internet.
-	Number int64 `ecs:"number"`
+	Number int64 `ecs:"number" json:"number,omitempty"`
 
 	// Organization name.
-	OrganizationName string `ecs:"organization.name"`
+	OrganizationName string `ecs:"organization.name" json:"organization.name,omitempty"`
 }

--- a/code/go/ecs/base.go
+++ b/code/go/ecs/base.go
@@ -32,21 +32,21 @@ type Base struct {
 	// If the event source has no original timestamp, this value is typically
 	// populated by the first time the event was received by the pipeline.
 	// Required field for all events.
-	Timestamp time.Time `ecs:"@timestamp"`
+	Timestamp time.Time `ecs:"@timestamp" json:"@timestamp,omitempty"`
 
 	// List of keywords used to tag each event.
-	Tags string `ecs:"tags"`
+	Tags string `ecs:"tags" json:"tags,omitempty"`
 
 	// Custom key/value pairs.
 	// Can be used to add meta information to events. Should not contain nested
 	// objects. All values are stored as keyword.
 	// Example: `docker` and `k8s` labels.
-	Labels map[string]interface{} `ecs:"labels"`
+	Labels map[string]interface{} `ecs:"labels" json:"labels,omitempty"`
 
 	// For log events the message field contains the log message, optimized for
 	// viewing in a log viewer.
 	// For structured logs without an original message field, other fields can
 	// be concatenated to form a human-readable summary of the event.
 	// If multiple messages exist, they can be combined into one message.
-	Message string `ecs:"message"`
+	Message string `ecs:"message" json:"message,omitempty"`
 }

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -38,20 +38,20 @@ type Client struct {
 	// store the raw address in the `.address` field.
 	// Then it should be duplicated to `.ip` or `.domain`, depending on which
 	// one it is.
-	Address string `ecs:"address"`
+	Address string `ecs:"address" json:"address,omitempty"`
 
 	// IP address of the client.
 	// Can be one or multiple IPv4 or IPv6 addresses.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Port of the client.
-	Port int64 `ecs:"port"`
+	Port int64 `ecs:"port" json:"port,omitempty"`
 
 	// MAC address of the client.
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// Client domain.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 
 	// The highest registered client domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -59,21 +59,21 @@ type Client struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	RegisteredDomain string `ecs:"registered_domain"`
+	RegisteredDomain string `ecs:"registered_domain" json:"registered_domain,omitempty"`
 
 	// Bytes sent from the client to the server.
-	Bytes int64 `ecs:"bytes"`
+	Bytes int64 `ecs:"bytes" json:"bytes,omitempty"`
 
 	// Packets sent from the client to the server.
-	Packets int64 `ecs:"packets"`
+	Packets int64 `ecs:"packets" json:"packets,omitempty"`
 
 	// Translated IP of source based NAT sessions (e.g. internal client to
 	// internet).
 	// Typically connections traversing load balancers, firewalls, or routers.
-	NatIP string `ecs:"nat.ip"`
+	NatIP string `ecs:"nat.ip" json:"nat.ip,omitempty"`
 
 	// Translated port of source based NAT sessions (e.g. internal client to
 	// internet).
 	// Typically connections traversing load balancers, firewalls, or routers.
-	NatPort int64 `ecs:"nat.port"`
+	NatPort int64 `ecs:"nat.port" json:"nat.port,omitempty"`
 }

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -23,26 +23,26 @@ package ecs
 type Cloud struct {
 	// Name of the cloud provider. Example values are aws, azure, gcp, or
 	// digitalocean.
-	Provider string `ecs:"provider"`
+	Provider string `ecs:"provider" json:"provider,omitempty"`
 
 	// Availability zone in which this host is running.
-	AvailabilityZone string `ecs:"availability_zone"`
+	AvailabilityZone string `ecs:"availability_zone" json:"availability_zone,omitempty"`
 
 	// Region in which this host is running.
-	Region string `ecs:"region"`
+	Region string `ecs:"region" json:"region,omitempty"`
 
 	// Instance ID of the host machine.
-	InstanceID string `ecs:"instance.id"`
+	InstanceID string `ecs:"instance.id" json:"instance.id,omitempty"`
 
 	// Instance name of the host machine.
-	InstanceName string `ecs:"instance.name"`
+	InstanceName string `ecs:"instance.name" json:"instance.name,omitempty"`
 
 	// Machine type of the host machine.
-	MachineType string `ecs:"machine.type"`
+	MachineType string `ecs:"machine.type" json:"machine.type,omitempty"`
 
 	// The cloud account or organization id used to identify different entities
 	// in a multi-tenant environment.
 	// Examples: AWS account id, Google Cloud ORG Id, or other unique
 	// identifier.
-	AccountID string `ecs:"account.id"`
+	AccountID string `ecs:"account.id" json:"account.id,omitempty"`
 }

--- a/code/go/ecs/container.go
+++ b/code/go/ecs/container.go
@@ -24,20 +24,20 @@ package ecs
 // These fields help correlate data based containers from any runtime.
 type Container struct {
 	// Runtime managing this container.
-	Runtime string `ecs:"runtime"`
+	Runtime string `ecs:"runtime" json:"runtime,omitempty"`
 
 	// Unique container id.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Name of the image the container was built on.
-	ImageName string `ecs:"image.name"`
+	ImageName string `ecs:"image.name" json:"image.name,omitempty"`
 
 	// Container image tag.
-	ImageTag string `ecs:"image.tag"`
+	ImageTag string `ecs:"image.tag" json:"image.tag,omitempty"`
 
 	// Container name.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Image labels.
-	Labels map[string]interface{} `ecs:"labels"`
+	Labels map[string]interface{} `ecs:"labels" json:"labels,omitempty"`
 }

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -27,20 +27,20 @@ type Destination struct {
 	// store the raw address in the `.address` field.
 	// Then it should be duplicated to `.ip` or `.domain`, depending on which
 	// one it is.
-	Address string `ecs:"address"`
+	Address string `ecs:"address" json:"address,omitempty"`
 
 	// IP address of the destination.
 	// Can be one or multiple IPv4 or IPv6 addresses.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Port of the destination.
-	Port int64 `ecs:"port"`
+	Port int64 `ecs:"port" json:"port,omitempty"`
 
 	// MAC address of the destination.
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// Destination domain.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 
 	// The highest registered destination domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -48,20 +48,20 @@ type Destination struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	RegisteredDomain string `ecs:"registered_domain"`
+	RegisteredDomain string `ecs:"registered_domain" json:"registered_domain,omitempty"`
 
 	// Bytes sent from the destination to the source.
-	Bytes int64 `ecs:"bytes"`
+	Bytes int64 `ecs:"bytes" json:"bytes,omitempty"`
 
 	// Packets sent from the destination to the source.
-	Packets int64 `ecs:"packets"`
+	Packets int64 `ecs:"packets" json:"packets,omitempty"`
 
 	// Translated ip of destination based NAT sessions (e.g. internet to
 	// private DMZ)
 	// Typically used with load balancers, firewalls, or routers.
-	NatIP string `ecs:"nat.ip"`
+	NatIP string `ecs:"nat.ip" json:"nat.ip,omitempty"`
 
 	// Port the source session is translated to by NAT Device.
 	// Typically used with load balancers, firewalls, or routers.
-	NatPort int64 `ecs:"nat.port"`
+	NatPort int64 `ecs:"nat.port" json:"nat.port,omitempty"`
 }

--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -32,23 +32,23 @@ type Dns struct {
 	// create one event per query (optionally as soon as the query is seen).
 	// And a second event containing all query details as well as an array of
 	// answers.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// The DNS packet identifier assigned by the program that generated the
 	// query. The identifier is copied to the response.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// The DNS operation code that specifies the kind of query in the message.
 	// This value is set by the originator of a query and copied into the
 	// response.
-	OpCode string `ecs:"op_code"`
+	OpCode string `ecs:"op_code" json:"op_code,omitempty"`
 
 	// Array of 2 letter DNS header flags.
 	// Expected values are: AA, TC, RD, RA, AD, CD, DO.
-	HeaderFlags string `ecs:"header_flags"`
+	HeaderFlags string `ecs:"header_flags" json:"header_flags,omitempty"`
 
 	// The DNS response code.
-	ResponseCode string `ecs:"response_code"`
+	ResponseCode string `ecs:"response_code" json:"response_code,omitempty"`
 
 	// The name being queried.
 	// If the name field contains non-printable characters (below 32 or above
@@ -56,13 +56,13 @@ type Dns struct {
 	// (\DDD). Back slashes and quotes should be escaped. Tabs, carriage
 	// returns, and line feeds should be converted to \t, \r, and \n
 	// respectively.
-	QuestionName string `ecs:"question.name"`
+	QuestionName string `ecs:"question.name" json:"question.name,omitempty"`
 
 	// The type of record being queried.
-	QuestionType string `ecs:"question.type"`
+	QuestionType string `ecs:"question.type" json:"question.type,omitempty"`
 
 	// The class of of records being queried.
-	QuestionClass string `ecs:"question.class"`
+	QuestionClass string `ecs:"question.class" json:"question.class,omitempty"`
 
 	// The highest registered domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -70,7 +70,7 @@ type Dns struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	QuestionRegisteredDomain string `ecs:"question.registered_domain"`
+	QuestionRegisteredDomain string `ecs:"question.registered_domain" json:"question.registered_domain,omitempty"`
 
 	// An array containing an object for each answer section returned by the
 	// server.
@@ -81,34 +81,34 @@ type Dns struct {
 	// answer objects must contain the `data` key. If more information is
 	// available, map as much of it to ECS as possible, and add any additional
 	// fields to the answer objects as custom fields.
-	Answers map[string]interface{} `ecs:"answers"`
+	Answers map[string]interface{} `ecs:"answers" json:"answers,omitempty"`
 
 	// The domain name to which this resource record pertains.
 	// If a chain of CNAME is being resolved, each answer's `name` should be
 	// the one that corresponds with the answer's `data`. It should not simply
 	// be the original `question.name` repeated.
-	AnswersName string `ecs:"answers.name"`
+	AnswersName string `ecs:"answers.name" json:"answers.name,omitempty"`
 
 	// The type of data contained in this resource record.
-	AnswersType string `ecs:"answers.type"`
+	AnswersType string `ecs:"answers.type" json:"answers.type,omitempty"`
 
 	// The class of DNS data contained in this resource record.
-	AnswersClass string `ecs:"answers.class"`
+	AnswersClass string `ecs:"answers.class" json:"answers.class,omitempty"`
 
 	// The time interval in seconds that this resource record may be cached
 	// before it should be discarded. Zero values mean that the data should not
 	// be cached.
-	AnswersTtl int64 `ecs:"answers.ttl"`
+	AnswersTtl int64 `ecs:"answers.ttl" json:"answers.ttl,omitempty"`
 
 	// The data describing the resource.
 	// The meaning of this data depends on the type and class of the resource
 	// record.
-	AnswersData string `ecs:"answers.data"`
+	AnswersData string `ecs:"answers.data" json:"answers.data,omitempty"`
 
 	// Array containing all IPs seen in `answers.data`.
 	// The `answers` array can be difficult to use, because of the variety of
 	// data formats it can contain. Extracting all IP addresses seen in there
 	// to `dns.resolved_ip` makes it possible to index them as IP addresses,
 	// and makes them easier to visualize and query for.
-	ResolvedIP string `ecs:"resolved_ip"`
+	ResolvedIP string `ecs:"resolved_ip" json:"resolved_ip,omitempty"`
 }

--- a/code/go/ecs/ecs.go
+++ b/code/go/ecs/ecs.go
@@ -26,5 +26,5 @@ type ECS struct {
 	// When querying across multiple indices -- which may conform to slightly
 	// different ECS versions -- this field lets integrations adjust to the
 	// schema version of the events.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 }

--- a/code/go/ecs/error.go
+++ b/code/go/ecs/error.go
@@ -24,14 +24,14 @@ package ecs
 // event itself contains an error.
 type Error struct {
 	// Unique identifier for the error.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Error message.
-	Message string `ecs:"message"`
+	Message string `ecs:"message" json:"message,omitempty"`
 
 	// Error code describing the error.
-	Code string `ecs:"code"`
+	Code string `ecs:"code" json:"code,omitempty"`
 
 	// The stack trace of this error in plain text.
-	StackTrace string `ecs:"stack_trace"`
+	StackTrace string `ecs:"stack_trace" json:"stack_trace,omitempty"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -35,13 +35,13 @@ import (
 // pressure measured on a host, or vulnerabilities measured on a scanned host.
 type Event struct {
 	// Unique ID to describe the event.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Identification code for this event, if one exists.
 	// Some event sources use event codes to identify messages unambiguously,
 	// regardless of message language or wording adjustments over time. An
 	// example of this is the Windows Event ID.
-	Code string `ecs:"code"`
+	Code string `ecs:"code" json:"code,omitempty"`
 
 	// The kind of the event.
 	// This gives information about what type of information the event
@@ -49,7 +49,7 @@ type Event struct {
 	// are `event`, `state`, `alarm`. Warning: In future versions of ECS, we
 	// plan to provide a list of acceptable values for this field, please use
 	// with caution.
-	Kind string `ecs:"kind"`
+	Kind string `ecs:"kind" json:"kind,omitempty"`
 
 	// Event category.
 	// This contains high-level information about the contents of the event. It
@@ -57,30 +57,30 @@ type Event struct {
 	// category contains multiple actions. Warning: In future versions of ECS,
 	// we plan to provide a list of acceptable values for this field, please
 	// use with caution.
-	Category string `ecs:"category"`
+	Category string `ecs:"category" json:"category,omitempty"`
 
 	// The action captured by the event.
 	// This describes the information in the event. It is more specific than
 	// `event.category`. Examples are `group-add`, `process-started`,
 	// `file-created`. The value is normally defined by the implementer.
-	Action string `ecs:"action"`
+	Action string `ecs:"action" json:"action,omitempty"`
 
 	// The outcome of the event.
 	// If the event describes an action, this fields contains the outcome of
 	// that action. Examples outcomes are `success` and `failure`. Warning: In
 	// future versions of ECS, we plan to provide a list of acceptable values
 	// for this field, please use with caution.
-	Outcome string `ecs:"outcome"`
+	Outcome string `ecs:"outcome" json:"outcome,omitempty"`
 
 	// Reserved for future usage.
 	// Please avoid using this field for user data.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// Name of the module this data is coming from.
 	// If your monitoring agent supports the concept of modules or plugins to
 	// process events of a given source (e.g. Apache logs), `event.module`
 	// should contain the name of this module.
-	Module string `ecs:"module"`
+	Module string `ecs:"module" json:"module,omitempty"`
 
 	// Name of the dataset.
 	// If an event source publishes more than one type of log or events (e.g.
@@ -88,40 +88,40 @@ type Event struct {
 	// event comes from.
 	// It's recommended but not required to start the dataset name with the
 	// module name, followed by a dot, then the dataset name.
-	Dataset string `ecs:"dataset"`
+	Dataset string `ecs:"dataset" json:"dataset,omitempty"`
 
 	// Source of the event.
 	// Event transports such as Syslog or the Windows Event Log typically
 	// mention the source of an event. It can be the name of the software that
 	// generated the event (e.g. Sysmon, httpd), or of a subsystem of the
 	// operating system (kernel, Microsoft-Windows-Security-Auditing).
-	Provider string `ecs:"provider"`
+	Provider string `ecs:"provider" json:"provider,omitempty"`
 
 	// Severity describes the original severity of the event. What the
 	// different severity values mean can very different between use cases.
 	// It's up to the implementer to make sure severities are consistent across
 	// events.
-	Severity int64 `ecs:"severity"`
+	Severity int64 `ecs:"severity" json:"severity,omitempty"`
 
 	// Raw text message of entire event. Used to demonstrate log integrity.
 	// This field is not indexed and doc_values are disabled. It cannot be
 	// searched, but it can be retrieved from `_source`.
-	Original string `ecs:"original"`
+	Original string `ecs:"original" json:"original,omitempty"`
 
 	// Hash (perhaps logstash fingerprint) of raw field to be able to
 	// demonstrate log integrity.
-	Hash string `ecs:"hash"`
+	Hash string `ecs:"hash" json:"hash,omitempty"`
 
 	// Duration of the event in nanoseconds.
 	// If event.start and event.end are known this value should be the
 	// difference between the end and start time.
-	Duration time.Duration `ecs:"duration"`
+	Duration time.Duration `ecs:"duration" json:"duration,omitempty"`
 
 	// Sequence number of the event.
 	// The sequence number is a value published by some event sources, to make
 	// the exact ordering of events unambiguous, regarless of the timestamp
 	// precision.
-	Sequence int64 `ecs:"sequence"`
+	Sequence int64 `ecs:"sequence" json:"sequence,omitempty"`
 
 	// This field should be populated when the event's timestamp does not
 	// include timezone information already (e.g. default Syslog timestamps).
@@ -129,7 +129,7 @@ type Event struct {
 	// Acceptable timezone formats are: a canonical ID (e.g.
 	// "Europe/Amsterdam"), abbreviated (e.g. "EST") or an HH:mm differential
 	// (e.g. "-05:00").
-	Timezone string `ecs:"timezone"`
+	Timezone string `ecs:"timezone" json:"timezone,omitempty"`
 
 	// event.created contains the date/time when the event was first read by an
 	// agent, or by your pipeline.
@@ -141,22 +141,22 @@ type Event struct {
 	// This can be used to monitor your agent's or pipeline's ability to keep
 	// up with your event source.
 	// In case the two timestamps are identical, @timestamp should be used.
-	Created time.Time `ecs:"created"`
+	Created time.Time `ecs:"created" json:"created,omitempty"`
 
 	// event.start contains the date when the event started or when the
 	// activity was first observed.
-	Start time.Time `ecs:"start"`
+	Start time.Time `ecs:"start" json:"start,omitempty"`
 
 	// event.end contains the date when the event ended or when the activity
 	// was last observed.
-	End time.Time `ecs:"end"`
+	End time.Time `ecs:"end" json:"end,omitempty"`
 
 	// Risk score or priority of the event (e.g. security solutions). Use your
 	// system's original value here.
-	RiskScore float64 `ecs:"risk_score"`
+	RiskScore float64 `ecs:"risk_score" json:"risk_score,omitempty"`
 
 	// Normalized risk score or priority of the event, on a scale of 0 to 100.
 	// This is mainly useful if you use more than one system that assigns risk
 	// scores, and you want to see a normalized value across all systems.
-	RiskScoreNorm float64 `ecs:"risk_score_norm"`
+	RiskScoreNorm float64 `ecs:"risk_score_norm" json:"risk_score_norm,omitempty"`
 }

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -31,62 +31,62 @@ import (
 // with the event or metric.
 type File struct {
 	// Name of the file including the extension, without the directory.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Directory where the file is located.
-	Directory string `ecs:"directory"`
+	Directory string `ecs:"directory" json:"directory,omitempty"`
 
 	// Full path to the file.
-	Path string `ecs:"path"`
+	Path string `ecs:"path" json:"path,omitempty"`
 
 	// Target path for symlinks.
-	TargetPath string `ecs:"target_path"`
+	TargetPath string `ecs:"target_path" json:"target_path,omitempty"`
 
 	// File extension.
-	Extension string `ecs:"extension"`
+	Extension string `ecs:"extension" json:"extension,omitempty"`
 
 	// File type (file, dir, or symlink).
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// Device that is the source of the file.
-	Device string `ecs:"device"`
+	Device string `ecs:"device" json:"device,omitempty"`
 
 	// Inode representing the file in the filesystem.
-	Inode string `ecs:"inode"`
+	Inode string `ecs:"inode" json:"inode,omitempty"`
 
 	// The user ID (UID) or security identifier (SID) of the file owner.
-	UID string `ecs:"uid"`
+	UID string `ecs:"uid" json:"uid,omitempty"`
 
 	// File owner's username.
-	Owner string `ecs:"owner"`
+	Owner string `ecs:"owner" json:"owner,omitempty"`
 
 	// Primary group ID (GID) of the file.
-	Gid string `ecs:"gid"`
+	Gid string `ecs:"gid" json:"gid,omitempty"`
 
 	// Primary group name of the file.
-	Group string `ecs:"group"`
+	Group string `ecs:"group" json:"group,omitempty"`
 
 	// Mode of the file in octal representation.
-	Mode string `ecs:"mode"`
+	Mode string `ecs:"mode" json:"mode,omitempty"`
 
 	// File size in bytes.
 	// Only relevant when `file.type` is "file".
-	Size int64 `ecs:"size"`
+	Size int64 `ecs:"size" json:"size,omitempty"`
 
 	// Last time the file content was modified.
-	Mtime time.Time `ecs:"mtime"`
+	Mtime time.Time `ecs:"mtime" json:"mtime,omitempty"`
 
 	// Last time the file attributes or metadata changed.
 	// Note that changes to the file content will update `mtime`. This implies
 	// `ctime` will be adjusted at the same time, since `mtime` is an attribute
 	// of the file.
-	Ctime time.Time `ecs:"ctime"`
+	Ctime time.Time `ecs:"ctime" json:"ctime,omitempty"`
 
 	// File creation time.
 	// Note that not all filesystems store the creation time.
-	Created time.Time `ecs:"created"`
+	Created time.Time `ecs:"created" json:"created,omitempty"`
 
 	// Last time the file was accessed.
 	// Note that not all filesystems keep track of access time.
-	Accessed time.Time `ecs:"accessed"`
+	Accessed time.Time `ecs:"accessed" json:"accessed,omitempty"`
 }

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -24,30 +24,30 @@ package ecs
 // or be user-supplied.
 type Geo struct {
 	// Longitude and latitude.
-	Location string `ecs:"location"`
+	Location string `ecs:"location" json:"location,omitempty"`
 
 	// Name of the continent.
-	ContinentName string `ecs:"continent_name"`
+	ContinentName string `ecs:"continent_name" json:"continent_name,omitempty"`
 
 	// Country name.
-	CountryName string `ecs:"country_name"`
+	CountryName string `ecs:"country_name" json:"country_name,omitempty"`
 
 	// Region name.
-	RegionName string `ecs:"region_name"`
+	RegionName string `ecs:"region_name" json:"region_name,omitempty"`
 
 	// City name.
-	CityName string `ecs:"city_name"`
+	CityName string `ecs:"city_name" json:"city_name,omitempty"`
 
 	// Country ISO code.
-	CountryIsoCode string `ecs:"country_iso_code"`
+	CountryIsoCode string `ecs:"country_iso_code" json:"country_iso_code,omitempty"`
 
 	// Region ISO code.
-	RegionIsoCode string `ecs:"region_iso_code"`
+	RegionIsoCode string `ecs:"region_iso_code" json:"region_iso_code,omitempty"`
 
 	// User-defined description of a location, at the level of granularity they
 	// care about.
 	// Could be the name of their data centers, the floor number, if this
 	// describes a local physical entity, city names.
 	// Not typically used in automated geolocation.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 }

--- a/code/go/ecs/group.go
+++ b/code/go/ecs/group.go
@@ -23,8 +23,8 @@ package ecs
 // event.
 type Group struct {
 	// Unique identifier for the group on the system/platform.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Name of the group.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 }

--- a/code/go/ecs/hash.go
+++ b/code/go/ecs/hash.go
@@ -25,14 +25,14 @@ package ecs
 // separators as appropriate (snake case, e.g. sha3_512).
 type Hash struct {
 	// MD5 hash.
-	Md5 string `ecs:"md5"`
+	Md5 string `ecs:"md5" json:"md5,omitempty"`
 
 	// SHA1 hash.
-	Sha1 string `ecs:"sha1"`
+	Sha1 string `ecs:"sha1" json:"sha1,omitempty"`
 
 	// SHA256 hash.
-	Sha256 string `ecs:"sha256"`
+	Sha256 string `ecs:"sha256" json:"sha256,omitempty"`
 
 	// SHA512 hash.
-	Sha512 string `ecs:"sha512"`
+	Sha512 string `ecs:"sha512" json:"sha512,omitempty"`
 }

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -27,35 +27,35 @@ type Host struct {
 	// Hostname of the host.
 	// It normally contains what the `hostname` command returns on the host
 	// machine.
-	Hostname string `ecs:"hostname"`
+	Hostname string `ecs:"hostname" json:"hostname,omitempty"`
 
 	// Name of the host.
 	// It can contain what `hostname` returns on Unix systems, the fully
 	// qualified domain name, or a name specified by the user. The sender
 	// decides which value to use.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Unique host id.
 	// As hostname is not always unique, use values that are meaningful in your
 	// environment.
 	// Example: The current usage of `beat.name`.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Host ip address.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Host mac address.
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// Type of host.
 	// For Cloud providers this can be the machine type like `t2.medium`. If
 	// vm, this could be the container, for example, or other information
 	// meaningful in your environment.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// Seconds the host has been up.
-	Uptime int64 `ecs:"uptime"`
+	Uptime int64 `ecs:"uptime" json:"uptime,omitempty"`
 
 	// Operating system architecture.
-	Architecture string `ecs:"architecture"`
+	Architecture string `ecs:"architecture" json:"architecture,omitempty"`
 }

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -25,32 +25,32 @@ type Http struct {
 	// HTTP request method.
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
-	RequestMethod string `ecs:"request.method"`
+	RequestMethod string `ecs:"request.method" json:"request.method,omitempty"`
 
 	// The full HTTP request body.
-	RequestBodyContent string `ecs:"request.body.content"`
+	RequestBodyContent string `ecs:"request.body.content" json:"request.body.content,omitempty"`
 
 	// Referrer for this HTTP request.
-	RequestReferrer string `ecs:"request.referrer"`
+	RequestReferrer string `ecs:"request.referrer" json:"request.referrer,omitempty"`
 
 	// HTTP response status code.
-	ResponseStatusCode int64 `ecs:"response.status_code"`
+	ResponseStatusCode int64 `ecs:"response.status_code" json:"response.status_code,omitempty"`
 
 	// The full HTTP response body.
-	ResponseBodyContent string `ecs:"response.body.content"`
+	ResponseBodyContent string `ecs:"response.body.content" json:"response.body.content,omitempty"`
 
 	// HTTP version.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Total size in bytes of the request (body and headers).
-	RequestBytes int64 `ecs:"request.bytes"`
+	RequestBytes int64 `ecs:"request.bytes" json:"request.bytes,omitempty"`
 
 	// Size in bytes of the request body.
-	RequestBodyBytes int64 `ecs:"request.body.bytes"`
+	RequestBodyBytes int64 `ecs:"request.body.bytes" json:"request.body.bytes,omitempty"`
 
 	// Total size in bytes of the response (body and headers).
-	ResponseBytes int64 `ecs:"response.bytes"`
+	ResponseBytes int64 `ecs:"response.bytes" json:"response.bytes,omitempty"`
 
 	// Size in bytes of the response body.
-	ResponseBodyBytes int64 `ecs:"response.body.bytes"`
+	ResponseBodyBytes int64 `ecs:"response.body.bytes" json:"response.body.bytes,omitempty"`
 }

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -23,7 +23,7 @@ package ecs
 type Log struct {
 	// Original log level of the log event.
 	// Some examples are `warn`, `error`, `i`.
-	Level string `ecs:"level"`
+	Level string `ecs:"level" json:"level,omitempty"`
 
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.
@@ -33,18 +33,18 @@ type Log struct {
 	// lines removed to clean up the log message.
 	// This field is not indexed and doc_values are disabled so it can't be
 	// queried but the value can be retrieved from `_source`.
-	Original string `ecs:"original"`
+	Original string `ecs:"original" json:"original,omitempty"`
 
 	// The name of the logger inside an application. This is usually the name
 	// of the class which initialized the logger, or can be a custom name.
-	Logger string `ecs:"logger"`
+	Logger string `ecs:"logger" json:"logger,omitempty"`
 
 	// The name of the source file which originated the log event.
-	OriginFileName string `ecs:"origin.file.name"`
+	OriginFileName string `ecs:"origin.file.name" json:"origin.file.name,omitempty"`
 
 	// The line number of the file which originated the log event.
-	OriginFileLine int32 `ecs:"origin.file.line"`
+	OriginFileLine int32 `ecs:"origin.file.line" json:"origin.file.line,omitempty"`
 
 	// The name of the function or method which originated the log event.
-	OriginFunction string `ecs:"origin.function"`
+	OriginFunction string `ecs:"origin.function" json:"origin.function,omitempty"`
 }

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -25,25 +25,25 @@ package ecs
 // activity associated with an event.
 type Network struct {
 	// Name given by operators to sections of their network.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec,
 	// pim, etc
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// IANA Protocol Number
 	// (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
 	// Standardized list of protocols. This aligns well with NetFlow and sFlow
 	// related logs which use the IANA Protocol Number.
-	IANANumber string `ecs:"iana_number"`
+	IANANumber string `ecs:"iana_number" json:"iana_number,omitempty"`
 
 	// Same as network.iana_number, but instead using the Keyword name of the
 	// transport layer (udp, tcp, ipv6-icmp, etc.)
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
-	Transport string `ecs:"transport"`
+	Transport string `ecs:"transport" json:"transport,omitempty"`
 
 	// A name given to an application level protocol. This can be arbitrarily
 	// assigned for things like microservices, but also apply to things like
@@ -52,12 +52,12 @@ type Network struct {
 	// owners, ports, or wire format.
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
-	Application string `ecs:"application"`
+	Application string `ecs:"application" json:"application,omitempty"`
 
 	// L7 Network protocol name. ex. http, lumberjack, transport protocol.
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
-	Protocol string `ecs:"protocol"`
+	Protocol string `ecs:"protocol" json:"protocol,omitempty"`
 
 	// Direction of the network traffic.
 	// Recommended values are:
@@ -72,24 +72,24 @@ type Network struct {
 	// When mapping events from a network or perimeter-based monitoring
 	// context, populate this field from the point of view of your network
 	// perimeter.
-	Direction string `ecs:"direction"`
+	Direction string `ecs:"direction" json:"direction,omitempty"`
 
 	// Host IP address when the source IP address is the proxy.
-	ForwardedIP string `ecs:"forwarded_ip"`
+	ForwardedIP string `ecs:"forwarded_ip" json:"forwarded_ip,omitempty"`
 
 	// A hash of source and destination IPs and ports, as well as the protocol
 	// used in a communication. This is a tool-agnostic standard to identify
 	// flows.
 	// Learn more at https://github.com/corelight/community-id-spec.
-	CommunityID string `ecs:"community_id"`
+	CommunityID string `ecs:"community_id" json:"community_id,omitempty"`
 
 	// Total bytes transferred in both directions.
 	// If `source.bytes` and `destination.bytes` are known, `network.bytes` is
 	// their sum.
-	Bytes int64 `ecs:"bytes"`
+	Bytes int64 `ecs:"bytes" json:"bytes,omitempty"`
 
 	// Total packets transferred in both directions.
 	// If `source.packets` and `destination.packets` are known,
 	// `network.packets` is their sum.
-	Packets int64 `ecs:"packets"`
+	Packets int64 `ecs:"packets" json:"packets,omitempty"`
 }

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -32,26 +32,26 @@ package ecs
 // used in processing events or metrics are not considered observers in ECS.
 type Observer struct {
 	// MAC address of the observer
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// IP address of the observer.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Hostname of the observer.
-	Hostname string `ecs:"hostname"`
+	Hostname string `ecs:"hostname" json:"hostname,omitempty"`
 
 	// observer vendor information.
-	Vendor string `ecs:"vendor"`
+	Vendor string `ecs:"vendor" json:"vendor,omitempty"`
 
 	// Observer version.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Observer serial number.
-	SerialNumber string `ecs:"serial_number"`
+	SerialNumber string `ecs:"serial_number" json:"serial_number,omitempty"`
 
 	// The type of the observer the data is coming from.
 	// There is no predefined list of observer types. Some examples are
 	// `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM
 	// server`.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 }

--- a/code/go/ecs/organization.go
+++ b/code/go/ecs/organization.go
@@ -25,8 +25,8 @@ package ecs
 // multiple organizations.
 type Organization struct {
 	// Organization name.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Unique identifier for the organization.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 }

--- a/code/go/ecs/os.go
+++ b/code/go/ecs/os.go
@@ -22,20 +22,20 @@ package ecs
 // The OS fields contain information about the operating system.
 type Os struct {
 	// Operating system platform (such centos, ubuntu, windows).
-	Platform string `ecs:"platform"`
+	Platform string `ecs:"platform" json:"platform,omitempty"`
 
 	// Operating system name, without the version.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Operating system name, including the version or code name.
-	Full string `ecs:"full"`
+	Full string `ecs:"full" json:"full,omitempty"`
 
 	// OS family (such as redhat, debian, freebsd, windows).
-	Family string `ecs:"family"`
+	Family string `ecs:"family" json:"family,omitempty"`
 
 	// Operating system version as a raw string.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Operating system kernel version as a raw string.
-	Kernel string `ecs:"kernel"`
+	Kernel string `ecs:"kernel" json:"kernel,omitempty"`
 }

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -29,43 +29,43 @@ import (
 // itself and is copied to the global field for correlation.
 type Process struct {
 	// Process id.
-	PID int64 `ecs:"pid"`
+	PID int64 `ecs:"pid" json:"pid,omitempty"`
 
 	// Process name.
 	// Sometimes called program name or similar.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Parent process' pid.
-	PPID int64 `ecs:"ppid"`
+	PPID int64 `ecs:"ppid" json:"ppid,omitempty"`
 
 	// Identifier of the group of processes the process belongs to.
-	PGID int64 `ecs:"pgid"`
+	PGID int64 `ecs:"pgid" json:"pgid,omitempty"`
 
 	// Array of process arguments.
 	// May be filtered to protect sensitive information.
-	Args []string `ecs:"args"`
+	Args []string `ecs:"args" json:"args,omitempty"`
 
 	// Absolute path to the process executable.
-	Executable string `ecs:"executable"`
+	Executable string `ecs:"executable" json:"executable,omitempty"`
 
 	// Process title.
 	// The proctitle, some times the same as process name. Can also be
 	// different: for example a browser setting its title to the web page
 	// currently opened.
-	Title string `ecs:"title"`
+	Title string `ecs:"title" json:"title,omitempty"`
 
 	// Thread ID.
-	ThreadID int64 `ecs:"thread.id"`
+	ThreadID int64 `ecs:"thread.id" json:"thread.id,omitempty"`
 
 	// Thread name.
-	ThreadName string `ecs:"thread.name"`
+	ThreadName string `ecs:"thread.name" json:"thread.name,omitempty"`
 
 	// The time the process started.
-	Start time.Time `ecs:"start"`
+	Start time.Time `ecs:"start" json:"start,omitempty"`
 
 	// Seconds the process has been up.
-	Uptime int64 `ecs:"uptime"`
+	Uptime int64 `ecs:"uptime" json:"uptime,omitempty"`
 
 	// The working directory of the process.
-	WorkingDirectory string `ecs:"working_directory"`
+	WorkingDirectory string `ecs:"working_directory" json:"working_directory,omitempty"`
 }

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -29,5 +29,5 @@ package ecs
 // matter where it appeared, by querying `related.ip:a.b.c.d`.
 type Related struct {
 	// All of the IPs seen on your event.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 }

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -38,20 +38,20 @@ type Server struct {
 	// store the raw address in the `.address` field.
 	// Then it should be duplicated to `.ip` or `.domain`, depending on which
 	// one it is.
-	Address string `ecs:"address"`
+	Address string `ecs:"address" json:"address,omitempty"`
 
 	// IP address of the server.
 	// Can be one or multiple IPv4 or IPv6 addresses.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Port of the server.
-	Port int64 `ecs:"port"`
+	Port int64 `ecs:"port" json:"port,omitempty"`
 
 	// MAC address of the server.
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// Server domain.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 
 	// The highest registered server domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -59,21 +59,21 @@ type Server struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	RegisteredDomain string `ecs:"registered_domain"`
+	RegisteredDomain string `ecs:"registered_domain" json:"registered_domain,omitempty"`
 
 	// Bytes sent from the server to the client.
-	Bytes int64 `ecs:"bytes"`
+	Bytes int64 `ecs:"bytes" json:"bytes,omitempty"`
 
 	// Packets sent from the server to the client.
-	Packets int64 `ecs:"packets"`
+	Packets int64 `ecs:"packets" json:"packets,omitempty"`
 
 	// Translated ip of destination based NAT sessions (e.g. internet to
 	// private DMZ)
 	// Typically used with load balancers, firewalls, or routers.
-	NatIP string `ecs:"nat.ip"`
+	NatIP string `ecs:"nat.ip" json:"nat.ip,omitempty"`
 
 	// Translated port of destination based NAT sessions (e.g. internet to
 	// private DMZ)
 	// Typically used with load balancers, firewalls, or routers.
-	NatPort int64 `ecs:"nat.port"`
+	NatPort int64 `ecs:"nat.port" json:"nat.port,omitempty"`
 }

--- a/code/go/ecs/service.go
+++ b/code/go/ecs/service.go
@@ -31,7 +31,7 @@ type Service struct {
 	// particular node emitted the event.
 	// Note that if you need to see the events from one specific host of the
 	// service, you should filter on that `host.name` or `host.id` instead.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Name of the service data is collected from.
 	// The name of the service is normally user given. This allows if two
@@ -42,24 +42,24 @@ type Service struct {
 	// In the case of Elasticsearch the service.name could contain the cluster
 	// name. For Beats the service.name is by default a copy of the
 	// `service.type` field if no name is specified.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// The type of the service data is collected from.
 	// The type can be used to group and correlate logs and metrics from one
 	// service type.
 	// Example: If logs or metrics are collected from Elasticsearch,
 	// `service.type` would be `elasticsearch`.
-	Type string `ecs:"type"`
+	Type string `ecs:"type" json:"type,omitempty"`
 
 	// Current state of the service.
-	State string `ecs:"state"`
+	State string `ecs:"state" json:"state,omitempty"`
 
 	// Version of the service the data was collected from.
 	// This allows to look at a data set only for a specific version of a
 	// service.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Ephemeral identifier of this service (if one exists).
 	// This id normally changes across restarts, but `service.id` does not.
-	EphemeralID string `ecs:"ephemeral_id"`
+	EphemeralID string `ecs:"ephemeral_id" json:"ephemeral_id,omitempty"`
 }

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -27,20 +27,20 @@ type Source struct {
 	// store the raw address in the `.address` field.
 	// Then it should be duplicated to `.ip` or `.domain`, depending on which
 	// one it is.
-	Address string `ecs:"address"`
+	Address string `ecs:"address" json:"address,omitempty"`
 
 	// IP address of the source.
 	// Can be one or multiple IPv4 or IPv6 addresses.
-	IP string `ecs:"ip"`
+	IP string `ecs:"ip" json:"ip,omitempty"`
 
 	// Port of the source.
-	Port int64 `ecs:"port"`
+	Port int64 `ecs:"port" json:"port,omitempty"`
 
 	// MAC address of the source.
-	MAC string `ecs:"mac"`
+	MAC string `ecs:"mac" json:"mac,omitempty"`
 
 	// Source domain.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 
 	// The highest registered source domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -48,21 +48,21 @@ type Source struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	RegisteredDomain string `ecs:"registered_domain"`
+	RegisteredDomain string `ecs:"registered_domain" json:"registered_domain,omitempty"`
 
 	// Bytes sent from the source to the destination.
-	Bytes int64 `ecs:"bytes"`
+	Bytes int64 `ecs:"bytes" json:"bytes,omitempty"`
 
 	// Packets sent from the source to the destination.
-	Packets int64 `ecs:"packets"`
+	Packets int64 `ecs:"packets" json:"packets,omitempty"`
 
 	// Translated ip of source based NAT sessions (e.g. internal client to
 	// internet)
 	// Typically connections traversing load balancers, firewalls, or routers.
-	NatIP string `ecs:"nat.ip"`
+	NatIP string `ecs:"nat.ip" json:"nat.ip,omitempty"`
 
 	// Translated port of source based NAT sessions. (e.g. internal client to
 	// internet)
 	// Typically used with load balancers, firewalls, or routers.
-	NatPort int64 `ecs:"nat.port"`
+	NatPort int64 `ecs:"nat.port" json:"nat.port,omitempty"`
 }

--- a/code/go/ecs/tracing.go
+++ b/code/go/ecs/tracing.go
@@ -28,10 +28,10 @@ type Tracing struct {
 	// A trace groups multiple events like transactions that belong together.
 	// For example, a user request handled by multiple inter-connected
 	// services.
-	TraceID string `ecs:"trace.id"`
+	TraceID string `ecs:"trace.id" json:"trace.id,omitempty"`
 
 	// Unique identifier of the transaction.
 	// A transaction is the highest level of work measured within a service,
 	// such as a request to a server.
-	TransactionID string `ecs:"transaction.id"`
+	TransactionID string `ecs:"transaction.id" json:"transaction.id,omitempty"`
 }

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -27,22 +27,22 @@ type Url struct {
 	// whereas in access logs, the URL is often just represented as a path.
 	// This field is meant to represent the URL as it was observed, complete or
 	// not.
-	Original string `ecs:"original"`
+	Original string `ecs:"original" json:"original,omitempty"`
 
 	// If full URLs are important to your use case, they should be stored in
 	// `url.full`, whether this field is reconstructed or present in the event
 	// source.
-	Full string `ecs:"full"`
+	Full string `ecs:"full" json:"full,omitempty"`
 
 	// Scheme of the request, such as "https".
 	// Note: The `:` is not part of the scheme.
-	Scheme string `ecs:"scheme"`
+	Scheme string `ecs:"scheme" json:"scheme,omitempty"`
 
 	// Domain of the url, such as "www.elastic.co".
 	// In some cases a URL may refer to an IP and/or port directly, without a
 	// domain name. In this case, the IP address would go to the `domain`
 	// field.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 
 	// The highest registered url domain, stripped of the subdomain.
 	// For example, the registered domain for "foo.google.com" is "google.com".
@@ -50,13 +50,13 @@ type Url struct {
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
 	// "co.uk".
-	RegisteredDomain string `ecs:"registered_domain"`
+	RegisteredDomain string `ecs:"registered_domain" json:"registered_domain,omitempty"`
 
 	// Port of the request, such as 443.
-	Port int64 `ecs:"port"`
+	Port int64 `ecs:"port" json:"port,omitempty"`
 
 	// Path of the request, such as "/search".
-	Path string `ecs:"path"`
+	Path string `ecs:"path" json:"path,omitempty"`
 
 	// The query field describes the query string of the request, such as
 	// "q=elasticsearch".
@@ -64,15 +64,15 @@ type Url struct {
 	// there is no query field. If there is a `?` but no query, the query field
 	// exists with an empty string. The `exists` query can be used to
 	// differentiate between the two cases.
-	Query string `ecs:"query"`
+	Query string `ecs:"query" json:"query,omitempty"`
 
 	// Portion of the url after the `#`, such as "top".
 	// The `#` is not part of the fragment.
-	Fragment string `ecs:"fragment"`
+	Fragment string `ecs:"fragment" json:"fragment,omitempty"`
 
 	// Username of the request.
-	Username string `ecs:"username"`
+	Username string `ecs:"username" json:"username,omitempty"`
 
 	// Password of the request.
-	Password string `ecs:"password"`
+	Password string `ecs:"password" json:"password,omitempty"`
 }

--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -25,23 +25,23 @@ package ecs
 // id, provide an array that includes all of them.
 type User struct {
 	// One or multiple unique identifiers of the user.
-	ID string `ecs:"id"`
+	ID string `ecs:"id" json:"id,omitempty"`
 
 	// Short name or login of the user.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// User's full name, if available.
-	FullName string `ecs:"full_name"`
+	FullName string `ecs:"full_name" json:"full_name,omitempty"`
 
 	// User email address.
-	Email string `ecs:"email"`
+	Email string `ecs:"email" json:"email,omitempty"`
 
 	// Unique user hash to correlate information for a user in anonymized form.
 	// Useful if `user.id` or `user.name` contain confidential information and
 	// cannot be used.
-	Hash string `ecs:"hash"`
+	Hash string `ecs:"hash" json:"hash,omitempty"`
 
 	// Name of the directory the user is a member of.
 	// For example, an LDAP or Active Directory domain name.
-	Domain string `ecs:"domain"`
+	Domain string `ecs:"domain" json:"domain,omitempty"`
 }

--- a/code/go/ecs/user_agent.go
+++ b/code/go/ecs/user_agent.go
@@ -24,14 +24,14 @@ package ecs
 // string.
 type UserAgent struct {
 	// Unparsed version of the user_agent.
-	Original string `ecs:"original"`
+	Original string `ecs:"original" json:"original,omitempty"`
 
 	// Name of the user agent.
-	Name string `ecs:"name"`
+	Name string `ecs:"name" json:"name,omitempty"`
 
 	// Version of the user agent.
-	Version string `ecs:"version"`
+	Version string `ecs:"version" json:"version,omitempty"`
 
 	// Name of the device.
-	DeviceName string `ecs:"device.name"`
+	DeviceName string `ecs:"device.name" json:"device.name,omitempty"`
 }

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -72,7 +72,7 @@ import (
 type {{.Name}} struct {
 {{- range $field := .Fields}}
 	// {{$field.Comment}}
-	{{$field.Name}} {{$field.Type}} \u0060ecs:"{{$field.JSONKey}}"\u0060
+	{{$field.Name}} {{$field.Type}} \u0060ecs:"{{$field.JSONKey}}" json:"{{$field.JSONKey}},omitempty"\u0060
 {{ end -}}
 }
 `


### PR DESCRIPTION
Specifying JSON tags with explicit lowercase names and the `omitempty` tag allows for easier (and slimmer, in terms of JSON payload size) integration of data processed by Go.

A lot of libraries (for me, https://github.com/segmentio/kafka-go and https://github.com/olivere/elastic) rely on the built-in `json.Marshal()` function to serialize things before they get shipped off, so this ensures that field names are canonical.