### PR TITLE
Backport #621 to 1.3: Flesh out the csv a little

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -37,9 +37,13 @@ Thanks, you're awesome :-) -->
 
 #### Breaking changes
 
+* Changed the order and column names in the csv. #621
+
 #### Bugfixes
 
 #### Added
+
+* Added the "Indexed", "Field\_Set" and "Description" columns to the csv. #621
 
 #### Improvements
 

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1,463 +1,463 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
-1.3.0,True,base,@timestamp,date,core,2016-05-23T08:05:34.853Z,Date/time when the event originated.
-1.3.0,True,base,labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",Custom key/value pairs.
-1.3.0,True,base,message,text,core,Hello World,Log message optimized for viewing in a log viewer.
-1.3.0,True,base,tags,keyword,core,"[""production"", ""env2""]",List of keywords used to tag each event.
-1.3.0,True,agent,agent.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this agent.
-1.3.0,True,agent,agent.id,keyword,core,8a4f500d,Unique identifier of this agent.
-1.3.0,True,agent,agent.name,keyword,core,foo,Custom name of the agent.
-1.3.0,True,agent,agent.type,keyword,core,filebeat,Type of the agent.
-1.3.0,True,agent,agent.version,keyword,core,6.0.0-rc2,Version of the agent.
-1.3.0,True,as,as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.3.0,True,as,as.organization.name,keyword,extended,Google LLC,Organization name.
-1.3.0,True,client,client.address,keyword,extended,,Client network address.
-1.3.0,True,client,client.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.3.0,True,client,client.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.3.0,True,client,client.bytes,long,core,184,Bytes sent from the client to the server.
-1.3.0,True,client,client.domain,keyword,core,,Client domain.
-1.3.0,True,client,client.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,client,client.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,client,client.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,client,client.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,client,client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,client,client.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,client,client.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,client,client.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,client,client.ip,ip,core,,IP address of the client.
-1.3.0,True,client,client.mac,keyword,core,,MAC address of the client.
-1.3.0,True,client,client.nat.ip,ip,extended,,Client NAT ip address
-1.3.0,True,client,client.nat.port,long,extended,,Client NAT port
-1.3.0,True,client,client.packets,long,core,12,Packets sent from the client to the server.
-1.3.0,True,client,client.port,long,core,,Port of the client.
-1.3.0,True,client,client.registered_domain,keyword,extended,google.com,"The highest registered client domain, stripped of the subdomain."
-1.3.0,True,client,client.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,client,client.user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,client,client.user.email,keyword,extended,,User email address.
-1.3.0,True,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,client,client.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,client,client.user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,client,client.user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
-1.3.0,True,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
-1.3.0,True,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
-1.3.0,True,cloud,cloud.instance.name,keyword,extended,,Instance name of the host machine.
-1.3.0,True,cloud,cloud.machine.type,keyword,extended,t2.medium,Machine type of the host machine.
-1.3.0,True,cloud,cloud.provider,keyword,extended,aws,Name of the cloud provider.
-1.3.0,True,cloud,cloud.region,keyword,extended,us-east-1,Region in which this host is running.
-1.3.0,True,container,container.id,keyword,core,,Unique container id.
-1.3.0,True,container,container.image.name,keyword,extended,,Name of the image the container was built on.
-1.3.0,True,container,container.image.tag,keyword,extended,,Container image tag.
-1.3.0,True,container,container.labels,object,extended,,Image labels.
-1.3.0,True,container,container.name,keyword,extended,,Container name.
-1.3.0,True,container,container.runtime,keyword,extended,docker,Runtime managing this container.
-1.3.0,True,destination,destination.address,keyword,extended,,Destination network address.
-1.3.0,True,destination,destination.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.3.0,True,destination,destination.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.3.0,True,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
-1.3.0,True,destination,destination.domain,keyword,core,,Destination domain.
-1.3.0,True,destination,destination.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,destination,destination.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,destination,destination.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,destination,destination.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,destination,destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,destination,destination.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,destination,destination.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,destination,destination.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,destination,destination.ip,ip,core,,IP address of the destination.
-1.3.0,True,destination,destination.mac,keyword,core,,MAC address of the destination.
-1.3.0,True,destination,destination.nat.ip,ip,extended,,Destination NAT ip
-1.3.0,True,destination,destination.nat.port,long,extended,,Destination NAT Port
-1.3.0,True,destination,destination.packets,long,core,12,Packets sent from the destination to the source.
-1.3.0,True,destination,destination.port,long,core,,Port of the destination.
-1.3.0,True,destination,destination.registered_domain,keyword,extended,google.com,"The highest registered destination domain, stripped of the subdomain."
-1.3.0,True,destination,destination.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,destination,destination.user.email,keyword,extended,,User email address.
-1.3.0,True,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,destination,destination.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,destination,destination.user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,dns,dns.answers,object,extended,,Array of DNS answers.
-1.3.0,True,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
-1.3.0,True,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
-1.3.0,True,dns,dns.answers.name,keyword,extended,www.google.com,The domain name to which this resource record pertains.
-1.3.0,True,dns,dns.answers.ttl,long,extended,180,The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached.
-1.3.0,True,dns,dns.answers.type,keyword,extended,CNAME,The type of data contained in this resource record.
-1.3.0,True,dns,dns.header_flags,keyword,extended,"['RD', 'RA']",Array of DNS header flags.
-1.3.0,True,dns,dns.id,keyword,extended,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
-1.3.0,True,dns,dns.op_code,keyword,extended,QUERY,The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
-1.3.0,True,dns,dns.question.class,keyword,extended,IN,The class of of records being queried.
-1.3.0,True,dns,dns.question.name,keyword,extended,www.google.com,The name being queried.
-1.3.0,True,dns,dns.question.registered_domain,keyword,extended,google.com,"The highest registered domain, stripped of the subdomain."
-1.3.0,True,dns,dns.question.subdomain,keyword,extended,www,The subdomain of the domain.
-1.3.0,True,dns,dns.question.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,dns,dns.question.type,keyword,extended,AAAA,The type of record being queried.
-1.3.0,True,dns,dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",Array containing all IPs seen in answers.data
-1.3.0,True,dns,dns.response_code,keyword,extended,NOERROR,The DNS response code.
-1.3.0,True,dns,dns.type,keyword,extended,answer,"The type of DNS event captured, query or answer."
-1.3.0,True,ecs,ecs.version,keyword,core,1.0.0,ECS version this event conforms to.
-1.3.0,True,error,error.code,keyword,core,,Error code describing the error.
-1.3.0,True,error,error.id,keyword,core,,Unique identifier for the error.
-1.3.0,True,error,error.message,text,core,,Error message.
-1.3.0,False,error,error.stack_trace,keyword,extended,,The stack trace of this error in plain text.
-1.3.0,True,error,error.type,keyword,extended,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
-1.3.0,True,event,event.action,keyword,core,user-password-change,The action captured by the event.
-1.3.0,True,event,event.category,keyword,core,user-management,Event category.
-1.3.0,True,event,event.code,keyword,extended,4648,Identification code for this event.
-1.3.0,True,event,event.created,date,core,2016-05-23 08:05:34.857000,Time when the event was first read by an agent or by your pipeline.
-1.3.0,True,event,event.dataset,keyword,core,apache.access,Name of the dataset.
-1.3.0,True,event,event.duration,long,core,,Duration of the event in nanoseconds.
-1.3.0,True,event,event.end,date,extended,,event.end contains the date when the event ended or when the activity was last observed.
-1.3.0,True,event,event.hash,keyword,extended,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
-1.3.0,True,event,event.id,keyword,core,8a4f500d,Unique ID to describe the event.
-1.3.0,True,event,event.ingested,date,core,2016-05-23 08:05:35.101000,Timestamp when an event arrived in the central data store.
-1.3.0,True,event,event.kind,keyword,extended,state,The kind of the event.
-1.3.0,True,event,event.module,keyword,core,apache,Name of the module this data is coming from.
-1.3.0,False,event,event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
-1.3.0,True,event,event.outcome,keyword,extended,success,The outcome of the event.
-1.3.0,True,event,event.provider,keyword,extended,kernel,Source of the event.
-1.3.0,True,event,event.risk_score,float,core,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
-1.3.0,True,event,event.risk_score_norm,float,extended,,Normalized risk score or priority of the event (0-100).
-1.3.0,True,event,event.sequence,long,extended,,Sequence number of the event.
-1.3.0,True,event,event.severity,long,core,7,Numeric severity of the event.
-1.3.0,True,event,event.start,date,extended,,event.start contains the date when the event started or when the activity was first observed.
-1.3.0,True,event,event.timezone,keyword,extended,,Event time zone.
-1.3.0,True,event,event.type,keyword,core,,Reserved for future usage.
-1.3.0,True,file,file.accessed,date,extended,,Last time the file was accessed.
-1.3.0,True,file,file.created,date,extended,,File creation time.
-1.3.0,True,file,file.ctime,date,extended,,Last time the file attributes or metadata changed.
-1.3.0,True,file,file.device,keyword,extended,sda,Device that is the source of the file.
-1.3.0,True,file,file.directory,keyword,extended,/home/alice,Directory where the file is located.
-1.3.0,True,file,file.extension,keyword,extended,png,File extension.
-1.3.0,True,file,file.gid,keyword,extended,1001,Primary group ID (GID) of the file.
-1.3.0,True,file,file.group,keyword,extended,alice,Primary group name of the file.
-1.3.0,True,file,file.hash.md5,keyword,extended,,MD5 hash.
-1.3.0,True,file,file.hash.sha1,keyword,extended,,SHA1 hash.
-1.3.0,True,file,file.hash.sha256,keyword,extended,,SHA256 hash.
-1.3.0,True,file,file.hash.sha512,keyword,extended,,SHA512 hash.
-1.3.0,True,file,file.inode,keyword,extended,256383,Inode representing the file in the filesystem.
-1.3.0,True,file,file.mode,keyword,extended,0640,Mode of the file in octal representation.
-1.3.0,True,file,file.mtime,date,extended,,Last time the file content was modified.
-1.3.0,True,file,file.name,keyword,extended,example.png,"Name of the file including the extension, without the directory."
-1.3.0,True,file,file.owner,keyword,extended,alice,File owner's username.
-1.3.0,True,file,file.path,keyword,extended,/home/alice/example.png,Full path to the file.
-1.3.0,True,file,file.size,long,extended,16384,File size in bytes.
-1.3.0,True,file,file.target_path,keyword,extended,,Target path for symlinks.
-1.3.0,True,file,file.type,keyword,extended,file,"File type (file, dir, or symlink)."
-1.3.0,True,file,file.uid,keyword,extended,1001,The user ID (UID) or security identifier (SID) of the file owner.
-1.3.0,True,geo,geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,geo,geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,geo,geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,geo,geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,geo,geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,geo,geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,geo,geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,geo,geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,group,group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,group,group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,group,group.name,keyword,extended,,Name of the group.
-1.3.0,True,hash,hash.md5,keyword,extended,,MD5 hash.
-1.3.0,True,hash,hash.sha1,keyword,extended,,SHA1 hash.
-1.3.0,True,hash,hash.sha256,keyword,extended,,SHA256 hash.
-1.3.0,True,hash,hash.sha512,keyword,extended,,SHA512 hash.
-1.3.0,True,host,host.architecture,keyword,core,x86_64,Operating system architecture.
-1.3.0,True,host,host.domain,keyword,extended,CONTOSO,Name of the directory the group is a member of.
-1.3.0,True,host,host.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,host,host.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,host,host.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,host,host.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,host,host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,host,host.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,host,host.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,host,host.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,host,host.hostname,keyword,core,,Hostname of the host.
-1.3.0,True,host,host.id,keyword,core,,Unique host id.
-1.3.0,True,host,host.ip,ip,core,,Host ip address.
-1.3.0,True,host,host.mac,keyword,core,,Host mac address.
-1.3.0,True,host,host.name,keyword,core,,Name of the host.
-1.3.0,True,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
-1.3.0,True,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.3.0,True,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
-1.3.0,True,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.3.0,True,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
-1.3.0,True,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
-1.3.0,True,host,host.type,keyword,core,,Type of host.
-1.3.0,True,host,host.uptime,long,extended,1325,Seconds the host has been up.
-1.3.0,True,host,host.user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,host,host.user.email,keyword,extended,,User email address.
-1.3.0,True,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,host,host.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,host,host.user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,host,host.user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
-1.3.0,True,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
-1.3.0,True,http,http.request.bytes,long,extended,1437,Total size in bytes of the request (body and headers).
-1.3.0,True,http,http.request.method,keyword,extended,"get, post, put",HTTP request method.
-1.3.0,True,http,http.request.referrer,keyword,extended,https://blog.example.com/,Referrer for this HTTP request.
-1.3.0,True,http,http.response.body.bytes,long,extended,887,Size in bytes of the response body.
-1.3.0,True,http,http.response.body.content,keyword,extended,Hello world,The full HTTP response body.
-1.3.0,True,http,http.response.bytes,long,extended,1437,Total size in bytes of the response (body and headers).
-1.3.0,True,http,http.response.status_code,long,extended,404,HTTP response status code.
-1.3.0,True,http,http.version,keyword,extended,1.1,HTTP version.
-1.3.0,True,log,log.level,keyword,core,error,Log level of the log event.
-1.3.0,True,log,log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
-1.3.0,True,log,log.origin.file.line,integer,extended,42,The line number of the file which originated the log event.
-1.3.0,True,log,log.origin.file.name,keyword,extended,Bootstrap.java,The file which originated the log event.
-1.3.0,True,log,log.origin.function,keyword,extended,init,The function which originated the log event.
-1.3.0,False,log,log.original,keyword,core,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
-1.3.0,True,log,log.syslog,object,extended,,Syslog metadata
-1.3.0,True,log,log.syslog.facility.code,long,extended,23,Syslog numeric facility of the event.
-1.3.0,True,log,log.syslog.facility.name,keyword,extended,local7,Syslog text-based facility of the event.
-1.3.0,True,log,log.syslog.priority,long,extended,135,Syslog priority of the event.
-1.3.0,True,log,log.syslog.severity.code,long,extended,3,Syslog numeric severity of the event.
-1.3.0,True,log,log.syslog.severity.name,keyword,extended,Error,Syslog text-based severity of the event.
-1.3.0,True,network,network.application,keyword,extended,aim,Application level protocol name.
-1.3.0,True,network,network.bytes,long,core,368,Total bytes transferred in both directions.
-1.3.0,True,network,network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
-1.3.0,True,network,network.direction,keyword,core,inbound,Direction of the network traffic.
-1.3.0,True,network,network.forwarded_ip,ip,core,192.1.1.2,Host IP address when the source IP address is the proxy.
-1.3.0,True,network,network.iana_number,keyword,extended,6,IANA Protocol Number.
-1.3.0,True,network,network.name,keyword,extended,Guest Wifi,Name given by operators to sections of their network.
-1.3.0,True,network,network.packets,long,core,24,Total packets transferred in both directions.
-1.3.0,True,network,network.protocol,keyword,core,http,L7 Network protocol name.
-1.3.0,True,network,network.transport,keyword,core,tcp,Protocol Name corresponding to the field `iana_number`.
-1.3.0,True,network,network.type,keyword,core,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
-1.3.0,True,observer,observer.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,observer,observer.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,observer,observer.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,observer,observer.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,observer,observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,observer,observer.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,observer,observer.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,observer,observer.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,observer,observer.hostname,keyword,core,,Hostname of the observer.
-1.3.0,True,observer,observer.ip,ip,core,,IP address of the observer.
-1.3.0,True,observer,observer.mac,keyword,core,,MAC address of the observer
-1.3.0,True,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
-1.3.0,True,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
-1.3.0,True,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.3.0,True,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
-1.3.0,True,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.3.0,True,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
-1.3.0,True,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
-1.3.0,True,observer,observer.product,keyword,extended,s200,The product name of the observer.
-1.3.0,True,observer,observer.serial_number,keyword,extended,,Observer serial number.
-1.3.0,True,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
-1.3.0,True,observer,observer.vendor,keyword,core,Symantec,Vendor name of the observer.
-1.3.0,True,observer,observer.version,keyword,core,,Observer version.
-1.3.0,True,organization,organization.id,keyword,extended,,Unique identifier for the organization.
-1.3.0,True,organization,organization.name,keyword,extended,,Organization name.
-1.3.0,True,os,os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
-1.3.0,True,os,os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.3.0,True,os,os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
-1.3.0,True,os,os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.3.0,True,os,os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
-1.3.0,True,os,os.version,keyword,extended,10.14.1,Operating system version as a raw string.
-1.3.0,True,package,package.architecture,keyword,extended,x86_64,Package architecture.
-1.3.0,True,package,package.build_version,keyword,extended,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
-1.3.0,True,package,package.checksum,keyword,extended,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.
-1.3.0,True,package,package.description,keyword,extended,Open source programming language to build simple/reliable/efficient software.,Description of the package.
-1.3.0,True,package,package.install_scope,keyword,extended,global,"Indicating how the package was installed, e.g. user-local, global."
-1.3.0,True,package,package.installed,date,extended,,Time when package was installed.
-1.3.0,True,package,package.license,keyword,extended,Apache License 2.0,Package license
-1.3.0,True,package,package.name,keyword,extended,go,Package name
-1.3.0,True,package,package.path,keyword,extended,/usr/local/Cellar/go/1.12.9/,Path where the package is installed.
-1.3.0,True,package,package.reference,keyword,extended,https://golang.org,Package reference URL
-1.3.0,True,package,package.size,long,extended,62231,Package size in bytes.
-1.3.0,True,package,package.type,keyword,extended,rpm,Package type
-1.3.0,True,package,package.version,keyword,extended,1.12.9,Package version
-1.3.0,True,process,process.args,keyword,extended,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
-1.3.0,True,process,process.args_count,long,extended,4,Length of the process.args array.
-1.3.0,True,process,process.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.3.0,True,process,process.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
-1.3.0,True,process,process.exit_code,long,extended,137,The exit code of the process.
-1.3.0,True,process,process.hash.md5,keyword,extended,,MD5 hash.
-1.3.0,True,process,process.hash.sha1,keyword,extended,,SHA1 hash.
-1.3.0,True,process,process.hash.sha256,keyword,extended,,SHA256 hash.
-1.3.0,True,process,process.hash.sha512,keyword,extended,,SHA512 hash.
-1.3.0,True,process,process.name,keyword,extended,ssh,Process name.
-1.3.0,True,process,process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
-1.3.0,True,process,process.parent.args_count,long,extended,4,Length of the process.args array.
-1.3.0,True,process,process.parent.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.3.0,True,process,process.parent.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
-1.3.0,True,process,process.parent.exit_code,long,extended,137,The exit code of the process.
-1.3.0,True,process,process.parent.name,keyword,extended,ssh,Process name.
-1.3.0,True,process,process.parent.pgid,long,extended,,Identifier of the group of processes the process belongs to.
-1.3.0,True,process,process.parent.pid,long,core,4242,Process id.
-1.3.0,True,process,process.parent.ppid,long,extended,4241,Parent process' pid.
-1.3.0,True,process,process.parent.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
-1.3.0,True,process,process.parent.thread.id,long,extended,4242,Thread ID.
-1.3.0,True,process,process.parent.thread.name,keyword,extended,thread-0,Thread name.
-1.3.0,True,process,process.parent.title,keyword,extended,,Process title.
-1.3.0,True,process,process.parent.uptime,long,extended,1325,Seconds the process has been up.
-1.3.0,True,process,process.parent.working_directory,keyword,extended,/home/alice,The working directory of the process.
-1.3.0,True,process,process.pgid,long,extended,,Identifier of the group of processes the process belongs to.
-1.3.0,True,process,process.pid,long,core,4242,Process id.
-1.3.0,True,process,process.ppid,long,extended,4241,Parent process' pid.
-1.3.0,True,process,process.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
-1.3.0,True,process,process.thread.id,long,extended,4242,Thread ID.
-1.3.0,True,process,process.thread.name,keyword,extended,thread-0,Thread name.
-1.3.0,True,process,process.title,keyword,extended,,Process title.
-1.3.0,True,process,process.uptime,long,extended,1325,Seconds the process has been up.
-1.3.0,True,process,process.working_directory,keyword,extended,/home/alice,The working directory of the process.
-1.3.0,True,related,related.ip,ip,extended,,All of the IPs seen on your event.
-1.3.0,True,server,server.address,keyword,extended,,Server network address.
-1.3.0,True,server,server.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.3.0,True,server,server.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.3.0,True,server,server.bytes,long,core,184,Bytes sent from the server to the client.
-1.3.0,True,server,server.domain,keyword,core,,Server domain.
-1.3.0,True,server,server.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,server,server.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,server,server.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,server,server.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,server,server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,server,server.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,server,server.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,server,server.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,server,server.ip,ip,core,,IP address of the server.
-1.3.0,True,server,server.mac,keyword,core,,MAC address of the server.
-1.3.0,True,server,server.nat.ip,ip,extended,,Server NAT ip
-1.3.0,True,server,server.nat.port,long,extended,,Server NAT port
-1.3.0,True,server,server.packets,long,core,12,Packets sent from the server to the client.
-1.3.0,True,server,server.port,long,core,,Port of the server.
-1.3.0,True,server,server.registered_domain,keyword,extended,google.com,"The highest registered server domain, stripped of the subdomain."
-1.3.0,True,server,server.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,server,server.user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,server,server.user.email,keyword,extended,,User email address.
-1.3.0,True,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,server,server.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,server,server.user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,server,server.user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
-1.3.0,True,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
-1.3.0,True,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
-1.3.0,True,service,service.node.name,keyword,extended,instance-0000000016,Name of the service node.
-1.3.0,True,service,service.state,keyword,core,,Current state of the service.
-1.3.0,True,service,service.type,keyword,core,elasticsearch,The type of the service.
-1.3.0,True,service,service.version,keyword,core,3.2.4,Version of the service.
-1.3.0,True,source,source.address,keyword,extended,,Source network address.
-1.3.0,True,source,source.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.3.0,True,source,source.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.3.0,True,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
-1.3.0,True,source,source.domain,keyword,core,,Source domain.
-1.3.0,True,source,source.geo.city_name,keyword,core,Montreal,City name.
-1.3.0,True,source,source.geo.continent_name,keyword,core,North America,Name of the continent.
-1.3.0,True,source,source.geo.country_iso_code,keyword,core,CA,Country ISO code.
-1.3.0,True,source,source.geo.country_name,keyword,core,Canada,Country name.
-1.3.0,True,source,source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.3.0,True,source,source.geo.name,keyword,extended,boston-dc,User-defined description of a location.
-1.3.0,True,source,source.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
-1.3.0,True,source,source.geo.region_name,keyword,core,Quebec,Region name.
-1.3.0,True,source,source.ip,ip,core,,IP address of the source.
-1.3.0,True,source,source.mac,keyword,core,,MAC address of the source.
-1.3.0,True,source,source.nat.ip,ip,extended,,Source NAT ip
-1.3.0,True,source,source.nat.port,long,extended,,Source NAT port
-1.3.0,True,source,source.packets,long,core,12,Packets sent from the source to the destination.
-1.3.0,True,source,source.port,long,core,,Port of the source.
-1.3.0,True,source,source.registered_domain,keyword,extended,google.com,"The highest registered source domain, stripped of the subdomain."
-1.3.0,True,source,source.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,source,source.user.email,keyword,extended,,User email address.
-1.3.0,True,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,source,source.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,source,source.user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,source,source.user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
-1.3.0,True,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
-1.3.0,True,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.
-1.3.0,True,threat,threat.tactic.reference,keyword,extended,https://attack.mitre.org/tactics/TA0040/,Threat tactic url reference.
-1.3.0,True,threat,threat.technique.id,keyword,extended,T1499,Threat technique id.
-1.3.0,True,threat,threat.technique.name,keyword,extended,endpoint denial of service,Threat technique name.
-1.3.0,True,threat,threat.technique.reference,keyword,extended,https://attack.mitre.org/techniques/T1499/,Threat technique reference.
-1.3.0,True,tls,tls.cipher,keyword,extended,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
-1.3.0,True,tls,tls.client.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
-1.3.0,True,tls,tls.client.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
-1.3.0,True,tls,tls.client.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.client.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.client.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.client.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
-1.3.0,True,tls,tls.client.ja3,keyword,extended,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
-1.3.0,True,tls,tls.client.not_after,date,extended,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
-1.3.0,True,tls,tls.client.not_before,date,extended,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
-1.3.0,True,tls,tls.client.server_name,keyword,extended,www.elastic.co,"Also called an SNI, this tells the server which hostname to which the client is attempting to connect. When this value is available, it should get copied to `destination.domain`."
-1.3.0,True,tls,tls.client.subject,keyword,extended,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
-1.3.0,True,tls,tls.client.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the client during the client hello.
-1.3.0,True,tls,tls.curve,keyword,extended,secp256r1,"String indicating the curve used for the given cipher, when applicable."
-1.3.0,True,tls,tls.established,boolean,extended,,Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
-1.3.0,True,tls,tls.next_protocol,keyword,extended,http/1.1,"String indicating the protocol being tunneled. Per the values in the IANA registry (https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case."
-1.3.0,True,tls,tls.resumed,boolean,extended,,Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
-1.3.0,True,tls,tls.server.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
-1.3.0,True,tls,tls.server.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
-1.3.0,True,tls,tls.server.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.server.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.server.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
-1.3.0,True,tls,tls.server.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
-1.3.0,True,tls,tls.server.ja3s,keyword,extended,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
-1.3.0,True,tls,tls.server.not_after,date,extended,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
-1.3.0,True,tls,tls.server.not_before,date,extended,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
-1.3.0,True,tls,tls.server.subject,keyword,extended,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
-1.3.0,True,tls,tls.server.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the server during the server hello.
-1.3.0,True,tls,tls.version,keyword,extended,1.2,Numeric part of the version parsed from the original string.
-1.3.0,True,tls,tls.version_protocol,keyword,extended,tls,Normalized lowercase protocol name parsed from original string.
-1.3.0,True,trace,trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
-1.3.0,True,transaction,transaction.id,keyword,extended,00f067aa0ba902b7,Unique identifier of the transaction.
-1.3.0,True,url,url.domain,keyword,extended,www.elastic.co,Domain of the url.
-1.3.0,True,url,url.extension,keyword,extended,png,File extension from the original request url.
-1.3.0,True,url,url.fragment,keyword,extended,,Portion of the url after the `#`.
-1.3.0,True,url,url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.3.0,True,url,url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.3.0,True,url,url.password,keyword,extended,,Password of the request.
-1.3.0,True,url,url.path,keyword,extended,,"Path of the request, such as ""/search""."
-1.3.0,True,url,url.port,long,extended,443,"Port of the request, such as 443."
-1.3.0,True,url,url.query,keyword,extended,,Query string of the request.
-1.3.0,True,url,url.registered_domain,keyword,extended,google.com,"The highest registered url domain, stripped of the subdomain."
-1.3.0,True,url,url.scheme,keyword,extended,https,Scheme of the url.
-1.3.0,True,url,url.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
-1.3.0,True,url,url.username,keyword,extended,,Username of the request.
-1.3.0,True,user,user.domain,keyword,extended,,Name of the directory the user is a member of.
-1.3.0,True,user,user.email,keyword,extended,,User email address.
-1.3.0,True,user,user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.3.0,True,user,user.group.domain,keyword,extended,,Name of the directory the group is a member of.
-1.3.0,True,user,user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
-1.3.0,True,user,user.group.name,keyword,extended,,Name of the group.
-1.3.0,True,user,user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
-1.3.0,True,user,user.id,keyword,core,,One or multiple unique identifiers of the user.
-1.3.0,True,user,user.name,keyword,core,albert,Short name or login of the user.
-1.3.0,True,user_agent,user_agent.device.name,keyword,extended,iPhone,Name of the device.
-1.3.0,True,user_agent,user_agent.name,keyword,extended,Safari,Name of the user agent.
-1.3.0,True,user_agent,user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed version of the user_agent.
-1.3.0,True,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
-1.3.0,True,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.3.0,True,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
-1.3.0,True,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.3.0,True,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
-1.3.0,True,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
-1.3.0,True,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.
-1.3.0,True,vulnerability,vulnerability.category,keyword,extended,"[""Firewall""]",Category of a vulnerability.
-1.3.0,True,vulnerability,vulnerability.classification,keyword,extended,CVSS,Classification of the vulnerability.
-1.3.0,True,vulnerability,vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
-1.3.0,True,vulnerability,vulnerability.enumeration,keyword,extended,CVE,Identifier of the vulnerability.
-1.3.0,True,vulnerability,vulnerability.id,keyword,extended,CVE-2019-00001,ID of the vulnerability.
-1.3.0,True,vulnerability,vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.
-1.3.0,True,vulnerability,vulnerability.report_id,keyword,extended,20191018.0001,Scan identification number.
-1.3.0,True,vulnerability,vulnerability.scanner.vendor,keyword,extended,Tenable,Name of the scanner vendor.
-1.3.0,True,vulnerability,vulnerability.score.base,float,extended,5.5,Vulnerability Base score.
-1.3.0,True,vulnerability,vulnerability.score.environmental,float,extended,5.5,Vulnerability Environmental score.
-1.3.0,True,vulnerability,vulnerability.score.temporal,float,extended,,Vulnerability Temporal score.
-1.3.0,True,vulnerability,vulnerability.score.version,keyword,extended,2.0,CVSS version.
-1.3.0,True,vulnerability,vulnerability.severity,keyword,extended,Critical,Severity of the vulnerability.
+1.3.0,true,base,@timestamp,date,core,2016-05-23T08:05:34.853Z,Date/time when the event originated.
+1.3.0,true,base,labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",Custom key/value pairs.
+1.3.0,true,base,message,text,core,Hello World,Log message optimized for viewing in a log viewer.
+1.3.0,true,base,tags,keyword,core,"[""production"", ""env2""]",List of keywords used to tag each event.
+1.3.0,true,agent,agent.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this agent.
+1.3.0,true,agent,agent.id,keyword,core,8a4f500d,Unique identifier of this agent.
+1.3.0,true,agent,agent.name,keyword,core,foo,Custom name of the agent.
+1.3.0,true,agent,agent.type,keyword,core,filebeat,Type of the agent.
+1.3.0,true,agent,agent.version,keyword,core,6.0.0-rc2,Version of the agent.
+1.3.0,true,as,as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,true,as,as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,true,client,client.address,keyword,extended,,Client network address.
+1.3.0,true,client,client.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,true,client,client.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,true,client,client.bytes,long,core,184,Bytes sent from the client to the server.
+1.3.0,true,client,client.domain,keyword,core,,Client domain.
+1.3.0,true,client,client.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,client,client.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,client,client.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,client,client.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,client,client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,client,client.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,client,client.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,client,client.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,client,client.ip,ip,core,,IP address of the client.
+1.3.0,true,client,client.mac,keyword,core,,MAC address of the client.
+1.3.0,true,client,client.nat.ip,ip,extended,,Client NAT ip address
+1.3.0,true,client,client.nat.port,long,extended,,Client NAT port
+1.3.0,true,client,client.packets,long,core,12,Packets sent from the client to the server.
+1.3.0,true,client,client.port,long,core,,Port of the client.
+1.3.0,true,client,client.registered_domain,keyword,extended,google.com,"The highest registered client domain, stripped of the subdomain."
+1.3.0,true,client,client.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,client,client.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,client,client.user.email,keyword,extended,,User email address.
+1.3.0,true,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,client,client.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,client,client.user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,client,client.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
+1.3.0,true,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
+1.3.0,true,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
+1.3.0,true,cloud,cloud.instance.name,keyword,extended,,Instance name of the host machine.
+1.3.0,true,cloud,cloud.machine.type,keyword,extended,t2.medium,Machine type of the host machine.
+1.3.0,true,cloud,cloud.provider,keyword,extended,aws,Name of the cloud provider.
+1.3.0,true,cloud,cloud.region,keyword,extended,us-east-1,Region in which this host is running.
+1.3.0,true,container,container.id,keyword,core,,Unique container id.
+1.3.0,true,container,container.image.name,keyword,extended,,Name of the image the container was built on.
+1.3.0,true,container,container.image.tag,keyword,extended,,Container image tag.
+1.3.0,true,container,container.labels,object,extended,,Image labels.
+1.3.0,true,container,container.name,keyword,extended,,Container name.
+1.3.0,true,container,container.runtime,keyword,extended,docker,Runtime managing this container.
+1.3.0,true,destination,destination.address,keyword,extended,,Destination network address.
+1.3.0,true,destination,destination.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,true,destination,destination.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,true,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
+1.3.0,true,destination,destination.domain,keyword,core,,Destination domain.
+1.3.0,true,destination,destination.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,destination,destination.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,destination,destination.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,destination,destination.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,destination,destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,destination,destination.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,destination,destination.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,destination,destination.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,destination,destination.ip,ip,core,,IP address of the destination.
+1.3.0,true,destination,destination.mac,keyword,core,,MAC address of the destination.
+1.3.0,true,destination,destination.nat.ip,ip,extended,,Destination NAT ip
+1.3.0,true,destination,destination.nat.port,long,extended,,Destination NAT Port
+1.3.0,true,destination,destination.packets,long,core,12,Packets sent from the destination to the source.
+1.3.0,true,destination,destination.port,long,core,,Port of the destination.
+1.3.0,true,destination,destination.registered_domain,keyword,extended,google.com,"The highest registered destination domain, stripped of the subdomain."
+1.3.0,true,destination,destination.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,destination,destination.user.email,keyword,extended,,User email address.
+1.3.0,true,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,destination,destination.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,destination,destination.user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,dns,dns.answers,object,extended,,Array of DNS answers.
+1.3.0,true,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
+1.3.0,true,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
+1.3.0,true,dns,dns.answers.name,keyword,extended,www.google.com,The domain name to which this resource record pertains.
+1.3.0,true,dns,dns.answers.ttl,long,extended,180,The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached.
+1.3.0,true,dns,dns.answers.type,keyword,extended,CNAME,The type of data contained in this resource record.
+1.3.0,true,dns,dns.header_flags,keyword,extended,"['RD', 'RA']",Array of DNS header flags.
+1.3.0,true,dns,dns.id,keyword,extended,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
+1.3.0,true,dns,dns.op_code,keyword,extended,QUERY,The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
+1.3.0,true,dns,dns.question.class,keyword,extended,IN,The class of of records being queried.
+1.3.0,true,dns,dns.question.name,keyword,extended,www.google.com,The name being queried.
+1.3.0,true,dns,dns.question.registered_domain,keyword,extended,google.com,"The highest registered domain, stripped of the subdomain."
+1.3.0,true,dns,dns.question.subdomain,keyword,extended,www,The subdomain of the domain.
+1.3.0,true,dns,dns.question.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,dns,dns.question.type,keyword,extended,AAAA,The type of record being queried.
+1.3.0,true,dns,dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",Array containing all IPs seen in answers.data
+1.3.0,true,dns,dns.response_code,keyword,extended,NOERROR,The DNS response code.
+1.3.0,true,dns,dns.type,keyword,extended,answer,"The type of DNS event captured, query or answer."
+1.3.0,true,ecs,ecs.version,keyword,core,1.0.0,ECS version this event conforms to.
+1.3.0,true,error,error.code,keyword,core,,Error code describing the error.
+1.3.0,true,error,error.id,keyword,core,,Unique identifier for the error.
+1.3.0,true,error,error.message,text,core,,Error message.
+1.3.0,false,error,error.stack_trace,keyword,extended,,The stack trace of this error in plain text.
+1.3.0,true,error,error.type,keyword,extended,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
+1.3.0,true,event,event.action,keyword,core,user-password-change,The action captured by the event.
+1.3.0,true,event,event.category,keyword,core,user-management,Event category.
+1.3.0,true,event,event.code,keyword,extended,4648,Identification code for this event.
+1.3.0,true,event,event.created,date,core,2016-05-23 08:05:34.857000,Time when the event was first read by an agent or by your pipeline.
+1.3.0,true,event,event.dataset,keyword,core,apache.access,Name of the dataset.
+1.3.0,true,event,event.duration,long,core,,Duration of the event in nanoseconds.
+1.3.0,true,event,event.end,date,extended,,event.end contains the date when the event ended or when the activity was last observed.
+1.3.0,true,event,event.hash,keyword,extended,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+1.3.0,true,event,event.id,keyword,core,8a4f500d,Unique ID to describe the event.
+1.3.0,true,event,event.ingested,date,core,2016-05-23 08:05:35.101000,Timestamp when an event arrived in the central data store.
+1.3.0,true,event,event.kind,keyword,extended,state,The kind of the event.
+1.3.0,true,event,event.module,keyword,core,apache,Name of the module this data is coming from.
+1.3.0,false,event,event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+1.3.0,true,event,event.outcome,keyword,extended,success,The outcome of the event.
+1.3.0,true,event,event.provider,keyword,extended,kernel,Source of the event.
+1.3.0,true,event,event.risk_score,float,core,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
+1.3.0,true,event,event.risk_score_norm,float,extended,,Normalized risk score or priority of the event (0-100).
+1.3.0,true,event,event.sequence,long,extended,,Sequence number of the event.
+1.3.0,true,event,event.severity,long,core,7,Numeric severity of the event.
+1.3.0,true,event,event.start,date,extended,,event.start contains the date when the event started or when the activity was first observed.
+1.3.0,true,event,event.timezone,keyword,extended,,Event time zone.
+1.3.0,true,event,event.type,keyword,core,,Reserved for future usage.
+1.3.0,true,file,file.accessed,date,extended,,Last time the file was accessed.
+1.3.0,true,file,file.created,date,extended,,File creation time.
+1.3.0,true,file,file.ctime,date,extended,,Last time the file attributes or metadata changed.
+1.3.0,true,file,file.device,keyword,extended,sda,Device that is the source of the file.
+1.3.0,true,file,file.directory,keyword,extended,/home/alice,Directory where the file is located.
+1.3.0,true,file,file.extension,keyword,extended,png,File extension.
+1.3.0,true,file,file.gid,keyword,extended,1001,Primary group ID (GID) of the file.
+1.3.0,true,file,file.group,keyword,extended,alice,Primary group name of the file.
+1.3.0,true,file,file.hash.md5,keyword,extended,,MD5 hash.
+1.3.0,true,file,file.hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,true,file,file.hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,true,file,file.hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,true,file,file.inode,keyword,extended,256383,Inode representing the file in the filesystem.
+1.3.0,true,file,file.mode,keyword,extended,0640,Mode of the file in octal representation.
+1.3.0,true,file,file.mtime,date,extended,,Last time the file content was modified.
+1.3.0,true,file,file.name,keyword,extended,example.png,"Name of the file including the extension, without the directory."
+1.3.0,true,file,file.owner,keyword,extended,alice,File owner's username.
+1.3.0,true,file,file.path,keyword,extended,/home/alice/example.png,Full path to the file.
+1.3.0,true,file,file.size,long,extended,16384,File size in bytes.
+1.3.0,true,file,file.target_path,keyword,extended,,Target path for symlinks.
+1.3.0,true,file,file.type,keyword,extended,file,"File type (file, dir, or symlink)."
+1.3.0,true,file,file.uid,keyword,extended,1001,The user ID (UID) or security identifier (SID) of the file owner.
+1.3.0,true,geo,geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,geo,geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,geo,geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,geo,geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,geo,geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,geo,geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,geo,geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,geo,geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,group,group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,group,group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,group,group.name,keyword,extended,,Name of the group.
+1.3.0,true,hash,hash.md5,keyword,extended,,MD5 hash.
+1.3.0,true,hash,hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,true,hash,hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,true,hash,hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,true,host,host.architecture,keyword,core,x86_64,Operating system architecture.
+1.3.0,true,host,host.domain,keyword,extended,CONTOSO,Name of the directory the group is a member of.
+1.3.0,true,host,host.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,host,host.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,host,host.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,host,host.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,host,host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,host,host.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,host,host.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,host,host.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,host,host.hostname,keyword,core,,Hostname of the host.
+1.3.0,true,host,host.id,keyword,core,,Unique host id.
+1.3.0,true,host,host.ip,ip,core,,Host ip address.
+1.3.0,true,host,host.mac,keyword,core,,Host mac address.
+1.3.0,true,host,host.name,keyword,core,,Name of the host.
+1.3.0,true,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,true,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,true,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,true,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,true,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,true,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,true,host,host.type,keyword,core,,Type of host.
+1.3.0,true,host,host.uptime,long,extended,1325,Seconds the host has been up.
+1.3.0,true,host,host.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,host,host.user.email,keyword,extended,,User email address.
+1.3.0,true,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,host,host.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,host,host.user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,host,host.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
+1.3.0,true,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
+1.3.0,true,http,http.request.bytes,long,extended,1437,Total size in bytes of the request (body and headers).
+1.3.0,true,http,http.request.method,keyword,extended,"get, post, put",HTTP request method.
+1.3.0,true,http,http.request.referrer,keyword,extended,https://blog.example.com/,Referrer for this HTTP request.
+1.3.0,true,http,http.response.body.bytes,long,extended,887,Size in bytes of the response body.
+1.3.0,true,http,http.response.body.content,keyword,extended,Hello world,The full HTTP response body.
+1.3.0,true,http,http.response.bytes,long,extended,1437,Total size in bytes of the response (body and headers).
+1.3.0,true,http,http.response.status_code,long,extended,404,HTTP response status code.
+1.3.0,true,http,http.version,keyword,extended,1.1,HTTP version.
+1.3.0,true,log,log.level,keyword,core,error,Log level of the log event.
+1.3.0,true,log,log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
+1.3.0,true,log,log.origin.file.line,integer,extended,42,The line number of the file which originated the log event.
+1.3.0,true,log,log.origin.file.name,keyword,extended,Bootstrap.java,The file which originated the log event.
+1.3.0,true,log,log.origin.function,keyword,extended,init,The function which originated the log event.
+1.3.0,false,log,log.original,keyword,core,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
+1.3.0,true,log,log.syslog,object,extended,,Syslog metadata
+1.3.0,true,log,log.syslog.facility.code,long,extended,23,Syslog numeric facility of the event.
+1.3.0,true,log,log.syslog.facility.name,keyword,extended,local7,Syslog text-based facility of the event.
+1.3.0,true,log,log.syslog.priority,long,extended,135,Syslog priority of the event.
+1.3.0,true,log,log.syslog.severity.code,long,extended,3,Syslog numeric severity of the event.
+1.3.0,true,log,log.syslog.severity.name,keyword,extended,Error,Syslog text-based severity of the event.
+1.3.0,true,network,network.application,keyword,extended,aim,Application level protocol name.
+1.3.0,true,network,network.bytes,long,core,368,Total bytes transferred in both directions.
+1.3.0,true,network,network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
+1.3.0,true,network,network.direction,keyword,core,inbound,Direction of the network traffic.
+1.3.0,true,network,network.forwarded_ip,ip,core,192.1.1.2,Host IP address when the source IP address is the proxy.
+1.3.0,true,network,network.iana_number,keyword,extended,6,IANA Protocol Number.
+1.3.0,true,network,network.name,keyword,extended,Guest Wifi,Name given by operators to sections of their network.
+1.3.0,true,network,network.packets,long,core,24,Total packets transferred in both directions.
+1.3.0,true,network,network.protocol,keyword,core,http,L7 Network protocol name.
+1.3.0,true,network,network.transport,keyword,core,tcp,Protocol Name corresponding to the field `iana_number`.
+1.3.0,true,network,network.type,keyword,core,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
+1.3.0,true,observer,observer.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,observer,observer.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,observer,observer.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,observer,observer.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,observer,observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,observer,observer.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,observer,observer.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,observer,observer.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,observer,observer.hostname,keyword,core,,Hostname of the observer.
+1.3.0,true,observer,observer.ip,ip,core,,IP address of the observer.
+1.3.0,true,observer,observer.mac,keyword,core,,MAC address of the observer
+1.3.0,true,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
+1.3.0,true,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,true,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,true,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,true,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,true,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,true,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,true,observer,observer.product,keyword,extended,s200,The product name of the observer.
+1.3.0,true,observer,observer.serial_number,keyword,extended,,Observer serial number.
+1.3.0,true,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
+1.3.0,true,observer,observer.vendor,keyword,core,Symantec,Vendor name of the observer.
+1.3.0,true,observer,observer.version,keyword,core,,Observer version.
+1.3.0,true,organization,organization.id,keyword,extended,,Unique identifier for the organization.
+1.3.0,true,organization,organization.name,keyword,extended,,Organization name.
+1.3.0,true,os,os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,true,os,os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,true,os,os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,true,os,os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,true,os,os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,true,os,os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,true,package,package.architecture,keyword,extended,x86_64,Package architecture.
+1.3.0,true,package,package.build_version,keyword,extended,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
+1.3.0,true,package,package.checksum,keyword,extended,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.
+1.3.0,true,package,package.description,keyword,extended,Open source programming language to build simple/reliable/efficient software.,Description of the package.
+1.3.0,true,package,package.install_scope,keyword,extended,global,"Indicating how the package was installed, e.g. user-local, global."
+1.3.0,true,package,package.installed,date,extended,,Time when package was installed.
+1.3.0,true,package,package.license,keyword,extended,Apache License 2.0,Package license
+1.3.0,true,package,package.name,keyword,extended,go,Package name
+1.3.0,true,package,package.path,keyword,extended,/usr/local/Cellar/go/1.12.9/,Path where the package is installed.
+1.3.0,true,package,package.reference,keyword,extended,https://golang.org,Package reference URL
+1.3.0,true,package,package.size,long,extended,62231,Package size in bytes.
+1.3.0,true,package,package.type,keyword,extended,rpm,Package type
+1.3.0,true,package,package.version,keyword,extended,1.12.9,Package version
+1.3.0,true,process,process.args,keyword,extended,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.3.0,true,process,process.args_count,long,extended,4,Length of the process.args array.
+1.3.0,true,process,process.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.3.0,true,process,process.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.3.0,true,process,process.exit_code,long,extended,137,The exit code of the process.
+1.3.0,true,process,process.hash.md5,keyword,extended,,MD5 hash.
+1.3.0,true,process,process.hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,true,process,process.hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,true,process,process.hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,true,process,process.name,keyword,extended,ssh,Process name.
+1.3.0,true,process,process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.3.0,true,process,process.parent.args_count,long,extended,4,Length of the process.args array.
+1.3.0,true,process,process.parent.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.3.0,true,process,process.parent.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.3.0,true,process,process.parent.exit_code,long,extended,137,The exit code of the process.
+1.3.0,true,process,process.parent.name,keyword,extended,ssh,Process name.
+1.3.0,true,process,process.parent.pgid,long,extended,,Identifier of the group of processes the process belongs to.
+1.3.0,true,process,process.parent.pid,long,core,4242,Process id.
+1.3.0,true,process,process.parent.ppid,long,extended,4241,Parent process' pid.
+1.3.0,true,process,process.parent.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
+1.3.0,true,process,process.parent.thread.id,long,extended,4242,Thread ID.
+1.3.0,true,process,process.parent.thread.name,keyword,extended,thread-0,Thread name.
+1.3.0,true,process,process.parent.title,keyword,extended,,Process title.
+1.3.0,true,process,process.parent.uptime,long,extended,1325,Seconds the process has been up.
+1.3.0,true,process,process.parent.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.3.0,true,process,process.pgid,long,extended,,Identifier of the group of processes the process belongs to.
+1.3.0,true,process,process.pid,long,core,4242,Process id.
+1.3.0,true,process,process.ppid,long,extended,4241,Parent process' pid.
+1.3.0,true,process,process.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
+1.3.0,true,process,process.thread.id,long,extended,4242,Thread ID.
+1.3.0,true,process,process.thread.name,keyword,extended,thread-0,Thread name.
+1.3.0,true,process,process.title,keyword,extended,,Process title.
+1.3.0,true,process,process.uptime,long,extended,1325,Seconds the process has been up.
+1.3.0,true,process,process.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.3.0,true,related,related.ip,ip,extended,,All of the IPs seen on your event.
+1.3.0,true,server,server.address,keyword,extended,,Server network address.
+1.3.0,true,server,server.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,true,server,server.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,true,server,server.bytes,long,core,184,Bytes sent from the server to the client.
+1.3.0,true,server,server.domain,keyword,core,,Server domain.
+1.3.0,true,server,server.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,server,server.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,server,server.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,server,server.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,server,server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,server,server.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,server,server.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,server,server.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,server,server.ip,ip,core,,IP address of the server.
+1.3.0,true,server,server.mac,keyword,core,,MAC address of the server.
+1.3.0,true,server,server.nat.ip,ip,extended,,Server NAT ip
+1.3.0,true,server,server.nat.port,long,extended,,Server NAT port
+1.3.0,true,server,server.packets,long,core,12,Packets sent from the server to the client.
+1.3.0,true,server,server.port,long,core,,Port of the server.
+1.3.0,true,server,server.registered_domain,keyword,extended,google.com,"The highest registered server domain, stripped of the subdomain."
+1.3.0,true,server,server.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,server,server.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,server,server.user.email,keyword,extended,,User email address.
+1.3.0,true,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,server,server.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,server,server.user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,server,server.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
+1.3.0,true,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+1.3.0,true,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
+1.3.0,true,service,service.node.name,keyword,extended,instance-0000000016,Name of the service node.
+1.3.0,true,service,service.state,keyword,core,,Current state of the service.
+1.3.0,true,service,service.type,keyword,core,elasticsearch,The type of the service.
+1.3.0,true,service,service.version,keyword,core,3.2.4,Version of the service.
+1.3.0,true,source,source.address,keyword,extended,,Source network address.
+1.3.0,true,source,source.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,true,source,source.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,true,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
+1.3.0,true,source,source.domain,keyword,core,,Source domain.
+1.3.0,true,source,source.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,true,source,source.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,true,source,source.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,true,source,source.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,true,source,source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,true,source,source.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,true,source,source.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,true,source,source.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,true,source,source.ip,ip,core,,IP address of the source.
+1.3.0,true,source,source.mac,keyword,core,,MAC address of the source.
+1.3.0,true,source,source.nat.ip,ip,extended,,Source NAT ip
+1.3.0,true,source,source.nat.port,long,extended,,Source NAT port
+1.3.0,true,source,source.packets,long,core,12,Packets sent from the source to the destination.
+1.3.0,true,source,source.port,long,core,,Port of the source.
+1.3.0,true,source,source.registered_domain,keyword,extended,google.com,"The highest registered source domain, stripped of the subdomain."
+1.3.0,true,source,source.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,source,source.user.email,keyword,extended,,User email address.
+1.3.0,true,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,source,source.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,source,source.user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,source,source.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
+1.3.0,true,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
+1.3.0,true,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.
+1.3.0,true,threat,threat.tactic.reference,keyword,extended,https://attack.mitre.org/tactics/TA0040/,Threat tactic url reference.
+1.3.0,true,threat,threat.technique.id,keyword,extended,T1499,Threat technique id.
+1.3.0,true,threat,threat.technique.name,keyword,extended,endpoint denial of service,Threat technique name.
+1.3.0,true,threat,threat.technique.reference,keyword,extended,https://attack.mitre.org/techniques/T1499/,Threat technique reference.
+1.3.0,true,tls,tls.cipher,keyword,extended,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
+1.3.0,true,tls,tls.client.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
+1.3.0,true,tls,tls.client.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
+1.3.0,true,tls,tls.client.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.client.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.client.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.client.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+1.3.0,true,tls,tls.client.ja3,keyword,extended,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
+1.3.0,true,tls,tls.client.not_after,date,extended,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
+1.3.0,true,tls,tls.client.not_before,date,extended,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
+1.3.0,true,tls,tls.client.server_name,keyword,extended,www.elastic.co,"Also called an SNI, this tells the server which hostname to which the client is attempting to connect. When this value is available, it should get copied to `destination.domain`."
+1.3.0,true,tls,tls.client.subject,keyword,extended,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
+1.3.0,true,tls,tls.client.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the client during the client hello.
+1.3.0,true,tls,tls.curve,keyword,extended,secp256r1,"String indicating the curve used for the given cipher, when applicable."
+1.3.0,true,tls,tls.established,boolean,extended,,Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
+1.3.0,true,tls,tls.next_protocol,keyword,extended,http/1.1,"String indicating the protocol being tunneled. Per the values in the IANA registry (https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case."
+1.3.0,true,tls,tls.resumed,boolean,extended,,Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+1.3.0,true,tls,tls.server.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
+1.3.0,true,tls,tls.server.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
+1.3.0,true,tls,tls.server.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.server.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.server.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,true,tls,tls.server.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
+1.3.0,true,tls,tls.server.ja3s,keyword,extended,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
+1.3.0,true,tls,tls.server.not_after,date,extended,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
+1.3.0,true,tls,tls.server.not_before,date,extended,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
+1.3.0,true,tls,tls.server.subject,keyword,extended,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
+1.3.0,true,tls,tls.server.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the server during the server hello.
+1.3.0,true,tls,tls.version,keyword,extended,1.2,Numeric part of the version parsed from the original string.
+1.3.0,true,tls,tls.version_protocol,keyword,extended,tls,Normalized lowercase protocol name parsed from original string.
+1.3.0,true,trace,trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
+1.3.0,true,transaction,transaction.id,keyword,extended,00f067aa0ba902b7,Unique identifier of the transaction.
+1.3.0,true,url,url.domain,keyword,extended,www.elastic.co,Domain of the url.
+1.3.0,true,url,url.extension,keyword,extended,png,File extension from the original request url.
+1.3.0,true,url,url.fragment,keyword,extended,,Portion of the url after the `#`.
+1.3.0,true,url,url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.3.0,true,url,url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.3.0,true,url,url.password,keyword,extended,,Password of the request.
+1.3.0,true,url,url.path,keyword,extended,,"Path of the request, such as ""/search""."
+1.3.0,true,url,url.port,long,extended,443,"Port of the request, such as 443."
+1.3.0,true,url,url.query,keyword,extended,,Query string of the request.
+1.3.0,true,url,url.registered_domain,keyword,extended,google.com,"The highest registered url domain, stripped of the subdomain."
+1.3.0,true,url,url.scheme,keyword,extended,https,Scheme of the url.
+1.3.0,true,url,url.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,true,url,url.username,keyword,extended,,Username of the request.
+1.3.0,true,user,user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,true,user,user.email,keyword,extended,,User email address.
+1.3.0,true,user,user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,true,user,user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,true,user,user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,true,user,user.group.name,keyword,extended,,Name of the group.
+1.3.0,true,user,user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,true,user,user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,true,user,user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,true,user_agent,user_agent.device.name,keyword,extended,iPhone,Name of the device.
+1.3.0,true,user_agent,user_agent.name,keyword,extended,Safari,Name of the user agent.
+1.3.0,true,user_agent,user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed version of the user_agent.
+1.3.0,true,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,true,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,true,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,true,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,true,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,true,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,true,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.
+1.3.0,true,vulnerability,vulnerability.category,keyword,extended,"[""Firewall""]",Category of a vulnerability.
+1.3.0,true,vulnerability,vulnerability.classification,keyword,extended,CVSS,Classification of the vulnerability.
+1.3.0,true,vulnerability,vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.3.0,true,vulnerability,vulnerability.enumeration,keyword,extended,CVE,Identifier of the vulnerability.
+1.3.0,true,vulnerability,vulnerability.id,keyword,extended,CVE-2019-00001,ID of the vulnerability.
+1.3.0,true,vulnerability,vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.
+1.3.0,true,vulnerability,vulnerability.report_id,keyword,extended,20191018.0001,Scan identification number.
+1.3.0,true,vulnerability,vulnerability.scanner.vendor,keyword,extended,Tenable,Name of the scanner vendor.
+1.3.0,true,vulnerability,vulnerability.score.base,float,extended,5.5,Vulnerability Base score.
+1.3.0,true,vulnerability,vulnerability.score.environmental,float,extended,5.5,Vulnerability Environmental score.
+1.3.0,true,vulnerability,vulnerability.score.temporal,float,extended,,Vulnerability Temporal score.
+1.3.0,true,vulnerability,vulnerability.score.version,keyword,extended,2.0,CVSS version.
+1.3.0,true,vulnerability,vulnerability.severity,keyword,extended,Critical,Severity of the vulnerability.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1,463 +1,463 @@
-Field,Type,Level,Example,ECS version
-@timestamp,date,core,2016-05-23T08:05:34.853Z,1.3.0
-labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",1.3.0
-message,text,core,Hello World,1.3.0
-tags,keyword,core,"[""production"", ""env2""]",1.3.0
-agent.ephemeral_id,keyword,extended,8a4f500f,1.3.0
-agent.id,keyword,core,8a4f500d,1.3.0
-agent.name,keyword,core,foo,1.3.0
-agent.type,keyword,core,filebeat,1.3.0
-agent.version,keyword,core,6.0.0-rc2,1.3.0
-as.number,long,extended,15169,1.3.0
-as.organization.name,keyword,extended,Google LLC,1.3.0
-client.address,keyword,extended,,1.3.0
-client.as.number,long,extended,15169,1.3.0
-client.as.organization.name,keyword,extended,Google LLC,1.3.0
-client.bytes,long,core,184,1.3.0
-client.domain,keyword,core,,1.3.0
-client.geo.city_name,keyword,core,Montreal,1.3.0
-client.geo.continent_name,keyword,core,North America,1.3.0
-client.geo.country_iso_code,keyword,core,CA,1.3.0
-client.geo.country_name,keyword,core,Canada,1.3.0
-client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-client.geo.name,keyword,extended,boston-dc,1.3.0
-client.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-client.geo.region_name,keyword,core,Quebec,1.3.0
-client.ip,ip,core,,1.3.0
-client.mac,keyword,core,,1.3.0
-client.nat.ip,ip,extended,,1.3.0
-client.nat.port,long,extended,,1.3.0
-client.packets,long,core,12,1.3.0
-client.port,long,core,,1.3.0
-client.registered_domain,keyword,extended,google.com,1.3.0
-client.top_level_domain,keyword,extended,co.uk,1.3.0
-client.user.domain,keyword,extended,,1.3.0
-client.user.email,keyword,extended,,1.3.0
-client.user.full_name,keyword,extended,Albert Einstein,1.3.0
-client.user.group.domain,keyword,extended,,1.3.0
-client.user.group.id,keyword,extended,,1.3.0
-client.user.group.name,keyword,extended,,1.3.0
-client.user.hash,keyword,extended,,1.3.0
-client.user.id,keyword,core,,1.3.0
-client.user.name,keyword,core,albert,1.3.0
-cloud.account.id,keyword,extended,666777888999,1.3.0
-cloud.availability_zone,keyword,extended,us-east-1c,1.3.0
-cloud.instance.id,keyword,extended,i-1234567890abcdef0,1.3.0
-cloud.instance.name,keyword,extended,,1.3.0
-cloud.machine.type,keyword,extended,t2.medium,1.3.0
-cloud.provider,keyword,extended,aws,1.3.0
-cloud.region,keyword,extended,us-east-1,1.3.0
-container.id,keyword,core,,1.3.0
-container.image.name,keyword,extended,,1.3.0
-container.image.tag,keyword,extended,,1.3.0
-container.labels,object,extended,,1.3.0
-container.name,keyword,extended,,1.3.0
-container.runtime,keyword,extended,docker,1.3.0
-destination.address,keyword,extended,,1.3.0
-destination.as.number,long,extended,15169,1.3.0
-destination.as.organization.name,keyword,extended,Google LLC,1.3.0
-destination.bytes,long,core,184,1.3.0
-destination.domain,keyword,core,,1.3.0
-destination.geo.city_name,keyword,core,Montreal,1.3.0
-destination.geo.continent_name,keyword,core,North America,1.3.0
-destination.geo.country_iso_code,keyword,core,CA,1.3.0
-destination.geo.country_name,keyword,core,Canada,1.3.0
-destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-destination.geo.name,keyword,extended,boston-dc,1.3.0
-destination.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-destination.geo.region_name,keyword,core,Quebec,1.3.0
-destination.ip,ip,core,,1.3.0
-destination.mac,keyword,core,,1.3.0
-destination.nat.ip,ip,extended,,1.3.0
-destination.nat.port,long,extended,,1.3.0
-destination.packets,long,core,12,1.3.0
-destination.port,long,core,,1.3.0
-destination.registered_domain,keyword,extended,google.com,1.3.0
-destination.top_level_domain,keyword,extended,co.uk,1.3.0
-destination.user.domain,keyword,extended,,1.3.0
-destination.user.email,keyword,extended,,1.3.0
-destination.user.full_name,keyword,extended,Albert Einstein,1.3.0
-destination.user.group.domain,keyword,extended,,1.3.0
-destination.user.group.id,keyword,extended,,1.3.0
-destination.user.group.name,keyword,extended,,1.3.0
-destination.user.hash,keyword,extended,,1.3.0
-destination.user.id,keyword,core,,1.3.0
-destination.user.name,keyword,core,albert,1.3.0
-dns.answers,object,extended,,1.3.0
-dns.answers.class,keyword,extended,IN,1.3.0
-dns.answers.data,keyword,extended,10.10.10.10,1.3.0
-dns.answers.name,keyword,extended,www.google.com,1.3.0
-dns.answers.ttl,long,extended,180,1.3.0
-dns.answers.type,keyword,extended,CNAME,1.3.0
-dns.header_flags,keyword,extended,"['RD', 'RA']",1.3.0
-dns.id,keyword,extended,62111,1.3.0
-dns.op_code,keyword,extended,QUERY,1.3.0
-dns.question.class,keyword,extended,IN,1.3.0
-dns.question.name,keyword,extended,www.google.com,1.3.0
-dns.question.registered_domain,keyword,extended,google.com,1.3.0
-dns.question.subdomain,keyword,extended,www,1.3.0
-dns.question.top_level_domain,keyword,extended,co.uk,1.3.0
-dns.question.type,keyword,extended,AAAA,1.3.0
-dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",1.3.0
-dns.response_code,keyword,extended,NOERROR,1.3.0
-dns.type,keyword,extended,answer,1.3.0
-ecs.version,keyword,core,1.0.0,1.3.0
-error.code,keyword,core,,1.3.0
-error.id,keyword,core,,1.3.0
-error.message,text,core,,1.3.0
-error.stack_trace,keyword,extended,,1.3.0
-error.type,keyword,extended,java.lang.NullPointerException,1.3.0
-event.action,keyword,core,user-password-change,1.3.0
-event.category,keyword,core,user-management,1.3.0
-event.code,keyword,extended,4648,1.3.0
-event.created,date,core,2016-05-23 08:05:34.857000,1.3.0
-event.dataset,keyword,core,apache.access,1.3.0
-event.duration,long,core,,1.3.0
-event.end,date,extended,,1.3.0
-event.hash,keyword,extended,123456789012345678901234567890ABCD,1.3.0
-event.id,keyword,core,8a4f500d,1.3.0
-event.ingested,date,core,2016-05-23 08:05:35.101000,1.3.0
-event.kind,keyword,extended,state,1.3.0
-event.module,keyword,core,apache,1.3.0
-event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,1.3.0
-event.outcome,keyword,extended,success,1.3.0
-event.provider,keyword,extended,kernel,1.3.0
-event.risk_score,float,core,,1.3.0
-event.risk_score_norm,float,extended,,1.3.0
-event.sequence,long,extended,,1.3.0
-event.severity,long,core,7,1.3.0
-event.start,date,extended,,1.3.0
-event.timezone,keyword,extended,,1.3.0
-event.type,keyword,core,,1.3.0
-file.accessed,date,extended,,1.3.0
-file.created,date,extended,,1.3.0
-file.ctime,date,extended,,1.3.0
-file.device,keyword,extended,sda,1.3.0
-file.directory,keyword,extended,/home/alice,1.3.0
-file.extension,keyword,extended,png,1.3.0
-file.gid,keyword,extended,1001,1.3.0
-file.group,keyword,extended,alice,1.3.0
-file.hash.md5,keyword,extended,,1.3.0
-file.hash.sha1,keyword,extended,,1.3.0
-file.hash.sha256,keyword,extended,,1.3.0
-file.hash.sha512,keyword,extended,,1.3.0
-file.inode,keyword,extended,256383,1.3.0
-file.mode,keyword,extended,0640,1.3.0
-file.mtime,date,extended,,1.3.0
-file.name,keyword,extended,example.png,1.3.0
-file.owner,keyword,extended,alice,1.3.0
-file.path,keyword,extended,/home/alice/example.png,1.3.0
-file.size,long,extended,16384,1.3.0
-file.target_path,keyword,extended,,1.3.0
-file.type,keyword,extended,file,1.3.0
-file.uid,keyword,extended,1001,1.3.0
-geo.city_name,keyword,core,Montreal,1.3.0
-geo.continent_name,keyword,core,North America,1.3.0
-geo.country_iso_code,keyword,core,CA,1.3.0
-geo.country_name,keyword,core,Canada,1.3.0
-geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-geo.name,keyword,extended,boston-dc,1.3.0
-geo.region_iso_code,keyword,core,CA-QC,1.3.0
-geo.region_name,keyword,core,Quebec,1.3.0
-group.domain,keyword,extended,,1.3.0
-group.id,keyword,extended,,1.3.0
-group.name,keyword,extended,,1.3.0
-hash.md5,keyword,extended,,1.3.0
-hash.sha1,keyword,extended,,1.3.0
-hash.sha256,keyword,extended,,1.3.0
-hash.sha512,keyword,extended,,1.3.0
-host.architecture,keyword,core,x86_64,1.3.0
-host.domain,keyword,extended,CONTOSO,1.3.0
-host.geo.city_name,keyword,core,Montreal,1.3.0
-host.geo.continent_name,keyword,core,North America,1.3.0
-host.geo.country_iso_code,keyword,core,CA,1.3.0
-host.geo.country_name,keyword,core,Canada,1.3.0
-host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-host.geo.name,keyword,extended,boston-dc,1.3.0
-host.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-host.geo.region_name,keyword,core,Quebec,1.3.0
-host.hostname,keyword,core,,1.3.0
-host.id,keyword,core,,1.3.0
-host.ip,ip,core,,1.3.0
-host.mac,keyword,core,,1.3.0
-host.name,keyword,core,,1.3.0
-host.os.family,keyword,extended,debian,1.3.0
-host.os.full,keyword,extended,Mac OS Mojave,1.3.0
-host.os.kernel,keyword,extended,4.4.0-112-generic,1.3.0
-host.os.name,keyword,extended,Mac OS X,1.3.0
-host.os.platform,keyword,extended,darwin,1.3.0
-host.os.version,keyword,extended,10.14.1,1.3.0
-host.type,keyword,core,,1.3.0
-host.uptime,long,extended,1325,1.3.0
-host.user.domain,keyword,extended,,1.3.0
-host.user.email,keyword,extended,,1.3.0
-host.user.full_name,keyword,extended,Albert Einstein,1.3.0
-host.user.group.domain,keyword,extended,,1.3.0
-host.user.group.id,keyword,extended,,1.3.0
-host.user.group.name,keyword,extended,,1.3.0
-host.user.hash,keyword,extended,,1.3.0
-host.user.id,keyword,core,,1.3.0
-host.user.name,keyword,core,albert,1.3.0
-http.request.body.bytes,long,extended,887,1.3.0
-http.request.body.content,keyword,extended,Hello world,1.3.0
-http.request.bytes,long,extended,1437,1.3.0
-http.request.method,keyword,extended,"get, post, put",1.3.0
-http.request.referrer,keyword,extended,https://blog.example.com/,1.3.0
-http.response.body.bytes,long,extended,887,1.3.0
-http.response.body.content,keyword,extended,Hello world,1.3.0
-http.response.bytes,long,extended,1437,1.3.0
-http.response.status_code,long,extended,404,1.3.0
-http.version,keyword,extended,1.1,1.3.0
-log.level,keyword,core,error,1.3.0
-log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,1.3.0
-log.origin.file.line,integer,extended,42,1.3.0
-log.origin.file.name,keyword,extended,Bootstrap.java,1.3.0
-log.origin.function,keyword,extended,init,1.3.0
-log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.3.0
-log.syslog,object,extended,,1.3.0
-log.syslog.facility.code,long,extended,23,1.3.0
-log.syslog.facility.name,keyword,extended,local7,1.3.0
-log.syslog.priority,long,extended,135,1.3.0
-log.syslog.severity.code,long,extended,3,1.3.0
-log.syslog.severity.name,keyword,extended,Error,1.3.0
-network.application,keyword,extended,aim,1.3.0
-network.bytes,long,core,368,1.3.0
-network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,1.3.0
-network.direction,keyword,core,inbound,1.3.0
-network.forwarded_ip,ip,core,192.1.1.2,1.3.0
-network.iana_number,keyword,extended,6,1.3.0
-network.name,keyword,extended,Guest Wifi,1.3.0
-network.packets,long,core,24,1.3.0
-network.protocol,keyword,core,http,1.3.0
-network.transport,keyword,core,tcp,1.3.0
-network.type,keyword,core,ipv4,1.3.0
-observer.geo.city_name,keyword,core,Montreal,1.3.0
-observer.geo.continent_name,keyword,core,North America,1.3.0
-observer.geo.country_iso_code,keyword,core,CA,1.3.0
-observer.geo.country_name,keyword,core,Canada,1.3.0
-observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-observer.geo.name,keyword,extended,boston-dc,1.3.0
-observer.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-observer.geo.region_name,keyword,core,Quebec,1.3.0
-observer.hostname,keyword,core,,1.3.0
-observer.ip,ip,core,,1.3.0
-observer.mac,keyword,core,,1.3.0
-observer.name,keyword,extended,1_proxySG,1.3.0
-observer.os.family,keyword,extended,debian,1.3.0
-observer.os.full,keyword,extended,Mac OS Mojave,1.3.0
-observer.os.kernel,keyword,extended,4.4.0-112-generic,1.3.0
-observer.os.name,keyword,extended,Mac OS X,1.3.0
-observer.os.platform,keyword,extended,darwin,1.3.0
-observer.os.version,keyword,extended,10.14.1,1.3.0
-observer.product,keyword,extended,s200,1.3.0
-observer.serial_number,keyword,extended,,1.3.0
-observer.type,keyword,core,firewall,1.3.0
-observer.vendor,keyword,core,Symantec,1.3.0
-observer.version,keyword,core,,1.3.0
-organization.id,keyword,extended,,1.3.0
-organization.name,keyword,extended,,1.3.0
-os.family,keyword,extended,debian,1.3.0
-os.full,keyword,extended,Mac OS Mojave,1.3.0
-os.kernel,keyword,extended,4.4.0-112-generic,1.3.0
-os.name,keyword,extended,Mac OS X,1.3.0
-os.platform,keyword,extended,darwin,1.3.0
-os.version,keyword,extended,10.14.1,1.3.0
-package.architecture,keyword,extended,x86_64,1.3.0
-package.build_version,keyword,extended,36f4f7e89dd61b0988b12ee000b98966867710cd,1.3.0
-package.checksum,keyword,extended,68b329da9893e34099c7d8ad5cb9c940,1.3.0
-package.description,keyword,extended,Open source programming language to build simple/reliable/efficient software.,1.3.0
-package.install_scope,keyword,extended,global,1.3.0
-package.installed,date,extended,,1.3.0
-package.license,keyword,extended,Apache License 2.0,1.3.0
-package.name,keyword,extended,go,1.3.0
-package.path,keyword,extended,/usr/local/Cellar/go/1.12.9/,1.3.0
-package.reference,keyword,extended,https://golang.org,1.3.0
-package.size,long,extended,62231,1.3.0
-package.type,keyword,extended,rpm,1.3.0
-package.version,keyword,extended,1.12.9,1.3.0
-process.args,keyword,extended,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",1.3.0
-process.args_count,long,extended,4,1.3.0
-process.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,1.3.0
-process.executable,keyword,extended,/usr/bin/ssh,1.3.0
-process.exit_code,long,extended,137,1.3.0
-process.hash.md5,keyword,extended,,1.3.0
-process.hash.sha1,keyword,extended,,1.3.0
-process.hash.sha256,keyword,extended,,1.3.0
-process.hash.sha512,keyword,extended,,1.3.0
-process.name,keyword,extended,ssh,1.3.0
-process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",1.3.0
-process.parent.args_count,long,extended,4,1.3.0
-process.parent.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,1.3.0
-process.parent.executable,keyword,extended,/usr/bin/ssh,1.3.0
-process.parent.exit_code,long,extended,137,1.3.0
-process.parent.name,keyword,extended,ssh,1.3.0
-process.parent.pgid,long,extended,,1.3.0
-process.parent.pid,long,core,4242,1.3.0
-process.parent.ppid,long,extended,4241,1.3.0
-process.parent.start,date,extended,2016-05-23T08:05:34.853Z,1.3.0
-process.parent.thread.id,long,extended,4242,1.3.0
-process.parent.thread.name,keyword,extended,thread-0,1.3.0
-process.parent.title,keyword,extended,,1.3.0
-process.parent.uptime,long,extended,1325,1.3.0
-process.parent.working_directory,keyword,extended,/home/alice,1.3.0
-process.pgid,long,extended,,1.3.0
-process.pid,long,core,4242,1.3.0
-process.ppid,long,extended,4241,1.3.0
-process.start,date,extended,2016-05-23T08:05:34.853Z,1.3.0
-process.thread.id,long,extended,4242,1.3.0
-process.thread.name,keyword,extended,thread-0,1.3.0
-process.title,keyword,extended,,1.3.0
-process.uptime,long,extended,1325,1.3.0
-process.working_directory,keyword,extended,/home/alice,1.3.0
-related.ip,ip,extended,,1.3.0
-server.address,keyword,extended,,1.3.0
-server.as.number,long,extended,15169,1.3.0
-server.as.organization.name,keyword,extended,Google LLC,1.3.0
-server.bytes,long,core,184,1.3.0
-server.domain,keyword,core,,1.3.0
-server.geo.city_name,keyword,core,Montreal,1.3.0
-server.geo.continent_name,keyword,core,North America,1.3.0
-server.geo.country_iso_code,keyword,core,CA,1.3.0
-server.geo.country_name,keyword,core,Canada,1.3.0
-server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-server.geo.name,keyword,extended,boston-dc,1.3.0
-server.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-server.geo.region_name,keyword,core,Quebec,1.3.0
-server.ip,ip,core,,1.3.0
-server.mac,keyword,core,,1.3.0
-server.nat.ip,ip,extended,,1.3.0
-server.nat.port,long,extended,,1.3.0
-server.packets,long,core,12,1.3.0
-server.port,long,core,,1.3.0
-server.registered_domain,keyword,extended,google.com,1.3.0
-server.top_level_domain,keyword,extended,co.uk,1.3.0
-server.user.domain,keyword,extended,,1.3.0
-server.user.email,keyword,extended,,1.3.0
-server.user.full_name,keyword,extended,Albert Einstein,1.3.0
-server.user.group.domain,keyword,extended,,1.3.0
-server.user.group.id,keyword,extended,,1.3.0
-server.user.group.name,keyword,extended,,1.3.0
-server.user.hash,keyword,extended,,1.3.0
-server.user.id,keyword,core,,1.3.0
-server.user.name,keyword,core,albert,1.3.0
-service.ephemeral_id,keyword,extended,8a4f500f,1.3.0
-service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,1.3.0
-service.name,keyword,core,elasticsearch-metrics,1.3.0
-service.node.name,keyword,extended,instance-0000000016,1.3.0
-service.state,keyword,core,,1.3.0
-service.type,keyword,core,elasticsearch,1.3.0
-service.version,keyword,core,3.2.4,1.3.0
-source.address,keyword,extended,,1.3.0
-source.as.number,long,extended,15169,1.3.0
-source.as.organization.name,keyword,extended,Google LLC,1.3.0
-source.bytes,long,core,184,1.3.0
-source.domain,keyword,core,,1.3.0
-source.geo.city_name,keyword,core,Montreal,1.3.0
-source.geo.continent_name,keyword,core,North America,1.3.0
-source.geo.country_iso_code,keyword,core,CA,1.3.0
-source.geo.country_name,keyword,core,Canada,1.3.0
-source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.3.0
-source.geo.name,keyword,extended,boston-dc,1.3.0
-source.geo.region_iso_code,keyword,core,CA-QC,1.3.0
-source.geo.region_name,keyword,core,Quebec,1.3.0
-source.ip,ip,core,,1.3.0
-source.mac,keyword,core,,1.3.0
-source.nat.ip,ip,extended,,1.3.0
-source.nat.port,long,extended,,1.3.0
-source.packets,long,core,12,1.3.0
-source.port,long,core,,1.3.0
-source.registered_domain,keyword,extended,google.com,1.3.0
-source.top_level_domain,keyword,extended,co.uk,1.3.0
-source.user.domain,keyword,extended,,1.3.0
-source.user.email,keyword,extended,,1.3.0
-source.user.full_name,keyword,extended,Albert Einstein,1.3.0
-source.user.group.domain,keyword,extended,,1.3.0
-source.user.group.id,keyword,extended,,1.3.0
-source.user.group.name,keyword,extended,,1.3.0
-source.user.hash,keyword,extended,,1.3.0
-source.user.id,keyword,core,,1.3.0
-source.user.name,keyword,core,albert,1.3.0
-threat.framework,keyword,extended,MITRE ATT&CK,1.3.0
-threat.tactic.id,keyword,extended,TA0040,1.3.0
-threat.tactic.name,keyword,extended,impact,1.3.0
-threat.tactic.reference,keyword,extended,https://attack.mitre.org/tactics/TA0040/,1.3.0
-threat.technique.id,keyword,extended,T1499,1.3.0
-threat.technique.name,keyword,extended,endpoint denial of service,1.3.0
-threat.technique.reference,keyword,extended,https://attack.mitre.org/techniques/T1499/,1.3.0
-tls.cipher,keyword,extended,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,1.3.0
-tls.client.certificate,keyword,extended,MII...,1.3.0
-tls.client.certificate_chain,keyword,extended,"['MII...', 'MII...']",1.3.0
-tls.client.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,1.3.0
-tls.client.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,1.3.0
-tls.client.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,1.3.0
-tls.client.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",1.3.0
-tls.client.ja3,keyword,extended,d4e5b18d6b55c71272893221c96ba240,1.3.0
-tls.client.not_after,date,extended,2021-01-01T00:00:00.000Z,1.3.0
-tls.client.not_before,date,extended,1970-01-01T00:00:00.000Z,1.3.0
-tls.client.server_name,keyword,extended,www.elastic.co,1.3.0
-tls.client.subject,keyword,extended,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",1.3.0
-tls.client.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",1.3.0
-tls.curve,keyword,extended,secp256r1,1.3.0
-tls.established,boolean,extended,,1.3.0
-tls.next_protocol,keyword,extended,http/1.1,1.3.0
-tls.resumed,boolean,extended,,1.3.0
-tls.server.certificate,keyword,extended,MII...,1.3.0
-tls.server.certificate_chain,keyword,extended,"['MII...', 'MII...']",1.3.0
-tls.server.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,1.3.0
-tls.server.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,1.3.0
-tls.server.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,1.3.0
-tls.server.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",1.3.0
-tls.server.ja3s,keyword,extended,394441ab65754e2207b1e1b457b3641d,1.3.0
-tls.server.not_after,date,extended,2021-01-01T00:00:00.000Z,1.3.0
-tls.server.not_before,date,extended,1970-01-01T00:00:00.000Z,1.3.0
-tls.server.subject,keyword,extended,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",1.3.0
-tls.server.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",1.3.0
-tls.version,keyword,extended,1.2,1.3.0
-tls.version_protocol,keyword,extended,tls,1.3.0
-trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,1.3.0
-transaction.id,keyword,extended,00f067aa0ba902b7,1.3.0
-url.domain,keyword,extended,www.elastic.co,1.3.0
-url.extension,keyword,extended,png,1.3.0
-url.fragment,keyword,extended,,1.3.0
-url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,1.3.0
-url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.3.0
-url.password,keyword,extended,,1.3.0
-url.path,keyword,extended,,1.3.0
-url.port,long,extended,443,1.3.0
-url.query,keyword,extended,,1.3.0
-url.registered_domain,keyword,extended,google.com,1.3.0
-url.scheme,keyword,extended,https,1.3.0
-url.top_level_domain,keyword,extended,co.uk,1.3.0
-url.username,keyword,extended,,1.3.0
-user.domain,keyword,extended,,1.3.0
-user.email,keyword,extended,,1.3.0
-user.full_name,keyword,extended,Albert Einstein,1.3.0
-user.group.domain,keyword,extended,,1.3.0
-user.group.id,keyword,extended,,1.3.0
-user.group.name,keyword,extended,,1.3.0
-user.hash,keyword,extended,,1.3.0
-user.id,keyword,core,,1.3.0
-user.name,keyword,core,albert,1.3.0
-user_agent.device.name,keyword,extended,iPhone,1.3.0
-user_agent.name,keyword,extended,Safari,1.3.0
-user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",1.3.0
-user_agent.os.family,keyword,extended,debian,1.3.0
-user_agent.os.full,keyword,extended,Mac OS Mojave,1.3.0
-user_agent.os.kernel,keyword,extended,4.4.0-112-generic,1.3.0
-user_agent.os.name,keyword,extended,Mac OS X,1.3.0
-user_agent.os.platform,keyword,extended,darwin,1.3.0
-user_agent.os.version,keyword,extended,10.14.1,1.3.0
-user_agent.version,keyword,extended,12.0,1.3.0
-vulnerability.category,keyword,extended,"[""Firewall""]",1.3.0
-vulnerability.classification,keyword,extended,CVSS,1.3.0
-vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",1.3.0
-vulnerability.enumeration,keyword,extended,CVE,1.3.0
-vulnerability.id,keyword,extended,CVE-2019-00001,1.3.0
-vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,1.3.0
-vulnerability.report_id,keyword,extended,20191018.0001,1.3.0
-vulnerability.scanner.vendor,keyword,extended,Tenable,1.3.0
-vulnerability.score.base,float,extended,5.5,1.3.0
-vulnerability.score.environmental,float,extended,5.5,1.3.0
-vulnerability.score.temporal,float,extended,,1.3.0
-vulnerability.score.version,keyword,extended,2.0,1.3.0
-vulnerability.severity,keyword,extended,Critical,1.3.0
+ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
+1.3.0,True,base,@timestamp,date,core,2016-05-23T08:05:34.853Z,Date/time when the event originated.
+1.3.0,True,base,labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",Custom key/value pairs.
+1.3.0,True,base,message,text,core,Hello World,Log message optimized for viewing in a log viewer.
+1.3.0,True,base,tags,keyword,core,"[""production"", ""env2""]",List of keywords used to tag each event.
+1.3.0,True,agent,agent.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this agent.
+1.3.0,True,agent,agent.id,keyword,core,8a4f500d,Unique identifier of this agent.
+1.3.0,True,agent,agent.name,keyword,core,foo,Custom name of the agent.
+1.3.0,True,agent,agent.type,keyword,core,filebeat,Type of the agent.
+1.3.0,True,agent,agent.version,keyword,core,6.0.0-rc2,Version of the agent.
+1.3.0,True,as,as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,True,as,as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,True,client,client.address,keyword,extended,,Client network address.
+1.3.0,True,client,client.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,True,client,client.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,True,client,client.bytes,long,core,184,Bytes sent from the client to the server.
+1.3.0,True,client,client.domain,keyword,core,,Client domain.
+1.3.0,True,client,client.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,client,client.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,client,client.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,client,client.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,client,client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,client,client.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,client,client.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,client,client.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,client,client.ip,ip,core,,IP address of the client.
+1.3.0,True,client,client.mac,keyword,core,,MAC address of the client.
+1.3.0,True,client,client.nat.ip,ip,extended,,Client NAT ip address
+1.3.0,True,client,client.nat.port,long,extended,,Client NAT port
+1.3.0,True,client,client.packets,long,core,12,Packets sent from the client to the server.
+1.3.0,True,client,client.port,long,core,,Port of the client.
+1.3.0,True,client,client.registered_domain,keyword,extended,google.com,"The highest registered client domain, stripped of the subdomain."
+1.3.0,True,client,client.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,client,client.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,client,client.user.email,keyword,extended,,User email address.
+1.3.0,True,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,client,client.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,client,client.user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,client,client.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
+1.3.0,True,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
+1.3.0,True,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
+1.3.0,True,cloud,cloud.instance.name,keyword,extended,,Instance name of the host machine.
+1.3.0,True,cloud,cloud.machine.type,keyword,extended,t2.medium,Machine type of the host machine.
+1.3.0,True,cloud,cloud.provider,keyword,extended,aws,Name of the cloud provider.
+1.3.0,True,cloud,cloud.region,keyword,extended,us-east-1,Region in which this host is running.
+1.3.0,True,container,container.id,keyword,core,,Unique container id.
+1.3.0,True,container,container.image.name,keyword,extended,,Name of the image the container was built on.
+1.3.0,True,container,container.image.tag,keyword,extended,,Container image tag.
+1.3.0,True,container,container.labels,object,extended,,Image labels.
+1.3.0,True,container,container.name,keyword,extended,,Container name.
+1.3.0,True,container,container.runtime,keyword,extended,docker,Runtime managing this container.
+1.3.0,True,destination,destination.address,keyword,extended,,Destination network address.
+1.3.0,True,destination,destination.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,True,destination,destination.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,True,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
+1.3.0,True,destination,destination.domain,keyword,core,,Destination domain.
+1.3.0,True,destination,destination.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,destination,destination.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,destination,destination.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,destination,destination.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,destination,destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,destination,destination.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,destination,destination.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,destination,destination.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,destination,destination.ip,ip,core,,IP address of the destination.
+1.3.0,True,destination,destination.mac,keyword,core,,MAC address of the destination.
+1.3.0,True,destination,destination.nat.ip,ip,extended,,Destination NAT ip
+1.3.0,True,destination,destination.nat.port,long,extended,,Destination NAT Port
+1.3.0,True,destination,destination.packets,long,core,12,Packets sent from the destination to the source.
+1.3.0,True,destination,destination.port,long,core,,Port of the destination.
+1.3.0,True,destination,destination.registered_domain,keyword,extended,google.com,"The highest registered destination domain, stripped of the subdomain."
+1.3.0,True,destination,destination.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,destination,destination.user.email,keyword,extended,,User email address.
+1.3.0,True,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,destination,destination.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,destination,destination.user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,dns,dns.answers,object,extended,,Array of DNS answers.
+1.3.0,True,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
+1.3.0,True,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
+1.3.0,True,dns,dns.answers.name,keyword,extended,www.google.com,The domain name to which this resource record pertains.
+1.3.0,True,dns,dns.answers.ttl,long,extended,180,The time interval in seconds that this resource record may be cached before it should be discarded. Zero values mean that the data should not be cached.
+1.3.0,True,dns,dns.answers.type,keyword,extended,CNAME,The type of data contained in this resource record.
+1.3.0,True,dns,dns.header_flags,keyword,extended,"['RD', 'RA']",Array of DNS header flags.
+1.3.0,True,dns,dns.id,keyword,extended,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
+1.3.0,True,dns,dns.op_code,keyword,extended,QUERY,The DNS operation code that specifies the kind of query in the message. This value is set by the originator of a query and copied into the response.
+1.3.0,True,dns,dns.question.class,keyword,extended,IN,The class of of records being queried.
+1.3.0,True,dns,dns.question.name,keyword,extended,www.google.com,The name being queried.
+1.3.0,True,dns,dns.question.registered_domain,keyword,extended,google.com,"The highest registered domain, stripped of the subdomain."
+1.3.0,True,dns,dns.question.subdomain,keyword,extended,www,The subdomain of the domain.
+1.3.0,True,dns,dns.question.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,dns,dns.question.type,keyword,extended,AAAA,The type of record being queried.
+1.3.0,True,dns,dns.resolved_ip,ip,extended,"['10.10.10.10', '10.10.10.11']",Array containing all IPs seen in answers.data
+1.3.0,True,dns,dns.response_code,keyword,extended,NOERROR,The DNS response code.
+1.3.0,True,dns,dns.type,keyword,extended,answer,"The type of DNS event captured, query or answer."
+1.3.0,True,ecs,ecs.version,keyword,core,1.0.0,ECS version this event conforms to.
+1.3.0,True,error,error.code,keyword,core,,Error code describing the error.
+1.3.0,True,error,error.id,keyword,core,,Unique identifier for the error.
+1.3.0,True,error,error.message,text,core,,Error message.
+1.3.0,False,error,error.stack_trace,keyword,extended,,The stack trace of this error in plain text.
+1.3.0,True,error,error.type,keyword,extended,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
+1.3.0,True,event,event.action,keyword,core,user-password-change,The action captured by the event.
+1.3.0,True,event,event.category,keyword,core,user-management,Event category.
+1.3.0,True,event,event.code,keyword,extended,4648,Identification code for this event.
+1.3.0,True,event,event.created,date,core,2016-05-23 08:05:34.857000,Time when the event was first read by an agent or by your pipeline.
+1.3.0,True,event,event.dataset,keyword,core,apache.access,Name of the dataset.
+1.3.0,True,event,event.duration,long,core,,Duration of the event in nanoseconds.
+1.3.0,True,event,event.end,date,extended,,event.end contains the date when the event ended or when the activity was last observed.
+1.3.0,True,event,event.hash,keyword,extended,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+1.3.0,True,event,event.id,keyword,core,8a4f500d,Unique ID to describe the event.
+1.3.0,True,event,event.ingested,date,core,2016-05-23 08:05:35.101000,Timestamp when an event arrived in the central data store.
+1.3.0,True,event,event.kind,keyword,extended,state,The kind of the event.
+1.3.0,True,event,event.module,keyword,core,apache,Name of the module this data is coming from.
+1.3.0,False,event,event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+1.3.0,True,event,event.outcome,keyword,extended,success,The outcome of the event.
+1.3.0,True,event,event.provider,keyword,extended,kernel,Source of the event.
+1.3.0,True,event,event.risk_score,float,core,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
+1.3.0,True,event,event.risk_score_norm,float,extended,,Normalized risk score or priority of the event (0-100).
+1.3.0,True,event,event.sequence,long,extended,,Sequence number of the event.
+1.3.0,True,event,event.severity,long,core,7,Numeric severity of the event.
+1.3.0,True,event,event.start,date,extended,,event.start contains the date when the event started or when the activity was first observed.
+1.3.0,True,event,event.timezone,keyword,extended,,Event time zone.
+1.3.0,True,event,event.type,keyword,core,,Reserved for future usage.
+1.3.0,True,file,file.accessed,date,extended,,Last time the file was accessed.
+1.3.0,True,file,file.created,date,extended,,File creation time.
+1.3.0,True,file,file.ctime,date,extended,,Last time the file attributes or metadata changed.
+1.3.0,True,file,file.device,keyword,extended,sda,Device that is the source of the file.
+1.3.0,True,file,file.directory,keyword,extended,/home/alice,Directory where the file is located.
+1.3.0,True,file,file.extension,keyword,extended,png,File extension.
+1.3.0,True,file,file.gid,keyword,extended,1001,Primary group ID (GID) of the file.
+1.3.0,True,file,file.group,keyword,extended,alice,Primary group name of the file.
+1.3.0,True,file,file.hash.md5,keyword,extended,,MD5 hash.
+1.3.0,True,file,file.hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,True,file,file.hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,True,file,file.hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,True,file,file.inode,keyword,extended,256383,Inode representing the file in the filesystem.
+1.3.0,True,file,file.mode,keyword,extended,0640,Mode of the file in octal representation.
+1.3.0,True,file,file.mtime,date,extended,,Last time the file content was modified.
+1.3.0,True,file,file.name,keyword,extended,example.png,"Name of the file including the extension, without the directory."
+1.3.0,True,file,file.owner,keyword,extended,alice,File owner's username.
+1.3.0,True,file,file.path,keyword,extended,/home/alice/example.png,Full path to the file.
+1.3.0,True,file,file.size,long,extended,16384,File size in bytes.
+1.3.0,True,file,file.target_path,keyword,extended,,Target path for symlinks.
+1.3.0,True,file,file.type,keyword,extended,file,"File type (file, dir, or symlink)."
+1.3.0,True,file,file.uid,keyword,extended,1001,The user ID (UID) or security identifier (SID) of the file owner.
+1.3.0,True,geo,geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,geo,geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,geo,geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,geo,geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,geo,geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,geo,geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,geo,geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,geo,geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,group,group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,group,group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,group,group.name,keyword,extended,,Name of the group.
+1.3.0,True,hash,hash.md5,keyword,extended,,MD5 hash.
+1.3.0,True,hash,hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,True,hash,hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,True,hash,hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,True,host,host.architecture,keyword,core,x86_64,Operating system architecture.
+1.3.0,True,host,host.domain,keyword,extended,CONTOSO,Name of the directory the group is a member of.
+1.3.0,True,host,host.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,host,host.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,host,host.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,host,host.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,host,host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,host,host.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,host,host.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,host,host.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,host,host.hostname,keyword,core,,Hostname of the host.
+1.3.0,True,host,host.id,keyword,core,,Unique host id.
+1.3.0,True,host,host.ip,ip,core,,Host ip address.
+1.3.0,True,host,host.mac,keyword,core,,Host mac address.
+1.3.0,True,host,host.name,keyword,core,,Name of the host.
+1.3.0,True,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,True,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,True,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,True,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,True,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,True,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,True,host,host.type,keyword,core,,Type of host.
+1.3.0,True,host,host.uptime,long,extended,1325,Seconds the host has been up.
+1.3.0,True,host,host.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,host,host.user.email,keyword,extended,,User email address.
+1.3.0,True,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,host,host.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,host,host.user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,host,host.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
+1.3.0,True,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
+1.3.0,True,http,http.request.bytes,long,extended,1437,Total size in bytes of the request (body and headers).
+1.3.0,True,http,http.request.method,keyword,extended,"get, post, put",HTTP request method.
+1.3.0,True,http,http.request.referrer,keyword,extended,https://blog.example.com/,Referrer for this HTTP request.
+1.3.0,True,http,http.response.body.bytes,long,extended,887,Size in bytes of the response body.
+1.3.0,True,http,http.response.body.content,keyword,extended,Hello world,The full HTTP response body.
+1.3.0,True,http,http.response.bytes,long,extended,1437,Total size in bytes of the response (body and headers).
+1.3.0,True,http,http.response.status_code,long,extended,404,HTTP response status code.
+1.3.0,True,http,http.version,keyword,extended,1.1,HTTP version.
+1.3.0,True,log,log.level,keyword,core,error,Log level of the log event.
+1.3.0,True,log,log.logger,keyword,core,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
+1.3.0,True,log,log.origin.file.line,integer,extended,42,The line number of the file which originated the log event.
+1.3.0,True,log,log.origin.file.name,keyword,extended,Bootstrap.java,The file which originated the log event.
+1.3.0,True,log,log.origin.function,keyword,extended,init,The function which originated the log event.
+1.3.0,False,log,log.original,keyword,core,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
+1.3.0,True,log,log.syslog,object,extended,,Syslog metadata
+1.3.0,True,log,log.syslog.facility.code,long,extended,23,Syslog numeric facility of the event.
+1.3.0,True,log,log.syslog.facility.name,keyword,extended,local7,Syslog text-based facility of the event.
+1.3.0,True,log,log.syslog.priority,long,extended,135,Syslog priority of the event.
+1.3.0,True,log,log.syslog.severity.code,long,extended,3,Syslog numeric severity of the event.
+1.3.0,True,log,log.syslog.severity.name,keyword,extended,Error,Syslog text-based severity of the event.
+1.3.0,True,network,network.application,keyword,extended,aim,Application level protocol name.
+1.3.0,True,network,network.bytes,long,core,368,Total bytes transferred in both directions.
+1.3.0,True,network,network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
+1.3.0,True,network,network.direction,keyword,core,inbound,Direction of the network traffic.
+1.3.0,True,network,network.forwarded_ip,ip,core,192.1.1.2,Host IP address when the source IP address is the proxy.
+1.3.0,True,network,network.iana_number,keyword,extended,6,IANA Protocol Number.
+1.3.0,True,network,network.name,keyword,extended,Guest Wifi,Name given by operators to sections of their network.
+1.3.0,True,network,network.packets,long,core,24,Total packets transferred in both directions.
+1.3.0,True,network,network.protocol,keyword,core,http,L7 Network protocol name.
+1.3.0,True,network,network.transport,keyword,core,tcp,Protocol Name corresponding to the field `iana_number`.
+1.3.0,True,network,network.type,keyword,core,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
+1.3.0,True,observer,observer.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,observer,observer.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,observer,observer.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,observer,observer.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,observer,observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,observer,observer.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,observer,observer.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,observer,observer.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,observer,observer.hostname,keyword,core,,Hostname of the observer.
+1.3.0,True,observer,observer.ip,ip,core,,IP address of the observer.
+1.3.0,True,observer,observer.mac,keyword,core,,MAC address of the observer
+1.3.0,True,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
+1.3.0,True,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,True,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,True,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,True,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,True,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,True,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,True,observer,observer.product,keyword,extended,s200,The product name of the observer.
+1.3.0,True,observer,observer.serial_number,keyword,extended,,Observer serial number.
+1.3.0,True,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
+1.3.0,True,observer,observer.vendor,keyword,core,Symantec,Vendor name of the observer.
+1.3.0,True,observer,observer.version,keyword,core,,Observer version.
+1.3.0,True,organization,organization.id,keyword,extended,,Unique identifier for the organization.
+1.3.0,True,organization,organization.name,keyword,extended,,Organization name.
+1.3.0,True,os,os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,True,os,os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,True,os,os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,True,os,os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,True,os,os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,True,os,os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,True,package,package.architecture,keyword,extended,x86_64,Package architecture.
+1.3.0,True,package,package.build_version,keyword,extended,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
+1.3.0,True,package,package.checksum,keyword,extended,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.
+1.3.0,True,package,package.description,keyword,extended,Open source programming language to build simple/reliable/efficient software.,Description of the package.
+1.3.0,True,package,package.install_scope,keyword,extended,global,"Indicating how the package was installed, e.g. user-local, global."
+1.3.0,True,package,package.installed,date,extended,,Time when package was installed.
+1.3.0,True,package,package.license,keyword,extended,Apache License 2.0,Package license
+1.3.0,True,package,package.name,keyword,extended,go,Package name
+1.3.0,True,package,package.path,keyword,extended,/usr/local/Cellar/go/1.12.9/,Path where the package is installed.
+1.3.0,True,package,package.reference,keyword,extended,https://golang.org,Package reference URL
+1.3.0,True,package,package.size,long,extended,62231,Package size in bytes.
+1.3.0,True,package,package.type,keyword,extended,rpm,Package type
+1.3.0,True,package,package.version,keyword,extended,1.12.9,Package version
+1.3.0,True,process,process.args,keyword,extended,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.3.0,True,process,process.args_count,long,extended,4,Length of the process.args array.
+1.3.0,True,process,process.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.3.0,True,process,process.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.3.0,True,process,process.exit_code,long,extended,137,The exit code of the process.
+1.3.0,True,process,process.hash.md5,keyword,extended,,MD5 hash.
+1.3.0,True,process,process.hash.sha1,keyword,extended,,SHA1 hash.
+1.3.0,True,process,process.hash.sha256,keyword,extended,,SHA256 hash.
+1.3.0,True,process,process.hash.sha512,keyword,extended,,SHA512 hash.
+1.3.0,True,process,process.name,keyword,extended,ssh,Process name.
+1.3.0,True,process,process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.3.0,True,process,process.parent.args_count,long,extended,4,Length of the process.args array.
+1.3.0,True,process,process.parent.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.3.0,True,process,process.parent.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.3.0,True,process,process.parent.exit_code,long,extended,137,The exit code of the process.
+1.3.0,True,process,process.parent.name,keyword,extended,ssh,Process name.
+1.3.0,True,process,process.parent.pgid,long,extended,,Identifier of the group of processes the process belongs to.
+1.3.0,True,process,process.parent.pid,long,core,4242,Process id.
+1.3.0,True,process,process.parent.ppid,long,extended,4241,Parent process' pid.
+1.3.0,True,process,process.parent.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
+1.3.0,True,process,process.parent.thread.id,long,extended,4242,Thread ID.
+1.3.0,True,process,process.parent.thread.name,keyword,extended,thread-0,Thread name.
+1.3.0,True,process,process.parent.title,keyword,extended,,Process title.
+1.3.0,True,process,process.parent.uptime,long,extended,1325,Seconds the process has been up.
+1.3.0,True,process,process.parent.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.3.0,True,process,process.pgid,long,extended,,Identifier of the group of processes the process belongs to.
+1.3.0,True,process,process.pid,long,core,4242,Process id.
+1.3.0,True,process,process.ppid,long,extended,4241,Parent process' pid.
+1.3.0,True,process,process.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
+1.3.0,True,process,process.thread.id,long,extended,4242,Thread ID.
+1.3.0,True,process,process.thread.name,keyword,extended,thread-0,Thread name.
+1.3.0,True,process,process.title,keyword,extended,,Process title.
+1.3.0,True,process,process.uptime,long,extended,1325,Seconds the process has been up.
+1.3.0,True,process,process.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.3.0,True,related,related.ip,ip,extended,,All of the IPs seen on your event.
+1.3.0,True,server,server.address,keyword,extended,,Server network address.
+1.3.0,True,server,server.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,True,server,server.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,True,server,server.bytes,long,core,184,Bytes sent from the server to the client.
+1.3.0,True,server,server.domain,keyword,core,,Server domain.
+1.3.0,True,server,server.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,server,server.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,server,server.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,server,server.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,server,server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,server,server.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,server,server.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,server,server.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,server,server.ip,ip,core,,IP address of the server.
+1.3.0,True,server,server.mac,keyword,core,,MAC address of the server.
+1.3.0,True,server,server.nat.ip,ip,extended,,Server NAT ip
+1.3.0,True,server,server.nat.port,long,extended,,Server NAT port
+1.3.0,True,server,server.packets,long,core,12,Packets sent from the server to the client.
+1.3.0,True,server,server.port,long,core,,Port of the server.
+1.3.0,True,server,server.registered_domain,keyword,extended,google.com,"The highest registered server domain, stripped of the subdomain."
+1.3.0,True,server,server.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,server,server.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,server,server.user.email,keyword,extended,,User email address.
+1.3.0,True,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,server,server.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,server,server.user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,server,server.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
+1.3.0,True,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+1.3.0,True,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
+1.3.0,True,service,service.node.name,keyword,extended,instance-0000000016,Name of the service node.
+1.3.0,True,service,service.state,keyword,core,,Current state of the service.
+1.3.0,True,service,service.type,keyword,core,elasticsearch,The type of the service.
+1.3.0,True,service,service.version,keyword,core,3.2.4,Version of the service.
+1.3.0,True,source,source.address,keyword,extended,,Source network address.
+1.3.0,True,source,source.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
+1.3.0,True,source,source.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.3.0,True,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
+1.3.0,True,source,source.domain,keyword,core,,Source domain.
+1.3.0,True,source,source.geo.city_name,keyword,core,Montreal,City name.
+1.3.0,True,source,source.geo.continent_name,keyword,core,North America,Name of the continent.
+1.3.0,True,source,source.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.3.0,True,source,source.geo.country_name,keyword,core,Canada,Country name.
+1.3.0,True,source,source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.3.0,True,source,source.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.3.0,True,source,source.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.3.0,True,source,source.geo.region_name,keyword,core,Quebec,Region name.
+1.3.0,True,source,source.ip,ip,core,,IP address of the source.
+1.3.0,True,source,source.mac,keyword,core,,MAC address of the source.
+1.3.0,True,source,source.nat.ip,ip,extended,,Source NAT ip
+1.3.0,True,source,source.nat.port,long,extended,,Source NAT port
+1.3.0,True,source,source.packets,long,core,12,Packets sent from the source to the destination.
+1.3.0,True,source,source.port,long,core,,Port of the source.
+1.3.0,True,source,source.registered_domain,keyword,extended,google.com,"The highest registered source domain, stripped of the subdomain."
+1.3.0,True,source,source.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,source,source.user.email,keyword,extended,,User email address.
+1.3.0,True,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,source,source.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,source,source.user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,source,source.user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
+1.3.0,True,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
+1.3.0,True,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.
+1.3.0,True,threat,threat.tactic.reference,keyword,extended,https://attack.mitre.org/tactics/TA0040/,Threat tactic url reference.
+1.3.0,True,threat,threat.technique.id,keyword,extended,T1499,Threat technique id.
+1.3.0,True,threat,threat.technique.name,keyword,extended,endpoint denial of service,Threat technique name.
+1.3.0,True,threat,threat.technique.reference,keyword,extended,https://attack.mitre.org/techniques/T1499/,Threat technique reference.
+1.3.0,True,tls,tls.cipher,keyword,extended,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
+1.3.0,True,tls,tls.client.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
+1.3.0,True,tls,tls.client.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.
+1.3.0,True,tls,tls.client.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.client.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.client.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.client.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+1.3.0,True,tls,tls.client.ja3,keyword,extended,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
+1.3.0,True,tls,tls.client.not_after,date,extended,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
+1.3.0,True,tls,tls.client.not_before,date,extended,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
+1.3.0,True,tls,tls.client.server_name,keyword,extended,www.elastic.co,"Also called an SNI, this tells the server which hostname to which the client is attempting to connect. When this value is available, it should get copied to `destination.domain`."
+1.3.0,True,tls,tls.client.subject,keyword,extended,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
+1.3.0,True,tls,tls.client.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the client during the client hello.
+1.3.0,True,tls,tls.curve,keyword,extended,secp256r1,"String indicating the curve used for the given cipher, when applicable."
+1.3.0,True,tls,tls.established,boolean,extended,,Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
+1.3.0,True,tls,tls.next_protocol,keyword,extended,http/1.1,"String indicating the protocol being tunneled. Per the values in the IANA registry (https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids), this string should be lower case."
+1.3.0,True,tls,tls.resumed,boolean,extended,,Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+1.3.0,True,tls,tls.server.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the server. This is usually mutually-exclusive of `server.certificate_chain` since this value also exists in that list.
+1.3.0,True,tls,tls.server.certificate_chain,keyword,extended,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is usually mutually-exclusive of `server.certificate` since that value should be the first certificate in the chain.
+1.3.0,True,tls,tls.server.hash.md5,keyword,extended,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,"Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.server.hash.sha1,keyword,extended,9E393D93138888D288266C2D915214D1D1CCEB2A,"Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.server.hash.sha256,keyword,extended,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,"Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server. For consistency with other hash values, this value should be formatted as an uppercase hash."
+1.3.0,True,tls,tls.server.issuer,keyword,extended,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
+1.3.0,True,tls,tls.server.ja3s,keyword,extended,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
+1.3.0,True,tls,tls.server.not_after,date,extended,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
+1.3.0,True,tls,tls.server.not_before,date,extended,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
+1.3.0,True,tls,tls.server.subject,keyword,extended,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
+1.3.0,True,tls,tls.server.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the server during the server hello.
+1.3.0,True,tls,tls.version,keyword,extended,1.2,Numeric part of the version parsed from the original string.
+1.3.0,True,tls,tls.version_protocol,keyword,extended,tls,Normalized lowercase protocol name parsed from original string.
+1.3.0,True,trace,trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
+1.3.0,True,transaction,transaction.id,keyword,extended,00f067aa0ba902b7,Unique identifier of the transaction.
+1.3.0,True,url,url.domain,keyword,extended,www.elastic.co,Domain of the url.
+1.3.0,True,url,url.extension,keyword,extended,png,File extension from the original request url.
+1.3.0,True,url,url.fragment,keyword,extended,,Portion of the url after the `#`.
+1.3.0,True,url,url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.3.0,True,url,url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.3.0,True,url,url.password,keyword,extended,,Password of the request.
+1.3.0,True,url,url.path,keyword,extended,,"Path of the request, such as ""/search""."
+1.3.0,True,url,url.port,long,extended,443,"Port of the request, such as 443."
+1.3.0,True,url,url.query,keyword,extended,,Query string of the request.
+1.3.0,True,url,url.registered_domain,keyword,extended,google.com,"The highest registered url domain, stripped of the subdomain."
+1.3.0,True,url,url.scheme,keyword,extended,https,Scheme of the url.
+1.3.0,True,url,url.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.3.0,True,url,url.username,keyword,extended,,Username of the request.
+1.3.0,True,user,user.domain,keyword,extended,,Name of the directory the user is a member of.
+1.3.0,True,user,user.email,keyword,extended,,User email address.
+1.3.0,True,user,user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.3.0,True,user,user.group.domain,keyword,extended,,Name of the directory the group is a member of.
+1.3.0,True,user,user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.3.0,True,user,user.group.name,keyword,extended,,Name of the group.
+1.3.0,True,user,user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.3.0,True,user,user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.3.0,True,user,user.name,keyword,core,albert,Short name or login of the user.
+1.3.0,True,user_agent,user_agent.device.name,keyword,extended,iPhone,Name of the device.
+1.3.0,True,user_agent,user_agent.name,keyword,extended,Safari,Name of the user agent.
+1.3.0,True,user_agent,user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed version of the user_agent.
+1.3.0,True,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.3.0,True,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.3.0,True,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.3.0,True,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.3.0,True,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.3.0,True,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.3.0,True,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.
+1.3.0,True,vulnerability,vulnerability.category,keyword,extended,"[""Firewall""]",Category of a vulnerability.
+1.3.0,True,vulnerability,vulnerability.classification,keyword,extended,CVSS,Classification of the vulnerability.
+1.3.0,True,vulnerability,vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.3.0,True,vulnerability,vulnerability.enumeration,keyword,extended,CVE,Identifier of the vulnerability.
+1.3.0,True,vulnerability,vulnerability.id,keyword,extended,CVE-2019-00001,ID of the vulnerability.
+1.3.0,True,vulnerability,vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.
+1.3.0,True,vulnerability,vulnerability.report_id,keyword,extended,20191018.0001,Scan identification number.
+1.3.0,True,vulnerability,vulnerability.scanner.vendor,keyword,extended,Tenable,Name of the scanner vendor.
+1.3.0,True,vulnerability,vulnerability.score.base,float,extended,5.5,Vulnerability Base score.
+1.3.0,True,vulnerability,vulnerability.score.environmental,float,extended,5.5,Vulnerability Environmental score.
+1.3.0,True,vulnerability,vulnerability.score.temporal,float,extended,,Vulnerability Temporal score.
+1.3.0,True,vulnerability,vulnerability.score.version,keyword,extended,2.0,CVSS version.
+1.3.0,True,vulnerability,vulnerability.severity,keyword,extended,Critical,Severity of the vulnerability.

--- a/scripts/generators/csv_generator.py
+++ b/scripts/generators/csv_generator.py
@@ -40,7 +40,7 @@ def save_csv(file, sorted_fields, version):
 
             schema_writer.writerow([
                 version,
-                field.get('index', True),
+                str(field.get('index', True)).lower(),
                 field_set,
                 field['flat_name'],
                 field['type'],

--- a/scripts/generators/csv_generator.py
+++ b/scripts/generators/csv_generator.py
@@ -29,12 +29,22 @@ def save_csv(file, sorted_fields, version):
                                    quoting=csv.QUOTE_MINIMAL,
                                    lineterminator='\n')
 
-        schema_writer.writerow(["Field", "Type", "Level", "Example", "ECS version"])
+        schema_writer.writerow(["ECS_Version", "Indexed", "Field_Set", "Field",
+                                "Type", "Level", "Example", "Description"])
         for field in sorted_fields:
+            key_parts = field['flat_name'].split('.')
+            if len(key_parts) == 1:
+                field_set = 'base'
+            else:
+                field_set = key_parts[0]
+
             schema_writer.writerow([
+                version,
+                field.get('index', True),
+                field_set,
                 field['flat_name'],
                 field['type'],
                 field['level'],
                 field.get('example', ''),
-                version
+                field['short'],
             ])


### PR DESCRIPTION
Backport of PR #621 and #638 to 1.3 branch. Original message:

In this PR:

* Add the field set column
* Add the short description
* Add whether the field should be indexed
* Reorder the columns a bit, so the stable length values are first

Preview GitHub's rendering of [generated/csv/fields.csv](https://github.com/webmat/ecs/blob/backport_622_1.3/generated/csv/fields.csv) (scroll right for definitions)