### PR TITLE
Improve array support in Go code generator

### DIFF
--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -45,7 +45,7 @@ type Dns struct {
 
 	// Array of 2 letter DNS header flags.
 	// Expected values are: AA, TC, RD, RA, AD, CD, DO.
-	HeaderFlags string `ecs:"header_flags"`
+	HeaderFlags []string `ecs:"header_flags"`
 
 	// The DNS response code.
 	ResponseCode string `ecs:"response_code"`
@@ -96,7 +96,7 @@ type Dns struct {
 	// answer objects must contain the `data` key. If more information is
 	// available, map as much of it to ECS as possible, and add any additional
 	// fields to the answer objects as custom fields.
-	Answers map[string]interface{} `ecs:"answers"`
+	Answers []map[string]interface{} `ecs:"answers"`
 
 	// The domain name to which this resource record pertains.
 	// If a chain of CNAME is being resolved, each answer's `name` should be
@@ -125,5 +125,5 @@ type Dns struct {
 	// data formats it can contain. Extracting all IP addresses seen in there
 	// to `dns.resolved_ip` makes it possible to index them as IP addresses,
 	// and makes them easier to visualize and query for.
-	ResolvedIP string `ecs:"resolved_ip"`
+	ResolvedIP []string `ecs:"resolved_ip"`
 }

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -37,7 +37,7 @@ type File struct {
 	// Attributes names will vary by platform. Here's a non-exhaustive list of
 	// values that are expected in this field: archive, compressed, directory,
 	// encrypted, execute, hidden, read, readonly, system, write.
-	Attributes string `ecs:"attributes"`
+	Attributes []string `ecs:"attributes"`
 
 	// Directory where the file is located. It should include the drive letter,
 	// when appropriate.

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -71,7 +71,7 @@ type Process struct {
 
 	// Array of process arguments.
 	// May be filtered to protect sensitive information.
-	ParentArgs string `ecs:"parent.args"`
+	ParentArgs []string `ecs:"parent.args"`
 
 	// Length of the process.args array.
 	// This field can be useful for querying or performing bucket analysis on

--- a/code/go/ecs/tls.go
+++ b/code/go/ecs/tls.go
@@ -63,7 +63,7 @@ type Tls struct {
 	ClientServerName string `ecs:"client.server_name"`
 
 	// Array of ciphers offered by the client during the client hello.
-	ClientSupportedCiphers string `ecs:"client.supported_ciphers"`
+	ClientSupportedCiphers []string `ecs:"client.supported_ciphers"`
 
 	// Distinguished name of subject of the x.509 certificate presented by the
 	// client.
@@ -84,7 +84,7 @@ type Tls struct {
 	// offered by the client. This is usually mutually-exclusive of
 	// `client.certificate` since that value should be the first certificate in
 	// the chain.
-	ClientCertificateChain string `ecs:"client.certificate_chain"`
+	ClientCertificateChain []string `ecs:"client.certificate_chain"`
 
 	// PEM-encoded stand-alone certificate offered by the client. This is
 	// usually mutually-exclusive of `client.certificate_chain` since this
@@ -127,7 +127,7 @@ type Tls struct {
 	// offered by the server. This is usually mutually-exclusive of
 	// `server.certificate` since that value should be the first certificate in
 	// the chain.
-	ServerCertificateChain string `ecs:"server.certificate_chain"`
+	ServerCertificateChain []string `ecs:"server.certificate_chain"`
 
 	// PEM-encoded stand-alone certificate offered by the server. This is
 	// usually mutually-exclusive of `server.certificate_chain` since this


### PR DESCRIPTION
ECS has a bunch of fields expected to be arrays. For example, `tls.client.supported_ciphers`:

```yaml
    - name: client.supported_ciphers
      type: keyword
      level: extended
      description: Array of ciphers offered by the client during the client hello.
      example: ["TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "..."]
```

However, the generated Go code is using a type of `string` instead of `[]string`:

https://github.com/elastic/ecs/blob/94e7376ed1e618bec7128e4b14f579a5c0111343/code/go/ecs/tls.go#L65-L66

Looking at the generator's code, it seems that it was updated to output a type of `[]string` for a particular field (`{process|parent}.args`), but there isn't generic support to output arrays:

https://github.com/elastic/ecs/blob/94e7376ed1e618bec7128e4b14f579a5c0111343/scripts/cmd/gocodegen/gocodegen.go#L272-L274

Instead of continuing patching the generator, this PR inspects the description of a field to tell if it should be output as an array.

Fields with a description that contain the term `array` in the first 10 characters of the description will be generated as an array datatype.

This allows for:
```yaml
description: Array of [...]
description: An array [...]
description: The array [...]
description: Sub-array [...]
```
but not:
```
description: Length of the array
```
This is a bit hacky but it seems the best choice given that libbeat doesn't expose the example key that could be used to check for an array neither allows to use custom keys as hints. (i.e. `is_array: true`).