### PR TITLE
Add the default text analyzer to some fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,9 +16,10 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Add default `text` analyzer to `user_agent.original`. #575
+* Add default `text` analyzer as a multi-field to `user_agent.original`. #575
 * Added `file.attributes`. #611
 * Add `file.drive_letter`. #620
+* Added default `text` analyzer as a multi-field to around 25 more fields. #680
 
 #### Improvements
 

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -22,14 +22,14 @@ package ecs
 // Fields to classify events and alerts according to a threat taxonomy such as
 // the Mitre ATT&CK framework.
 // These fields are for users to classify alerts from all of their sources
-// (e.g. IDS, NGFW, etc.) within a  common taxonomy. The threat.tactic.* are
-// meant to capture the high level category of the threat  (e.g. "impact"). The
+// (e.g. IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are
+// meant to capture the high level category of the threat (e.g. "impact"). The
 // threat.technique.* fields are meant to capture which kind of approach is
-// used by  this detected threat, to accomplish the goal (e.g. "endpoint denial
+// used by this detected threat, to accomplish the goal (e.g. "endpoint denial
 // of service").
 type Threat struct {
 	// Name of the threat framework used to further categorize and classify the
-	// tactic and technique of the reported threat.   Framework classification
+	// tactic and technique of the reported threat. Framework classification
 	// can be provided by detecting systems, evaluated at ingest time, or
 	// retrospectively tagged to events.
 	Framework string `ecs:"framework"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3994,7 +3994,7 @@ example: `co.uk`
 
 Fields to classify events and alerts according to a threat taxonomy such as the Mitre ATT&CK framework.
 
-These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a  common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat  (e.g. "impact"). The threat.technique.* fields are meant to capture which kind of approach is used by  this detected threat, to accomplish the goal (e.g. "endpoint denial of service").
+These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat (e.g. "impact"). The threat.technique.* fields are meant to capture which kind of approach is used by this detected threat, to accomplish the goal (e.g. "endpoint denial of service").
 
 ==== Threat Field Details
 
@@ -4005,7 +4005,7 @@ These fields are for users to classify alerts from all of their sources (e.g. ID
 // ===============================================================
 
 | threat.framework
-| Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat.   Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events.
+| Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat. Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events.
 
 type: keyword
 
@@ -4063,6 +4063,12 @@ example: `T1499`
 | The name of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
 
 type: keyword
+
+Multi-fields:
+
+* threat.technique.name.text (type: text)
+
+
 
 example: `endpoint denial of service`
 
@@ -4907,6 +4913,12 @@ example: `CVSS`
 | The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
 
 type: keyword
+
+Multi-fields:
+
+* vulnerability.description.text (type: text)
+
+
 
 example: `In macOS before 2.12.6, there is a vulnerability in the RPC...`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -183,6 +183,12 @@ example: `15169`
 
 type: keyword
 
+Multi-fields:
+
+* as.organization.name.text (type: text)
+
+
+
 example: `Google LLC`
 
 | extended
@@ -1075,6 +1081,12 @@ type: text
 
 type: keyword
 
+Multi-fields:
+
+* error.stack_trace.text (type: text)
+
+
+
 
 
 | extended
@@ -1566,6 +1578,12 @@ example: `alice`
 
 type: keyword
 
+Multi-fields:
+
+* file.path.text (type: text)
+
+
+
 example: `/home/alice/example.png`
 
 | extended
@@ -1589,6 +1607,12 @@ example: `16384`
 | Target path for symlinks.
 
 type: keyword
+
+Multi-fields:
+
+* file.target_path.text (type: text)
+
+
 
 
 
@@ -2082,6 +2106,12 @@ example: `887`
 
 type: keyword
 
+Multi-fields:
+
+* http.request.body.content.text (type: text)
+
+
+
 example: `Hello world`
 
 | extended
@@ -2138,6 +2168,12 @@ example: `887`
 | The full HTTP response body.
 
 type: keyword
+
+Multi-fields:
+
+* http.response.body.content.text (type: text)
+
+
 
 example: `Hello world`
 
@@ -2699,6 +2735,12 @@ type: keyword
 
 type: keyword
 
+Multi-fields:
+
+* organization.name.text (type: text)
+
+
+
 
 
 | extended
@@ -2736,6 +2778,12 @@ example: `debian`
 
 type: keyword
 
+Multi-fields:
+
+* os.full.text (type: text)
+
+
+
 example: `Mac OS Mojave`
 
 | extended
@@ -2757,6 +2805,12 @@ example: `4.4.0-112-generic`
 | Operating system name, without the version.
 
 type: keyword
+
+Multi-fields:
+
+* os.name.text (type: text)
+
+
 
 example: `Mac OS X`
 
@@ -3009,6 +3063,12 @@ Some arguments may be filtered to protect sensitive information.
 
 type: keyword
 
+Multi-fields:
+
+* process.command_line.text (type: text)
+
+
+
 example: `/usr/bin/ssh -l user 10.0.0.16`
 
 | extended
@@ -3019,6 +3079,12 @@ example: `/usr/bin/ssh -l user 10.0.0.16`
 | Absolute path to the process executable.
 
 type: keyword
+
+Multi-fields:
+
+* process.executable.text (type: text)
+
+
 
 example: `/usr/bin/ssh`
 
@@ -3045,6 +3111,12 @@ example: `137`
 Sometimes called program name or similar.
 
 type: keyword
+
+Multi-fields:
+
+* process.name.text (type: text)
+
+
 
 example: `ssh`
 
@@ -3085,6 +3157,12 @@ Some arguments may be filtered to protect sensitive information.
 
 type: keyword
 
+Multi-fields:
+
+* process.parent.command_line.text (type: text)
+
+
+
 example: `/usr/bin/ssh -l user 10.0.0.16`
 
 | extended
@@ -3095,6 +3173,12 @@ example: `/usr/bin/ssh -l user 10.0.0.16`
 | Absolute path to the process executable.
 
 type: keyword
+
+Multi-fields:
+
+* process.parent.executable.text (type: text)
+
+
 
 example: `/usr/bin/ssh`
 
@@ -3121,6 +3205,12 @@ example: `137`
 Sometimes called program name or similar.
 
 type: keyword
+
+Multi-fields:
+
+* process.parent.name.text (type: text)
+
+
 
 example: `ssh`
 
@@ -3201,6 +3291,12 @@ The proctitle, some times the same as process name. Can also be different: for e
 
 type: keyword
 
+Multi-fields:
+
+* process.parent.title.text (type: text)
+
+
+
 
 
 | extended
@@ -3222,6 +3318,12 @@ example: `1325`
 | The working directory of the process.
 
 type: keyword
+
+Multi-fields:
+
+* process.parent.working_directory.text (type: text)
+
+
 
 example: `/home/alice`
 
@@ -3302,6 +3404,12 @@ The proctitle, some times the same as process name. Can also be different: for e
 
 type: keyword
 
+Multi-fields:
+
+* process.title.text (type: text)
+
+
+
 
 
 | extended
@@ -3323,6 +3431,12 @@ example: `1325`
 | The working directory of the process.
 
 type: keyword
+
+Multi-fields:
+
+* process.working_directory.text (type: text)
+
+
 
 example: `/home/alice`
 
@@ -4403,6 +4517,12 @@ type: keyword
 
 type: keyword
 
+Multi-fields:
+
+* url.full.text (type: text)
+
+
+
 example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 
 | extended
@@ -4417,6 +4537,12 @@ Note that in network monitoring, the observed URL may be a full URL, whereas in 
 This field is meant to represent the URL as it was observed, complete or not.
 
 type: keyword
+
+Multi-fields:
+
+* url.original.text (type: text)
+
+
 
 example: `https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch`
 
@@ -4568,6 +4694,12 @@ type: keyword
 
 type: keyword
 
+Multi-fields:
+
+* user.full_name.text (type: text)
+
+
+
 example: `Albert Einstein`
 
 | extended
@@ -4602,6 +4734,12 @@ type: keyword
 | Short name or login of the user.
 
 type: keyword
+
+Multi-fields:
+
+* user.name.text (type: text)
+
+
 
 example: `albert`
 
@@ -4682,7 +4820,7 @@ type: keyword
 
 Multi-fields:
 
-user_agent.original.text (type: text)
+* user_agent.original.text (type: text)
 
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -129,6 +129,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
       example: Google LLC
   - name: client
@@ -171,6 +175,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
       example: Google LLC
     - name: bytes
@@ -313,6 +321,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: user.group.domain
@@ -350,6 +362,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: cloud
@@ -477,6 +493,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
       example: Google LLC
     - name: bytes
@@ -618,6 +638,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: user.group.domain
@@ -655,6 +679,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: dns
@@ -876,6 +904,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The stack trace of this error in plain text.
     - name: type
       level: extended
@@ -1224,6 +1256,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Full path to the file.
       example: /home/alice/example.png
     - name: size
@@ -1237,6 +1273,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Target path for symlinks.
     - name: type
       level: extended
@@ -1488,6 +1528,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
     - name: os.kernel
@@ -1500,6 +1544,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, without the version.
       example: Mac OS X
     - name: os.platform
@@ -1544,6 +1592,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: user.group.domain
@@ -1581,6 +1633,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: http
@@ -1600,6 +1656,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The full HTTP request body.
       example: Hello world
     - name: request.bytes
@@ -1633,6 +1693,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The full HTTP response body.
       example: Hello world
     - name: response.bytes
@@ -1984,6 +2048,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
     - name: os.kernel
@@ -1996,6 +2064,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, without the version.
       example: Mac OS X
     - name: os.platform
@@ -2060,6 +2132,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
   - name: os
     title: Operating System
@@ -2077,6 +2153,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
     - name: kernel
@@ -2089,6 +2169,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, without the version.
       example: Mac OS X
     - name: platform
@@ -2234,6 +2318,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -2243,6 +2331,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
     - name: exit_code
@@ -2277,6 +2369,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -2306,6 +2402,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -2315,6 +2415,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
     - name: parent.exit_code
@@ -2329,6 +2433,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -2371,6 +2479,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -2384,6 +2496,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The working directory of the process.
       example: /home/alice
     - name: pgid
@@ -2424,6 +2540,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -2437,6 +2557,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The working directory of the process.
       example: /home/alice
   - name: related
@@ -2499,6 +2623,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
       example: Google LLC
     - name: bytes
@@ -2641,6 +2769,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: user.group.domain
@@ -2678,6 +2810,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: service
@@ -2795,6 +2931,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Organization name.
       example: Google LLC
     - name: bytes
@@ -2937,6 +3077,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: user.group.domain
@@ -2974,6 +3118,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: threat
@@ -3328,6 +3476,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -3336,6 +3488,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -3433,6 +3589,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: User's full name, if available.
       example: Albert Einstein
     - name: group.domain
@@ -3470,6 +3630,10 @@
       level: core
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Short name or login of the user.
       example: albert
   - name: user_agent
@@ -3513,6 +3677,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
     - name: os.kernel
@@ -3525,6 +3693,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: Operating system name, without the version.
       example: Mac OS X
     - name: os.platform

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3131,9 +3131,9 @@
       such as the Mitre ATT&CK framework.
 
       These fields are for users to classify alerts from all of their sources (e.g.
-      IDS, NGFW, etc.) within a  common taxonomy. The threat.tactic.* are meant to
-      capture the high level category of the threat  (e.g. "impact"). The threat.technique.*
-      fields are meant to capture which kind of approach is used by  this detected
+      IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to
+      capture the high level category of the threat (e.g. "impact"). The threat.technique.*
+      fields are meant to capture which kind of approach is used by this detected
       threat, to accomplish the goal (e.g. "endpoint denial of service").'
     type: group
     fields:
@@ -3142,7 +3142,7 @@
       type: keyword
       ignore_above: 1024
       description: Name of the threat framework used to further categorize and classify
-        the tactic and technique of the reported threat.   Framework classification
+        the tactic and technique of the reported threat. Framework classification
         can be provided by detecting systems, evaluated at ingest time, or retrospectively
         tagged to events.
       example: MITRE ATT&CK
@@ -3182,6 +3182,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The name of technique used by this tactic. You can use the Mitre
         ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
         )
@@ -3746,6 +3750,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -420,6 +420,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,threat,threat.tactic.reference,keyword,extended,https://attack.mitre.org/tactics/TA0040/,Threat tactic url reference.
 1.4.0-dev,true,threat,threat.technique.id,keyword,extended,T1499,Threat technique id.
 1.4.0-dev,true,threat,threat.technique.name,keyword,extended,endpoint denial of service,Threat technique name.
+1.4.0-dev,true,threat,threat.technique.name.text,text,extended,endpoint denial of service,Threat technique name.
 1.4.0-dev,true,threat,threat.technique.reference,keyword,extended,https://attack.mitre.org/techniques/T1499/,Threat technique reference.
 1.4.0-dev,true,tls,tls.cipher,keyword,extended,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 1.4.0-dev,true,tls,tls.client.certificate,keyword,extended,MII...,PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
@@ -494,6 +495,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,vulnerability,vulnerability.category,keyword,extended,"[""Firewall""]",Category of a vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.classification,keyword,extended,CVSS,Classification of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.4.0-dev,true,vulnerability,vulnerability.description.text,text,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.enumeration,keyword,extended,CVE,Identifier of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.id,keyword,extended,CVE-2019-00001,ID of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -10,9 +10,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,agent,agent.version,keyword,core,6.0.0-rc2,Version of the agent.
 1.4.0-dev,true,as,as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.4.0-dev,true,as,as.organization.name,keyword,extended,Google LLC,Organization name.
+1.4.0-dev,true,as,as.organization.name.text,text,extended,Google LLC,Organization name.
 1.4.0-dev,true,client,client.address,keyword,extended,,Client network address.
 1.4.0-dev,true,client,client.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.4.0-dev,true,client,client.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.4.0-dev,true,client,as.organization.name.text,text,extended,Google LLC,Organization name.
 1.4.0-dev,true,client,client.bytes,long,core,184,Bytes sent from the client to the server.
 1.4.0-dev,true,client,client.domain,keyword,core,,Client domain.
 1.4.0-dev,true,client,client.geo.city_name,keyword,core,Montreal,City name.
@@ -34,12 +36,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,client,client.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,client,client.user.email,keyword,extended,,User email address.
 1.4.0-dev,true,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,client,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,client,client.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,client,client.user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,client,client.user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,client,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
 1.4.0-dev,true,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
 1.4.0-dev,true,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
@@ -56,6 +60,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,destination,destination.address,keyword,extended,,Destination network address.
 1.4.0-dev,true,destination,destination.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.4.0-dev,true,destination,destination.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.4.0-dev,true,destination,as.organization.name.text,text,extended,Google LLC,Organization name.
 1.4.0-dev,true,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
 1.4.0-dev,true,destination,destination.domain,keyword,core,,Destination domain.
 1.4.0-dev,true,destination,destination.geo.city_name,keyword,core,Montreal,City name.
@@ -77,12 +82,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,destination,destination.user.email,keyword,extended,,User email address.
 1.4.0-dev,true,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,destination,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,destination,destination.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,destination,destination.user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,destination,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,dns,dns.answers,object,extended,,Array of DNS answers.
 1.4.0-dev,true,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
 1.4.0-dev,true,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
@@ -106,6 +113,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,error,error.id,keyword,core,,Unique identifier for the error.
 1.4.0-dev,true,error,error.message,text,core,,Error message.
 1.4.0-dev,false,error,error.stack_trace,keyword,extended,,The stack trace of this error in plain text.
+1.4.0-dev,false,error,error.stack_trace.text,text,extended,,The stack trace of this error in plain text.
 1.4.0-dev,true,error,error.type,keyword,extended,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 1.4.0-dev,true,event,event.action,keyword,core,user-password-change,The action captured by the event.
 1.4.0-dev,true,event,event.category,keyword,core,user-management,Event category.
@@ -147,8 +155,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,file,file.name,keyword,extended,example.png,"Name of the file including the extension, without the directory."
 1.4.0-dev,true,file,file.owner,keyword,extended,alice,File owner's username.
 1.4.0-dev,true,file,file.path,keyword,extended,/home/alice/example.png,Full path to the file.
+1.4.0-dev,true,file,file.path.text,text,extended,/home/alice/example.png,Full path to the file.
 1.4.0-dev,true,file,file.size,long,extended,16384,File size in bytes.
 1.4.0-dev,true,file,file.target_path,keyword,extended,,Target path for symlinks.
+1.4.0-dev,true,file,file.target_path.text,text,extended,,Target path for symlinks.
 1.4.0-dev,true,file,file.type,keyword,extended,file,"File type (file, dir, or symlink)."
 1.4.0-dev,true,file,file.uid,keyword,extended,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.4.0-dev,true,geo,geo.city_name,keyword,core,Montreal,City name.
@@ -183,8 +193,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,host,host.name,keyword,core,,Name of the host.
 1.4.0-dev,true,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.4.0-dev,true,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.4.0-dev,true,host,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.4.0-dev,true,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.4.0-dev,true,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.4.0-dev,true,host,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.4.0-dev,true,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.4.0-dev,true,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.4.0-dev,true,host,host.type,keyword,core,,Type of host.
@@ -192,19 +204,23 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,host,host.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,host,host.user.email,keyword,extended,,User email address.
 1.4.0-dev,true,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,host,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,host,host.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,host,host.user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,host,host.user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,host,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
 1.4.0-dev,true,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
+1.4.0-dev,true,http,http.request.body.content.text,text,extended,Hello world,The full HTTP request body.
 1.4.0-dev,true,http,http.request.bytes,long,extended,1437,Total size in bytes of the request (body and headers).
 1.4.0-dev,true,http,http.request.method,keyword,extended,"get, post, put",HTTP request method.
 1.4.0-dev,true,http,http.request.referrer,keyword,extended,https://blog.example.com/,Referrer for this HTTP request.
 1.4.0-dev,true,http,http.response.body.bytes,long,extended,887,Size in bytes of the response body.
 1.4.0-dev,true,http,http.response.body.content,keyword,extended,Hello world,The full HTTP response body.
+1.4.0-dev,true,http,http.response.body.content.text,text,extended,Hello world,The full HTTP response body.
 1.4.0-dev,true,http,http.response.bytes,long,extended,1437,Total size in bytes of the response (body and headers).
 1.4.0-dev,true,http,http.response.status_code,long,extended,404,HTTP response status code.
 1.4.0-dev,true,http,http.version,keyword,extended,1.1,HTTP version.
@@ -245,8 +261,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
 1.4.0-dev,true,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.4.0-dev,true,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.4.0-dev,true,observer,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.4.0-dev,true,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.4.0-dev,true,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.4.0-dev,true,observer,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.4.0-dev,true,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.4.0-dev,true,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.4.0-dev,true,observer,observer.product,keyword,extended,s200,The product name of the observer.
@@ -256,10 +274,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,observer,observer.version,keyword,core,,Observer version.
 1.4.0-dev,true,organization,organization.id,keyword,extended,,Unique identifier for the organization.
 1.4.0-dev,true,organization,organization.name,keyword,extended,,Organization name.
+1.4.0-dev,true,organization,organization.name.text,text,extended,,Organization name.
 1.4.0-dev,true,os,os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.4.0-dev,true,os,os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.4.0-dev,true,os,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.4.0-dev,true,os,os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.4.0-dev,true,os,os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.4.0-dev,true,os,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.4.0-dev,true,os,os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.4.0-dev,true,os,os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.4.0-dev,true,package,package.architecture,keyword,extended,x86_64,Package architecture.
@@ -278,19 +299,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,process,process.args,keyword,extended,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
 1.4.0-dev,true,process,process.args_count,long,extended,4,Length of the process.args array.
 1.4.0-dev,true,process,process.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.4.0-dev,true,process,process.command_line.text,text,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.4.0-dev,true,process,process.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.4.0-dev,true,process,process.executable.text,text,extended,/usr/bin/ssh,Absolute path to the process executable.
 1.4.0-dev,true,process,process.exit_code,long,extended,137,The exit code of the process.
 1.4.0-dev,true,process,process.hash.md5,keyword,extended,,MD5 hash.
 1.4.0-dev,true,process,process.hash.sha1,keyword,extended,,SHA1 hash.
 1.4.0-dev,true,process,process.hash.sha256,keyword,extended,,SHA256 hash.
 1.4.0-dev,true,process,process.hash.sha512,keyword,extended,,SHA512 hash.
 1.4.0-dev,true,process,process.name,keyword,extended,ssh,Process name.
+1.4.0-dev,true,process,process.name.text,text,extended,ssh,Process name.
 1.4.0-dev,true,process,process.parent.args,keyword,extended,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
 1.4.0-dev,true,process,process.parent.args_count,long,extended,4,Length of the process.args array.
 1.4.0-dev,true,process,process.parent.command_line,keyword,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.4.0-dev,true,process,process.parent.command_line.text,text,extended,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.4.0-dev,true,process,process.parent.executable,keyword,extended,/usr/bin/ssh,Absolute path to the process executable.
+1.4.0-dev,true,process,process.parent.executable.text,text,extended,/usr/bin/ssh,Absolute path to the process executable.
 1.4.0-dev,true,process,process.parent.exit_code,long,extended,137,The exit code of the process.
 1.4.0-dev,true,process,process.parent.name,keyword,extended,ssh,Process name.
+1.4.0-dev,true,process,process.parent.name.text,text,extended,ssh,Process name.
 1.4.0-dev,true,process,process.parent.pgid,long,extended,,Identifier of the group of processes the process belongs to.
 1.4.0-dev,true,process,process.parent.pid,long,core,4242,Process id.
 1.4.0-dev,true,process,process.parent.ppid,long,extended,4241,Parent process' pid.
@@ -298,8 +325,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,process,process.parent.thread.id,long,extended,4242,Thread ID.
 1.4.0-dev,true,process,process.parent.thread.name,keyword,extended,thread-0,Thread name.
 1.4.0-dev,true,process,process.parent.title,keyword,extended,,Process title.
+1.4.0-dev,true,process,process.parent.title.text,text,extended,,Process title.
 1.4.0-dev,true,process,process.parent.uptime,long,extended,1325,Seconds the process has been up.
 1.4.0-dev,true,process,process.parent.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.4.0-dev,true,process,process.parent.working_directory.text,text,extended,/home/alice,The working directory of the process.
 1.4.0-dev,true,process,process.pgid,long,extended,,Identifier of the group of processes the process belongs to.
 1.4.0-dev,true,process,process.pid,long,core,4242,Process id.
 1.4.0-dev,true,process,process.ppid,long,extended,4241,Parent process' pid.
@@ -307,12 +336,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,process,process.thread.id,long,extended,4242,Thread ID.
 1.4.0-dev,true,process,process.thread.name,keyword,extended,thread-0,Thread name.
 1.4.0-dev,true,process,process.title,keyword,extended,,Process title.
+1.4.0-dev,true,process,process.title.text,text,extended,,Process title.
 1.4.0-dev,true,process,process.uptime,long,extended,1325,Seconds the process has been up.
 1.4.0-dev,true,process,process.working_directory,keyword,extended,/home/alice,The working directory of the process.
+1.4.0-dev,true,process,process.working_directory.text,text,extended,/home/alice,The working directory of the process.
 1.4.0-dev,true,related,related.ip,ip,extended,,All of the IPs seen on your event.
 1.4.0-dev,true,server,server.address,keyword,extended,,Server network address.
 1.4.0-dev,true,server,server.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.4.0-dev,true,server,server.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.4.0-dev,true,server,as.organization.name.text,text,extended,Google LLC,Organization name.
 1.4.0-dev,true,server,server.bytes,long,core,184,Bytes sent from the server to the client.
 1.4.0-dev,true,server,server.domain,keyword,core,,Server domain.
 1.4.0-dev,true,server,server.geo.city_name,keyword,core,Montreal,City name.
@@ -334,12 +366,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,server,server.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,server,server.user.email,keyword,extended,,User email address.
 1.4.0-dev,true,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,server,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,server,server.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,server,server.user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,server,server.user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,server,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
 1.4.0-dev,true,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 1.4.0-dev,true,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
@@ -350,6 +384,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,source,source.address,keyword,extended,,Source network address.
 1.4.0-dev,true,source,source.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.4.0-dev,true,source,source.as.organization.name,keyword,extended,Google LLC,Organization name.
+1.4.0-dev,true,source,as.organization.name.text,text,extended,Google LLC,Organization name.
 1.4.0-dev,true,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
 1.4.0-dev,true,source,source.domain,keyword,core,,Source domain.
 1.4.0-dev,true,source,source.geo.city_name,keyword,core,Montreal,City name.
@@ -371,12 +406,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,source,source.user.email,keyword,extended,,User email address.
 1.4.0-dev,true,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,source,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,source,source.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,source,source.user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,source,source.user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,source,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
 1.4.0-dev,true,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
 1.4.0-dev,true,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.
@@ -419,7 +456,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,url,url.extension,keyword,extended,png,File extension from the original request url.
 1.4.0-dev,true,url,url.fragment,keyword,extended,,Portion of the url after the `#`.
 1.4.0-dev,true,url,url.full,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.4.0-dev,true,url,url.full.text,text,extended,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.4.0-dev,true,url,url.original,keyword,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.4.0-dev,true,url,url.original.text,text,extended,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.4.0-dev,true,url,url.password,keyword,extended,,Password of the request.
 1.4.0-dev,true,url,url.path,keyword,extended,,"Path of the request, such as ""/search""."
 1.4.0-dev,true,url,url.port,long,extended,443,"Port of the request, such as 443."
@@ -431,20 +470,24 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,user,user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.4.0-dev,true,user,user.email,keyword,extended,,User email address.
 1.4.0-dev,true,user,user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
+1.4.0-dev,true,user,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.4.0-dev,true,user,user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.4.0-dev,true,user,user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.4.0-dev,true,user,user.group.name,keyword,extended,,Name of the group.
 1.4.0-dev,true,user,user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.4.0-dev,true,user,user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.4.0-dev,true,user,user.name,keyword,core,albert,Short name or login of the user.
+1.4.0-dev,true,user,user.name.text,text,core,albert,Short name or login of the user.
 1.4.0-dev,true,user_agent,user_agent.device.name,keyword,extended,iPhone,Name of the device.
 1.4.0-dev,true,user_agent,user_agent.name,keyword,extended,Safari,Name of the user agent.
 1.4.0-dev,true,user_agent,user_agent.original,keyword,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 1.4.0-dev,true,user_agent,user_agent.original.text,text,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 1.4.0-dev,true,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.4.0-dev,true,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.4.0-dev,true,user_agent,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.4.0-dev,true,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.4.0-dev,true,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
+1.4.0-dev,true,user_agent,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.4.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.4.0-dev,true,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.4.0-dev,true,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4497,7 +4497,7 @@ tags:
   type: keyword
 threat.framework:
   description: Name of the threat framework used to further categorize and classify
-    the tactic and technique of the reported threat.   Framework classification can
+    the tactic and technique of the reported threat. Framework classification can
     be provided by detecting systems, evaluated at ingest time, or retrospectively
     tagged to events.
   example: MITRE ATT&CK
@@ -4564,6 +4564,11 @@ threat.technique.name:
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: threat.technique.name.text
+    name: text
+    norms: false
+    type: text
   name: technique.name
   order: 4
   short: Threat technique name.
@@ -5385,6 +5390,11 @@ vulnerability.description:
   flat_name: vulnerability.description
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: vulnerability.description.text
+    name: text
+    norms: false
+    type: text
   name: description
   order: 8
   short: Description of the vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -97,6 +97,11 @@ as.organization.name:
   flat_name: as.organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: as.organization.name.text
+    name: text
+    norms: false
+    type: text
   name: organization.name
   order: 1
   short: Organization name.
@@ -133,6 +138,11 @@ client.as.organization.name:
   flat_name: client.as.organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: as.organization.name.text
+    name: text
+    norms: false
+    type: text
   name: organization.name
   order: 1
   original_fieldset: as
@@ -370,6 +380,11 @@ client.user.full_name:
   flat_name: client.user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   original_fieldset: user
@@ -437,6 +452,11 @@ client.user.name:
   flat_name: client.user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: user
@@ -602,6 +622,11 @@ destination.as.organization.name:
   flat_name: destination.as.organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: as.organization.name.text
+    name: text
+    norms: false
+    type: text
   name: organization.name
   order: 1
   original_fieldset: as
@@ -838,6 +863,11 @@ destination.user.full_name:
   flat_name: destination.user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   original_fieldset: user
@@ -905,6 +935,11 @@ destination.user.name:
   flat_name: destination.user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: user
@@ -1196,6 +1231,11 @@ error.stack_trace:
   ignore_above: 1024
   index: false
   level: extended
+  multi_fields:
+  - flat_name: error.stack_trace.text
+    name: text
+    norms: false
+    type: text
   name: stack_trace
   order: 4
   short: The stack trace of this error in plain text.
@@ -1689,6 +1729,11 @@ file.path:
   flat_name: file.path
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: file.path.text
+    name: text
+    norms: false
+    type: text
   name: path
   order: 2
   short: Full path to the file.
@@ -1709,6 +1754,11 @@ file.target_path:
   flat_name: file.target_path
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: file.target_path.text
+    name: text
+    norms: false
+    type: text
   name: target_path
   order: 3
   short: Target path for symlinks.
@@ -2068,6 +2118,11 @@ host.os.full:
   flat_name: host.os.full
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.full.text
+    name: text
+    norms: false
+    type: text
   name: full
   order: 2
   original_fieldset: os
@@ -2090,6 +2145,11 @@ host.os.name:
   flat_name: host.os.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: os
@@ -2166,6 +2226,11 @@ host.user.full_name:
   flat_name: host.user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   original_fieldset: user
@@ -2233,6 +2298,11 @@ host.user.name:
   flat_name: host.user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: user
@@ -2254,6 +2324,11 @@ http.request.body.content:
   flat_name: http.request.body.content
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: http.request.body.content.text
+    name: text
+    norms: false
+    type: text
   name: request.body.content
   order: 1
   short: The full HTTP request body.
@@ -2307,6 +2382,11 @@ http.response.body.content:
   flat_name: http.response.body.content
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: http.response.body.content.text
+    name: text
+    norms: false
+    type: text
   name: response.body.content
   order: 4
   short: The full HTTP response body.
@@ -2820,6 +2900,11 @@ observer.os.full:
   flat_name: observer.os.full
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.full.text
+    name: text
+    norms: false
+    type: text
   name: full
   order: 2
   original_fieldset: os
@@ -2842,6 +2927,11 @@ observer.os.name:
   flat_name: observer.os.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: os
@@ -2934,6 +3024,11 @@ organization.name:
   flat_name: organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: organization.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 0
   short: Organization name.
@@ -2954,6 +3049,11 @@ os.full:
   flat_name: os.full
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.full.text
+    name: text
+    norms: false
+    type: text
   name: full
   order: 2
   short: Operating system name, including the version or code name.
@@ -2974,6 +3074,11 @@ os.name:
   flat_name: os.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   short: Operating system name, without the version.
@@ -3173,6 +3278,11 @@ process.command_line:
   flat_name: process.command_line
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.command_line.text
+    name: text
+    norms: false
+    type: text
   name: command_line
   order: 8
   short: Full command line that started the process.
@@ -3183,6 +3293,11 @@ process.executable:
   flat_name: process.executable
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.executable.text
+    name: text
+    norms: false
+    type: text
   name: executable
   order: 14
   short: Absolute path to the process executable.
@@ -3247,6 +3362,11 @@ process.name:
   flat_name: process.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 2
   short: Process name.
@@ -3289,6 +3409,11 @@ process.parent.command_line:
   flat_name: process.parent.command_line
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.parent.command_line.text
+    name: text
+    norms: false
+    type: text
   name: parent.command_line
   order: 9
   short: Full command line that started the process.
@@ -3299,6 +3424,11 @@ process.parent.executable:
   flat_name: process.parent.executable
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.parent.executable.text
+    name: text
+    norms: false
+    type: text
   name: parent.executable
   order: 15
   short: Absolute path to the process executable.
@@ -3323,6 +3453,11 @@ process.parent.name:
   flat_name: process.parent.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.parent.name.text
+    name: text
+    norms: false
+    type: text
   name: parent.name
   order: 3
   short: Process name.
@@ -3393,6 +3528,11 @@ process.parent.title:
   flat_name: process.parent.title
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.parent.title.text
+    name: text
+    norms: false
+    type: text
   name: parent.title
   order: 17
   short: Process title.
@@ -3412,6 +3552,11 @@ process.parent.working_directory:
   flat_name: process.parent.working_directory
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.parent.working_directory.text
+    name: text
+    norms: false
+    type: text
   name: parent.working_directory
   order: 27
   short: The working directory of the process.
@@ -3482,6 +3627,11 @@ process.title:
   flat_name: process.title
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.title.text
+    name: text
+    norms: false
+    type: text
   name: title
   order: 16
   short: Process title.
@@ -3501,6 +3651,11 @@ process.working_directory:
   flat_name: process.working_directory
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: process.working_directory.text
+    name: text
+    norms: false
+    type: text
   name: working_directory
   order: 26
   short: The working directory of the process.
@@ -3545,6 +3700,11 @@ server.as.organization.name:
   flat_name: server.as.organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: as.organization.name.text
+    name: text
+    norms: false
+    type: text
   name: organization.name
   order: 1
   original_fieldset: as
@@ -3782,6 +3942,11 @@ server.user.full_name:
   flat_name: server.user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   original_fieldset: user
@@ -3849,6 +4014,11 @@ server.user.name:
   flat_name: server.user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: user
@@ -3991,6 +4161,11 @@ source.as.organization.name:
   flat_name: source.as.organization.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: as.organization.name.text
+    name: text
+    norms: false
+    type: text
   name: organization.name
   order: 1
   original_fieldset: as
@@ -4228,6 +4403,11 @@ source.user.full_name:
   flat_name: source.user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   original_fieldset: user
@@ -4295,6 +4475,11 @@ source.user.name:
   flat_name: source.user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: user
@@ -4815,6 +5000,11 @@ url.full:
   flat_name: url.full
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: url.full.text
+    name: text
+    norms: false
+    type: text
   name: full
   order: 1
   short: Full unparsed URL.
@@ -4830,6 +5020,11 @@ url.original:
   flat_name: url.original
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: url.original.text
+    name: text
+    norms: false
+    type: text
   name: original
   order: 0
   short: Unmodified original url as seen in the event source.
@@ -4956,6 +5151,11 @@ user.full_name:
   flat_name: user.full_name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
   name: full_name
   order: 2
   short: User's full name, if available.
@@ -5020,6 +5220,11 @@ user.name:
   flat_name: user.name
   ignore_above: 1024
   level: core
+  multi_fields:
+  - flat_name: user.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   short: Short name or login of the user.
@@ -5077,6 +5282,11 @@ user_agent.os.full:
   flat_name: user_agent.os.full
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.full.text
+    name: text
+    norms: false
+    type: text
   name: full
   order: 2
   original_fieldset: os
@@ -5099,6 +5309,11 @@ user_agent.os.name:
   flat_name: user_agent.os.name
   ignore_above: 1024
   level: extended
+  multi_fields:
+  - flat_name: os.name.text
+    name: text
+    norms: false
+    type: text
   name: name
   order: 1
   original_fieldset: os

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4961,14 +4961,14 @@ threat:
     such as the Mitre ATT&CK framework.
 
     These fields are for users to classify alerts from all of their sources (e.g.
-    IDS, NGFW, etc.) within a  common taxonomy. The threat.tactic.* are meant to capture
-    the high level category of the threat  (e.g. "impact"). The threat.technique.*
-    fields are meant to capture which kind of approach is used by  this detected threat,
+    IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture
+    the high level category of the threat (e.g. "impact"). The threat.technique.*
+    fields are meant to capture which kind of approach is used by this detected threat,
     to accomplish the goal (e.g. "endpoint denial of service").'
   fields:
     framework:
       description: Name of the threat framework used to further categorize and classify
-        the tactic and technique of the reported threat.   Framework classification
+        the tactic and technique of the reported threat. Framework classification
         can be provided by detecting systems, evaluated at ingest time, or retrospectively
         tagged to events.
       example: MITRE ATT&CK
@@ -5035,6 +5035,11 @@ threat:
       flat_name: threat.technique.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: threat.technique.name.text
+        name: text
+        norms: false
+        type: text
       name: technique.name
       order: 4
       short: Threat technique name.
@@ -5944,6 +5949,11 @@ vulnerability:
       flat_name: vulnerability.description
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: vulnerability.description.text
+        name: text
+        norms: false
+        type: text
       name: description
       order: 8
       short: Description of the vulnerability.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -104,6 +104,11 @@ as:
       flat_name: as.organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: as.organization.name.text
+        name: text
+        norms: false
+        type: text
       name: organization.name
       order: 1
       short: Organization name.
@@ -242,6 +247,11 @@ client:
       flat_name: client.as.organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: as.organization.name.text
+        name: text
+        norms: false
+        type: text
       name: organization.name
       order: 1
       original_fieldset: as
@@ -479,6 +489,11 @@ client:
       flat_name: client.user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       original_fieldset: user
@@ -546,6 +561,11 @@ client:
       flat_name: client.user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: user
@@ -753,6 +773,11 @@ destination:
       flat_name: destination.as.organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: as.organization.name.text
+        name: text
+        norms: false
+        type: text
       name: organization.name
       order: 1
       original_fieldset: as
@@ -989,6 +1014,11 @@ destination:
       flat_name: destination.user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       original_fieldset: user
@@ -1056,6 +1086,11 @@ destination:
       flat_name: destination.user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: user
@@ -1388,6 +1423,11 @@ error:
       ignore_above: 1024
       index: false
       level: extended
+      multi_fields:
+      - flat_name: error.stack_trace.text
+        name: text
+        norms: false
+        type: text
       name: stack_trace
       order: 4
       short: The stack trace of this error in plain text.
@@ -1917,6 +1957,11 @@ file:
       flat_name: file.path
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: file.path.text
+        name: text
+        norms: false
+        type: text
       name: path
       order: 2
       short: Full path to the file.
@@ -1937,6 +1982,11 @@ file:
       flat_name: file.target_path
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: file.target_path.text
+        name: text
+        norms: false
+        type: text
       name: target_path
       order: 3
       short: Target path for symlinks.
@@ -2366,6 +2416,11 @@ host:
       flat_name: host.os.full
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.full.text
+        name: text
+        norms: false
+        type: text
       name: full
       order: 2
       original_fieldset: os
@@ -2388,6 +2443,11 @@ host:
       flat_name: host.os.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: os
@@ -2465,6 +2525,11 @@ host:
       flat_name: host.user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       original_fieldset: user
@@ -2532,6 +2597,11 @@ host:
       flat_name: host.user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: user
@@ -2567,6 +2637,11 @@ http:
       flat_name: http.request.body.content
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: http.request.body.content.text
+        name: text
+        norms: false
+        type: text
       name: request.body.content
       order: 1
       short: The full HTTP request body.
@@ -2620,6 +2695,11 @@ http:
       flat_name: http.response.body.content
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: http.response.body.content.text
+        name: text
+        norms: false
+        type: text
       name: response.body.content
       order: 4
       short: The full HTTP response body.
@@ -3152,6 +3232,11 @@ observer:
       flat_name: observer.os.full
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.full.text
+        name: text
+        norms: false
+        type: text
       name: full
       order: 2
       original_fieldset: os
@@ -3174,6 +3259,11 @@ observer:
       flat_name: observer.os.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: os
@@ -3282,6 +3372,11 @@ organization:
       flat_name: organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: organization.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 0
       short: Organization name.
@@ -3311,6 +3406,11 @@ os:
       flat_name: os.full
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.full.text
+        name: text
+        norms: false
+        type: text
       name: full
       order: 2
       short: Operating system name, including the version or code name.
@@ -3331,6 +3431,11 @@ os:
       flat_name: os.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       short: Operating system name, without the version.
@@ -3563,6 +3668,11 @@ process:
       flat_name: process.command_line
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.command_line.text
+        name: text
+        norms: false
+        type: text
       name: command_line
       order: 8
       short: Full command line that started the process.
@@ -3573,6 +3683,11 @@ process:
       flat_name: process.executable
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.executable.text
+        name: text
+        norms: false
+        type: text
       name: executable
       order: 14
       short: Absolute path to the process executable.
@@ -3637,6 +3752,11 @@ process:
       flat_name: process.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 2
       short: Process name.
@@ -3679,6 +3799,11 @@ process:
       flat_name: process.parent.command_line
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.parent.command_line.text
+        name: text
+        norms: false
+        type: text
       name: parent.command_line
       order: 9
       short: Full command line that started the process.
@@ -3689,6 +3814,11 @@ process:
       flat_name: process.parent.executable
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.parent.executable.text
+        name: text
+        norms: false
+        type: text
       name: parent.executable
       order: 15
       short: Absolute path to the process executable.
@@ -3713,6 +3843,11 @@ process:
       flat_name: process.parent.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.parent.name.text
+        name: text
+        norms: false
+        type: text
       name: parent.name
       order: 3
       short: Process name.
@@ -3783,6 +3918,11 @@ process:
       flat_name: process.parent.title
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.parent.title.text
+        name: text
+        norms: false
+        type: text
       name: parent.title
       order: 17
       short: Process title.
@@ -3802,6 +3942,11 @@ process:
       flat_name: process.parent.working_directory
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.parent.working_directory.text
+        name: text
+        norms: false
+        type: text
       name: parent.working_directory
       order: 27
       short: The working directory of the process.
@@ -3872,6 +4017,11 @@ process:
       flat_name: process.title
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.title.text
+        name: text
+        norms: false
+        type: text
       name: title
       order: 16
       short: Process title.
@@ -3891,6 +4041,11 @@ process:
       flat_name: process.working_directory
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: process.working_directory.text
+        name: text
+        norms: false
+        type: text
       name: working_directory
       order: 26
       short: The working directory of the process.
@@ -3978,6 +4133,11 @@ server:
       flat_name: server.as.organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: as.organization.name.text
+        name: text
+        norms: false
+        type: text
       name: organization.name
       order: 1
       original_fieldset: as
@@ -4215,6 +4375,11 @@ server:
       flat_name: server.user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       original_fieldset: user
@@ -4282,6 +4447,11 @@ server:
       flat_name: server.user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: user
@@ -4452,6 +4622,11 @@ source:
       flat_name: source.as.organization.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: as.organization.name.text
+        name: text
+        norms: false
+        type: text
       name: organization.name
       order: 1
       original_fieldset: as
@@ -4689,6 +4864,11 @@ source:
       flat_name: source.user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       original_fieldset: user
@@ -4756,6 +4936,11 @@ source:
       flat_name: source.user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: user
@@ -5328,6 +5513,11 @@ url:
       flat_name: url.full
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: url.full.text
+        name: text
+        norms: false
+        type: text
       name: full
       order: 1
       short: Full unparsed URL.
@@ -5343,6 +5533,11 @@ url:
       flat_name: url.original
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: url.original.text
+        name: text
+        norms: false
+        type: text
       name: original
       order: 0
       short: Unmodified original url as seen in the event source.
@@ -5482,6 +5677,11 @@ user:
       flat_name: user.full_name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: user.full_name.text
+        name: text
+        norms: false
+        type: text
       name: full_name
       order: 2
       short: User's full name, if available.
@@ -5546,6 +5746,11 @@ user:
       flat_name: user.name
       ignore_above: 1024
       level: core
+      multi_fields:
+      - flat_name: user.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       short: Short name or login of the user.
@@ -5624,6 +5829,11 @@ user_agent:
       flat_name: user_agent.os.full
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.full.text
+        name: text
+        norms: false
+        type: text
       name: full
       order: 2
       original_fieldset: os
@@ -5646,6 +5856,11 @@ user_agent:
       flat_name: user_agent.os.name
       ignore_above: 1024
       level: extended
+      multi_fields:
+      - flat_name: os.name.text
+        name: text
+        norms: false
+        type: text
       name: name
       order: 1
       original_fieldset: os

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2008,6 +2008,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -2369,6 +2375,12 @@
               "type": "keyword"
             }, 
             "description": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -55,6 +55,12 @@
             "organization": {
               "properties": {
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -76,6 +82,12 @@
                 "organization": {
                   "properties": {
                     "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -167,6 +179,12 @@
                   "type": "keyword"
                 }, 
                 "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -195,6 +213,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -291,6 +315,12 @@
                 "organization": {
                   "properties": {
                     "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -382,6 +412,12 @@
                   "type": "keyword"
                 }, 
                 "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -410,6 +446,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -519,6 +561,12 @@
             }, 
             "stack_trace": {
               "doc_values": false, 
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "index": false, 
               "type": "keyword"
@@ -685,6 +733,12 @@
               "type": "keyword"
             }, 
             "path": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -692,6 +746,12 @@
               "type": "long"
             }, 
             "target_path": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -847,6 +907,12 @@
                   "type": "keyword"
                 }, 
                 "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -855,6 +921,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -886,6 +958,12 @@
                   "type": "keyword"
                 }, 
                 "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -914,6 +992,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -931,6 +1015,12 @@
                       "type": "long"
                     }, 
                     "content": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -957,6 +1047,12 @@
                       "type": "long"
                     }, 
                     "content": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -1153,6 +1249,12 @@
                   "type": "keyword"
                 }, 
                 "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1161,6 +1263,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1203,6 +1311,12 @@
               "type": "keyword"
             }, 
             "name": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }
@@ -1215,6 +1329,12 @@
               "type": "keyword"
             }, 
             "full": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -1223,6 +1343,12 @@
               "type": "keyword"
             }, 
             "name": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -1300,10 +1426,22 @@
               "type": "long"
             }, 
             "command_line": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
             "executable": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -1331,6 +1469,12 @@
               }
             }, 
             "name": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -1344,10 +1488,22 @@
                   "type": "long"
                 }, 
                 "command_line": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
                 "executable": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1355,6 +1511,12 @@
                   "type": "long"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1382,6 +1544,12 @@
                   }
                 }, 
                 "title": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1389,6 +1557,12 @@
                   "type": "long"
                 }, 
                 "working_directory": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -1418,6 +1592,12 @@
               }
             }, 
             "title": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -1425,6 +1605,12 @@
               "type": "long"
             }, 
             "working_directory": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }
@@ -1451,6 +1637,12 @@
                 "organization": {
                   "properties": {
                     "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -1542,6 +1734,12 @@
                   "type": "keyword"
                 }, 
                 "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1570,6 +1768,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -1627,6 +1831,12 @@
                 "organization": {
                   "properties": {
                     "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false, 
+                          "type": "text"
+                        }
+                      }, 
                       "ignore_above": 1024, 
                       "type": "keyword"
                     }
@@ -1718,6 +1928,12 @@
                   "type": "keyword"
                 }, 
                 "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -1746,6 +1962,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }
@@ -1958,10 +2180,22 @@
               "type": "keyword"
             }, 
             "full": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
             "original": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -2009,6 +2243,12 @@
               "type": "keyword"
             }, 
             "full_name": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }, 
@@ -2037,6 +2277,12 @@
               "type": "keyword"
             }, 
             "name": {
+              "fields": {
+                "text": {
+                  "norms": false, 
+                  "type": "text"
+                }
+              }, 
               "ignore_above": 1024, 
               "type": "keyword"
             }
@@ -2073,6 +2319,12 @@
                   "type": "keyword"
                 }, 
                 "full": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 
@@ -2081,6 +2333,12 @@
                   "type": "keyword"
                 }, 
                 "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false, 
+                      "type": "text"
+                    }
+                  }, 
                   "ignore_above": 1024, 
                   "type": "keyword"
                 }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2007,6 +2007,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -2368,6 +2374,12 @@
             "type": "keyword"
           }, 
           "description": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -54,6 +54,12 @@
           "organization": {
             "properties": {
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -75,6 +81,12 @@
               "organization": {
                 "properties": {
                   "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -166,6 +178,12 @@
                 "type": "keyword"
               }, 
               "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -194,6 +212,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -290,6 +314,12 @@
               "organization": {
                 "properties": {
                   "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -381,6 +411,12 @@
                 "type": "keyword"
               }, 
               "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -409,6 +445,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -518,6 +560,12 @@
           }, 
           "stack_trace": {
             "doc_values": false, 
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "index": false, 
             "type": "keyword"
@@ -684,6 +732,12 @@
             "type": "keyword"
           }, 
           "path": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -691,6 +745,12 @@
             "type": "long"
           }, 
           "target_path": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -846,6 +906,12 @@
                 "type": "keyword"
               }, 
               "full": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -854,6 +920,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -885,6 +957,12 @@
                 "type": "keyword"
               }, 
               "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -913,6 +991,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -930,6 +1014,12 @@
                     "type": "long"
                   }, 
                   "content": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -956,6 +1046,12 @@
                     "type": "long"
                   }, 
                   "content": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -1152,6 +1248,12 @@
                 "type": "keyword"
               }, 
               "full": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1160,6 +1262,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1202,6 +1310,12 @@
             "type": "keyword"
           }, 
           "name": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }
@@ -1214,6 +1328,12 @@
             "type": "keyword"
           }, 
           "full": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -1222,6 +1342,12 @@
             "type": "keyword"
           }, 
           "name": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -1299,10 +1425,22 @@
             "type": "long"
           }, 
           "command_line": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
           "executable": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -1330,6 +1468,12 @@
             }
           }, 
           "name": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -1343,10 +1487,22 @@
                 "type": "long"
               }, 
               "command_line": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
               "executable": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1354,6 +1510,12 @@
                 "type": "long"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1381,6 +1543,12 @@
                 }
               }, 
               "title": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1388,6 +1556,12 @@
                 "type": "long"
               }, 
               "working_directory": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -1417,6 +1591,12 @@
             }
           }, 
           "title": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -1424,6 +1604,12 @@
             "type": "long"
           }, 
           "working_directory": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }
@@ -1450,6 +1636,12 @@
               "organization": {
                 "properties": {
                   "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -1541,6 +1733,12 @@
                 "type": "keyword"
               }, 
               "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1569,6 +1767,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -1626,6 +1830,12 @@
               "organization": {
                 "properties": {
                   "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false, 
+                        "type": "text"
+                      }
+                    }, 
                     "ignore_above": 1024, 
                     "type": "keyword"
                   }
@@ -1717,6 +1927,12 @@
                 "type": "keyword"
               }, 
               "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -1745,6 +1961,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }
@@ -1957,10 +2179,22 @@
             "type": "keyword"
           }, 
           "full": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
           "original": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -2008,6 +2242,12 @@
             "type": "keyword"
           }, 
           "full_name": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }, 
@@ -2036,6 +2276,12 @@
             "type": "keyword"
           }, 
           "name": {
+            "fields": {
+              "text": {
+                "norms": false, 
+                "type": "text"
+              }
+            }, 
             "ignore_above": 1024, 
             "type": "keyword"
           }
@@ -2072,6 +2318,12 @@
                 "type": "keyword"
               }, 
               "full": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 
@@ -2080,6 +2332,12 @@
                 "type": "keyword"
               }, 
               "name": {
+                "fields": {
+                  "text": {
+                    "norms": false, 
+                    "type": "text"
+                  }
+                }, 
                 "ignore_above": 1024, 
                 "type": "keyword"
               }, 

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -32,3 +32,6 @@
       description: >
         Organization name.
       example: Google LLC
+      multi_fields:
+      - type: text
+        name: text

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -42,4 +42,6 @@
       index: false
       description: >
         The stack trace of this error in plain text.
-
+      multi_fields:
+      - type: text
+        name: text

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -29,11 +29,17 @@
     type: keyword
     description: Full path to the file.
     example: '/home/alice/example.png'
+    multi_fields:
+    - type: text
+      name: text
 
   - name: target_path
     level: extended
     type: keyword
     description: Target path for symlinks.
+    multi_fields:
+    - type: text
+      name: text
 
   - name: extension
     level: extended

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -25,6 +25,9 @@
       description: >
         The full HTTP request body.
       example: Hello world
+      multi_fields:
+      - type: text
+        name: text
 
     - name: request.referrer
       level: extended
@@ -47,6 +50,9 @@
       description: >
         The full HTTP response body.
       example: Hello world
+      multi_fields:
+      - type: text
+        name: text
 
     - name: version
       level: extended

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -17,6 +17,9 @@
       type: keyword
       description: >
         Organization name.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: id
       level: extended

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -26,6 +26,9 @@
       example: "Mac OS X"
       description: >
         Operating system name, without the version.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: full
       level: extended
@@ -33,6 +36,9 @@
       example: "Mac OS Mojave"
       description: >
         Operating system name, including the version or code name.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: family
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -52,6 +52,9 @@
 
         Sometimes called program name or similar.
       example: ssh
+      multi_fields:
+      - type: text
+        name: text
 
     - name: parent.name
       level: extended
@@ -62,6 +65,9 @@
 
         Sometimes called program name or similar.
       example: ssh
+      multi_fields:
+      - type: text
+        name: text
 
 
     - name: ppid
@@ -106,6 +112,9 @@
 
         Some arguments may be filtered to protect sensitive information.
       example: "/usr/bin/ssh -l user 10.0.0.16"
+      multi_fields:
+      - type: text
+        name: text
 
     - name: parent.command_line
       level: extended
@@ -117,6 +126,9 @@
 
         Some arguments may be filtered to protect sensitive information.
       example: "/usr/bin/ssh -l user 10.0.0.16"
+      multi_fields:
+      - type: text
+        name: text
 
 
     - name: args
@@ -170,6 +182,9 @@
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
+      multi_fields:
+      - type: text
+        name: text
 
     - name: parent.executable
       level: extended
@@ -177,6 +192,9 @@
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
+      multi_fields:
+      - type: text
+        name: text
 
 
     - name: title
@@ -188,6 +206,9 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: parent.title
       level: extended
@@ -198,6 +219,9 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
+      multi_fields:
+      - type: text
+        name: text
 
 
     - name: thread.id
@@ -268,6 +292,9 @@
       example: /home/alice
       description: >
         The working directory of the process.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: parent.working_directory
       level: extended
@@ -275,6 +302,9 @@
       example: /home/alice
       description: >
         The working directory of the process.
+      multi_fields:
+      - type: text
+        name: text
 
 
     - name: exit_code

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -57,6 +57,9 @@
     - name: technique.name
       level: extended
       type: keyword
+      multi_fields:
+      - type: text
+        name: text
       short: Threat technique name.
       description: >
           The name of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -6,11 +6,11 @@
   description: >
    Fields to classify events and alerts according to a threat taxonomy such as the Mitre ATT&CK framework.
 
-   These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a 
-   common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat 
-   (e.g. "impact"). The threat.technique.* fields are meant to capture which kind of approach is used by 
+   These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a
+   common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat
+   (e.g. "impact"). The threat.technique.* fields are meant to capture which kind of approach is used by
    this detected threat, to accomplish the goal (e.g. "endpoint denial of service").
-  
+
   type: group
   fields:
 
@@ -19,10 +19,10 @@
       type: keyword
       short: Threat classification framework.
       description: >
-        Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat.  
+        Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat.
         Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events.
 
-      example: MITRE ATT&CK 
+      example: MITRE ATT&CK
 
     - name: tactic.name
       level: extended

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -22,6 +22,9 @@
         or not.
       example: >
         https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
+      multi_fields:
+      - type: text
+        name: text
 
     - name: full
       level: extended
@@ -32,6 +35,9 @@
         `url.full`, whether this field is reconstructed or present in the
         event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
+      multi_fields:
+      - type: text
+        name: text
 
     - name: scheme
       level: extended

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -33,6 +33,9 @@
       example: albert
       description: >
         Short name or login of the user.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: full_name
       level: extended
@@ -40,6 +43,9 @@
       example: Albert Einstein
       description: >
         User's full name, if available.
+      multi_fields:
+      - type: text
+        name: text
 
     - name: email
       level: extended
@@ -60,7 +66,7 @@
     - name: domain
       level: extended
       type: keyword
-      short: Name of the directory the user is a member of. 
+      short: Name of the directory the user is a member of.
       description: >
           Name of the directory the user is a member of.
 

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -111,6 +111,9 @@
     - name: description
       level: extended
       type: keyword
+      multi_fields:
+      - type: text
+        name: text
       short: Description of the vulnerability.
       description: >
         The description of the vulnerability that provides additional context of the

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -82,7 +82,7 @@ def render_field_details_row(field):
     if 'multi_fields' in field:
         field_type_with_mf += "\n\nMulti-fields:\n\n"
         for mf in field['multi_fields']:
-            field_type_with_mf += "{} (type: {})\n\n".format(mf['flat_name'], mf['type'])
+            field_type_with_mf += "* {} (type: {})\n\n".format(mf['flat_name'], mf['type'])
 
     text = field_details_row().format(
         field_flat_name=field['flat_name'],

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -140,7 +140,7 @@ def duplicate_reusable_fieldsets(schema, fields_flat, fields_nested):
                 # Poor folks deepcopy, sorry -- A Rubyist
                 copied_field = field.copy()
                 if 'multi_fields' in copied_field:
-                    copied_field['multi_fields'] = copied_field['multi_fields'].copy()
+                    copied_field['multi_fields'] = map(lambda mf: mf.copy(), copied_field['multi_fields'])
 
                 destination_name = new_nesting + '.' + field['flat_name']
                 copied_field['flat_name'] = destination_name


### PR DESCRIPTION
This implements many fields mentioned in https://github.com/elastic/ecs/issues/570.


Note: I'm not adding `host.name`, mentioned in 570 because the default analyzer doesn't split on `-`. So I'm not sure it's worth adding. Please let me know if I'm missing something.

In going over the fields, I've identified a few more that I think may be interesting to add to this PR. Please voice your opinions. I'm happy to hold off or add now:

  * dns.question.name
  * threat.technique.name
  * vulnerability.description
  * tls.client.issuer, tls.client.subject, tls.server.issuer, tls.server.subject

@neu5ron @randomuserid @rw-access @MikePaquette @peasead