### PR TITLE
Add process.parent by duplicating all fields explicitly

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,7 @@ Thanks, you're awesome :-) -->
 * Added `process.exit_code`. #600
 
 * Added fields in `tls.*` to support analysis of TLS protocol events. #606
+* Added `process.parent.*`. #612
 
 ### Improvements
 

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -31,22 +31,42 @@ type Process struct {
 	// Process id.
 	PID int64 `ecs:"pid"`
 
+	// Process id.
+	ParentPID int64 `ecs:"parent.pid"`
+
 	// Process name.
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
+	// Process name.
+	// Sometimes called program name or similar.
+	ParentName string `ecs:"parent.name"`
+
 	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 
+	// Parent process' pid.
+	ParentPPID int64 `ecs:"parent.ppid"`
+
 	// Identifier of the group of processes the process belongs to.
 	PGID int64 `ecs:"pgid"`
+
+	// Identifier of the group of processes the process belongs to.
+	ParentPGID int64 `ecs:"parent.pgid"`
 
 	// Array of process arguments.
 	// May be filtered to protect sensitive information.
 	Args []string `ecs:"args"`
 
+	// Array of process arguments.
+	// May be filtered to protect sensitive information.
+	ParentArgs string `ecs:"parent.args"`
+
 	// Absolute path to the process executable.
 	Executable string `ecs:"executable"`
+
+	// Absolute path to the process executable.
+	ParentExecutable string `ecs:"parent.executable"`
 
 	// Process title.
 	// The proctitle, some times the same as process name. Can also be
@@ -54,23 +74,49 @@ type Process struct {
 	// currently opened.
 	Title string `ecs:"title"`
 
+	// Process title.
+	// The proctitle, some times the same as process name. Can also be
+	// different: for example a browser setting its title to the web page
+	// currently opened.
+	ParentTitle string `ecs:"parent.title"`
+
 	// Thread ID.
 	ThreadID int64 `ecs:"thread.id"`
+
+	// Thread ID.
+	ParentThreadID int64 `ecs:"parent.thread.id"`
 
 	// Thread name.
 	ThreadName string `ecs:"thread.name"`
 
+	// Thread name.
+	ParentThreadName string `ecs:"parent.thread.name"`
+
 	// The time the process started.
 	Start time.Time `ecs:"start"`
+
+	// The time the process started.
+	ParentStart time.Time `ecs:"parent.start"`
 
 	// Seconds the process has been up.
 	Uptime int64 `ecs:"uptime"`
 
+	// Seconds the process has been up.
+	ParentUptime int64 `ecs:"parent.uptime"`
+
 	// The working directory of the process.
 	WorkingDirectory string `ecs:"working_directory"`
+
+	// The working directory of the process.
+	ParentWorkingDirectory string `ecs:"parent.working_directory"`
 
 	// The exit code of the process, if this is a termination event.
 	// The field should be absent if there is no exit code for the event (e.g.
 	// process start).
 	ExitCode int64 `ecs:"exit_code"`
+
+	// The exit code of the process, if this is a termination event.
+	// The field should be absent if there is no exit code for the event (e.g.
+	// process start).
+	ParentExitCode int64 `ecs:"parent.exit_code"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2974,6 +2974,157 @@ example: `ssh`
 
 // ===============================================================
 
+| process.parent.args
+| Array of process arguments.
+
+May be filtered to protect sensitive information.
+
+type: keyword
+
+example: `['ssh', '-l', 'user', '10.0.0.16']`
+
+| extended
+
+// ===============================================================
+
+| process.parent.executable
+| Absolute path to the process executable.
+
+type: keyword
+
+example: `/usr/bin/ssh`
+
+| extended
+
+// ===============================================================
+
+| process.parent.exit_code
+| The exit code of the process, if this is a termination event.
+
+The field should be absent if there is no exit code for the event (e.g. process start).
+
+type: long
+
+example: `137`
+
+| extended
+
+// ===============================================================
+
+| process.parent.name
+| Process name.
+
+Sometimes called program name or similar.
+
+type: keyword
+
+example: `ssh`
+
+| extended
+
+// ===============================================================
+
+| process.parent.pgid
+| Identifier of the group of processes the process belongs to.
+
+type: long
+
+
+
+| extended
+
+// ===============================================================
+
+| process.parent.pid
+| Process id.
+
+type: long
+
+example: `4242`
+
+| core
+
+// ===============================================================
+
+| process.parent.ppid
+| Parent process' pid.
+
+type: long
+
+example: `4241`
+
+| extended
+
+// ===============================================================
+
+| process.parent.start
+| The time the process started.
+
+type: date
+
+example: `2016-05-23T08:05:34.853Z`
+
+| extended
+
+// ===============================================================
+
+| process.parent.thread.id
+| Thread ID.
+
+type: long
+
+example: `4242`
+
+| extended
+
+// ===============================================================
+
+| process.parent.thread.name
+| Thread name.
+
+type: keyword
+
+example: `thread-0`
+
+| extended
+
+// ===============================================================
+
+| process.parent.title
+| Process title.
+
+The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
+| process.parent.uptime
+| Seconds the process has been up.
+
+type: long
+
+example: `1325`
+
+| extended
+
+// ===============================================================
+
+| process.parent.working_directory
+| The working directory of the process.
+
+type: keyword
+
+example: `/home/alice`
+
+| extended
+
+// ===============================================================
+
 | process.pgid
 | Identifier of the group of processes the process belongs to.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2224,6 +2224,93 @@
 
         Sometimes called program name or similar.'
       example: ssh
+    - name: parent.args
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of process arguments.
+
+        May be filtered to protect sensitive information.'
+      example:
+      - ssh
+      - -l
+      - user
+      - 10.0.0.16
+    - name: parent.executable
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+    - name: parent.exit_code
+      level: extended
+      type: long
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+    - name: parent.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+    - name: parent.pgid
+      level: extended
+      type: long
+      format: string
+      description: Identifier of the group of processes the process belongs to.
+    - name: parent.pid
+      level: core
+      type: long
+      format: string
+      description: Process id.
+      example: 4242
+    - name: parent.ppid
+      level: extended
+      type: long
+      format: string
+      description: Parent process' pid.
+      example: 4241
+    - name: parent.start
+      level: extended
+      type: date
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+    - name: parent.thread.id
+      level: extended
+      type: long
+      format: string
+      description: Thread ID.
+      example: 4242
+    - name: parent.thread.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Thread name.
+      example: thread-0
+    - name: parent.title
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+    - name: parent.uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
+    - name: parent.working_directory
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The working directory of the process.
+      example: /home/alice
     - name: pgid
       level: extended
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -279,6 +279,19 @@ process.hash.sha1,keyword,extended,,1.2.0-dev
 process.hash.sha256,keyword,extended,,1.2.0-dev
 process.hash.sha512,keyword,extended,,1.2.0-dev
 process.name,keyword,extended,ssh,1.2.0-dev
+process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",1.2.0-dev
+process.parent.executable,keyword,extended,/usr/bin/ssh,1.2.0-dev
+process.parent.exit_code,long,extended,137,1.2.0-dev
+process.parent.name,keyword,extended,ssh,1.2.0-dev
+process.parent.pgid,long,extended,,1.2.0-dev
+process.parent.pid,long,core,4242,1.2.0-dev
+process.parent.ppid,long,extended,4241,1.2.0-dev
+process.parent.start,date,extended,2016-05-23T08:05:34.853Z,1.2.0-dev
+process.parent.thread.id,long,extended,4242,1.2.0-dev
+process.parent.thread.name,keyword,extended,thread-0,1.2.0-dev
+process.parent.title,keyword,extended,,1.2.0-dev
+process.parent.uptime,long,extended,1325,1.2.0-dev
+process.parent.working_directory,keyword,extended,/home/alice,1.2.0-dev
 process.pgid,long,extended,,1.2.0-dev
 process.pid,long,core,4242,1.2.0-dev
 process.ppid,long,extended,4241,1.2.0-dev

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3095,7 +3095,7 @@ process.args:
   ignore_above: 1024
   level: extended
   name: args
-  order: 4
+  order: 8
   short: Array of process arguments.
   type: keyword
 process.executable:
@@ -3105,7 +3105,7 @@ process.executable:
   ignore_above: 1024
   level: extended
   name: executable
-  order: 5
+  order: 10
   short: Absolute path to the process executable.
   type: keyword
 process.exit_code:
@@ -3117,7 +3117,7 @@ process.exit_code:
   flat_name: process.exit_code
   level: extended
   name: exit_code
-  order: 12
+  order: 24
   short: The exit code of the process.
   type: long
 process.hash.md5:
@@ -3169,8 +3169,147 @@ process.name:
   ignore_above: 1024
   level: extended
   name: name
-  order: 1
+  order: 2
   short: Process name.
+  type: keyword
+process.parent.args:
+  description: 'Array of process arguments.
+
+    May be filtered to protect sensitive information.'
+  example:
+  - ssh
+  - -l
+  - user
+  - 10.0.0.16
+  flat_name: process.parent.args
+  ignore_above: 1024
+  level: extended
+  name: parent.args
+  order: 9
+  short: Array of process arguments.
+  type: keyword
+process.parent.executable:
+  description: Absolute path to the process executable.
+  example: /usr/bin/ssh
+  flat_name: process.parent.executable
+  ignore_above: 1024
+  level: extended
+  name: parent.executable
+  order: 11
+  short: Absolute path to the process executable.
+  type: keyword
+process.parent.exit_code:
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.parent.exit_code
+  level: extended
+  name: parent.exit_code
+  order: 25
+  short: The exit code of the process.
+  type: long
+process.parent.name:
+  description: 'Process name.
+
+    Sometimes called program name or similar.'
+  example: ssh
+  flat_name: process.parent.name
+  ignore_above: 1024
+  level: extended
+  name: parent.name
+  order: 3
+  short: Process name.
+  type: keyword
+process.parent.pgid:
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.parent.pgid
+  format: string
+  level: extended
+  name: parent.pgid
+  order: 7
+  short: Identifier of the group of processes the process belongs to.
+  type: long
+process.parent.pid:
+  description: Process id.
+  example: 4242
+  flat_name: process.parent.pid
+  format: string
+  level: core
+  name: parent.pid
+  order: 1
+  short: Process id.
+  type: long
+process.parent.ppid:
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.parent.ppid
+  format: string
+  level: extended
+  name: parent.ppid
+  order: 5
+  short: Parent process' pid.
+  type: long
+process.parent.start:
+  description: The time the process started.
+  example: '2016-05-23T08:05:34.853Z'
+  flat_name: process.parent.start
+  level: extended
+  name: parent.start
+  order: 19
+  short: The time the process started.
+  type: date
+process.parent.thread.id:
+  description: Thread ID.
+  example: 4242
+  flat_name: process.parent.thread.id
+  format: string
+  level: extended
+  name: parent.thread.id
+  order: 15
+  short: Thread ID.
+  type: long
+process.parent.thread.name:
+  description: Thread name.
+  example: thread-0
+  flat_name: process.parent.thread.name
+  ignore_above: 1024
+  level: extended
+  name: parent.thread.name
+  order: 17
+  short: Thread name.
+  type: keyword
+process.parent.title:
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.parent.title
+  ignore_above: 1024
+  level: extended
+  name: parent.title
+  order: 13
+  short: Process title.
+  type: keyword
+process.parent.uptime:
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.parent.uptime
+  level: extended
+  name: parent.uptime
+  order: 21
+  short: Seconds the process has been up.
+  type: long
+process.parent.working_directory:
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.parent.working_directory
+  ignore_above: 1024
+  level: extended
+  name: parent.working_directory
+  order: 23
+  short: The working directory of the process.
   type: keyword
 process.pgid:
   description: Identifier of the group of processes the process belongs to.
@@ -3178,7 +3317,7 @@ process.pgid:
   format: string
   level: extended
   name: pgid
-  order: 3
+  order: 6
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.pid:
@@ -3198,7 +3337,7 @@ process.ppid:
   format: string
   level: extended
   name: ppid
-  order: 2
+  order: 4
   short: Parent process' pid.
   type: long
 process.start:
@@ -3207,7 +3346,7 @@ process.start:
   flat_name: process.start
   level: extended
   name: start
-  order: 9
+  order: 18
   short: The time the process started.
   type: date
 process.thread.id:
@@ -3217,7 +3356,7 @@ process.thread.id:
   format: string
   level: extended
   name: thread.id
-  order: 7
+  order: 14
   short: Thread ID.
   type: long
 process.thread.name:
@@ -3227,7 +3366,7 @@ process.thread.name:
   ignore_above: 1024
   level: extended
   name: thread.name
-  order: 8
+  order: 16
   short: Thread name.
   type: keyword
 process.title:
@@ -3239,7 +3378,7 @@ process.title:
   ignore_above: 1024
   level: extended
   name: title
-  order: 6
+  order: 12
   short: Process title.
   type: keyword
 process.uptime:
@@ -3248,7 +3387,7 @@ process.uptime:
   flat_name: process.uptime
   level: extended
   name: uptime
-  order: 10
+  order: 20
   short: Seconds the process has been up.
   type: long
 process.working_directory:
@@ -3258,7 +3397,7 @@ process.working_directory:
   ignore_above: 1024
   level: extended
   name: working_directory
-  order: 11
+  order: 22
   short: The working directory of the process.
   type: keyword
 related.ip:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3483,7 +3483,7 @@ process:
       ignore_above: 1024
       level: extended
       name: args
-      order: 4
+      order: 8
       short: Array of process arguments.
       type: keyword
     executable:
@@ -3493,7 +3493,7 @@ process:
       ignore_above: 1024
       level: extended
       name: executable
-      order: 5
+      order: 10
       short: Absolute path to the process executable.
       type: keyword
     exit_code:
@@ -3505,7 +3505,7 @@ process:
       flat_name: process.exit_code
       level: extended
       name: exit_code
-      order: 12
+      order: 24
       short: The exit code of the process.
       type: long
     hash.md5:
@@ -3557,8 +3557,147 @@ process:
       ignore_above: 1024
       level: extended
       name: name
-      order: 1
+      order: 2
       short: Process name.
+      type: keyword
+    parent.args:
+      description: 'Array of process arguments.
+
+        May be filtered to protect sensitive information.'
+      example:
+      - ssh
+      - -l
+      - user
+      - 10.0.0.16
+      flat_name: process.parent.args
+      ignore_above: 1024
+      level: extended
+      name: parent.args
+      order: 9
+      short: Array of process arguments.
+      type: keyword
+    parent.executable:
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+      flat_name: process.parent.executable
+      ignore_above: 1024
+      level: extended
+      name: parent.executable
+      order: 11
+      short: Absolute path to the process executable.
+      type: keyword
+    parent.exit_code:
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+      flat_name: process.parent.exit_code
+      level: extended
+      name: parent.exit_code
+      order: 25
+      short: The exit code of the process.
+      type: long
+    parent.name:
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+      flat_name: process.parent.name
+      ignore_above: 1024
+      level: extended
+      name: parent.name
+      order: 3
+      short: Process name.
+      type: keyword
+    parent.pgid:
+      description: Identifier of the group of processes the process belongs to.
+      flat_name: process.parent.pgid
+      format: string
+      level: extended
+      name: parent.pgid
+      order: 7
+      short: Identifier of the group of processes the process belongs to.
+      type: long
+    parent.pid:
+      description: Process id.
+      example: 4242
+      flat_name: process.parent.pid
+      format: string
+      level: core
+      name: parent.pid
+      order: 1
+      short: Process id.
+      type: long
+    parent.ppid:
+      description: Parent process' pid.
+      example: 4241
+      flat_name: process.parent.ppid
+      format: string
+      level: extended
+      name: parent.ppid
+      order: 5
+      short: Parent process' pid.
+      type: long
+    parent.start:
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+      flat_name: process.parent.start
+      level: extended
+      name: parent.start
+      order: 19
+      short: The time the process started.
+      type: date
+    parent.thread.id:
+      description: Thread ID.
+      example: 4242
+      flat_name: process.parent.thread.id
+      format: string
+      level: extended
+      name: parent.thread.id
+      order: 15
+      short: Thread ID.
+      type: long
+    parent.thread.name:
+      description: Thread name.
+      example: thread-0
+      flat_name: process.parent.thread.name
+      ignore_above: 1024
+      level: extended
+      name: parent.thread.name
+      order: 17
+      short: Thread name.
+      type: keyword
+    parent.title:
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+      flat_name: process.parent.title
+      ignore_above: 1024
+      level: extended
+      name: parent.title
+      order: 13
+      short: Process title.
+      type: keyword
+    parent.uptime:
+      description: Seconds the process has been up.
+      example: 1325
+      flat_name: process.parent.uptime
+      level: extended
+      name: parent.uptime
+      order: 21
+      short: Seconds the process has been up.
+      type: long
+    parent.working_directory:
+      description: The working directory of the process.
+      example: /home/alice
+      flat_name: process.parent.working_directory
+      ignore_above: 1024
+      level: extended
+      name: parent.working_directory
+      order: 23
+      short: The working directory of the process.
       type: keyword
     pgid:
       description: Identifier of the group of processes the process belongs to.
@@ -3566,7 +3705,7 @@ process:
       format: string
       level: extended
       name: pgid
-      order: 3
+      order: 6
       short: Identifier of the group of processes the process belongs to.
       type: long
     pid:
@@ -3586,7 +3725,7 @@ process:
       format: string
       level: extended
       name: ppid
-      order: 2
+      order: 4
       short: Parent process' pid.
       type: long
     start:
@@ -3595,7 +3734,7 @@ process:
       flat_name: process.start
       level: extended
       name: start
-      order: 9
+      order: 18
       short: The time the process started.
       type: date
     thread.id:
@@ -3605,7 +3744,7 @@ process:
       format: string
       level: extended
       name: thread.id
-      order: 7
+      order: 14
       short: Thread ID.
       type: long
     thread.name:
@@ -3615,7 +3754,7 @@ process:
       ignore_above: 1024
       level: extended
       name: thread.name
-      order: 8
+      order: 16
       short: Thread name.
       type: keyword
     title:
@@ -3627,7 +3766,7 @@ process:
       ignore_above: 1024
       level: extended
       name: title
-      order: 6
+      order: 12
       short: Process title.
       type: keyword
     uptime:
@@ -3636,7 +3775,7 @@ process:
       flat_name: process.uptime
       level: extended
       name: uptime
-      order: 10
+      order: 20
       short: Seconds the process has been up.
       type: long
     working_directory:
@@ -3646,7 +3785,7 @@ process:
       ignore_above: 1024
       level: extended
       name: working_directory
-      order: 11
+      order: 22
       short: The working directory of the process.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1312,6 +1312,59 @@
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
+            "parent": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
+                "executable": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
+                "exit_code": {
+                  "type": "long"
+                }, 
+                "name": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
+                "pgid": {
+                  "type": "long"
+                }, 
+                "pid": {
+                  "type": "long"
+                }, 
+                "ppid": {
+                  "type": "long"
+                }, 
+                "start": {
+                  "type": "date"
+                }, 
+                "thread": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    }, 
+                    "name": {
+                      "ignore_above": 1024, 
+                      "type": "keyword"
+                    }
+                  }
+                }, 
+                "title": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
+                "uptime": {
+                  "type": "long"
+                }, 
+                "working_directory": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }
+              }
+            }, 
             "pgid": {
               "type": "long"
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1311,6 +1311,59 @@
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
+          "parent": {
+            "properties": {
+              "args": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
+              "executable": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
+              "exit_code": {
+                "type": "long"
+              }, 
+              "name": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
+              "pgid": {
+                "type": "long"
+              }, 
+              "pid": {
+                "type": "long"
+              }, 
+              "ppid": {
+                "type": "long"
+              }, 
+              "start": {
+                "type": "date"
+              }, 
+              "thread": {
+                "properties": {
+                  "id": {
+                    "type": "long"
+                  }, 
+                  "name": {
+                    "ignore_above": 1024, 
+                    "type": "keyword"
+                  }
+                }
+              }, 
+              "title": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
+              "uptime": {
+                "type": "long"
+              }, 
+              "working_directory": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }
+            }
+          }, 
           "pgid": {
             "type": "long"
           }, 

--- a/generated/legacy/template.json
+++ b/generated/legacy/template.json
@@ -915,6 +915,59 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "parent": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "exit_code": {
+                  "type": "long"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "pgid": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "ppid": {
+                  "type": "long"
+                },
+                "start": {
+                  "type": "date"
+                },
+                "thread": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "title": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "uptime": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "pgid": {
               "type": "long"
             },

--- a/schema.json
+++ b/schema.json
@@ -2179,6 +2179,136 @@
         "required": false, 
         "type": "keyword"
       }, 
+      "process.parent.args": {
+        "description": "Array of process arguments.\nMay be filtered to protect sensitive information.", 
+        "example": "['ssh', '-l', 'user', '10.0.0.16']", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.args", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.parent.executable": {
+        "description": "Absolute path to the process executable.", 
+        "example": "/usr/bin/ssh", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.executable", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.parent.exit_code": {
+        "description": "The exit code of the process, if this is a termination event.\nThe field should be absent if there is no exit code for the event (e.g. process start).", 
+        "example": "137", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.exit_code", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.name": {
+        "description": "Process name.\nSometimes called program name or similar.", 
+        "example": "ssh", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.parent.pgid": {
+        "description": "Identifier of the group of processes the process belongs to.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.pgid", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.pid": {
+        "description": "Process id.", 
+        "example": "4242", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "core", 
+        "name": "process.parent.pid", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.ppid": {
+        "description": "Parent process' pid.", 
+        "example": "4241", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.ppid", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.start": {
+        "description": "The time the process started.", 
+        "example": "2016-05-23T08:05:34.853Z", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.start", 
+        "required": false, 
+        "type": "date"
+      }, 
+      "process.parent.thread.id": {
+        "description": "Thread ID.", 
+        "example": "4242", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.thread.id", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.thread.name": {
+        "description": "Thread name.", 
+        "example": "thread-0", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.thread.name", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.parent.title": {
+        "description": "Process title.\nThe proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.", 
+        "example": "", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.title", 
+        "required": false, 
+        "type": "keyword"
+      }, 
+      "process.parent.uptime": {
+        "description": "Seconds the process has been up.", 
+        "example": "1325", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.uptime", 
+        "required": false, 
+        "type": "long"
+      }, 
+      "process.parent.working_directory": {
+        "description": "The working directory of the process.", 
+        "example": "/home/alice", 
+        "footnote": "", 
+        "group": 2, 
+        "level": "extended", 
+        "name": "process.parent.working_directory", 
+        "required": false, 
+        "type": "keyword"
+      }, 
       "process.pgid": {
         "description": "Identifier of the group of processes the process belongs to.", 
         "example": "", 

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -1,3 +1,17 @@
+# HEADS UP
+# This field set supports capturing the parent process (one level).
+#
+# Doing so via normal reuse/nesting is tricky mainly because it's reused as a
+# different name: the "process" field set is nested as "parent".
+# This is the only occurence of this in ECS, so it's not supported.
+#
+# The workaround is to simply duplicate each field to generate the "parent.*"
+# equivalent of each "process.*" field. Please maintain each duplicate exactly as
+# the main field (e.g. same wording & example), as if it was normal nesting.
+#
+# Each such duplicated field for the parent process is directly below the original
+# field, which will hopefully help maintain this until a better solution is in place.
+
 ---
 - name: process
   title: Process
@@ -20,6 +34,15 @@
         Process id.
       example: 4242
 
+    - name: parent.pid
+      format: string
+      level: core
+      type: long
+      description: >
+        Process id.
+      example: 4242
+
+
     - name: name
       level: extended
       type: keyword
@@ -30,6 +53,17 @@
         Sometimes called program name or similar.
       example: ssh
 
+    - name: parent.name
+      level: extended
+      type: keyword
+      short: Process name.
+      description: >
+        Process name.
+
+        Sometimes called program name or similar.
+      example: ssh
+
+
     - name: ppid
       format: string
       level: extended
@@ -38,12 +72,29 @@
         Parent process' pid.
       example: 4241
 
+    - name: parent.ppid
+      format: string
+      level: extended
+      type: long
+      description: >
+        Parent process' pid.
+      example: 4241
+
+
     - name: pgid
       format: string
       level: extended
       type: long
       description: >
         Identifier of the group of processes the process belongs to.
+
+    - name: parent.pgid
+      format: string
+      level: extended
+      type: long
+      description: >
+        Identifier of the group of processes the process belongs to.
+
 
     - name: args
       level: extended
@@ -55,12 +106,31 @@
         May be filtered to protect sensitive information.
       example: ["ssh", "-l", "user", "10.0.0.16"]
 
+    - name: parent.args
+      level: extended
+      type: keyword
+      short: Array of process arguments.
+      description: >
+        Array of process arguments.
+
+        May be filtered to protect sensitive information.
+      example: ["ssh", "-l", "user", "10.0.0.16"]
+
+
     - name: executable
       level: extended
       type: keyword
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
+
+    - name: parent.executable
+      level: extended
+      type: keyword
+      description: >
+        Absolute path to the process executable.
+      example: /usr/bin/ssh
+
 
     - name: title
       level: extended
@@ -72,6 +142,17 @@
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
 
+    - name: parent.title
+      level: extended
+      type: keyword
+      short: Process title.
+      description: >
+        Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.
+
+
     - name: thread.id
       format: string
       level: extended
@@ -80,12 +161,29 @@
       description: >
         Thread ID.
 
+    - name: parent.thread.id
+      format: string
+      level: extended
+      type: long
+      example: 4242
+      description: >
+        Thread ID.
+
+
     - name: thread.name
       level: extended
       type: keyword
       example: 'thread-0'
       description: >
         Thread name.
+
+    - name: parent.thread.name
+      level: extended
+      type: keyword
+      example: 'thread-0'
+      description: >
+        Thread name.
+
 
     - name: start
       level: extended
@@ -94,12 +192,28 @@
       description: >
         The time the process started.
 
+    - name: parent.start
+      level: extended
+      type: date
+      example: "2016-05-23T08:05:34.853Z"
+      description: >
+        The time the process started.
+
+
     - name: uptime
       level: extended
       type: long
       example: 1325
       description: >
         Seconds the process has been up.
+
+    - name: parent.uptime
+      level: extended
+      type: long
+      example: 1325
+      description: >
+        Seconds the process has been up.
+
 
     - name: working_directory
       level: extended
@@ -108,7 +222,26 @@
       description: >
         The working directory of the process.
 
+    - name: parent.working_directory
+      level: extended
+      type: keyword
+      example: /home/alice
+      description: >
+        The working directory of the process.
+
+
     - name: exit_code
+      level: extended
+      type: long
+      example: 137
+      short: The exit code of the process.
+      description: >
+        The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g.
+        process start).
+
+    - name: parent.exit_code
       level: extended
       type: long
       example: 137


### PR DESCRIPTION
Doing this via normal field reuse is pretty tricky at this time. This is the
first time a field set gets reused under a different name ("process" nested as "parent").

So for now I suggest simply duplicating all fields.

In order to avoid issues with this duplication:

- I call this out and explain it at length in a comment at the top of the `process.yml` file.
- Each duplicate entry is directly below the entry it copies in this file
  (e.g. `process.pid` is directly followed by `process.parent.pid`)
  - Note that the generated docs are sorted by the flattened key name. So all `parent.*`
    fields will actually be grouped in the generated files.

Closes #597.