### PR TITLE
Backport #650 to 1.0: Flesh out the csv a little

### DIFF
--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1,280 +1,280 @@
-Field,Type,Level,Example,ECS version
-@timestamp,date,core,2016-05-23T08:05:34.853Z,1.0.1
-labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",1.0.1
-message,text,core,Hello World,1.0.1
-tags,keyword,core,"[""production"", ""env2""]",1.0.1
-agent.ephemeral_id,keyword,extended,8a4f500f,1.0.1
-agent.id,keyword,core,8a4f500d,1.0.1
-agent.name,keyword,core,foo,1.0.1
-agent.type,keyword,core,filebeat,1.0.1
-agent.version,keyword,core,6.0.0-rc2,1.0.1
-client.address,keyword,extended,,1.0.1
-client.bytes,long,core,184,1.0.1
-client.domain,keyword,core,,1.0.1
-client.geo.city_name,keyword,core,Montreal,1.0.1
-client.geo.continent_name,keyword,core,North America,1.0.1
-client.geo.country_iso_code,keyword,core,CA,1.0.1
-client.geo.country_name,keyword,core,Canada,1.0.1
-client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-client.geo.name,keyword,extended,boston-dc,1.0.1
-client.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-client.geo.region_name,keyword,core,Quebec,1.0.1
-client.ip,ip,core,,1.0.1
-client.mac,keyword,core,,1.0.1
-client.packets,long,core,12,1.0.1
-client.port,long,core,,1.0.1
-client.user.email,keyword,extended,,1.0.1
-client.user.full_name,keyword,extended,Albert Einstein,1.0.1
-client.user.group.id,keyword,extended,,1.0.1
-client.user.group.name,keyword,extended,,1.0.1
-client.user.hash,keyword,extended,,1.0.1
-client.user.id,keyword,core,,1.0.1
-client.user.name,keyword,core,albert,1.0.1
-cloud.account.id,keyword,extended,666777888999,1.0.1
-cloud.availability_zone,keyword,extended,us-east-1c,1.0.1
-cloud.instance.id,keyword,extended,i-1234567890abcdef0,1.0.1
-cloud.instance.name,keyword,extended,,1.0.1
-cloud.machine.type,keyword,extended,t2.medium,1.0.1
-cloud.provider,keyword,extended,aws,1.0.1
-cloud.region,keyword,extended,us-east-1,1.0.1
-container.id,keyword,core,,1.0.1
-container.image.name,keyword,extended,,1.0.1
-container.image.tag,keyword,extended,,1.0.1
-container.labels,object,extended,,1.0.1
-container.name,keyword,extended,,1.0.1
-container.runtime,keyword,extended,docker,1.0.1
-destination.address,keyword,extended,,1.0.1
-destination.bytes,long,core,184,1.0.1
-destination.domain,keyword,core,,1.0.1
-destination.geo.city_name,keyword,core,Montreal,1.0.1
-destination.geo.continent_name,keyword,core,North America,1.0.1
-destination.geo.country_iso_code,keyword,core,CA,1.0.1
-destination.geo.country_name,keyword,core,Canada,1.0.1
-destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-destination.geo.name,keyword,extended,boston-dc,1.0.1
-destination.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-destination.geo.region_name,keyword,core,Quebec,1.0.1
-destination.ip,ip,core,,1.0.1
-destination.mac,keyword,core,,1.0.1
-destination.packets,long,core,12,1.0.1
-destination.port,long,core,,1.0.1
-destination.user.email,keyword,extended,,1.0.1
-destination.user.full_name,keyword,extended,Albert Einstein,1.0.1
-destination.user.group.id,keyword,extended,,1.0.1
-destination.user.group.name,keyword,extended,,1.0.1
-destination.user.hash,keyword,extended,,1.0.1
-destination.user.id,keyword,core,,1.0.1
-destination.user.name,keyword,core,albert,1.0.1
-ecs.version,keyword,core,1.0.0,1.0.1
-error.code,keyword,core,,1.0.1
-error.id,keyword,core,,1.0.1
-error.message,text,core,,1.0.1
-event.action,keyword,core,user-password-change,1.0.1
-event.category,keyword,core,user-management,1.0.1
-event.created,date,core,,1.0.1
-event.dataset,keyword,core,stats,1.0.1
-event.duration,long,core,,1.0.1
-event.end,date,extended,,1.0.1
-event.hash,keyword,extended,123456789012345678901234567890ABCD,1.0.1
-event.id,keyword,core,8a4f500d,1.0.1
-event.kind,keyword,extended,state,1.0.1
-event.module,keyword,core,mysql,1.0.1
-event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,1.0.1
-event.outcome,keyword,extended,success,1.0.1
-event.risk_score,float,core,,1.0.1
-event.risk_score_norm,float,extended,,1.0.1
-event.severity,long,core,7,1.0.1
-event.start,date,extended,,1.0.1
-event.timezone,keyword,extended,,1.0.1
-event.type,keyword,core,,1.0.1
-file.ctime,date,extended,,1.0.1
-file.device,keyword,extended,,1.0.1
-file.extension,keyword,extended,png,1.0.1
-file.gid,keyword,extended,,1.0.1
-file.group,keyword,extended,,1.0.1
-file.inode,keyword,extended,,1.0.1
-file.mode,keyword,extended,416,1.0.1
-file.mtime,date,extended,,1.0.1
-file.owner,keyword,extended,,1.0.1
-file.path,keyword,extended,,1.0.1
-file.size,long,extended,,1.0.1
-file.target_path,keyword,extended,,1.0.1
-file.type,keyword,extended,,1.0.1
-file.uid,keyword,extended,,1.0.1
-geo.city_name,keyword,core,Montreal,1.0.1
-geo.continent_name,keyword,core,North America,1.0.1
-geo.country_iso_code,keyword,core,CA,1.0.1
-geo.country_name,keyword,core,Canada,1.0.1
-geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-geo.name,keyword,extended,boston-dc,1.0.1
-geo.region_iso_code,keyword,core,CA-QC,1.0.1
-geo.region_name,keyword,core,Quebec,1.0.1
-group.id,keyword,extended,,1.0.1
-group.name,keyword,extended,,1.0.1
-host.architecture,keyword,core,x86_64,1.0.1
-host.geo.city_name,keyword,core,Montreal,1.0.1
-host.geo.continent_name,keyword,core,North America,1.0.1
-host.geo.country_iso_code,keyword,core,CA,1.0.1
-host.geo.country_name,keyword,core,Canada,1.0.1
-host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-host.geo.name,keyword,extended,boston-dc,1.0.1
-host.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-host.geo.region_name,keyword,core,Quebec,1.0.1
-host.hostname,keyword,core,,1.0.1
-host.id,keyword,core,,1.0.1
-host.ip,ip,core,,1.0.1
-host.mac,keyword,core,,1.0.1
-host.name,keyword,core,,1.0.1
-host.os.family,keyword,extended,debian,1.0.1
-host.os.full,keyword,extended,Mac OS Mojave,1.0.1
-host.os.kernel,keyword,extended,4.4.0-112-generic,1.0.1
-host.os.name,keyword,extended,Mac OS X,1.0.1
-host.os.platform,keyword,extended,darwin,1.0.1
-host.os.version,keyword,extended,10.14.1,1.0.1
-host.type,keyword,core,,1.0.1
-host.user.email,keyword,extended,,1.0.1
-host.user.full_name,keyword,extended,Albert Einstein,1.0.1
-host.user.group.id,keyword,extended,,1.0.1
-host.user.group.name,keyword,extended,,1.0.1
-host.user.hash,keyword,extended,,1.0.1
-host.user.id,keyword,core,,1.0.1
-host.user.name,keyword,core,albert,1.0.1
-http.request.body.bytes,long,extended,887,1.0.1
-http.request.body.content,keyword,extended,Hello world,1.0.1
-http.request.bytes,long,extended,1437,1.0.1
-http.request.method,keyword,extended,"get, post, put",1.0.1
-http.request.referrer,keyword,extended,https://blog.example.com/,1.0.1
-http.response.body.bytes,long,extended,887,1.0.1
-http.response.body.content,keyword,extended,Hello world,1.0.1
-http.response.bytes,long,extended,1437,1.0.1
-http.response.status_code,long,extended,404,1.0.1
-http.version,keyword,extended,1.1,1.0.1
-log.level,keyword,core,err,1.0.1
-log.original,keyword,core,Sep 19 08:26:10 localhost My log,1.0.1
-network.application,keyword,extended,aim,1.0.1
-network.bytes,long,core,368,1.0.1
-network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,1.0.1
-network.direction,keyword,core,inbound,1.0.1
-network.forwarded_ip,ip,core,192.1.1.2,1.0.1
-network.iana_number,keyword,extended,6,1.0.1
-network.name,keyword,extended,Guest Wifi,1.0.1
-network.packets,long,core,24,1.0.1
-network.protocol,keyword,core,http,1.0.1
-network.transport,keyword,core,tcp,1.0.1
-network.type,keyword,core,ipv4,1.0.1
-observer.geo.city_name,keyword,core,Montreal,1.0.1
-observer.geo.continent_name,keyword,core,North America,1.0.1
-observer.geo.country_iso_code,keyword,core,CA,1.0.1
-observer.geo.country_name,keyword,core,Canada,1.0.1
-observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-observer.geo.name,keyword,extended,boston-dc,1.0.1
-observer.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-observer.geo.region_name,keyword,core,Quebec,1.0.1
-observer.hostname,keyword,core,,1.0.1
-observer.ip,ip,core,,1.0.1
-observer.mac,keyword,core,,1.0.1
-observer.os.family,keyword,extended,debian,1.0.1
-observer.os.full,keyword,extended,Mac OS Mojave,1.0.1
-observer.os.kernel,keyword,extended,4.4.0-112-generic,1.0.1
-observer.os.name,keyword,extended,Mac OS X,1.0.1
-observer.os.platform,keyword,extended,darwin,1.0.1
-observer.os.version,keyword,extended,10.14.1,1.0.1
-observer.serial_number,keyword,extended,,1.0.1
-observer.type,keyword,core,firewall,1.0.1
-observer.vendor,keyword,core,,1.0.1
-observer.version,keyword,core,,1.0.1
-organization.id,keyword,extended,,1.0.1
-organization.name,keyword,extended,,1.0.1
-os.family,keyword,extended,debian,1.0.1
-os.full,keyword,extended,Mac OS Mojave,1.0.1
-os.kernel,keyword,extended,4.4.0-112-generic,1.0.1
-os.name,keyword,extended,Mac OS X,1.0.1
-os.platform,keyword,extended,darwin,1.0.1
-os.version,keyword,extended,10.14.1,1.0.1
-process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",1.0.1
-process.executable,keyword,extended,/usr/bin/ssh,1.0.1
-process.name,keyword,extended,ssh,1.0.1
-process.pid,long,core,4242,1.0.1
-process.ppid,long,extended,4241,1.0.1
-process.start,date,extended,2016-05-23T08:05:34.853Z,1.0.1
-process.thread.id,long,extended,4242,1.0.1
-process.title,keyword,extended,,1.0.1
-process.working_directory,keyword,extended,/home/alice,1.0.1
-related.ip,ip,extended,,1.0.1
-server.address,keyword,extended,,1.0.1
-server.bytes,long,core,184,1.0.1
-server.domain,keyword,core,,1.0.1
-server.geo.city_name,keyword,core,Montreal,1.0.1
-server.geo.continent_name,keyword,core,North America,1.0.1
-server.geo.country_iso_code,keyword,core,CA,1.0.1
-server.geo.country_name,keyword,core,Canada,1.0.1
-server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-server.geo.name,keyword,extended,boston-dc,1.0.1
-server.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-server.geo.region_name,keyword,core,Quebec,1.0.1
-server.ip,ip,core,,1.0.1
-server.mac,keyword,core,,1.0.1
-server.packets,long,core,12,1.0.1
-server.port,long,core,,1.0.1
-server.user.email,keyword,extended,,1.0.1
-server.user.full_name,keyword,extended,Albert Einstein,1.0.1
-server.user.group.id,keyword,extended,,1.0.1
-server.user.group.name,keyword,extended,,1.0.1
-server.user.hash,keyword,extended,,1.0.1
-server.user.id,keyword,core,,1.0.1
-server.user.name,keyword,core,albert,1.0.1
-service.ephemeral_id,keyword,extended,8a4f500f,1.0.1
-service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,1.0.1
-service.name,keyword,core,elasticsearch-metrics,1.0.1
-service.state,keyword,core,,1.0.1
-service.type,keyword,core,elasticsearch,1.0.1
-service.version,keyword,core,3.2.4,1.0.1
-source.address,keyword,extended,,1.0.1
-source.bytes,long,core,184,1.0.1
-source.domain,keyword,core,,1.0.1
-source.geo.city_name,keyword,core,Montreal,1.0.1
-source.geo.continent_name,keyword,core,North America,1.0.1
-source.geo.country_iso_code,keyword,core,CA,1.0.1
-source.geo.country_name,keyword,core,Canada,1.0.1
-source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",1.0.1
-source.geo.name,keyword,extended,boston-dc,1.0.1
-source.geo.region_iso_code,keyword,core,CA-QC,1.0.1
-source.geo.region_name,keyword,core,Quebec,1.0.1
-source.ip,ip,core,,1.0.1
-source.mac,keyword,core,,1.0.1
-source.packets,long,core,12,1.0.1
-source.port,long,core,,1.0.1
-source.user.email,keyword,extended,,1.0.1
-source.user.full_name,keyword,extended,Albert Einstein,1.0.1
-source.user.group.id,keyword,extended,,1.0.1
-source.user.group.name,keyword,extended,,1.0.1
-source.user.hash,keyword,extended,,1.0.1
-source.user.id,keyword,core,,1.0.1
-source.user.name,keyword,core,albert,1.0.1
-url.domain,keyword,extended,www.elastic.co,1.0.1
-url.fragment,keyword,extended,,1.0.1
-url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,1.0.1
-url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,1.0.1
-url.password,keyword,extended,,1.0.1
-url.path,keyword,extended,,1.0.1
-url.port,long,extended,443,1.0.1
-url.query,keyword,extended,,1.0.1
-url.scheme,keyword,extended,https,1.0.1
-url.username,keyword,extended,,1.0.1
-user.email,keyword,extended,,1.0.1
-user.full_name,keyword,extended,Albert Einstein,1.0.1
-user.group.id,keyword,extended,,1.0.1
-user.group.name,keyword,extended,,1.0.1
-user.hash,keyword,extended,,1.0.1
-user.id,keyword,core,,1.0.1
-user.name,keyword,core,albert,1.0.1
-user_agent.device.name,keyword,extended,iPhone,1.0.1
-user_agent.name,keyword,extended,Safari,1.0.1
-user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",1.0.1
-user_agent.os.family,keyword,extended,debian,1.0.1
-user_agent.os.full,keyword,extended,Mac OS Mojave,1.0.1
-user_agent.os.kernel,keyword,extended,4.4.0-112-generic,1.0.1
-user_agent.os.name,keyword,extended,Mac OS X,1.0.1
-user_agent.os.platform,keyword,extended,darwin,1.0.1
-user_agent.os.version,keyword,extended,10.14.1,1.0.1
-user_agent.version,keyword,extended,12.0,1.0.1
+ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
+1.0.1,true,base,@timestamp,date,core,2016-05-23T08:05:34.853Z,Date/time when the event originated.
+1.0.1,true,base,labels,object,core,"{'application': 'foo-bar', 'env': 'production'}",Custom key/value pairs.
+1.0.1,true,base,message,text,core,Hello World,Log message optimized for viewing in a log viewer.
+1.0.1,true,base,tags,keyword,core,"[""production"", ""env2""]",List of keywords used to tag each event.
+1.0.1,true,agent,agent.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this agent.
+1.0.1,true,agent,agent.id,keyword,core,8a4f500d,Unique identifier of this agent.
+1.0.1,true,agent,agent.name,keyword,core,foo,Custom name of the agent.
+1.0.1,true,agent,agent.type,keyword,core,filebeat,Type of the agent.
+1.0.1,true,agent,agent.version,keyword,core,6.0.0-rc2,Version of the agent.
+1.0.1,true,client,client.address,keyword,extended,,Client network address.
+1.0.1,true,client,client.bytes,long,core,184,Bytes sent from the client to the server.
+1.0.1,true,client,client.domain,keyword,core,,Client domain.
+1.0.1,true,client,client.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,client,client.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,client,client.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,client,client.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,client,client.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,client,client.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,client,client.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,client,client.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,client,client.ip,ip,core,,IP address of the client.
+1.0.1,true,client,client.mac,keyword,core,,MAC address of the client.
+1.0.1,true,client,client.packets,long,core,12,Packets sent from the client to the server.
+1.0.1,true,client,client.port,long,core,,Port of the client.
+1.0.1,true,client,client.user.email,keyword,extended,,User email address.
+1.0.1,true,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,client,client.user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,client,client.user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
+1.0.1,true,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
+1.0.1,true,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
+1.0.1,true,cloud,cloud.instance.name,keyword,extended,,Instance name of the host machine.
+1.0.1,true,cloud,cloud.machine.type,keyword,extended,t2.medium,Machine type of the host machine.
+1.0.1,true,cloud,cloud.provider,keyword,extended,aws,Name of the cloud provider.
+1.0.1,true,cloud,cloud.region,keyword,extended,us-east-1,Region in which this host is running.
+1.0.1,true,container,container.id,keyword,core,,Unique container id.
+1.0.1,true,container,container.image.name,keyword,extended,,Name of the image the container was built on.
+1.0.1,true,container,container.image.tag,keyword,extended,,Container image tag.
+1.0.1,true,container,container.labels,object,extended,,Image labels.
+1.0.1,true,container,container.name,keyword,extended,,Container name.
+1.0.1,true,container,container.runtime,keyword,extended,docker,Runtime managing this container.
+1.0.1,true,destination,destination.address,keyword,extended,,Destination network address.
+1.0.1,true,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
+1.0.1,true,destination,destination.domain,keyword,core,,Destination domain.
+1.0.1,true,destination,destination.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,destination,destination.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,destination,destination.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,destination,destination.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,destination,destination.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,destination,destination.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,destination,destination.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,destination,destination.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,destination,destination.ip,ip,core,,IP address of the destination.
+1.0.1,true,destination,destination.mac,keyword,core,,MAC address of the destination.
+1.0.1,true,destination,destination.packets,long,core,12,Packets sent from the destination to the source.
+1.0.1,true,destination,destination.port,long,core,,Port of the destination.
+1.0.1,true,destination,destination.user.email,keyword,extended,,User email address.
+1.0.1,true,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,destination,destination.user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,ecs,ecs.version,keyword,core,1.0.0,ECS version this event conforms to.
+1.0.1,true,error,error.code,keyword,core,,Error code describing the error.
+1.0.1,true,error,error.id,keyword,core,,Unique identifier for the error.
+1.0.1,true,error,error.message,text,core,,Error message.
+1.0.1,true,event,event.action,keyword,core,user-password-change,The action captured by the event.
+1.0.1,true,event,event.category,keyword,core,user-management,Event category.
+1.0.1,true,event,event.created,date,core,,Time when the event was first read by an agent or by your pipeline.
+1.0.1,true,event,event.dataset,keyword,core,stats,Name of the dataset.
+1.0.1,true,event,event.duration,long,core,,Duration of the event in nanoseconds.
+1.0.1,true,event,event.end,date,extended,,event.end contains the date when the event ended or when the activity was last observed.
+1.0.1,true,event,event.hash,keyword,extended,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+1.0.1,true,event,event.id,keyword,core,8a4f500d,Unique ID to describe the event.
+1.0.1,true,event,event.kind,keyword,extended,state,The kind of the event.
+1.0.1,true,event,event.module,keyword,core,mysql,Name of the module this data is coming from.
+1.0.1,false,event,event.original,keyword,core,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+1.0.1,true,event,event.outcome,keyword,extended,success,The outcome of the event.
+1.0.1,true,event,event.risk_score,float,core,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
+1.0.1,true,event,event.risk_score_norm,float,extended,,Normalized risk score or priority of the event (0-100).
+1.0.1,true,event,event.severity,long,core,7,Original severity of the event.
+1.0.1,true,event,event.start,date,extended,,event.start contains the date when the event started or when the activity was first observed.
+1.0.1,true,event,event.timezone,keyword,extended,,Event time zone.
+1.0.1,true,event,event.type,keyword,core,,Reserved for future usage.
+1.0.1,true,file,file.ctime,date,extended,,Last time file metadata changed.
+1.0.1,true,file,file.device,keyword,extended,,Device that is the source of the file.
+1.0.1,true,file,file.extension,keyword,extended,png,File extension.
+1.0.1,true,file,file.gid,keyword,extended,,Primary group ID (GID) of the file.
+1.0.1,true,file,file.group,keyword,extended,,Primary group name of the file.
+1.0.1,true,file,file.inode,keyword,extended,,Inode representing the file in the filesystem.
+1.0.1,true,file,file.mode,keyword,extended,416,Mode of the file in octal representation.
+1.0.1,true,file,file.mtime,date,extended,,Last time file content was modified.
+1.0.1,true,file,file.owner,keyword,extended,,File owner's username.
+1.0.1,true,file,file.path,keyword,extended,,Path to the file.
+1.0.1,true,file,file.size,long,extended,,File size in bytes (field is only added when `type` is `file`).
+1.0.1,true,file,file.target_path,keyword,extended,,Target path for symlinks.
+1.0.1,true,file,file.type,keyword,extended,,"File type (file, dir, or symlink)."
+1.0.1,true,file,file.uid,keyword,extended,,The user ID (UID) or security identifier (SID) of the file owner.
+1.0.1,true,geo,geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,geo,geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,geo,geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,geo,geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,geo,geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,geo,geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,geo,geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,geo,geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,group,group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,group,group.name,keyword,extended,,Name of the group.
+1.0.1,true,host,host.architecture,keyword,core,x86_64,Operating system architecture.
+1.0.1,true,host,host.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,host,host.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,host,host.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,host,host.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,host,host.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,host,host.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,host,host.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,host,host.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,host,host.hostname,keyword,core,,Hostname of the host.
+1.0.1,true,host,host.id,keyword,core,,Unique host id.
+1.0.1,true,host,host.ip,ip,core,,Host ip address.
+1.0.1,true,host,host.mac,keyword,core,,Host mac address.
+1.0.1,true,host,host.name,keyword,core,,Name of the host.
+1.0.1,true,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.0.1,true,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.0.1,true,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.0.1,true,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.0.1,true,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.0.1,true,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.0.1,true,host,host.type,keyword,core,,Type of host.
+1.0.1,true,host,host.user.email,keyword,extended,,User email address.
+1.0.1,true,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,host,host.user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,host,host.user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
+1.0.1,true,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
+1.0.1,true,http,http.request.bytes,long,extended,1437,Total size in bytes of the request (body and headers).
+1.0.1,true,http,http.request.method,keyword,extended,"get, post, put",HTTP request method.
+1.0.1,true,http,http.request.referrer,keyword,extended,https://blog.example.com/,Referrer for this HTTP request.
+1.0.1,true,http,http.response.body.bytes,long,extended,887,Size in bytes of the response body.
+1.0.1,true,http,http.response.body.content,keyword,extended,Hello world,The full HTTP response body.
+1.0.1,true,http,http.response.bytes,long,extended,1437,Total size in bytes of the response (body and headers).
+1.0.1,true,http,http.response.status_code,long,extended,404,HTTP response status code.
+1.0.1,true,http,http.version,keyword,extended,1.1,HTTP version.
+1.0.1,true,log,log.level,keyword,core,err,Log level of the log event.
+1.0.1,false,log,log.original,keyword,core,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
+1.0.1,true,network,network.application,keyword,extended,aim,Application level protocol name.
+1.0.1,true,network,network.bytes,long,core,368,Total bytes transferred in both directions.
+1.0.1,true,network,network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
+1.0.1,true,network,network.direction,keyword,core,inbound,Direction of the network traffic.
+1.0.1,true,network,network.forwarded_ip,ip,core,192.1.1.2,Host IP address when the source IP address is the proxy.
+1.0.1,true,network,network.iana_number,keyword,extended,6,IANA Protocol Number.
+1.0.1,true,network,network.name,keyword,extended,Guest Wifi,Name given by operators to sections of their network.
+1.0.1,true,network,network.packets,long,core,24,Total packets transferred in both directions.
+1.0.1,true,network,network.protocol,keyword,core,http,L7 Network protocol name.
+1.0.1,true,network,network.transport,keyword,core,tcp,Protocol Name corresponding to the field `iana_number`.
+1.0.1,true,network,network.type,keyword,core,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
+1.0.1,true,observer,observer.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,observer,observer.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,observer,observer.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,observer,observer.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,observer,observer.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,observer,observer.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,observer,observer.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,observer,observer.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,observer,observer.hostname,keyword,core,,Hostname of the observer.
+1.0.1,true,observer,observer.ip,ip,core,,IP address of the observer.
+1.0.1,true,observer,observer.mac,keyword,core,,MAC address of the observer
+1.0.1,true,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.0.1,true,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.0.1,true,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.0.1,true,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.0.1,true,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.0.1,true,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.0.1,true,observer,observer.serial_number,keyword,extended,,Observer serial number.
+1.0.1,true,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
+1.0.1,true,observer,observer.vendor,keyword,core,,observer vendor information.
+1.0.1,true,observer,observer.version,keyword,core,,Observer version.
+1.0.1,true,organization,organization.id,keyword,extended,,Unique identifier for the organization.
+1.0.1,true,organization,organization.name,keyword,extended,,Organization name.
+1.0.1,true,os,os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.0.1,true,os,os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.0.1,true,os,os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.0.1,true,os,os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.0.1,true,os,os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.0.1,true,os,os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.0.1,true,process,process.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.0.1,true,process,process.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.0.1,true,process,process.name,keyword,extended,ssh,Process name.
+1.0.1,true,process,process.pid,long,core,4242,Process id.
+1.0.1,true,process,process.ppid,long,extended,4241,Parent process' pid.
+1.0.1,true,process,process.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
+1.0.1,true,process,process.thread.id,long,extended,4242,Thread ID.
+1.0.1,true,process,process.title,keyword,extended,,Process title.
+1.0.1,true,process,process.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.0.1,true,related,related.ip,ip,extended,,All of the IPs seen on your event.
+1.0.1,true,server,server.address,keyword,extended,,Server network address.
+1.0.1,true,server,server.bytes,long,core,184,Bytes sent from the server to the client.
+1.0.1,true,server,server.domain,keyword,core,,Server domain.
+1.0.1,true,server,server.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,server,server.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,server,server.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,server,server.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,server,server.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,server,server.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,server,server.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,server,server.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,server,server.ip,ip,core,,IP address of the server.
+1.0.1,true,server,server.mac,keyword,core,,MAC address of the server.
+1.0.1,true,server,server.packets,long,core,12,Packets sent from the server to the client.
+1.0.1,true,server,server.port,long,core,,Port of the server.
+1.0.1,true,server,server.user.email,keyword,extended,,User email address.
+1.0.1,true,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,server,server.user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,server,server.user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
+1.0.1,true,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+1.0.1,true,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
+1.0.1,true,service,service.state,keyword,core,,Current state of the service.
+1.0.1,true,service,service.type,keyword,core,elasticsearch,The type of the service.
+1.0.1,true,service,service.version,keyword,core,3.2.4,Version of the service.
+1.0.1,true,source,source.address,keyword,extended,,Source network address.
+1.0.1,true,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
+1.0.1,true,source,source.domain,keyword,core,,Source domain.
+1.0.1,true,source,source.geo.city_name,keyword,core,Montreal,City name.
+1.0.1,true,source,source.geo.continent_name,keyword,core,North America,Name of the continent.
+1.0.1,true,source,source.geo.country_iso_code,keyword,core,CA,Country ISO code.
+1.0.1,true,source,source.geo.country_name,keyword,core,Canada,Country name.
+1.0.1,true,source,source.geo.location,geo_point,core,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.0.1,true,source,source.geo.name,keyword,extended,boston-dc,User-defined description of a location.
+1.0.1,true,source,source.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
+1.0.1,true,source,source.geo.region_name,keyword,core,Quebec,Region name.
+1.0.1,true,source,source.ip,ip,core,,IP address of the source.
+1.0.1,true,source,source.mac,keyword,core,,MAC address of the source.
+1.0.1,true,source,source.packets,long,core,12,Packets sent from the source to the destination.
+1.0.1,true,source,source.port,long,core,,Port of the source.
+1.0.1,true,source,source.user.email,keyword,extended,,User email address.
+1.0.1,true,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,source,source.user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,source,source.user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,url,url.domain,keyword,extended,www.elastic.co,Domain of the url.
+1.0.1,true,url,url.fragment,keyword,extended,,Portion of the url after the `#`.
+1.0.1,true,url,url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.0.1,true,url,url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.0.1,true,url,url.password,keyword,extended,,Password of the request.
+1.0.1,true,url,url.path,keyword,extended,,"Path of the request, such as ""/search""."
+1.0.1,true,url,url.port,long,extended,443,"Port of the request, such as 443."
+1.0.1,true,url,url.query,keyword,extended,,Query string of the request.
+1.0.1,true,url,url.scheme,keyword,extended,https,Scheme of the url.
+1.0.1,true,url,url.username,keyword,extended,,Username of the request.
+1.0.1,true,user,user.email,keyword,extended,,User email address.
+1.0.1,true,user,user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.0.1,true,user,user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
+1.0.1,true,user,user.group.name,keyword,extended,,Name of the group.
+1.0.1,true,user,user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
+1.0.1,true,user,user.id,keyword,core,,One or multiple unique identifiers of the user.
+1.0.1,true,user,user.name,keyword,core,albert,Short name or login of the user.
+1.0.1,true,user_agent,user_agent.device.name,keyword,extended,iPhone,Name of the device.
+1.0.1,true,user_agent,user_agent.name,keyword,extended,Safari,Name of the user agent.
+1.0.1,true,user_agent,user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed version of the user_agent.
+1.0.1,true,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.0.1,true,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.0.1,true,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.0.1,true,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.0.1,true,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.0.1,true,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
+1.0.1,true,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.

--- a/scripts/generators/csv_generator.py
+++ b/scripts/generators/csv_generator.py
@@ -29,12 +29,22 @@ def save_csv(file, sorted_fields, version):
                                    quoting=csv.QUOTE_MINIMAL,
                                    lineterminator='\n')
 
-        schema_writer.writerow(["Field", "Type", "Level", "Example", "ECS version"])
+        schema_writer.writerow(["ECS_Version", "Indexed", "Field_Set", "Field",
+                                "Type", "Level", "Example", "Description"])
         for field in sorted_fields:
+            key_parts = field['flat_name'].split('.')
+            if len(key_parts) == 1:
+                field_set = 'base'
+            else:
+                field_set = key_parts[0]
+
             schema_writer.writerow([
+                version,
+                str(field.get('index', True)).lower(),
+                field_set,
                 field['flat_name'],
                 field['type'],
                 field['level'],
                 field.get('example', ''),
-                version
+                field['short'],
             ])


### PR DESCRIPTION
Backport of PR #650 to 1.0 branch. Original message:

In this PR:

* Add the field set column
* Add the short description
* Add whether the field should be indexed
* Reorder the columns a bit, so the stable length values are first

Preview GitHub's rendering of [generated/csv/fields.csv](https://github.com/webmat/ecs/blob/backport_650_1.0/generated/csv/fields.csv) (scroll right for definitions)