### PR TITLE
updated description to text datatype

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4781,7 +4781,7 @@ example: `CVSS`
 | vulnerability.description
 | The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
 
-type: keyword
+type: text
 
 example: `In macOS before 2.12.6, there is a vulnerability in the RPC...`
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3582,8 +3582,7 @@
       example: CVSS
     - name: description
       level: extended
-      type: keyword
-      ignore_above: 1024
+      type: text
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -451,7 +451,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.4.0-dev,true,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.
 1.4.0-dev,true,vulnerability,vulnerability.category,keyword,extended,"[""Firewall""]",Category of a vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.classification,keyword,extended,CVSS,Classification of the vulnerability.
-1.4.0-dev,true,vulnerability,vulnerability.description,keyword,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.4.0-dev,true,vulnerability,vulnerability.description,text,extended,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.enumeration,keyword,extended,CVE,Identifier of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.id,keyword,extended,CVE-2019-00001,ID of the vulnerability.
 1.4.0-dev,true,vulnerability,vulnerability.reference,keyword,extended,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5182,12 +5182,12 @@ vulnerability.description:
     Vulnerabilities and Exposure CVE description])
   example: In macOS before 2.12.6, there is a vulnerability in the RPC...
   flat_name: vulnerability.description
-  ignore_above: 1024
   level: extended
   name: description
+  norms: false
   order: 8
   short: Description of the vulnerability.
-  type: keyword
+  type: text
 vulnerability.enumeration:
   description: The type of identifier used for this vulnerability. For example (https://cve.mitre.org/about/)
   example: CVE

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5741,12 +5741,12 @@ vulnerability:
         Vulnerabilities and Exposure CVE description])
       example: In macOS before 2.12.6, there is a vulnerability in the RPC...
       flat_name: vulnerability.description
-      ignore_above: 1024
       level: extended
       name: description
+      norms: false
       order: 8
       short: Description of the vulnerability.
-      type: keyword
+      type: text
     enumeration:
       description: The type of identifier used for this vulnerability. For example
         (https://cve.mitre.org/about/)

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2115,8 +2115,8 @@
               "type": "keyword"
             }, 
             "description": {
-              "ignore_above": 1024, 
-              "type": "keyword"
+              "norms": false, 
+              "type": "text"
             }, 
             "enumeration": {
               "ignore_above": 1024, 

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2114,8 +2114,8 @@
             "type": "keyword"
           }, 
           "description": {
-            "ignore_above": 1024, 
-            "type": "keyword"
+            "norms": false, 
+            "type": "text"
           }, 
           "enumeration": {
             "ignore_above": 1024, 

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -110,7 +110,7 @@
 
     - name: description
       level: extended
-      type: keyword
+      type: text
       short: Description of the vulnerability.
       description: >
         The description of the vulnerability that provides additional context of the


### PR DESCRIPTION
Referencing elastic/ecs#680  to change the datatype of `vulnerability.description` from `keyword` to `text`.