### PR TITLE
Backport #592 to 1.2: Add link to ecs-logging project

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -6,6 +6,8 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 * {beats}
 * APM
 * Infrastructure UI and Logs UI
+* Log formatters that support ECS out of the box for various languages can be found
+  https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 
 // TODO Insert community & partner solutions here
 


### PR DESCRIPTION
Backport of PR #592 to 1.2 branch. Original message:

Pointing users to log formatters that support ECS out of the box.