### PR TITLE
Remove tls.server.supported_ciphers field (#662)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Removed unnecessary field `tls.server.supported_ciphers`. #662
+
 #### Added
 
 #### Improvements

--- a/code/go/ecs/tls.go
+++ b/code/go/ecs/tls.go
@@ -110,9 +110,6 @@ type Tls struct {
 	// handshake.
 	ServerJa3s string `ecs:"server.ja3s"`
 
-	// Array of ciphers offered by the server during the server hello.
-	ServerSupportedCiphers string `ecs:"server.supported_ciphers"`
-
 	// Subject of the x.509 certificate presented by the server.
 	ServerSubject string `ecs:"server.subject"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4279,17 +4279,6 @@ example: `CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com`
 
 // ===============================================================
 
-| tls.server.supported_ciphers
-| Array of ciphers offered by the server during the server hello.
-
-type: keyword
-
-example: `['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']`
-
-| extended
-
-// ===============================================================
-
 | tls.version
 | Numeric part of the version parsed from the original string.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3250,15 +3250,6 @@
       ignore_above: 1024
       description: Subject of the x.509 certificate presented by the server.
       example: CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com
-    - name: server.supported_ciphers
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Array of ciphers offered by the server during the server hello.
-      example:
-      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-      - '...'
     - name: version
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -411,7 +411,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.3.0,true,tls,tls.server.not_after,date,extended,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
 1.3.0,true,tls,tls.server.not_before,date,extended,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
 1.3.0,true,tls,tls.server.subject,keyword,extended,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
-1.3.0,true,tls,tls.server.supported_ciphers,keyword,extended,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the server during the server hello.
 1.3.0,true,tls,tls.version,keyword,extended,1.2,Numeric part of the version parsed from the original string.
 1.3.0,true,tls,tls.version_protocol,keyword,extended,tls,Normalized lowercase protocol name parsed from original string.
 1.3.0,true,trace,trace.id,keyword,extended,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4610,7 +4610,7 @@ tls.server.certificate:
   ignore_above: 1024
   level: extended
   name: server.certificate
-  order: 26
+  order: 25
   short: PEM-encoded stand-alone certificate offered by the server. This is usually
     mutually-exclusive of `server.certificate_chain` since this value also exists
     in that list.
@@ -4626,7 +4626,7 @@ tls.server.certificate_chain:
   ignore_above: 1024
   level: extended
   name: server.certificate_chain
-  order: 25
+  order: 24
   short: Array of PEM-encoded certificates that make up the certificate chain offered
     by the server. This is usually mutually-exclusive of `server.certificate` since
     that value should be the first certificate in the chain.
@@ -4640,7 +4640,7 @@ tls.server.hash.md5:
   ignore_above: 1024
   level: extended
   name: server.hash.md5
-  order: 27
+  order: 26
   short: Certificate fingerprint using the MD5 digest of DER-encoded version of certificate
     offered by the server. For consistency with other hash values, this value should
     be formatted as an uppercase hash.
@@ -4654,7 +4654,7 @@ tls.server.hash.sha1:
   ignore_above: 1024
   level: extended
   name: server.hash.sha1
-  order: 28
+  order: 27
   short: Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate
     offered by the server. For consistency with other hash values, this value should
     be formatted as an uppercase hash.
@@ -4668,7 +4668,7 @@ tls.server.hash.sha256:
   ignore_above: 1024
   level: extended
   name: server.hash.sha256
-  order: 29
+  order: 28
   short: Certificate fingerprint using the SHA256 digest of DER-encoded version of
     certificate offered by the server. For consistency with other hash values, this
     value should be formatted as an uppercase hash.
@@ -4680,7 +4680,7 @@ tls.server.issuer:
   ignore_above: 1024
   level: extended
   name: server.issuer
-  order: 22
+  order: 21
   short: Subject of the issuer of the x.509 certificate presented by the server.
   type: keyword
 tls.server.ja3s:
@@ -4701,7 +4701,7 @@ tls.server.not_after:
   flat_name: tls.server.not_after
   level: extended
   name: server.not_after
-  order: 24
+  order: 23
   short: Timestamp indicating when server certificate is no longer considered valid.
   type: date
 tls.server.not_before:
@@ -4710,7 +4710,7 @@ tls.server.not_before:
   flat_name: tls.server.not_before
   level: extended
   name: server.not_before
-  order: 23
+  order: 22
   short: Timestamp indicating when server certificate is first considered valid.
   type: date
 tls.server.subject:
@@ -4720,21 +4720,8 @@ tls.server.subject:
   ignore_above: 1024
   level: extended
   name: server.subject
-  order: 21
-  short: Subject of the x.509 certificate presented by the server.
-  type: keyword
-tls.server.supported_ciphers:
-  description: Array of ciphers offered by the server during the server hello.
-  example:
-  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-  - '...'
-  flat_name: tls.server.supported_ciphers
-  ignore_above: 1024
-  level: extended
-  name: server.supported_ciphers
   order: 20
-  short: Array of ciphers offered by the server during the server hello.
+  short: Subject of the x.509 certificate presented by the server.
   type: keyword
 tls.version:
   description: Numeric part of the version parsed from the original string.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5095,7 +5095,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.certificate
-      order: 26
+      order: 25
       short: PEM-encoded stand-alone certificate offered by the server. This is usually
         mutually-exclusive of `server.certificate_chain` since this value also exists
         in that list.
@@ -5111,7 +5111,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.certificate_chain
-      order: 25
+      order: 24
       short: Array of PEM-encoded certificates that make up the certificate chain
         offered by the server. This is usually mutually-exclusive of `server.certificate`
         since that value should be the first certificate in the chain.
@@ -5125,7 +5125,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.hash.md5
-      order: 27
+      order: 26
       short: Certificate fingerprint using the MD5 digest of DER-encoded version of
         certificate offered by the server. For consistency with other hash values,
         this value should be formatted as an uppercase hash.
@@ -5139,7 +5139,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.hash.sha1
-      order: 28
+      order: 27
       short: Certificate fingerprint using the SHA1 digest of DER-encoded version
         of certificate offered by the server. For consistency with other hash values,
         this value should be formatted as an uppercase hash.
@@ -5153,7 +5153,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.hash.sha256
-      order: 29
+      order: 28
       short: Certificate fingerprint using the SHA256 digest of DER-encoded version
         of certificate offered by the server. For consistency with other hash values,
         this value should be formatted as an uppercase hash.
@@ -5166,7 +5166,7 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.issuer
-      order: 22
+      order: 21
       short: Subject of the issuer of the x.509 certificate presented by the server.
       type: keyword
     server.ja3s:
@@ -5187,7 +5187,7 @@ tls:
       flat_name: tls.server.not_after
       level: extended
       name: server.not_after
-      order: 24
+      order: 23
       short: Timestamp indicating when server certificate is no longer considered
         valid.
       type: date
@@ -5198,7 +5198,7 @@ tls:
       flat_name: tls.server.not_before
       level: extended
       name: server.not_before
-      order: 23
+      order: 22
       short: Timestamp indicating when server certificate is first considered valid.
       type: date
     server.subject:
@@ -5208,21 +5208,8 @@ tls:
       ignore_above: 1024
       level: extended
       name: server.subject
-      order: 21
-      short: Subject of the x.509 certificate presented by the server.
-      type: keyword
-    server.supported_ciphers:
-      description: Array of ciphers offered by the server during the server hello.
-      example:
-      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-      - '...'
-      flat_name: tls.server.supported_ciphers
-      ignore_above: 1024
-      level: extended
-      name: server.supported_ciphers
       order: 20
-      short: Array of ciphers offered by the server during the server hello.
+      short: Subject of the x.509 certificate presented by the server.
       type: keyword
     version:
       description: Numeric part of the version parsed from the original string.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1914,10 +1914,6 @@
                 "subject": {
                   "ignore_above": 1024, 
                   "type": "keyword"
-                }, 
-                "supported_ciphers": {
-                  "ignore_above": 1024, 
-                  "type": "keyword"
                 }
               }
             }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1913,10 +1913,6 @@
               "subject": {
                 "ignore_above": 1024, 
                 "type": "keyword"
-              }, 
-              "supported_ciphers": {
-                "ignore_above": 1024, 
-                "type": "keyword"
               }
             }
           }, 

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -144,12 +144,6 @@
       description: A hash that identifies servers based on how they perform an SSL/TLS handshake.
       example: 394441ab65754e2207b1e1b457b3641d
 
-    - name: server.supported_ciphers
-      type: keyword
-      level: extended
-      description: Array of ciphers offered by the server during the server hello.
-      example: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."]
-
     - name: server.subject
       type: keyword
       level: extended


### PR DESCRIPTION
Unlike the client, the server doesn't provide a list of supported ciphers in its hello message.