### PR TITLE
Move to --direct_html doc build option:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs:
 	if [ ! -d $(PWD)/build/docs ]; then \
 		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
 	fi
-	./build/docs/build_docs --asciidoctor --doc ./docs/index.asciidoc --chunk=1 $(OPEN_DOCS) --out ./build/html_docs
+	./build/docs/build_docs --asciidoctor --direct_html --doc ./docs/index.asciidoc --chunk=1 $(OPEN_DOCS) --out ./build/html_docs
 
 # Format code and files in the repo.
 .PHONY: fmt


### PR DESCRIPTION
- Better asciidoctor compatibility
- Moar fast builds

Relates to https://github.com/elastic/docs/pull/1559