### PR TITLE
Add session id for process and process.parent

### DIFF
--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -54,6 +54,26 @@ type Process struct {
 	// Identifier of the group of processes the process belongs to.
 	ParentPGID int64 `ecs:"parent.pgid"`
 
+	// The Windows or POSIX session identifier for a process.
+	// On Windows systems, this corresponds to the LUID of the session itself
+	// rather than and individual process access token. For more information
+	// see `AuthenticationId` at
+	// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+	// On POSIX systems, this corresponds to the session id returned from a
+	// call to `setsid`
+	// (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+	SessionID string `ecs:"session_id"`
+
+	// The Windows or POSIX session identifier for a process.
+	// On Windows systems, this corresponds to the LUID of the session itself
+	// rather than and individual process access token. For more information
+	// see `AuthenticationId` at
+	// https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+	// On POSIX systems, this corresponds to the session id returned from a
+	// call to `setsid`
+	// (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+	ParentSessionID string `ecs:"parent.session_id"`
+
 	// Full command line that started the process, including the absolute path
 	// to the executable, and all arguments.
 	// Some arguments may be filtered to protect sensitive information.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3311,6 +3311,21 @@ example: `4241`
 
 // ===============================================================
 
+| process.parent.session_id
+| The Windows or POSIX session identifier for a process.
+
+On Windows systems, this corresponds to the LUID of the session itself rather than and individual process access token. For more information see `AuthenticationId` at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+On POSIX systems, this corresponds to the session id returned from a call to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+
+type: keyword
+
+
+
+| extended
+
+// ===============================================================
+
 | process.parent.start
 | The time the process started.
 
@@ -3419,6 +3434,21 @@ example: `4242`
 type: long
 
 example: `4241`
+
+| extended
+
+// ===============================================================
+
+| process.session_id
+| The Windows or POSIX session identifier for a process.
+
+On Windows systems, this corresponds to the LUID of the session itself rather than and individual process access token. For more information see `AuthenticationId` at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+On POSIX systems, this corresponds to the session id returned from a call to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+
+type: keyword
+
+
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2494,6 +2494,18 @@
       format: string
       description: Parent process' pid.
       example: 4241
+    - name: parent.session_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself rather
+        than and individual process access token. For more information see `AuthenticationId`
+        at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a call
+        to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
     - name: parent.start
       level: extended
       type: date
@@ -2555,6 +2567,18 @@
       format: string
       description: Parent process' pid.
       example: 4241
+    - name: session_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself rather
+        than and individual process access token. For more information see `AuthenticationId`
+        at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a call
+        to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
     - name: start
       level: extended
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -323,6 +323,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,process,process.parent.pgid,long,extended,,Identifier of the group of processes the process belongs to.
 1.5.0-dev,true,process,process.parent.pid,long,core,4242,Process id.
 1.5.0-dev,true,process,process.parent.ppid,long,extended,4241,Parent process' pid.
+1.5.0-dev,true,process,process.parent.session_id,keyword,extended,,The POSIX or Windows session identifier for a process.
 1.5.0-dev,true,process,process.parent.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
 1.5.0-dev,true,process,process.parent.thread.id,long,extended,4242,Thread ID.
 1.5.0-dev,true,process,process.parent.thread.name,keyword,extended,thread-0,Thread name.
@@ -334,6 +335,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,process,process.pgid,long,extended,,Identifier of the group of processes the process belongs to.
 1.5.0-dev,true,process,process.pid,long,core,4242,Process id.
 1.5.0-dev,true,process,process.ppid,long,extended,4241,Parent process' pid.
+1.5.0-dev,true,process,process.session_id,keyword,extended,,The Windows or POSIX session identifier for a process.
 1.5.0-dev,true,process,process.start,date,extended,2016-05-23T08:05:34.853Z,The time the process started.
 1.5.0-dev,true,process,process.thread.id,long,extended,4242,Thread ID.
 1.5.0-dev,true,process,process.thread.name,keyword,extended,thread-0,Thread name.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3834,7 +3834,7 @@ process.args:
   ignore_above: 1024
   level: extended
   name: args
-  order: 10
+  order: 12
   short: Array of process arguments.
   type: keyword
 process.args_count:
@@ -3848,7 +3848,7 @@ process.args_count:
   flat_name: process.args_count
   level: extended
   name: args_count
-  order: 12
+  order: 14
   short: Length of the process.args array.
   type: long
 process.command_line:
@@ -3867,7 +3867,7 @@ process.command_line:
     norms: false
     type: text
   name: command_line
-  order: 8
+  order: 10
   short: Full command line that started the process.
   type: keyword
 process.executable:
@@ -3883,7 +3883,7 @@ process.executable:
     norms: false
     type: text
   name: executable
-  order: 14
+  order: 16
   short: Absolute path to the process executable.
   type: keyword
 process.exit_code:
@@ -3896,7 +3896,7 @@ process.exit_code:
   flat_name: process.exit_code
   level: extended
   name: exit_code
-  order: 28
+  order: 30
   short: The exit code of the process.
   type: long
 process.hash.md5:
@@ -3975,7 +3975,7 @@ process.parent.args:
   ignore_above: 1024
   level: extended
   name: parent.args
-  order: 11
+  order: 13
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -3989,7 +3989,7 @@ process.parent.args_count:
   flat_name: process.parent.args_count
   level: extended
   name: parent.args_count
-  order: 13
+  order: 15
   short: Length of the process.args array.
   type: long
 process.parent.command_line:
@@ -4008,7 +4008,7 @@ process.parent.command_line:
     norms: false
     type: text
   name: parent.command_line
-  order: 9
+  order: 11
   short: Full command line that started the process.
   type: keyword
 process.parent.executable:
@@ -4024,7 +4024,7 @@ process.parent.executable:
     norms: false
     type: text
   name: parent.executable
-  order: 15
+  order: 17
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -4037,7 +4037,7 @@ process.parent.exit_code:
   flat_name: process.parent.exit_code
   level: extended
   name: parent.exit_code
-  order: 29
+  order: 31
   short: The exit code of the process.
   type: long
 process.parent.name:
@@ -4090,6 +4090,23 @@ process.parent.ppid:
   order: 5
   short: Parent process' pid.
   type: long
+process.parent.session_id:
+  dashed_name: process-parent-session-id
+  description: 'The Windows or POSIX session identifier for a process.
+
+    On Windows systems, this corresponds to the LUID of the session itself rather
+    than and individual process access token. For more information see `AuthenticationId`
+    at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+    On POSIX systems, this corresponds to the session id returned from a call to `setsid`
+    (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
+  flat_name: process.parent.session_id
+  ignore_above: 1024
+  level: extended
+  name: parent.session_id
+  order: 9
+  short: The POSIX or Windows session identifier for a process.
+  type: keyword
 process.parent.start:
   dashed_name: process-parent-start
   description: The time the process started.
@@ -4097,7 +4114,7 @@ process.parent.start:
   flat_name: process.parent.start
   level: extended
   name: parent.start
-  order: 23
+  order: 25
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -4108,7 +4125,7 @@ process.parent.thread.id:
   format: string
   level: extended
   name: parent.thread.id
-  order: 19
+  order: 21
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -4119,7 +4136,7 @@ process.parent.thread.name:
   ignore_above: 1024
   level: extended
   name: parent.thread.name
-  order: 21
+  order: 23
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -4137,7 +4154,7 @@ process.parent.title:
     norms: false
     type: text
   name: parent.title
-  order: 17
+  order: 19
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -4147,7 +4164,7 @@ process.parent.uptime:
   flat_name: process.parent.uptime
   level: extended
   name: parent.uptime
-  order: 25
+  order: 27
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -4163,7 +4180,7 @@ process.parent.working_directory:
     norms: false
     type: text
   name: parent.working_directory
-  order: 27
+  order: 29
   short: The working directory of the process.
   type: keyword
 process.pgid:
@@ -4198,6 +4215,23 @@ process.ppid:
   order: 4
   short: Parent process' pid.
   type: long
+process.session_id:
+  dashed_name: process-session-id
+  description: 'The Windows or POSIX session identifier for a process.
+
+    On Windows systems, this corresponds to the LUID of the session itself rather
+    than and individual process access token. For more information see `AuthenticationId`
+    at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+    On POSIX systems, this corresponds to the session id returned from a call to `setsid`
+    (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
+  flat_name: process.session_id
+  ignore_above: 1024
+  level: extended
+  name: session_id
+  order: 8
+  short: The Windows or POSIX session identifier for a process.
+  type: keyword
 process.start:
   dashed_name: process-start
   description: The time the process started.
@@ -4205,7 +4239,7 @@ process.start:
   flat_name: process.start
   level: extended
   name: start
-  order: 22
+  order: 24
   short: The time the process started.
   type: date
 process.thread.id:
@@ -4216,7 +4250,7 @@ process.thread.id:
   format: string
   level: extended
   name: thread.id
-  order: 18
+  order: 20
   short: Thread ID.
   type: long
 process.thread.name:
@@ -4227,7 +4261,7 @@ process.thread.name:
   ignore_above: 1024
   level: extended
   name: thread.name
-  order: 20
+  order: 22
   short: Thread name.
   type: keyword
 process.title:
@@ -4245,7 +4279,7 @@ process.title:
     norms: false
     type: text
   name: title
-  order: 16
+  order: 18
   short: Process title.
   type: keyword
 process.uptime:
@@ -4255,7 +4289,7 @@ process.uptime:
   flat_name: process.uptime
   level: extended
   name: uptime
-  order: 24
+  order: 26
   short: Seconds the process has been up.
   type: long
 process.working_directory:
@@ -4271,7 +4305,7 @@ process.working_directory:
     norms: false
     type: text
   name: working_directory
-  order: 26
+  order: 28
   short: The working directory of the process.
   type: keyword
 registry.data.bytes:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4232,7 +4232,7 @@ process:
       ignore_above: 1024
       level: extended
       name: args
-      order: 10
+      order: 12
       short: Array of process arguments.
       type: keyword
     args_count:
@@ -4246,7 +4246,7 @@ process:
       flat_name: process.args_count
       level: extended
       name: args_count
-      order: 12
+      order: 14
       short: Length of the process.args array.
       type: long
     command_line:
@@ -4265,7 +4265,7 @@ process:
         norms: false
         type: text
       name: command_line
-      order: 8
+      order: 10
       short: Full command line that started the process.
       type: keyword
     executable:
@@ -4281,7 +4281,7 @@ process:
         norms: false
         type: text
       name: executable
-      order: 14
+      order: 16
       short: Absolute path to the process executable.
       type: keyword
     exit_code:
@@ -4294,7 +4294,7 @@ process:
       flat_name: process.exit_code
       level: extended
       name: exit_code
-      order: 28
+      order: 30
       short: The exit code of the process.
       type: long
     hash.md5:
@@ -4373,7 +4373,7 @@ process:
       ignore_above: 1024
       level: extended
       name: parent.args
-      order: 11
+      order: 13
       short: Array of process arguments.
       type: keyword
     parent.args_count:
@@ -4387,7 +4387,7 @@ process:
       flat_name: process.parent.args_count
       level: extended
       name: parent.args_count
-      order: 13
+      order: 15
       short: Length of the process.args array.
       type: long
     parent.command_line:
@@ -4406,7 +4406,7 @@ process:
         norms: false
         type: text
       name: parent.command_line
-      order: 9
+      order: 11
       short: Full command line that started the process.
       type: keyword
     parent.executable:
@@ -4422,7 +4422,7 @@ process:
         norms: false
         type: text
       name: parent.executable
-      order: 15
+      order: 17
       short: Absolute path to the process executable.
       type: keyword
     parent.exit_code:
@@ -4435,7 +4435,7 @@ process:
       flat_name: process.parent.exit_code
       level: extended
       name: parent.exit_code
-      order: 29
+      order: 31
       short: The exit code of the process.
       type: long
     parent.name:
@@ -4488,6 +4488,23 @@ process:
       order: 5
       short: Parent process' pid.
       type: long
+    parent.session_id:
+      dashed_name: process-parent-session-id
+      description: 'The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself rather
+        than and individual process access token. For more information see `AuthenticationId`
+        at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a call
+        to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
+      flat_name: process.parent.session_id
+      ignore_above: 1024
+      level: extended
+      name: parent.session_id
+      order: 9
+      short: The POSIX or Windows session identifier for a process.
+      type: keyword
     parent.start:
       dashed_name: process-parent-start
       description: The time the process started.
@@ -4495,7 +4512,7 @@ process:
       flat_name: process.parent.start
       level: extended
       name: parent.start
-      order: 23
+      order: 25
       short: The time the process started.
       type: date
     parent.thread.id:
@@ -4506,7 +4523,7 @@ process:
       format: string
       level: extended
       name: parent.thread.id
-      order: 19
+      order: 21
       short: Thread ID.
       type: long
     parent.thread.name:
@@ -4517,7 +4534,7 @@ process:
       ignore_above: 1024
       level: extended
       name: parent.thread.name
-      order: 21
+      order: 23
       short: Thread name.
       type: keyword
     parent.title:
@@ -4535,7 +4552,7 @@ process:
         norms: false
         type: text
       name: parent.title
-      order: 17
+      order: 19
       short: Process title.
       type: keyword
     parent.uptime:
@@ -4545,7 +4562,7 @@ process:
       flat_name: process.parent.uptime
       level: extended
       name: parent.uptime
-      order: 25
+      order: 27
       short: Seconds the process has been up.
       type: long
     parent.working_directory:
@@ -4561,7 +4578,7 @@ process:
         norms: false
         type: text
       name: parent.working_directory
-      order: 27
+      order: 29
       short: The working directory of the process.
       type: keyword
     pgid:
@@ -4596,6 +4613,23 @@ process:
       order: 4
       short: Parent process' pid.
       type: long
+    session_id:
+      dashed_name: process-session-id
+      description: 'The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself rather
+        than and individual process access token. For more information see `AuthenticationId`
+        at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a call
+        to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).'
+      flat_name: process.session_id
+      ignore_above: 1024
+      level: extended
+      name: session_id
+      order: 8
+      short: The Windows or POSIX session identifier for a process.
+      type: keyword
     start:
       dashed_name: process-start
       description: The time the process started.
@@ -4603,7 +4637,7 @@ process:
       flat_name: process.start
       level: extended
       name: start
-      order: 22
+      order: 24
       short: The time the process started.
       type: date
     thread.id:
@@ -4614,7 +4648,7 @@ process:
       format: string
       level: extended
       name: thread.id
-      order: 18
+      order: 20
       short: Thread ID.
       type: long
     thread.name:
@@ -4625,7 +4659,7 @@ process:
       ignore_above: 1024
       level: extended
       name: thread.name
-      order: 20
+      order: 22
       short: Thread name.
       type: keyword
     title:
@@ -4643,7 +4677,7 @@ process:
         norms: false
         type: text
       name: title
-      order: 16
+      order: 18
       short: Process title.
       type: keyword
     uptime:
@@ -4653,7 +4687,7 @@ process:
       flat_name: process.uptime
       level: extended
       name: uptime
-      order: 24
+      order: 26
       short: Seconds the process has been up.
       type: long
     working_directory:
@@ -4669,7 +4703,7 @@ process:
         norms: false
         type: text
       name: working_directory
-      order: 26
+      order: 28
       short: The working directory of the process.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1537,6 +1537,10 @@
                 "ppid": {
                   "type": "long"
                 }, 
+                "session_id": {
+                  "ignore_above": 1024, 
+                  "type": "keyword"
+                }, 
                 "start": {
                   "type": "date"
                 }, 
@@ -1584,6 +1588,10 @@
             }, 
             "ppid": {
               "type": "long"
+            }, 
+            "session_id": {
+              "ignore_above": 1024, 
+              "type": "keyword"
             }, 
             "start": {
               "type": "date"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1536,6 +1536,10 @@
               "ppid": {
                 "type": "long"
               }, 
+              "session_id": {
+                "ignore_above": 1024, 
+                "type": "keyword"
+              }, 
               "start": {
                 "type": "date"
               }, 
@@ -1583,6 +1587,10 @@
           }, 
           "ppid": {
             "type": "long"
+          }, 
+          "session_id": {
+            "ignore_above": 1024, 
+            "type": "keyword"
           }, 
           "start": {
             "type": "date"

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -102,6 +102,35 @@
         Identifier of the group of processes the process belongs to.
 
 
+    - name: session_id
+      level: extended
+      type: keyword
+      short: The Windows or POSIX session identifier for a process.
+      description: >
+        The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself
+        rather than and individual process access token. For more information
+        see `AuthenticationId` at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a
+        call to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+
+    - name: parent.session_id
+      level: extended
+      type: keyword
+      short: The POSIX or Windows session identifier for a process.
+      description: >
+        The Windows or POSIX session identifier for a process.
+
+        On Windows systems, this corresponds to the LUID of the session itself
+        rather than and individual process access token. For more information
+        see `AuthenticationId` at https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control.
+
+        On POSIX systems, this corresponds to the session id returned from a
+        call to `setsid` (https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html).
+
+
     - name: command_line
       level: extended
       type: keyword


### PR DESCRIPTION
So, as the docs state, this field would be representative of a session identifier for processes. Currently in our endpoint pre-elastic schema we ship two fields for process events:

1. a Windows specific "authentication_id" which corresponds to the `AuthenticationId` LUID [here](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-token_control)
2. a POSIX specific "session_id" which corresponds to the value returned from a call to [`setsid`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsid.html)

These fields are somewhat complex in the Windows and POSIX parlance because:

1. A Windows session LUID corresponds directly to a user's logon session, but is also passed to every process spawned during that logon session
2. A POSIX `sid` value corresponds often to a user's terminal session, but, in the case of daemonized processes, is decoupled from an actual "user session"
3. Windows LUIDs need to be represented in a string format
4. POSIX `sid` values are just a `pid_t` structure, so they're numbers

That said, despite not necessarily being coupled to a "user session" -- both values are directly tied to a process executing and represent some sort of session information. Therefore, I don't think it's a stretch to unify on a platform-agnostic definition that can be added to the ECS spec under `process` rather than `user`.

Additionally, since this value could either be a string or an integer, I made them type `keyword` so we could leverage either.

Thoughts?