### PR TITLE
Run misspell on the schema definitions too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ makelint:
 .PHONY: misspell
 misspell:
 	go get github.com/client9/misspell/cmd/misspell
-	misspell README.md CONTRIBUTING.md
+	misspell README.md CONTRIBUTING.md schemas/*
 
 .PHONY: reload_docs
 reload_docs: generator docs

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -3,7 +3,7 @@
 #
 # Doing so via normal reuse/nesting is tricky mainly because it's reused as a
 # different name: the "process" field set is nested as "parent".
-# This is the only occurence of this in ECS, so it's not supported.
+# This is the only occurrence of this in ECS, so it's not supported.
 #
 # The workaround is to simply duplicate each field to generate the "parent.*"
 # equivalent of each "process.*" field. Please maintain each duplicate exactly as


### PR DESCRIPTION
This used to be covered by running spell-checker on the readme. But the schema's no longer there.