### PR TITLE
Marks items as arrays if required.

### DIFF
--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -37,6 +37,7 @@
       level: core
       type: object
       object_type: keyword
+      is_array: true
       example: {env: production, application: foo-bar}
       short: Custom key/value pairs.
       description: >

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -48,6 +48,7 @@
     - name: header_flags
       level: extended
       type: keyword
+      is_array: true
       short: Array of DNS header flags.
       description: >
         Array of 2 letter DNS header flags.
@@ -129,6 +130,7 @@
     - name: answers
       level: extended
       type: object
+      is_array: true
       short: Array of DNS answers.
       description: >
         An array containing an object for each answer section returned by
@@ -190,6 +192,7 @@
     - name: resolved_ip
       level: extended
       type: ip
+      is_array: true
       short: Array containing all IPs seen in answers.data
       description: >
         Array containing all IPs seen in `answers.data`.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -122,6 +122,7 @@
     - name: args
       level: extended
       type: keyword
+      is_array: true
       short: Array of process arguments.
       description: >
         Array of process arguments, starting with the absolute path to the executable.
@@ -132,6 +133,7 @@
     - name: parent.args
       level: extended
       type: keyword
+      is_array: true
       short: Array of process arguments.
       description: >
         Array of process arguments.

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -69,6 +69,7 @@
 
     - name: client.supported_ciphers
       type: keyword
+      is_array: true
       level: extended
       description: Array of ciphers offered by the client during the client hello.
       example: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."]
@@ -99,6 +100,7 @@
 
     - name: client.certificate_chain
       type: keyword
+      is_array: true
       level: extended
       description: >
         Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is
@@ -146,6 +148,7 @@
 
     - name: server.supported_ciphers
       type: keyword
+      is_array: true
       level: extended
       description: Array of ciphers offered by the server during the server hello.
       example: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."]
@@ -176,6 +179,7 @@
 
     - name: server.certificate_chain
       type: keyword
+      is_array: true
       level: extended
       description: >
         Array of PEM-encoded certificates that make up the certificate chain offered by the server. This is

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -24,6 +24,7 @@
     - name: id
       level: core
       type: keyword
+      is_array: true
       description: >
         One or multiple unique identifiers of the user.
 


### PR DESCRIPTION
This is to aid code generation for languages that support array constructs.

Note: This field is optional, the default value is false. Lack of field presence implies a value of false.