### PR TITLE
Fix a mistake in the custom fields doc page.

### DIFF
--- a/docs/using-custom-fields.asciidoc
+++ b/docs/using-custom-fields.asciidoc
@@ -33,7 +33,8 @@ Example:
 [source,json]
 -------------
 { "labels": { "foo_id": "beef42", "env": "production" },
-  "event": { "message": "..." }
+  "message": "...",
+  "event": { ... }
 }
 -------------
 


### PR DESCRIPTION
`message` was incorrectly nested inside `event`