### PR TITLE
Refactor schema reader to use intermediate schema structure

### DIFF
--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -14,7 +14,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,client,client.address,keyword,extended,,Client network address.
 1.5.0-dev,true,client,client.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.5.0-dev,true,client,client.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.5.0-dev,true,client,as.organization.name.text,text,extended,Google LLC,Organization name.
+1.5.0-dev,true,client,client.as.organization.name.text,text,extended,Google LLC,Organization name.
 1.5.0-dev,true,client,client.bytes,long,core,184,Bytes sent from the client to the server.
 1.5.0-dev,true,client,client.domain,keyword,core,,Client domain.
 1.5.0-dev,true,client,client.geo.city_name,keyword,core,Montreal,City name.
@@ -36,14 +36,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,client,client.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.5.0-dev,true,client,client.user.email,keyword,extended,,User email address.
 1.5.0-dev,true,client,client.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.5.0-dev,true,client,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
+1.5.0-dev,true,client,client.user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.5.0-dev,true,client,client.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.5.0-dev,true,client,client.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.5.0-dev,true,client,client.user.group.name,keyword,extended,,Name of the group.
 1.5.0-dev,true,client,client.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.5.0-dev,true,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,client,client.user.name,keyword,core,albert,Short name or login of the user.
-1.5.0-dev,true,client,user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,client,client.user.name.text,text,core,albert,Short name or login of the user.
 1.5.0-dev,true,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
 1.5.0-dev,true,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
 1.5.0-dev,true,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
@@ -60,7 +60,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,destination,destination.address,keyword,extended,,Destination network address.
 1.5.0-dev,true,destination,destination.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.5.0-dev,true,destination,destination.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.5.0-dev,true,destination,as.organization.name.text,text,extended,Google LLC,Organization name.
+1.5.0-dev,true,destination,destination.as.organization.name.text,text,extended,Google LLC,Organization name.
 1.5.0-dev,true,destination,destination.bytes,long,core,184,Bytes sent from the destination to the source.
 1.5.0-dev,true,destination,destination.domain,keyword,core,,Destination domain.
 1.5.0-dev,true,destination,destination.geo.city_name,keyword,core,Montreal,City name.
@@ -82,14 +82,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.5.0-dev,true,destination,destination.user.email,keyword,extended,,User email address.
 1.5.0-dev,true,destination,destination.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.5.0-dev,true,destination,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
+1.5.0-dev,true,destination,destination.user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.5.0-dev,true,destination,destination.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.5.0-dev,true,destination,destination.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.5.0-dev,true,destination,destination.user.group.name,keyword,extended,,Name of the group.
 1.5.0-dev,true,destination,destination.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.5.0-dev,true,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
-1.5.0-dev,true,destination,user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,destination,destination.user.name.text,text,core,albert,Short name or login of the user.
 1.5.0-dev,true,dns,dns.answers,object,extended,,Array of DNS answers.
 1.5.0-dev,true,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
 1.5.0-dev,true,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
@@ -195,10 +195,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,host,host.name,keyword,core,,Name of the host.
 1.5.0-dev,true,host,host.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.5.0-dev,true,host,host.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.5.0-dev,true,host,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.5.0-dev,true,host,host.os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.5.0-dev,true,host,host.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.5.0-dev,true,host,host.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.5.0-dev,true,host,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
+1.5.0-dev,true,host,host.os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.5.0-dev,true,host,host.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.5.0-dev,true,host,host.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.5.0-dev,true,host,host.type,keyword,core,,Type of host.
@@ -206,14 +206,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,host,host.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.5.0-dev,true,host,host.user.email,keyword,extended,,User email address.
 1.5.0-dev,true,host,host.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.5.0-dev,true,host,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
+1.5.0-dev,true,host,host.user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.5.0-dev,true,host,host.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.5.0-dev,true,host,host.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.5.0-dev,true,host,host.user.group.name,keyword,extended,,Name of the group.
 1.5.0-dev,true,host,host.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.5.0-dev,true,host,host.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,host,host.user.name,keyword,core,albert,Short name or login of the user.
-1.5.0-dev,true,host,user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,host,host.user.name.text,text,core,albert,Short name or login of the user.
 1.5.0-dev,true,http,http.request.body.bytes,long,extended,887,Size in bytes of the request body.
 1.5.0-dev,true,http,http.request.body.content,keyword,extended,Hello world,The full HTTP request body.
 1.5.0-dev,true,http,http.request.body.content.text,text,extended,Hello world,The full HTTP request body.
@@ -263,10 +263,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
 1.5.0-dev,true,observer,observer.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.5.0-dev,true,observer,observer.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.5.0-dev,true,observer,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.5.0-dev,true,observer,observer.os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.5.0-dev,true,observer,observer.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.5.0-dev,true,observer,observer.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.5.0-dev,true,observer,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
+1.5.0-dev,true,observer,observer.os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.5.0-dev,true,observer,observer.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.5.0-dev,true,observer,observer.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.5.0-dev,true,observer,observer.product,keyword,extended,s200,The product name of the observer.
@@ -362,7 +362,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,server,server.address,keyword,extended,,Server network address.
 1.5.0-dev,true,server,server.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.5.0-dev,true,server,server.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.5.0-dev,true,server,as.organization.name.text,text,extended,Google LLC,Organization name.
+1.5.0-dev,true,server,server.as.organization.name.text,text,extended,Google LLC,Organization name.
 1.5.0-dev,true,server,server.bytes,long,core,184,Bytes sent from the server to the client.
 1.5.0-dev,true,server,server.domain,keyword,core,,Server domain.
 1.5.0-dev,true,server,server.geo.city_name,keyword,core,Montreal,City name.
@@ -384,14 +384,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,server,server.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.5.0-dev,true,server,server.user.email,keyword,extended,,User email address.
 1.5.0-dev,true,server,server.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.5.0-dev,true,server,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
+1.5.0-dev,true,server,server.user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.5.0-dev,true,server,server.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.5.0-dev,true,server,server.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.5.0-dev,true,server,server.user.group.name,keyword,extended,,Name of the group.
 1.5.0-dev,true,server,server.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.5.0-dev,true,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,server,server.user.name,keyword,core,albert,Short name or login of the user.
-1.5.0-dev,true,server,user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,server,server.user.name.text,text,core,albert,Short name or login of the user.
 1.5.0-dev,true,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
 1.5.0-dev,true,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 1.5.0-dev,true,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
@@ -402,7 +402,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,source,source.address,keyword,extended,,Source network address.
 1.5.0-dev,true,source,source.as.number,long,extended,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.5.0-dev,true,source,source.as.organization.name,keyword,extended,Google LLC,Organization name.
-1.5.0-dev,true,source,as.organization.name.text,text,extended,Google LLC,Organization name.
+1.5.0-dev,true,source,source.as.organization.name.text,text,extended,Google LLC,Organization name.
 1.5.0-dev,true,source,source.bytes,long,core,184,Bytes sent from the source to the destination.
 1.5.0-dev,true,source,source.domain,keyword,core,,Source domain.
 1.5.0-dev,true,source,source.geo.city_name,keyword,core,Montreal,City name.
@@ -424,14 +424,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.
 1.5.0-dev,true,source,source.user.email,keyword,extended,,User email address.
 1.5.0-dev,true,source,source.user.full_name,keyword,extended,Albert Einstein,"User's full name, if available."
-1.5.0-dev,true,source,user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
+1.5.0-dev,true,source,source.user.full_name.text,text,extended,Albert Einstein,"User's full name, if available."
 1.5.0-dev,true,source,source.user.group.domain,keyword,extended,,Name of the directory the group is a member of.
 1.5.0-dev,true,source,source.user.group.id,keyword,extended,,Unique identifier for the group on the system/platform.
 1.5.0-dev,true,source,source.user.group.name,keyword,extended,,Name of the group.
 1.5.0-dev,true,source,source.user.hash,keyword,extended,,Unique user hash to correlate information for a user in anonymized form.
 1.5.0-dev,true,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,source,source.user.name,keyword,core,albert,Short name or login of the user.
-1.5.0-dev,true,source,user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,source,source.user.name.text,text,core,albert,Short name or login of the user.
 1.5.0-dev,true,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
 1.5.0-dev,true,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
 1.5.0-dev,true,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.
@@ -503,10 +503,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,user_agent,user_agent.original.text,text,extended,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 1.5.0-dev,true,user_agent,user_agent.os.family,keyword,extended,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.5.0-dev,true,user_agent,user_agent.os.full,keyword,extended,Mac OS Mojave,"Operating system name, including the version or code name."
-1.5.0-dev,true,user_agent,os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
+1.5.0-dev,true,user_agent,user_agent.os.full.text,text,extended,Mac OS Mojave,"Operating system name, including the version or code name."
 1.5.0-dev,true,user_agent,user_agent.os.kernel,keyword,extended,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.5.0-dev,true,user_agent,user_agent.os.name,keyword,extended,Mac OS X,"Operating system name, without the version."
-1.5.0-dev,true,user_agent,os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
+1.5.0-dev,true,user_agent,user_agent.os.name.text,text,extended,Mac OS X,"Operating system name, without the version."
 1.5.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.5.0-dev,true,user_agent,user_agent.os.version,keyword,extended,10.14.1,Operating system version as a raw string.
 1.5.0-dev,true,user_agent,user_agent.version,keyword,extended,12.0,Version of the user agent.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -95,6 +95,7 @@ as.number:
   level: extended
   name: number
   order: 0
+  original_fieldset: as
   short: Unique number allocated to the autonomous system. The autonomous system number
     (ASN) uniquely identifies each network on the Internet.
   type: long
@@ -112,6 +113,7 @@ as.organization.name:
     type: text
   name: organization.name
   order: 1
+  original_fieldset: as
   short: Organization name.
   type: keyword
 client.address:
@@ -130,7 +132,7 @@ client.address:
   short: Client network address.
   type: keyword
 client.as.number:
-  dashed_name: as-number
+  dashed_name: client-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
     number (ASN) uniquely identifies each network on the Internet.
   example: 15169
@@ -143,14 +145,14 @@ client.as.number:
     (ASN) uniquely identifies each network on the Internet.
   type: long
 client.as.organization.name:
-  dashed_name: as-organization-name
+  dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: client.as.organization.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: as.organization.name.text
+  - flat_name: client.as.organization.name.text
     name: text
     norms: false
     type: text
@@ -181,7 +183,7 @@ client.domain:
   short: Client domain.
   type: keyword
 client.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: client-geo-city-name
   description: City name.
   example: Montreal
   flat_name: client.geo.city_name
@@ -193,7 +195,7 @@ client.geo.city_name:
   short: City name.
   type: keyword
 client.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: client-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: client.geo.continent_name
@@ -205,7 +207,7 @@ client.geo.continent_name:
   short: Name of the continent.
   type: keyword
 client.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: client-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: client.geo.country_iso_code
@@ -217,7 +219,7 @@ client.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 client.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: client-geo-country-name
   description: Country name.
   example: Canada
   flat_name: client.geo.country_name
@@ -229,7 +231,7 @@ client.geo.country_name:
   short: Country name.
   type: keyword
 client.geo.location:
-  dashed_name: geo-location
+  dashed_name: client-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: client.geo.location
@@ -240,7 +242,7 @@ client.geo.location:
   short: Longitude and latitude.
   type: geo_point
 client.geo.name:
-  dashed_name: geo-name
+  dashed_name: client-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -258,7 +260,7 @@ client.geo.name:
   short: User-defined description of a location.
   type: keyword
 client.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: client-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: client.geo.region_iso_code
@@ -270,7 +272,7 @@ client.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 client.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: client-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: client.geo.region_name
@@ -382,7 +384,7 @@ client.top_level_domain:
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 client.user.domain:
-  dashed_name: user-domain
+  dashed_name: client-user-domain
   description: 'Name of the directory the user is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -395,7 +397,7 @@ client.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 client.user.email:
-  dashed_name: user-email
+  dashed_name: client-user-email
   description: User email address.
   flat_name: client.user.email
   ignore_above: 1024
@@ -406,14 +408,14 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
-  dashed_name: user-full-name
+  dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: client.user.full_name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: user.full_name.text
+  - flat_name: client.user.full_name.text
     name: text
     norms: false
     type: text
@@ -423,7 +425,7 @@ client.user.full_name:
   short: User's full name, if available.
   type: keyword
 client.user.group.domain:
-  dashed_name: group-domain
+  dashed_name: client-user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -432,33 +434,33 @@ client.user.group.domain:
   level: extended
   name: domain
   order: 2
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 client.user.group.id:
-  dashed_name: group-id
+  dashed_name: client-user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: client.user.group.id
   ignore_above: 1024
   level: extended
   name: id
   order: 0
-  original_fieldset: user
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 client.user.group.name:
-  dashed_name: group-name
+  dashed_name: client-user-group-name
   description: Name of the group.
   flat_name: client.user.group.name
   ignore_above: 1024
   level: extended
   name: name
   order: 1
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 client.user.hash:
-  dashed_name: user-hash
+  dashed_name: client-user-hash
   description: 'Unique user hash to correlate information for a user in anonymized
     form.
 
@@ -473,7 +475,7 @@ client.user.hash:
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 client.user.id:
-  dashed_name: user-id
+  dashed_name: client-user-id
   description: One or multiple unique identifiers of the user.
   flat_name: client.user.id
   ignore_above: 1024
@@ -484,14 +486,14 @@ client.user.id:
   short: One or multiple unique identifiers of the user.
   type: keyword
 client.user.name:
-  dashed_name: user-name
+  dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: client.user.name
   ignore_above: 1024
   level: core
   multi_fields:
-  - flat_name: user.name.text
+  - flat_name: client.user.name.text
     name: text
     norms: false
     type: text
@@ -657,7 +659,7 @@ destination.address:
   short: Destination network address.
   type: keyword
 destination.as.number:
-  dashed_name: as-number
+  dashed_name: destination-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
     number (ASN) uniquely identifies each network on the Internet.
   example: 15169
@@ -670,14 +672,14 @@ destination.as.number:
     (ASN) uniquely identifies each network on the Internet.
   type: long
 destination.as.organization.name:
-  dashed_name: as-organization-name
+  dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: destination.as.organization.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: as.organization.name.text
+  - flat_name: destination.as.organization.name.text
     name: text
     norms: false
     type: text
@@ -708,7 +710,7 @@ destination.domain:
   short: Destination domain.
   type: keyword
 destination.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: destination-geo-city-name
   description: City name.
   example: Montreal
   flat_name: destination.geo.city_name
@@ -720,7 +722,7 @@ destination.geo.city_name:
   short: City name.
   type: keyword
 destination.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: destination-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: destination.geo.continent_name
@@ -732,7 +734,7 @@ destination.geo.continent_name:
   short: Name of the continent.
   type: keyword
 destination.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: destination-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: destination.geo.country_iso_code
@@ -744,7 +746,7 @@ destination.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 destination.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: destination-geo-country-name
   description: Country name.
   example: Canada
   flat_name: destination.geo.country_name
@@ -756,7 +758,7 @@ destination.geo.country_name:
   short: Country name.
   type: keyword
 destination.geo.location:
-  dashed_name: geo-location
+  dashed_name: destination-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: destination.geo.location
@@ -767,7 +769,7 @@ destination.geo.location:
   short: Longitude and latitude.
   type: geo_point
 destination.geo.name:
-  dashed_name: geo-name
+  dashed_name: destination-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -785,7 +787,7 @@ destination.geo.name:
   short: User-defined description of a location.
   type: keyword
 destination.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: destination-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: destination.geo.region_iso_code
@@ -797,7 +799,7 @@ destination.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 destination.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: destination-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: destination.geo.region_name
@@ -908,7 +910,7 @@ destination.top_level_domain:
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 destination.user.domain:
-  dashed_name: user-domain
+  dashed_name: destination-user-domain
   description: 'Name of the directory the user is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -921,7 +923,7 @@ destination.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 destination.user.email:
-  dashed_name: user-email
+  dashed_name: destination-user-email
   description: User email address.
   flat_name: destination.user.email
   ignore_above: 1024
@@ -932,14 +934,14 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
-  dashed_name: user-full-name
+  dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: destination.user.full_name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: user.full_name.text
+  - flat_name: destination.user.full_name.text
     name: text
     norms: false
     type: text
@@ -949,7 +951,7 @@ destination.user.full_name:
   short: User's full name, if available.
   type: keyword
 destination.user.group.domain:
-  dashed_name: group-domain
+  dashed_name: destination-user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -958,33 +960,33 @@ destination.user.group.domain:
   level: extended
   name: domain
   order: 2
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 destination.user.group.id:
-  dashed_name: group-id
+  dashed_name: destination-user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: destination.user.group.id
   ignore_above: 1024
   level: extended
   name: id
   order: 0
-  original_fieldset: user
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 destination.user.group.name:
-  dashed_name: group-name
+  dashed_name: destination-user-group-name
   description: Name of the group.
   flat_name: destination.user.group.name
   ignore_above: 1024
   level: extended
   name: name
   order: 1
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 destination.user.hash:
-  dashed_name: user-hash
+  dashed_name: destination-user-hash
   description: 'Unique user hash to correlate information for a user in anonymized
     form.
 
@@ -999,7 +1001,7 @@ destination.user.hash:
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 destination.user.id:
-  dashed_name: user-id
+  dashed_name: destination-user-id
   description: One or multiple unique identifiers of the user.
   flat_name: destination.user.id
   ignore_above: 1024
@@ -1010,14 +1012,14 @@ destination.user.id:
   short: One or multiple unique identifiers of the user.
   type: keyword
 destination.user.name:
-  dashed_name: user-name
+  dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: destination.user.name
   ignore_above: 1024
   level: core
   multi_fields:
-  - flat_name: user.name.text
+  - flat_name: destination.user.name.text
     name: text
     norms: false
     type: text
@@ -2075,7 +2077,7 @@ file.group:
   short: Primary group name of the file.
   type: keyword
 file.hash.md5:
-  dashed_name: hash-md5
+  dashed_name: file-hash-md5
   description: MD5 hash.
   flat_name: file.hash.md5
   ignore_above: 1024
@@ -2086,7 +2088,7 @@ file.hash.md5:
   short: MD5 hash.
   type: keyword
 file.hash.sha1:
-  dashed_name: hash-sha1
+  dashed_name: file-hash-sha1
   description: SHA1 hash.
   flat_name: file.hash.sha1
   ignore_above: 1024
@@ -2097,7 +2099,7 @@ file.hash.sha1:
   short: SHA1 hash.
   type: keyword
 file.hash.sha256:
-  dashed_name: hash-sha256
+  dashed_name: file-hash-sha256
   description: SHA256 hash.
   flat_name: file.hash.sha256
   ignore_above: 1024
@@ -2108,7 +2110,7 @@ file.hash.sha256:
   short: SHA256 hash.
   type: keyword
 file.hash.sha512:
-  dashed_name: hash-sha512
+  dashed_name: file-hash-sha512
   description: SHA512 hash.
   flat_name: file.hash.sha512
   ignore_above: 1024
@@ -2246,6 +2248,7 @@ geo.city_name:
   level: core
   name: city_name
   order: 4
+  original_fieldset: geo
   short: City name.
   type: keyword
 geo.continent_name:
@@ -2257,6 +2260,7 @@ geo.continent_name:
   level: core
   name: continent_name
   order: 1
+  original_fieldset: geo
   short: Name of the continent.
   type: keyword
 geo.country_iso_code:
@@ -2268,6 +2272,7 @@ geo.country_iso_code:
   level: core
   name: country_iso_code
   order: 5
+  original_fieldset: geo
   short: Country ISO code.
   type: keyword
 geo.country_name:
@@ -2279,6 +2284,7 @@ geo.country_name:
   level: core
   name: country_name
   order: 2
+  original_fieldset: geo
   short: Country name.
   type: keyword
 geo.location:
@@ -2289,6 +2295,7 @@ geo.location:
   level: core
   name: location
   order: 0
+  original_fieldset: geo
   short: Longitude and latitude.
   type: geo_point
 geo.name:
@@ -2306,6 +2313,7 @@ geo.name:
   level: extended
   name: name
   order: 7
+  original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
 geo.region_iso_code:
@@ -2317,6 +2325,7 @@ geo.region_iso_code:
   level: core
   name: region_iso_code
   order: 6
+  original_fieldset: geo
   short: Region ISO code.
   type: keyword
 geo.region_name:
@@ -2328,6 +2337,7 @@ geo.region_name:
   level: core
   name: region_name
   order: 3
+  original_fieldset: geo
   short: Region name.
   type: keyword
 group.domain:
@@ -2340,6 +2350,7 @@ group.domain:
   level: extended
   name: domain
   order: 2
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 group.id:
@@ -2350,6 +2361,7 @@ group.id:
   level: extended
   name: id
   order: 0
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 group.name:
@@ -2360,6 +2372,7 @@ group.name:
   level: extended
   name: name
   order: 1
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 hash.md5:
@@ -2370,6 +2383,7 @@ hash.md5:
   level: extended
   name: md5
   order: 0
+  original_fieldset: hash
   short: MD5 hash.
   type: keyword
 hash.sha1:
@@ -2380,6 +2394,7 @@ hash.sha1:
   level: extended
   name: sha1
   order: 1
+  original_fieldset: hash
   short: SHA1 hash.
   type: keyword
 hash.sha256:
@@ -2390,6 +2405,7 @@ hash.sha256:
   level: extended
   name: sha256
   order: 2
+  original_fieldset: hash
   short: SHA256 hash.
   type: keyword
 hash.sha512:
@@ -2400,6 +2416,7 @@ hash.sha512:
   level: extended
   name: sha512
   order: 3
+  original_fieldset: hash
   short: SHA512 hash.
   type: keyword
 host.architecture:
@@ -2427,7 +2444,7 @@ host.domain:
   short: Name of the directory the group is a member of.
   type: keyword
 host.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: host-geo-city-name
   description: City name.
   example: Montreal
   flat_name: host.geo.city_name
@@ -2439,7 +2456,7 @@ host.geo.city_name:
   short: City name.
   type: keyword
 host.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: host-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: host.geo.continent_name
@@ -2451,7 +2468,7 @@ host.geo.continent_name:
   short: Name of the continent.
   type: keyword
 host.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: host-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: host.geo.country_iso_code
@@ -2463,7 +2480,7 @@ host.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 host.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: host-geo-country-name
   description: Country name.
   example: Canada
   flat_name: host.geo.country_name
@@ -2475,7 +2492,7 @@ host.geo.country_name:
   short: Country name.
   type: keyword
 host.geo.location:
-  dashed_name: geo-location
+  dashed_name: host-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: host.geo.location
@@ -2486,7 +2503,7 @@ host.geo.location:
   short: Longitude and latitude.
   type: geo_point
 host.geo.name:
-  dashed_name: geo-name
+  dashed_name: host-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -2504,7 +2521,7 @@ host.geo.name:
   short: User-defined description of a location.
   type: keyword
 host.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: host-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: host.geo.region_iso_code
@@ -2516,7 +2533,7 @@ host.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 host.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: host-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: host.geo.region_name
@@ -2586,7 +2603,7 @@ host.name:
   short: Name of the host.
   type: keyword
 host.os.family:
-  dashed_name: os-family
+  dashed_name: host-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
   example: debian
   flat_name: host.os.family
@@ -2598,14 +2615,14 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
-  dashed_name: os-full
+  dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: host.os.full
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.full.text
+  - flat_name: host.os.full.text
     name: text
     norms: false
     type: text
@@ -2615,7 +2632,7 @@ host.os.full:
   short: Operating system name, including the version or code name.
   type: keyword
 host.os.kernel:
-  dashed_name: os-kernel
+  dashed_name: host-os-kernel
   description: Operating system kernel version as a raw string.
   example: 4.4.0-112-generic
   flat_name: host.os.kernel
@@ -2627,14 +2644,14 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
-  dashed_name: os-name
+  dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: host.os.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.name.text
+  - flat_name: host.os.name.text
     name: text
     norms: false
     type: text
@@ -2644,7 +2661,7 @@ host.os.name:
   short: Operating system name, without the version.
   type: keyword
 host.os.platform:
-  dashed_name: os-platform
+  dashed_name: host-os-platform
   description: Operating system platform (such centos, ubuntu, windows).
   example: darwin
   flat_name: host.os.platform
@@ -2656,7 +2673,7 @@ host.os.platform:
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
 host.os.version:
-  dashed_name: os-version
+  dashed_name: host-os-version
   description: Operating system version as a raw string.
   example: 10.14.1
   flat_name: host.os.version
@@ -2691,7 +2708,7 @@ host.uptime:
   short: Seconds the host has been up.
   type: long
 host.user.domain:
-  dashed_name: user-domain
+  dashed_name: host-user-domain
   description: 'Name of the directory the user is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -2704,7 +2721,7 @@ host.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 host.user.email:
-  dashed_name: user-email
+  dashed_name: host-user-email
   description: User email address.
   flat_name: host.user.email
   ignore_above: 1024
@@ -2715,14 +2732,14 @@ host.user.email:
   short: User email address.
   type: keyword
 host.user.full_name:
-  dashed_name: user-full-name
+  dashed_name: host-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: host.user.full_name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: user.full_name.text
+  - flat_name: host.user.full_name.text
     name: text
     norms: false
     type: text
@@ -2732,7 +2749,7 @@ host.user.full_name:
   short: User's full name, if available.
   type: keyword
 host.user.group.domain:
-  dashed_name: group-domain
+  dashed_name: host-user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -2741,33 +2758,33 @@ host.user.group.domain:
   level: extended
   name: domain
   order: 2
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 host.user.group.id:
-  dashed_name: group-id
+  dashed_name: host-user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: host.user.group.id
   ignore_above: 1024
   level: extended
   name: id
   order: 0
-  original_fieldset: user
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 host.user.group.name:
-  dashed_name: group-name
+  dashed_name: host-user-group-name
   description: Name of the group.
   flat_name: host.user.group.name
   ignore_above: 1024
   level: extended
   name: name
   order: 1
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 host.user.hash:
-  dashed_name: user-hash
+  dashed_name: host-user-hash
   description: 'Unique user hash to correlate information for a user in anonymized
     form.
 
@@ -2782,7 +2799,7 @@ host.user.hash:
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 host.user.id:
-  dashed_name: user-id
+  dashed_name: host-user-id
   description: One or multiple unique identifiers of the user.
   flat_name: host.user.id
   ignore_above: 1024
@@ -2793,14 +2810,14 @@ host.user.id:
   short: One or multiple unique identifiers of the user.
   type: keyword
 host.user.name:
-  dashed_name: user-name
+  dashed_name: host-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: host.user.name
   ignore_above: 1024
   level: core
   multi_fields:
-  - flat_name: user.name.text
+  - flat_name: host.user.name.text
     name: text
     norms: false
     type: text
@@ -3286,7 +3303,7 @@ network.type:
     etc
   type: keyword
 observer.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: observer-geo-city-name
   description: City name.
   example: Montreal
   flat_name: observer.geo.city_name
@@ -3298,7 +3315,7 @@ observer.geo.city_name:
   short: City name.
   type: keyword
 observer.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: observer-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: observer.geo.continent_name
@@ -3310,7 +3327,7 @@ observer.geo.continent_name:
   short: Name of the continent.
   type: keyword
 observer.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: observer-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: observer.geo.country_iso_code
@@ -3322,7 +3339,7 @@ observer.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 observer.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: observer-geo-country-name
   description: Country name.
   example: Canada
   flat_name: observer.geo.country_name
@@ -3334,7 +3351,7 @@ observer.geo.country_name:
   short: Country name.
   type: keyword
 observer.geo.location:
-  dashed_name: geo-location
+  dashed_name: observer-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: observer.geo.location
@@ -3345,7 +3362,7 @@ observer.geo.location:
   short: Longitude and latitude.
   type: geo_point
 observer.geo.name:
-  dashed_name: geo-name
+  dashed_name: observer-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -3363,7 +3380,7 @@ observer.geo.name:
   short: User-defined description of a location.
   type: keyword
 observer.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: observer-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: observer.geo.region_iso_code
@@ -3375,7 +3392,7 @@ observer.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 observer.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: observer-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: observer.geo.region_name
@@ -3432,7 +3449,7 @@ observer.name:
   short: Custom name of the observer.
   type: keyword
 observer.os.family:
-  dashed_name: os-family
+  dashed_name: observer-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
   example: debian
   flat_name: observer.os.family
@@ -3444,14 +3461,14 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
-  dashed_name: os-full
+  dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: observer.os.full
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.full.text
+  - flat_name: observer.os.full.text
     name: text
     norms: false
     type: text
@@ -3461,7 +3478,7 @@ observer.os.full:
   short: Operating system name, including the version or code name.
   type: keyword
 observer.os.kernel:
-  dashed_name: os-kernel
+  dashed_name: observer-os-kernel
   description: Operating system kernel version as a raw string.
   example: 4.4.0-112-generic
   flat_name: observer.os.kernel
@@ -3473,14 +3490,14 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
-  dashed_name: os-name
+  dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: observer.os.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.name.text
+  - flat_name: observer.os.name.text
     name: text
     norms: false
     type: text
@@ -3490,7 +3507,7 @@ observer.os.name:
   short: Operating system name, without the version.
   type: keyword
 observer.os.platform:
-  dashed_name: os-platform
+  dashed_name: observer-os-platform
   description: Operating system platform (such centos, ubuntu, windows).
   example: darwin
   flat_name: observer.os.platform
@@ -3502,7 +3519,7 @@ observer.os.platform:
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
 observer.os.version:
-  dashed_name: os-version
+  dashed_name: observer-os-version
   description: Operating system version as a raw string.
   example: 10.14.1
   flat_name: observer.os.version
@@ -3603,6 +3620,7 @@ os.family:
   level: extended
   name: family
   order: 3
+  original_fieldset: os
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 os.full:
@@ -3619,6 +3637,7 @@ os.full:
     type: text
   name: full
   order: 2
+  original_fieldset: os
   short: Operating system name, including the version or code name.
   type: keyword
 os.kernel:
@@ -3630,6 +3649,7 @@ os.kernel:
   level: extended
   name: kernel
   order: 5
+  original_fieldset: os
   short: Operating system kernel version as a raw string.
   type: keyword
 os.name:
@@ -3646,6 +3666,7 @@ os.name:
     type: text
   name: name
   order: 1
+  original_fieldset: os
   short: Operating system name, without the version.
   type: keyword
 os.platform:
@@ -3657,6 +3678,7 @@ os.platform:
   level: extended
   name: platform
   order: 0
+  original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
 os.version:
@@ -3668,6 +3690,7 @@ os.version:
   level: extended
   name: version
   order: 4
+  original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
 package.architecture:
@@ -3900,7 +3923,7 @@ process.exit_code:
   short: The exit code of the process.
   type: long
 process.hash.md5:
-  dashed_name: hash-md5
+  dashed_name: process-hash-md5
   description: MD5 hash.
   flat_name: process.hash.md5
   ignore_above: 1024
@@ -3911,7 +3934,7 @@ process.hash.md5:
   short: MD5 hash.
   type: keyword
 process.hash.sha1:
-  dashed_name: hash-sha1
+  dashed_name: process-hash-sha1
   description: SHA1 hash.
   flat_name: process.hash.sha1
   ignore_above: 1024
@@ -3922,7 +3945,7 @@ process.hash.sha1:
   short: SHA1 hash.
   type: keyword
 process.hash.sha256:
-  dashed_name: hash-sha256
+  dashed_name: process-hash-sha256
   description: SHA256 hash.
   flat_name: process.hash.sha256
   ignore_above: 1024
@@ -3933,7 +3956,7 @@ process.hash.sha256:
   short: SHA256 hash.
   type: keyword
 process.hash.sha512:
-  dashed_name: hash-sha512
+  dashed_name: process-hash-sha512
   description: SHA512 hash.
   flat_name: process.hash.sha512
   ignore_above: 1024
@@ -4494,7 +4517,7 @@ server.address:
   short: Server network address.
   type: keyword
 server.as.number:
-  dashed_name: as-number
+  dashed_name: server-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
     number (ASN) uniquely identifies each network on the Internet.
   example: 15169
@@ -4507,14 +4530,14 @@ server.as.number:
     (ASN) uniquely identifies each network on the Internet.
   type: long
 server.as.organization.name:
-  dashed_name: as-organization-name
+  dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: server.as.organization.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: as.organization.name.text
+  - flat_name: server.as.organization.name.text
     name: text
     norms: false
     type: text
@@ -4545,7 +4568,7 @@ server.domain:
   short: Server domain.
   type: keyword
 server.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: server-geo-city-name
   description: City name.
   example: Montreal
   flat_name: server.geo.city_name
@@ -4557,7 +4580,7 @@ server.geo.city_name:
   short: City name.
   type: keyword
 server.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: server-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: server.geo.continent_name
@@ -4569,7 +4592,7 @@ server.geo.continent_name:
   short: Name of the continent.
   type: keyword
 server.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: server-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: server.geo.country_iso_code
@@ -4581,7 +4604,7 @@ server.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 server.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: server-geo-country-name
   description: Country name.
   example: Canada
   flat_name: server.geo.country_name
@@ -4593,7 +4616,7 @@ server.geo.country_name:
   short: Country name.
   type: keyword
 server.geo.location:
-  dashed_name: geo-location
+  dashed_name: server-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: server.geo.location
@@ -4604,7 +4627,7 @@ server.geo.location:
   short: Longitude and latitude.
   type: geo_point
 server.geo.name:
-  dashed_name: geo-name
+  dashed_name: server-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -4622,7 +4645,7 @@ server.geo.name:
   short: User-defined description of a location.
   type: keyword
 server.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: server-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: server.geo.region_iso_code
@@ -4634,7 +4657,7 @@ server.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 server.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: server-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: server.geo.region_name
@@ -4746,7 +4769,7 @@ server.top_level_domain:
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 server.user.domain:
-  dashed_name: user-domain
+  dashed_name: server-user-domain
   description: 'Name of the directory the user is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -4759,7 +4782,7 @@ server.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 server.user.email:
-  dashed_name: user-email
+  dashed_name: server-user-email
   description: User email address.
   flat_name: server.user.email
   ignore_above: 1024
@@ -4770,14 +4793,14 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
-  dashed_name: user-full-name
+  dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: server.user.full_name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: user.full_name.text
+  - flat_name: server.user.full_name.text
     name: text
     norms: false
     type: text
@@ -4787,7 +4810,7 @@ server.user.full_name:
   short: User's full name, if available.
   type: keyword
 server.user.group.domain:
-  dashed_name: group-domain
+  dashed_name: server-user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -4796,33 +4819,33 @@ server.user.group.domain:
   level: extended
   name: domain
   order: 2
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 server.user.group.id:
-  dashed_name: group-id
+  dashed_name: server-user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: server.user.group.id
   ignore_above: 1024
   level: extended
   name: id
   order: 0
-  original_fieldset: user
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 server.user.group.name:
-  dashed_name: group-name
+  dashed_name: server-user-group-name
   description: Name of the group.
   flat_name: server.user.group.name
   ignore_above: 1024
   level: extended
   name: name
   order: 1
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 server.user.hash:
-  dashed_name: user-hash
+  dashed_name: server-user-hash
   description: 'Unique user hash to correlate information for a user in anonymized
     form.
 
@@ -4837,7 +4860,7 @@ server.user.hash:
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 server.user.id:
-  dashed_name: user-id
+  dashed_name: server-user-id
   description: One or multiple unique identifiers of the user.
   flat_name: server.user.id
   ignore_above: 1024
@@ -4848,14 +4871,14 @@ server.user.id:
   short: One or multiple unique identifiers of the user.
   type: keyword
 server.user.name:
-  dashed_name: user-name
+  dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: server.user.name
   ignore_above: 1024
   level: core
   multi_fields:
-  - flat_name: user.name.text
+  - flat_name: server.user.name.text
     name: text
     norms: false
     type: text
@@ -4992,7 +5015,7 @@ source.address:
   short: Source network address.
   type: keyword
 source.as.number:
-  dashed_name: as-number
+  dashed_name: source-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
     number (ASN) uniquely identifies each network on the Internet.
   example: 15169
@@ -5005,14 +5028,14 @@ source.as.number:
     (ASN) uniquely identifies each network on the Internet.
   type: long
 source.as.organization.name:
-  dashed_name: as-organization-name
+  dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: source.as.organization.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: as.organization.name.text
+  - flat_name: source.as.organization.name.text
     name: text
     norms: false
     type: text
@@ -5043,7 +5066,7 @@ source.domain:
   short: Source domain.
   type: keyword
 source.geo.city_name:
-  dashed_name: geo-city-name
+  dashed_name: source-geo-city-name
   description: City name.
   example: Montreal
   flat_name: source.geo.city_name
@@ -5055,7 +5078,7 @@ source.geo.city_name:
   short: City name.
   type: keyword
 source.geo.continent_name:
-  dashed_name: geo-continent-name
+  dashed_name: source-geo-continent-name
   description: Name of the continent.
   example: North America
   flat_name: source.geo.continent_name
@@ -5067,7 +5090,7 @@ source.geo.continent_name:
   short: Name of the continent.
   type: keyword
 source.geo.country_iso_code:
-  dashed_name: geo-country-iso-code
+  dashed_name: source-geo-country-iso-code
   description: Country ISO code.
   example: CA
   flat_name: source.geo.country_iso_code
@@ -5079,7 +5102,7 @@ source.geo.country_iso_code:
   short: Country ISO code.
   type: keyword
 source.geo.country_name:
-  dashed_name: geo-country-name
+  dashed_name: source-geo-country-name
   description: Country name.
   example: Canada
   flat_name: source.geo.country_name
@@ -5091,7 +5114,7 @@ source.geo.country_name:
   short: Country name.
   type: keyword
 source.geo.location:
-  dashed_name: geo-location
+  dashed_name: source-geo-location
   description: Longitude and latitude.
   example: '{ "lon": -73.614830, "lat": 45.505918 }'
   flat_name: source.geo.location
@@ -5102,7 +5125,7 @@ source.geo.location:
   short: Longitude and latitude.
   type: geo_point
 source.geo.name:
-  dashed_name: geo-name
+  dashed_name: source-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
 
@@ -5120,7 +5143,7 @@ source.geo.name:
   short: User-defined description of a location.
   type: keyword
 source.geo.region_iso_code:
-  dashed_name: geo-region-iso-code
+  dashed_name: source-geo-region-iso-code
   description: Region ISO code.
   example: CA-QC
   flat_name: source.geo.region_iso_code
@@ -5132,7 +5155,7 @@ source.geo.region_iso_code:
   short: Region ISO code.
   type: keyword
 source.geo.region_name:
-  dashed_name: geo-region-name
+  dashed_name: source-geo-region-name
   description: Region name.
   example: Quebec
   flat_name: source.geo.region_name
@@ -5244,7 +5267,7 @@ source.top_level_domain:
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 source.user.domain:
-  dashed_name: user-domain
+  dashed_name: source-user-domain
   description: 'Name of the directory the user is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -5257,7 +5280,7 @@ source.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 source.user.email:
-  dashed_name: user-email
+  dashed_name: source-user-email
   description: User email address.
   flat_name: source.user.email
   ignore_above: 1024
@@ -5268,14 +5291,14 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
-  dashed_name: user-full-name
+  dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: source.user.full_name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: user.full_name.text
+  - flat_name: source.user.full_name.text
     name: text
     norms: false
     type: text
@@ -5285,7 +5308,7 @@ source.user.full_name:
   short: User's full name, if available.
   type: keyword
 source.user.group.domain:
-  dashed_name: group-domain
+  dashed_name: source-user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -5294,33 +5317,33 @@ source.user.group.domain:
   level: extended
   name: domain
   order: 2
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 source.user.group.id:
-  dashed_name: group-id
+  dashed_name: source-user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: source.user.group.id
   ignore_above: 1024
   level: extended
   name: id
   order: 0
-  original_fieldset: user
+  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 source.user.group.name:
-  dashed_name: group-name
+  dashed_name: source-user-group-name
   description: Name of the group.
   flat_name: source.user.group.name
   ignore_above: 1024
   level: extended
   name: name
   order: 1
-  original_fieldset: user
+  original_fieldset: group
   short: Name of the group.
   type: keyword
 source.user.hash:
-  dashed_name: user-hash
+  dashed_name: source-user-hash
   description: 'Unique user hash to correlate information for a user in anonymized
     form.
 
@@ -5335,7 +5358,7 @@ source.user.hash:
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 source.user.id:
-  dashed_name: user-id
+  dashed_name: source-user-id
   description: One or multiple unique identifiers of the user.
   flat_name: source.user.id
   ignore_above: 1024
@@ -5346,14 +5369,14 @@ source.user.id:
   short: One or multiple unique identifiers of the user.
   type: keyword
 source.user.name:
-  dashed_name: user-name
+  dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: source.user.name
   ignore_above: 1024
   level: core
   multi_fields:
-  - flat_name: user.name.text
+  - flat_name: source.user.name.text
     name: text
     norms: false
     type: text
@@ -6069,6 +6092,7 @@ user.domain:
   level: extended
   name: domain
   order: 5
+  original_fieldset: user
   short: Name of the directory the user is a member of.
   type: keyword
 user.email:
@@ -6079,6 +6103,7 @@ user.email:
   level: extended
   name: email
   order: 3
+  original_fieldset: user
   short: User email address.
   type: keyword
 user.full_name:
@@ -6095,10 +6120,11 @@ user.full_name:
     type: text
   name: full_name
   order: 2
+  original_fieldset: user
   short: User's full name, if available.
   type: keyword
 user.group.domain:
-  dashed_name: group-domain
+  dashed_name: user-group-domain
   description: 'Name of the directory the group is a member of.
 
     For example, an LDAP or Active Directory domain name.'
@@ -6111,7 +6137,7 @@ user.group.domain:
   short: Name of the directory the group is a member of.
   type: keyword
 user.group.id:
-  dashed_name: group-id
+  dashed_name: user-group-id
   description: Unique identifier for the group on the system/platform.
   flat_name: user.group.id
   ignore_above: 1024
@@ -6122,7 +6148,7 @@ user.group.id:
   short: Unique identifier for the group on the system/platform.
   type: keyword
 user.group.name:
-  dashed_name: group-name
+  dashed_name: user-group-name
   description: Name of the group.
   flat_name: user.group.name
   ignore_above: 1024
@@ -6144,6 +6170,7 @@ user.hash:
   level: extended
   name: hash
   order: 4
+  original_fieldset: user
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
@@ -6154,6 +6181,7 @@ user.id:
   level: core
   name: id
   order: 0
+  original_fieldset: user
   short: One or multiple unique identifiers of the user.
   type: keyword
 user.name:
@@ -6170,6 +6198,7 @@ user.name:
     type: text
   name: name
   order: 1
+  original_fieldset: user
   short: Short name or login of the user.
   type: keyword
 user_agent.device.name:
@@ -6212,7 +6241,7 @@ user_agent.original:
   short: Unparsed user_agent string.
   type: keyword
 user_agent.os.family:
-  dashed_name: os-family
+  dashed_name: user-agent-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
   example: debian
   flat_name: user_agent.os.family
@@ -6224,14 +6253,14 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
-  dashed_name: os-full
+  dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: user_agent.os.full
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.full.text
+  - flat_name: user_agent.os.full.text
     name: text
     norms: false
     type: text
@@ -6241,7 +6270,7 @@ user_agent.os.full:
   short: Operating system name, including the version or code name.
   type: keyword
 user_agent.os.kernel:
-  dashed_name: os-kernel
+  dashed_name: user-agent-os-kernel
   description: Operating system kernel version as a raw string.
   example: 4.4.0-112-generic
   flat_name: user_agent.os.kernel
@@ -6253,14 +6282,14 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
-  dashed_name: os-name
+  dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: user_agent.os.name
   ignore_above: 1024
   level: extended
   multi_fields:
-  - flat_name: os.name.text
+  - flat_name: user_agent.os.name.text
     name: text
     norms: false
     type: text
@@ -6270,7 +6299,7 @@ user_agent.os.name:
   short: Operating system name, without the version.
   type: keyword
 user_agent.os.platform:
-  dashed_name: os-platform
+  dashed_name: user-agent-os-platform
   description: Operating system platform (such centos, ubuntu, windows).
   example: darwin
   flat_name: user_agent.os.platform
@@ -6282,7 +6311,7 @@ user_agent.os.platform:
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
 user_agent.os.version:
-  dashed_name: os-version
+  dashed_name: user-agent-os-version
   description: Operating system version as a raw string.
   example: 10.14.1
   flat_name: user_agent.os.version

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -242,7 +242,7 @@ client:
       short: Client network address.
       type: keyword
     as.number:
-      dashed_name: as-number
+      dashed_name: client-as-number
       description: Unique number allocated to the autonomous system. The autonomous
         system number (ASN) uniquely identifies each network on the Internet.
       example: 15169
@@ -255,14 +255,14 @@ client:
         number (ASN) uniquely identifies each network on the Internet.
       type: long
     as.organization.name:
-      dashed_name: as-organization-name
+      dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: client.as.organization.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: as.organization.name.text
+      - flat_name: client.as.organization.name.text
         name: text
         norms: false
         type: text
@@ -293,7 +293,7 @@ client:
       short: Client domain.
       type: keyword
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: client-geo-city-name
       description: City name.
       example: Montreal
       flat_name: client.geo.city_name
@@ -305,7 +305,7 @@ client:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: client-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: client.geo.continent_name
@@ -317,7 +317,7 @@ client:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: client-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: client.geo.country_iso_code
@@ -329,7 +329,7 @@ client:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: client-geo-country-name
       description: Country name.
       example: Canada
       flat_name: client.geo.country_name
@@ -341,7 +341,7 @@ client:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: client-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: client.geo.location
@@ -352,7 +352,7 @@ client:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: client-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -370,7 +370,7 @@ client:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: client-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: client.geo.region_iso_code
@@ -382,7 +382,7 @@ client:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: client-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: client.geo.region_name
@@ -494,7 +494,7 @@ client:
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:
-      dashed_name: user-domain
+      dashed_name: client-user-domain
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -507,7 +507,7 @@ client:
       short: Name of the directory the user is a member of.
       type: keyword
     user.email:
-      dashed_name: user-email
+      dashed_name: client-user-email
       description: User email address.
       flat_name: client.user.email
       ignore_above: 1024
@@ -518,14 +518,14 @@ client:
       short: User email address.
       type: keyword
     user.full_name:
-      dashed_name: user-full-name
+      dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: client.user.full_name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: user.full_name.text
+      - flat_name: client.user.full_name.text
         name: text
         norms: false
         type: text
@@ -535,7 +535,7 @@ client:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      dashed_name: group-domain
+      dashed_name: client-user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -544,33 +544,33 @@ client:
       level: extended
       name: domain
       order: 2
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
-      dashed_name: group-id
+      dashed_name: client-user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: client.user.group.id
       ignore_above: 1024
       level: extended
       name: id
       order: 0
-      original_fieldset: user
+      original_fieldset: group
       short: Unique identifier for the group on the system/platform.
       type: keyword
     user.group.name:
-      dashed_name: group-name
+      dashed_name: client-user-group-name
       description: Name of the group.
       flat_name: client.user.group.name
       ignore_above: 1024
       level: extended
       name: name
       order: 1
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the group.
       type: keyword
     user.hash:
-      dashed_name: user-hash
+      dashed_name: client-user-hash
       description: 'Unique user hash to correlate information for a user in anonymized
         form.
 
@@ -585,7 +585,7 @@ client:
       short: Unique user hash to correlate information for a user in anonymized form.
       type: keyword
     user.id:
-      dashed_name: user-id
+      dashed_name: client-user-id
       description: One or multiple unique identifiers of the user.
       flat_name: client.user.id
       ignore_above: 1024
@@ -596,14 +596,14 @@ client:
       short: One or multiple unique identifiers of the user.
       type: keyword
     user.name:
-      dashed_name: user-name
+      dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: client.user.name
       ignore_above: 1024
       level: core
       multi_fields:
-      - flat_name: user.name.text
+      - flat_name: client.user.name.text
         name: text
         norms: false
         type: text
@@ -811,7 +811,7 @@ destination:
       short: Destination network address.
       type: keyword
     as.number:
-      dashed_name: as-number
+      dashed_name: destination-as-number
       description: Unique number allocated to the autonomous system. The autonomous
         system number (ASN) uniquely identifies each network on the Internet.
       example: 15169
@@ -824,14 +824,14 @@ destination:
         number (ASN) uniquely identifies each network on the Internet.
       type: long
     as.organization.name:
-      dashed_name: as-organization-name
+      dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: destination.as.organization.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: as.organization.name.text
+      - flat_name: destination.as.organization.name.text
         name: text
         norms: false
         type: text
@@ -862,7 +862,7 @@ destination:
       short: Destination domain.
       type: keyword
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: destination-geo-city-name
       description: City name.
       example: Montreal
       flat_name: destination.geo.city_name
@@ -874,7 +874,7 @@ destination:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: destination-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: destination.geo.continent_name
@@ -886,7 +886,7 @@ destination:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: destination-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: destination.geo.country_iso_code
@@ -898,7 +898,7 @@ destination:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: destination-geo-country-name
       description: Country name.
       example: Canada
       flat_name: destination.geo.country_name
@@ -910,7 +910,7 @@ destination:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: destination-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: destination.geo.location
@@ -921,7 +921,7 @@ destination:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: destination-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -939,7 +939,7 @@ destination:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: destination-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: destination.geo.region_iso_code
@@ -951,7 +951,7 @@ destination:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: destination-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: destination.geo.region_name
@@ -1062,7 +1062,7 @@ destination:
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:
-      dashed_name: user-domain
+      dashed_name: destination-user-domain
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -1075,7 +1075,7 @@ destination:
       short: Name of the directory the user is a member of.
       type: keyword
     user.email:
-      dashed_name: user-email
+      dashed_name: destination-user-email
       description: User email address.
       flat_name: destination.user.email
       ignore_above: 1024
@@ -1086,14 +1086,14 @@ destination:
       short: User email address.
       type: keyword
     user.full_name:
-      dashed_name: user-full-name
+      dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: destination.user.full_name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: user.full_name.text
+      - flat_name: destination.user.full_name.text
         name: text
         norms: false
         type: text
@@ -1103,7 +1103,7 @@ destination:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      dashed_name: group-domain
+      dashed_name: destination-user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -1112,33 +1112,33 @@ destination:
       level: extended
       name: domain
       order: 2
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
-      dashed_name: group-id
+      dashed_name: destination-user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: destination.user.group.id
       ignore_above: 1024
       level: extended
       name: id
       order: 0
-      original_fieldset: user
+      original_fieldset: group
       short: Unique identifier for the group on the system/platform.
       type: keyword
     user.group.name:
-      dashed_name: group-name
+      dashed_name: destination-user-group-name
       description: Name of the group.
       flat_name: destination.user.group.name
       ignore_above: 1024
       level: extended
       name: name
       order: 1
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the group.
       type: keyword
     user.hash:
-      dashed_name: user-hash
+      dashed_name: destination-user-hash
       description: 'Unique user hash to correlate information for a user in anonymized
         form.
 
@@ -1153,7 +1153,7 @@ destination:
       short: Unique user hash to correlate information for a user in anonymized form.
       type: keyword
     user.id:
-      dashed_name: user-id
+      dashed_name: destination-user-id
       description: One or multiple unique identifiers of the user.
       flat_name: destination.user.id
       ignore_above: 1024
@@ -1164,14 +1164,14 @@ destination:
       short: One or multiple unique identifiers of the user.
       type: keyword
     user.name:
-      dashed_name: user-name
+      dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: destination.user.name
       ignore_above: 1024
       level: core
       multi_fields:
-      - flat_name: user.name.text
+      - flat_name: destination.user.name.text
         name: text
         norms: false
         type: text
@@ -2313,7 +2313,7 @@ file:
       short: Primary group name of the file.
       type: keyword
     hash.md5:
-      dashed_name: hash-md5
+      dashed_name: file-hash-md5
       description: MD5 hash.
       flat_name: file.hash.md5
       ignore_above: 1024
@@ -2324,7 +2324,7 @@ file:
       short: MD5 hash.
       type: keyword
     hash.sha1:
-      dashed_name: hash-sha1
+      dashed_name: file-hash-sha1
       description: SHA1 hash.
       flat_name: file.hash.sha1
       ignore_above: 1024
@@ -2335,7 +2335,7 @@ file:
       short: SHA1 hash.
       type: keyword
     hash.sha256:
-      dashed_name: hash-sha256
+      dashed_name: file-hash-sha256
       description: SHA256 hash.
       flat_name: file.hash.sha256
       ignore_above: 1024
@@ -2346,7 +2346,7 @@ file:
       short: SHA256 hash.
       type: keyword
     hash.sha512:
-      dashed_name: hash-sha512
+      dashed_name: file-hash-sha512
       description: SHA512 hash.
       flat_name: file.hash.sha512
       ignore_above: 1024
@@ -2734,7 +2734,7 @@ host:
       short: Name of the directory the group is a member of.
       type: keyword
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: host-geo-city-name
       description: City name.
       example: Montreal
       flat_name: host.geo.city_name
@@ -2746,7 +2746,7 @@ host:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: host-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: host.geo.continent_name
@@ -2758,7 +2758,7 @@ host:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: host-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: host.geo.country_iso_code
@@ -2770,7 +2770,7 @@ host:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: host-geo-country-name
       description: Country name.
       example: Canada
       flat_name: host.geo.country_name
@@ -2782,7 +2782,7 @@ host:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: host-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: host.geo.location
@@ -2793,7 +2793,7 @@ host:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: host-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -2811,7 +2811,7 @@ host:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: host-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: host.geo.region_iso_code
@@ -2823,7 +2823,7 @@ host:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: host-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: host.geo.region_name
@@ -2894,7 +2894,7 @@ host:
       short: Name of the host.
       type: keyword
     os.family:
-      dashed_name: os-family
+      dashed_name: host-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
       example: debian
       flat_name: host.os.family
@@ -2906,14 +2906,14 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      dashed_name: os-full
+      dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: host.os.full
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.full.text
+      - flat_name: host.os.full.text
         name: text
         norms: false
         type: text
@@ -2923,7 +2923,7 @@ host:
       short: Operating system name, including the version or code name.
       type: keyword
     os.kernel:
-      dashed_name: os-kernel
+      dashed_name: host-os-kernel
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
       flat_name: host.os.kernel
@@ -2935,14 +2935,14 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      dashed_name: os-name
+      dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: host.os.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.name.text
+      - flat_name: host.os.name.text
         name: text
         norms: false
         type: text
@@ -2952,7 +2952,7 @@ host:
       short: Operating system name, without the version.
       type: keyword
     os.platform:
-      dashed_name: os-platform
+      dashed_name: host-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
       flat_name: host.os.platform
@@ -2964,7 +2964,7 @@ host:
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
     os.version:
-      dashed_name: os-version
+      dashed_name: host-os-version
       description: Operating system version as a raw string.
       example: 10.14.1
       flat_name: host.os.version
@@ -3000,7 +3000,7 @@ host:
       short: Seconds the host has been up.
       type: long
     user.domain:
-      dashed_name: user-domain
+      dashed_name: host-user-domain
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -3013,7 +3013,7 @@ host:
       short: Name of the directory the user is a member of.
       type: keyword
     user.email:
-      dashed_name: user-email
+      dashed_name: host-user-email
       description: User email address.
       flat_name: host.user.email
       ignore_above: 1024
@@ -3024,14 +3024,14 @@ host:
       short: User email address.
       type: keyword
     user.full_name:
-      dashed_name: user-full-name
+      dashed_name: host-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: host.user.full_name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: user.full_name.text
+      - flat_name: host.user.full_name.text
         name: text
         norms: false
         type: text
@@ -3041,7 +3041,7 @@ host:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      dashed_name: group-domain
+      dashed_name: host-user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -3050,33 +3050,33 @@ host:
       level: extended
       name: domain
       order: 2
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
-      dashed_name: group-id
+      dashed_name: host-user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: host.user.group.id
       ignore_above: 1024
       level: extended
       name: id
       order: 0
-      original_fieldset: user
+      original_fieldset: group
       short: Unique identifier for the group on the system/platform.
       type: keyword
     user.group.name:
-      dashed_name: group-name
+      dashed_name: host-user-group-name
       description: Name of the group.
       flat_name: host.user.group.name
       ignore_above: 1024
       level: extended
       name: name
       order: 1
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the group.
       type: keyword
     user.hash:
-      dashed_name: user-hash
+      dashed_name: host-user-hash
       description: 'Unique user hash to correlate information for a user in anonymized
         form.
 
@@ -3091,7 +3091,7 @@ host:
       short: Unique user hash to correlate information for a user in anonymized form.
       type: keyword
     user.id:
-      dashed_name: user-id
+      dashed_name: host-user-id
       description: One or multiple unique identifiers of the user.
       flat_name: host.user.id
       ignore_above: 1024
@@ -3102,14 +3102,14 @@ host:
       short: One or multiple unique identifiers of the user.
       type: keyword
     user.name:
-      dashed_name: user-name
+      dashed_name: host-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: host.user.name
       ignore_above: 1024
       level: core
       multi_fields:
-      - flat_name: user.name.text
+      - flat_name: host.user.name.text
         name: text
         norms: false
         type: text
@@ -3626,7 +3626,7 @@ observer:
     are not considered observers in ECS.'
   fields:
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: observer-geo-city-name
       description: City name.
       example: Montreal
       flat_name: observer.geo.city_name
@@ -3638,7 +3638,7 @@ observer:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: observer-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: observer.geo.continent_name
@@ -3650,7 +3650,7 @@ observer:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: observer-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: observer.geo.country_iso_code
@@ -3662,7 +3662,7 @@ observer:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: observer-geo-country-name
       description: Country name.
       example: Canada
       flat_name: observer.geo.country_name
@@ -3674,7 +3674,7 @@ observer:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: observer-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: observer.geo.location
@@ -3685,7 +3685,7 @@ observer:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: observer-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -3703,7 +3703,7 @@ observer:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: observer-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: observer.geo.region_iso_code
@@ -3715,7 +3715,7 @@ observer:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: observer-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: observer.geo.region_name
@@ -3772,7 +3772,7 @@ observer:
       short: Custom name of the observer.
       type: keyword
     os.family:
-      dashed_name: os-family
+      dashed_name: observer-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
       example: debian
       flat_name: observer.os.family
@@ -3784,14 +3784,14 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      dashed_name: os-full
+      dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: observer.os.full
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.full.text
+      - flat_name: observer.os.full.text
         name: text
         norms: false
         type: text
@@ -3801,7 +3801,7 @@ observer:
       short: Operating system name, including the version or code name.
       type: keyword
     os.kernel:
-      dashed_name: os-kernel
+      dashed_name: observer-os-kernel
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
       flat_name: observer.os.kernel
@@ -3813,14 +3813,14 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      dashed_name: os-name
+      dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: observer.os.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.name.text
+      - flat_name: observer.os.name.text
         name: text
         norms: false
         type: text
@@ -3830,7 +3830,7 @@ observer:
       short: Operating system name, without the version.
       type: keyword
     os.platform:
-      dashed_name: os-platform
+      dashed_name: observer-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
       flat_name: observer.os.platform
@@ -3842,7 +3842,7 @@ observer:
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
     os.version:
-      dashed_name: os-version
+      dashed_name: observer-os-version
       description: Operating system version as a raw string.
       example: 10.14.1
       flat_name: observer.os.version
@@ -4298,7 +4298,7 @@ process:
       short: The exit code of the process.
       type: long
     hash.md5:
-      dashed_name: hash-md5
+      dashed_name: process-hash-md5
       description: MD5 hash.
       flat_name: process.hash.md5
       ignore_above: 1024
@@ -4309,7 +4309,7 @@ process:
       short: MD5 hash.
       type: keyword
     hash.sha1:
-      dashed_name: hash-sha1
+      dashed_name: process-hash-sha1
       description: SHA1 hash.
       flat_name: process.hash.sha1
       ignore_above: 1024
@@ -4320,7 +4320,7 @@ process:
       short: SHA1 hash.
       type: keyword
     hash.sha256:
-      dashed_name: hash-sha256
+      dashed_name: process-hash-sha256
       description: SHA256 hash.
       flat_name: process.hash.sha256
       ignore_above: 1024
@@ -4331,7 +4331,7 @@ process:
       short: SHA256 hash.
       type: keyword
     hash.sha512:
-      dashed_name: hash-sha512
+      dashed_name: process-hash-sha512
       description: SHA512 hash.
       flat_name: process.hash.sha512
       ignore_above: 1024
@@ -4961,7 +4961,7 @@ server:
       short: Server network address.
       type: keyword
     as.number:
-      dashed_name: as-number
+      dashed_name: server-as-number
       description: Unique number allocated to the autonomous system. The autonomous
         system number (ASN) uniquely identifies each network on the Internet.
       example: 15169
@@ -4974,14 +4974,14 @@ server:
         number (ASN) uniquely identifies each network on the Internet.
       type: long
     as.organization.name:
-      dashed_name: as-organization-name
+      dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: server.as.organization.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: as.organization.name.text
+      - flat_name: server.as.organization.name.text
         name: text
         norms: false
         type: text
@@ -5012,7 +5012,7 @@ server:
       short: Server domain.
       type: keyword
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: server-geo-city-name
       description: City name.
       example: Montreal
       flat_name: server.geo.city_name
@@ -5024,7 +5024,7 @@ server:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: server-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: server.geo.continent_name
@@ -5036,7 +5036,7 @@ server:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: server-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: server.geo.country_iso_code
@@ -5048,7 +5048,7 @@ server:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: server-geo-country-name
       description: Country name.
       example: Canada
       flat_name: server.geo.country_name
@@ -5060,7 +5060,7 @@ server:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: server-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: server.geo.location
@@ -5071,7 +5071,7 @@ server:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: server-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -5089,7 +5089,7 @@ server:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: server-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: server.geo.region_iso_code
@@ -5101,7 +5101,7 @@ server:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: server-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: server.geo.region_name
@@ -5213,7 +5213,7 @@ server:
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:
-      dashed_name: user-domain
+      dashed_name: server-user-domain
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -5226,7 +5226,7 @@ server:
       short: Name of the directory the user is a member of.
       type: keyword
     user.email:
-      dashed_name: user-email
+      dashed_name: server-user-email
       description: User email address.
       flat_name: server.user.email
       ignore_above: 1024
@@ -5237,14 +5237,14 @@ server:
       short: User email address.
       type: keyword
     user.full_name:
-      dashed_name: user-full-name
+      dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: server.user.full_name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: user.full_name.text
+      - flat_name: server.user.full_name.text
         name: text
         norms: false
         type: text
@@ -5254,7 +5254,7 @@ server:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      dashed_name: group-domain
+      dashed_name: server-user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -5263,33 +5263,33 @@ server:
       level: extended
       name: domain
       order: 2
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
-      dashed_name: group-id
+      dashed_name: server-user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: server.user.group.id
       ignore_above: 1024
       level: extended
       name: id
       order: 0
-      original_fieldset: user
+      original_fieldset: group
       short: Unique identifier for the group on the system/platform.
       type: keyword
     user.group.name:
-      dashed_name: group-name
+      dashed_name: server-user-group-name
       description: Name of the group.
       flat_name: server.user.group.name
       ignore_above: 1024
       level: extended
       name: name
       order: 1
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the group.
       type: keyword
     user.hash:
-      dashed_name: user-hash
+      dashed_name: server-user-hash
       description: 'Unique user hash to correlate information for a user in anonymized
         form.
 
@@ -5304,7 +5304,7 @@ server:
       short: Unique user hash to correlate information for a user in anonymized form.
       type: keyword
     user.id:
-      dashed_name: user-id
+      dashed_name: server-user-id
       description: One or multiple unique identifiers of the user.
       flat_name: server.user.id
       ignore_above: 1024
@@ -5315,14 +5315,14 @@ server:
       short: One or multiple unique identifiers of the user.
       type: keyword
     user.name:
-      dashed_name: user-name
+      dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: server.user.name
       ignore_above: 1024
       level: core
       multi_fields:
-      - flat_name: user.name.text
+      - flat_name: server.user.name.text
         name: text
         norms: false
         type: text
@@ -5487,7 +5487,7 @@ source:
       short: Source network address.
       type: keyword
     as.number:
-      dashed_name: as-number
+      dashed_name: source-as-number
       description: Unique number allocated to the autonomous system. The autonomous
         system number (ASN) uniquely identifies each network on the Internet.
       example: 15169
@@ -5500,14 +5500,14 @@ source:
         number (ASN) uniquely identifies each network on the Internet.
       type: long
     as.organization.name:
-      dashed_name: as-organization-name
+      dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: source.as.organization.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: as.organization.name.text
+      - flat_name: source.as.organization.name.text
         name: text
         norms: false
         type: text
@@ -5538,7 +5538,7 @@ source:
       short: Source domain.
       type: keyword
     geo.city_name:
-      dashed_name: geo-city-name
+      dashed_name: source-geo-city-name
       description: City name.
       example: Montreal
       flat_name: source.geo.city_name
@@ -5550,7 +5550,7 @@ source:
       short: City name.
       type: keyword
     geo.continent_name:
-      dashed_name: geo-continent-name
+      dashed_name: source-geo-continent-name
       description: Name of the continent.
       example: North America
       flat_name: source.geo.continent_name
@@ -5562,7 +5562,7 @@ source:
       short: Name of the continent.
       type: keyword
     geo.country_iso_code:
-      dashed_name: geo-country-iso-code
+      dashed_name: source-geo-country-iso-code
       description: Country ISO code.
       example: CA
       flat_name: source.geo.country_iso_code
@@ -5574,7 +5574,7 @@ source:
       short: Country ISO code.
       type: keyword
     geo.country_name:
-      dashed_name: geo-country-name
+      dashed_name: source-geo-country-name
       description: Country name.
       example: Canada
       flat_name: source.geo.country_name
@@ -5586,7 +5586,7 @@ source:
       short: Country name.
       type: keyword
     geo.location:
-      dashed_name: geo-location
+      dashed_name: source-geo-location
       description: Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
       flat_name: source.geo.location
@@ -5597,7 +5597,7 @@ source:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      dashed_name: geo-name
+      dashed_name: source-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -5615,7 +5615,7 @@ source:
       short: User-defined description of a location.
       type: keyword
     geo.region_iso_code:
-      dashed_name: geo-region-iso-code
+      dashed_name: source-geo-region-iso-code
       description: Region ISO code.
       example: CA-QC
       flat_name: source.geo.region_iso_code
@@ -5627,7 +5627,7 @@ source:
       short: Region ISO code.
       type: keyword
     geo.region_name:
-      dashed_name: geo-region-name
+      dashed_name: source-geo-region-name
       description: Region name.
       example: Quebec
       flat_name: source.geo.region_name
@@ -5739,7 +5739,7 @@ source:
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:
-      dashed_name: user-domain
+      dashed_name: source-user-domain
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -5752,7 +5752,7 @@ source:
       short: Name of the directory the user is a member of.
       type: keyword
     user.email:
-      dashed_name: user-email
+      dashed_name: source-user-email
       description: User email address.
       flat_name: source.user.email
       ignore_above: 1024
@@ -5763,14 +5763,14 @@ source:
       short: User email address.
       type: keyword
     user.full_name:
-      dashed_name: user-full-name
+      dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: source.user.full_name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: user.full_name.text
+      - flat_name: source.user.full_name.text
         name: text
         norms: false
         type: text
@@ -5780,7 +5780,7 @@ source:
       short: User's full name, if available.
       type: keyword
     user.group.domain:
-      dashed_name: group-domain
+      dashed_name: source-user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -5789,33 +5789,33 @@ source:
       level: extended
       name: domain
       order: 2
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the directory the group is a member of.
       type: keyword
     user.group.id:
-      dashed_name: group-id
+      dashed_name: source-user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: source.user.group.id
       ignore_above: 1024
       level: extended
       name: id
       order: 0
-      original_fieldset: user
+      original_fieldset: group
       short: Unique identifier for the group on the system/platform.
       type: keyword
     user.group.name:
-      dashed_name: group-name
+      dashed_name: source-user-group-name
       description: Name of the group.
       flat_name: source.user.group.name
       ignore_above: 1024
       level: extended
       name: name
       order: 1
-      original_fieldset: user
+      original_fieldset: group
       short: Name of the group.
       type: keyword
     user.hash:
-      dashed_name: user-hash
+      dashed_name: source-user-hash
       description: 'Unique user hash to correlate information for a user in anonymized
         form.
 
@@ -5830,7 +5830,7 @@ source:
       short: Unique user hash to correlate information for a user in anonymized form.
       type: keyword
     user.id:
-      dashed_name: user-id
+      dashed_name: source-user-id
       description: One or multiple unique identifiers of the user.
       flat_name: source.user.id
       ignore_above: 1024
@@ -5841,14 +5841,14 @@ source:
       short: One or multiple unique identifiers of the user.
       type: keyword
     user.name:
-      dashed_name: user-name
+      dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: source.user.name
       ignore_above: 1024
       level: core
       multi_fields:
-      - flat_name: user.name.text
+      - flat_name: source.user.name.text
         name: text
         norms: false
         type: text
@@ -6657,7 +6657,7 @@ user:
       short: User's full name, if available.
       type: keyword
     group.domain:
-      dashed_name: group-domain
+      dashed_name: user-group-domain
       description: 'Name of the directory the group is a member of.
 
         For example, an LDAP or Active Directory domain name.'
@@ -6670,7 +6670,7 @@ user:
       short: Name of the directory the group is a member of.
       type: keyword
     group.id:
-      dashed_name: group-id
+      dashed_name: user-group-id
       description: Unique identifier for the group on the system/platform.
       flat_name: user.group.id
       ignore_above: 1024
@@ -6681,7 +6681,7 @@ user:
       short: Unique identifier for the group on the system/platform.
       type: keyword
     group.name:
-      dashed_name: group-name
+      dashed_name: user-group-name
       description: Name of the group.
       flat_name: user.group.name
       ignore_above: 1024
@@ -6792,7 +6792,7 @@ user_agent:
       short: Unparsed user_agent string.
       type: keyword
     os.family:
-      dashed_name: os-family
+      dashed_name: user-agent-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
       example: debian
       flat_name: user_agent.os.family
@@ -6804,14 +6804,14 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      dashed_name: os-full
+      dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: user_agent.os.full
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.full.text
+      - flat_name: user_agent.os.full.text
         name: text
         norms: false
         type: text
@@ -6821,7 +6821,7 @@ user_agent:
       short: Operating system name, including the version or code name.
       type: keyword
     os.kernel:
-      dashed_name: os-kernel
+      dashed_name: user-agent-os-kernel
       description: Operating system kernel version as a raw string.
       example: 4.4.0-112-generic
       flat_name: user_agent.os.kernel
@@ -6833,14 +6833,14 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      dashed_name: os-name
+      dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: user_agent.os.name
       ignore_above: 1024
       level: extended
       multi_fields:
-      - flat_name: os.name.text
+      - flat_name: user_agent.os.name.text
         name: text
         norms: false
         type: text
@@ -6850,7 +6850,7 @@ user_agent:
       short: Operating system name, without the version.
       type: keyword
     os.platform:
-      dashed_name: os-platform
+      dashed_name: user-agent-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
       flat_name: user_agent.os.platform
@@ -6862,7 +6862,7 @@ user_agent:
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
     os.version:
-      dashed_name: os-version
+      dashed_name: user-agent-os-version
       description: Operating system version as a raw string.
       example: 10.14.1
       flat_name: user_agent.os.version

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -59,29 +59,6 @@ class TestSchemaReader(unittest.TestCase):
         schema_reader.field_set_defaults(field)
         self.assertEqual(field, {'description': 'a field', 'short': 'a field', 'type': 'faketype'})
 
-    def test_field_name_representations_nested(self):
-        nested = {'name': 'nested'}
-        schema_reader.field_name_representations(nested, 'parent.')
-        self.assertEqual(nested, {'name': 'nested', 'flat_name': 'parent.nested', 'dashed_name': 'parent-nested'})
-
-    def test_field_name_representations_root(self):
-        nested = {'name': 'root_field'}
-        schema_reader.field_name_representations(nested, '')
-        self.assertEqual(nested, {'name': 'root_field', 'flat_name': 'root_field', 'dashed_name': 'root-field'})
-
-    def test_field_cleanup_values(self):
-        field = {'name': 'myfield', 'type': 'faketype', 'description': 'a field   '}
-        schema_reader.field_cleanup_values(field, 'event.')
-        expected = {
-            'name': 'myfield',
-            'type': 'faketype',
-            'flat_name': 'event.myfield',
-            'dashed_name': 'event-myfield',
-            'description': 'a field',
-            'short': 'a field'
-        }
-        self.assertEqual(field, expected)
-
     def test_field_set_multi_field_defaults_missing_name(self):
         field = {
             'name': 'myfield',


### PR DESCRIPTION
This PR improves the ECS ability to nest reusable fields inside other reusable field sets.  Currently there is at least one example of multiple reuse: "group" fields are reused in "user", and "user" is then reused by "client", "destination", "host", "server", and "source".  However, the implementation in master depends on the "group" fields being copied to "user" before all of the "user" fields are copied to the final locations.  This works because the "group" key comes before the "user" key when iterating over the keys in the schema dictionary, but this will not be the case for other places we might want to use multi-level nesting.

This PR adds an intermediate data structure representing the schema which contains references to reused field sets rather than immediately copying them.  Using references removes the dependency on the order fieldsets are read in.  The intermediate representation is then rendered into the same formats as before by recursively replacing the references with copies.

The output from the refactored version diverges from the original in a few ways.  Most notably original_fieldset now refers to the closest reusable fieldset (previously client.user.group.domain would have original_fieldset: user instead of original_fieldset: group).  original_fieldset is also populated in every reusable fieldset, even when the fieldset is not embedded.  dashed_name now matches flat_name more closely.

TODO: add/update tests