### PR TITLE
Add host.domain field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -10,6 +10,7 @@ Thanks, you're awesome :-) -->
 ### Bugfixes
 
 ### Added
+* Added `host.domain` field. #591
 
 ### Improvements
 

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -59,7 +59,9 @@ type Host struct {
 	// Operating system architecture.
 	Architecture string `ecs:"architecture"`
 
-	// Name of the directory the group is a member of.
-	// For example, an LDAP or Active Directory domain name.
+	// Name of the domain of which the host is a member.
+	// For example, on Windows this could be the host's Active Directory domain
+	// or NetBIOS domain name.  For Linux this could be the domain of the
+	// host's LDAP provider.
 	Domain string `ecs:"domain"`
 }

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -58,4 +58,8 @@ type Host struct {
 
 	// Operating system architecture.
 	Architecture string `ecs:"architecture"`
+
+	// Name of the directory the group is a member of.
+	// For example, an LDAP or Active Directory domain name.
+	Domain string `ecs:"domain"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1902,9 +1902,9 @@ example: `x86_64`
 // ===============================================================
 
 | host.domain
-| Name of the directory the group is a member of.
+| Name of the domain of which the host is a member. 
 
-For example, an LDAP or Active Directory domain name.
+For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name.  For Linux this could be the domain of the host's LDAP provider.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1908,7 +1908,7 @@ For example, an LDAP or Active Directory domain name.
 
 type: keyword
 
-
+example: `CONTOSO`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1901,6 +1901,19 @@ example: `x86_64`
 
 // ===============================================================
 
+| host.domain
+| Name of the directory the group is a member of.
+
+For example, an LDAP or Active Directory domain name.
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | host.hostname
 | Hostname of the host.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1377,6 +1377,7 @@
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+      example: CONTOSO
     - name: geo.city_name
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1370,6 +1370,13 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: geo.city_name
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1374,9 +1374,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the domain of which the host is a member. \nFor example,\
+        \ on Windows this could be the host's Active Directory domain or NetBIOS domain\
+        \ name.  For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
     - name: geo.city_name
       level: core

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -166,6 +166,7 @@ hash.sha1,keyword,extended,,1.2.0-dev
 hash.sha256,keyword,extended,,1.2.0-dev
 hash.sha512,keyword,extended,,1.2.0-dev
 host.architecture,keyword,core,x86_64,1.2.0-dev
+host.domain,keyword,extended,,1.2.0-dev
 host.geo.city_name,keyword,core,Montreal,1.2.0-dev
 host.geo.continent_name,keyword,core,North America,1.2.0-dev
 host.geo.country_iso_code,keyword,core,CA,1.2.0-dev

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -166,7 +166,7 @@ hash.sha1,keyword,extended,,1.2.0-dev
 hash.sha256,keyword,extended,,1.2.0-dev
 hash.sha512,keyword,extended,,1.2.0-dev
 host.architecture,keyword,core,x86_64,1.2.0-dev
-host.domain,keyword,extended,,1.2.0-dev
+host.domain,keyword,extended,CONTOSO,1.2.0-dev
 host.geo.city_name,keyword,core,Montreal,1.2.0-dev
 host.geo.continent_name,keyword,core,North America,1.2.0-dev
 host.geo.country_iso_code,keyword,core,CA,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1876,6 +1876,17 @@ host.architecture:
   order: 7
   short: Operating system architecture.
   type: keyword
+host.domain:
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  order: 8
+  short: Name of the directory the group is a member of.
+  type: keyword
 host.geo.city_name:
   description: City name.
   example: Montreal

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1880,6 +1880,7 @@ host.domain:
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
+  example: CONTOSO
   flat_name: host.domain
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1877,9 +1877,9 @@ host.architecture:
   short: Operating system architecture.
   type: keyword
 host.domain:
-  description: 'Name of the directory the group is a member of.
-
-    For example, an LDAP or Active Directory domain name.'
+  description: "Name of the domain of which the host is a member. \nFor example, on\
+    \ Windows this could be the host's Active Directory domain or NetBIOS domain name.\
+    \  For Linux this could be the domain of the host's LDAP provider."
   example: CONTOSO
   flat_name: host.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2173,6 +2173,17 @@ host:
       order: 7
       short: Operating system architecture.
       type: keyword
+    domain:
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: host.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      order: 8
+      short: Name of the directory the group is a member of.
+      type: keyword
     geo.city_name:
       description: City name.
       example: Montreal

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2174,9 +2174,9 @@ host:
       short: Operating system architecture.
       type: keyword
     domain:
-      description: 'Name of the directory the group is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
+      description: "Name of the domain of which the host is a member. \nFor example,\
+        \ on Windows this could be the host's Active Directory domain or NetBIOS domain\
+        \ name.  For Linux this could be the domain of the host's LDAP provider."
       example: CONTOSO
       flat_name: host.domain
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2177,6 +2177,7 @@ host:
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+      example: CONTOSO
       flat_name: host.domain
       ignore_above: 1024
       level: extended

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -779,6 +779,10 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "domain": {
+              "ignore_above": 1024, 
+              "type": "keyword"
+            }, 
             "geo": {
               "properties": {
                 "city_name": {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -778,6 +778,10 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "domain": {
+            "ignore_above": 1024, 
+            "type": "keyword"
+          }, 
           "geo": {
             "properties": {
               "city_name": {

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -571,6 +571,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "domain": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "hostname": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/schema.json
+++ b/schema.json
@@ -1388,7 +1388,7 @@
         "type": "keyword"
       }, 
       "host.domain": {
-        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.", 
+        "description": "Name of the domain of which the host is a member. \nFor example, on Windows this could be the host's Active Directory domain or NetBIOS domain name.  For Linux this could be the domain of the host's LDAP provider.", 
         "example": "CONTOSO", 
         "footnote": "", 
         "group": 2, 

--- a/schema.json
+++ b/schema.json
@@ -1387,6 +1387,16 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "host.domain": {
+        "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "host.domain", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "host.hostname": {
         "description": "Hostname of the host.\nIt normally contains what the `hostname` command returns on the host machine.", 
         "example": "", 

--- a/schema.json
+++ b/schema.json
@@ -1389,7 +1389,7 @@
       }, 
       "host.domain": {
         "description": "Name of the directory the group is a member of.\nFor example, an LDAP or Active Directory domain name.", 
-        "example": "", 
+        "example": "CONTOSO", 
         "footnote": "", 
         "group": 2, 
         "level": "extended", 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -88,5 +88,5 @@
         Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.
-
+      example: CONTOSO 
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -85,8 +85,9 @@
       type: keyword
       short: Name of the directory the group is a member of.
       description: >
-        Name of the directory the group is a member of.
+        Name of the domain of which the host is a member. 
 
-        For example, an LDAP or Active Directory domain name.
+        For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. 
+        For Linux this could be the domain of the host's LDAP provider.
       example: CONTOSO
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -79,3 +79,14 @@
       example: "x86_64"
       description: >
         Operating system architecture.
+
+    - name: domain
+      level: extended
+      type: keyword
+      short: Name of the directory the group is a member of.
+      description: >
+        Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.
+
+

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -88,5 +88,5 @@
         Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.
-      example: CONTOSO 
+      example: CONTOSO
 


### PR DESCRIPTION
I'm working with windows events 4741,4742 and 4743.
When mapping into ECS I realize that I need a field host.domain 
I found also that host.domain is necessary when mapping certain Fortigate Logs 
