### PR TITLE
Split changelog in two sections

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -1,15 +1,20 @@
 <!-- When adding an entry to the Changelog:
+
 - Please follow the Keep a Changelog: http://keepachangelog.com/ guidelines.
 - Please insert your changelog line ordered by PR ID.
+- Make sure you add your entry to the correct section (schema or tooling).
+
 Thanks, you're awesome :-) -->
 
 ## Unreleased
 
-### Breaking changes
+### Schema Changes
 
-### Bugfixes
+#### Breaking changes
 
-### Added
+#### Bugfixes
+
+#### Added
 
 * Added `vulnerability.*` fields to represent vulnerability information. #581
 * Added `event.ingested` as the ingest timestamp. #582
@@ -23,23 +28,39 @@ Thanks, you're awesome :-) -->
 * Added `process.parent.*`. #612
 * Added `process.args_count`. #615
 
-### Improvements
+#### Improvements
 
-### Deprecated
+#### Deprecated
+
+
+### Tooling and Artifact Changes
+
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
+#### Improvements
+
+#### Deprecated
 
 
 <!-- All empty sections:
 
 ## Unreleased
 
-### Breaking changes
+### Schema Changes
+### Tooling and Artifact Changes
 
-### Bugfixes
+#### Breaking changes
 
-### Added
+#### Bugfixes
 
-### Improvements
+#### Added
 
-### Deprecated
+#### Improvements
+
+#### Deprecated
 
 -->


### PR DESCRIPTION
This will let us differentiate between schema (normative) changes and changes
to the tooling and artifacts around the schema.