### PR TITLE
Incorporating IPFIX/Netflow fields into existing ECS field sets

### DIFF
--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -33,8 +33,17 @@ type Destination struct {
 	// Can be one or multiple IPv4 or IPv6 addresses.
 	IP string `ecs:"ip"`
 
+	// Count of the number of high-order bits that define an IPv4 or IPv6
+	// network address in a destination network.
+	IPNetworkPrefix int64 `ecs:"ip.network_prefix"`
+
 	// Port of the destination.
 	Port int64 `ecs:"port"`
+
+	// Text description for commonly used ports, e.g. dns, http, https, smtp.
+	// The field value must be normalized to lowercase for querying. See the
+	// documentation section "Implementing ECS".
+	PortName string `ecs:"port_name"`
 
 	// MAC address of the destination.
 	MAC string `ecs:"mac"`

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -27,11 +27,31 @@ type Network struct {
 	// Name given by operators to sections of their network.
 	Name string `ecs:"name"`
 
+	// The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag
+	// Control Information) field as defined in IEEE 802.1Q. This could be the
+	// VLAN's numeric identifier or text description.
+	Dot1qCtag string `ecs:"dot1q_ctag"`
+
+	// The VLAN identifier portion of the TCI (Tag Control Information) field
+	// of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's
+	// numeric identifier or text description.
+	Dot1qVlan string `ecs:"dot1q_vlan"`
+
 	// In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec,
 	// pim, etc
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
 	Type string `ecs:"type"`
+
+	// In the case of IPv4 packets this would correspond to the TOS (Type of
+	// Service) field. In the case of IPv6 packets this would correspond to the
+	// Traffic Class field.
+	ClassOfService int64 `ecs:"class_of_service"`
+
+	// This could be represented using a numeric value or a text description.
+	// For example, an ICMP echo request would have "type = 8" and "code = 0",
+	// which could be represented as "0x0800" or "ICMP Echo".
+	IcmpTypeCode string `ecs:"icmp_type_code"`
 
 	// IANA Protocol Number
 	// (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
@@ -44,6 +64,15 @@ type Network struct {
 	// The field value must be normalized to lowercase for querying. See the
 	// documentation section "Implementing ECS".
 	Transport string `ecs:"transport"`
+
+	// The value of the fragment identification field from an IPv4 or IPv6
+	// packet header.
+	FragmentIdentification int64 `ecs:"fragment_identification"`
+
+	// This could be represented using a numeric value or text description. For
+	// example, a TCP syncrhonize flag could be represented as "0x0002" or
+	// "SYN".
+	TcpControlBits string `ecs:"tcp_control_bits"`
 
 	// A name given to an application level protocol. This can be arbitrarily
 	// assigned for things like microservices, but also apply to things like
@@ -74,6 +103,28 @@ type Network struct {
 	// perimeter.
 	Direction string `ecs:"direction"`
 
+	// From the observation point of a network event, the network interface
+	// from which frames or packets were transmitted. For example, in the case
+	// of a switch or router this might be the port name (e.g. eth0, ge-0/1,
+	// GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+	EgressInterface string `ecs:"egress_interface"`
+
+	// From the observation point of a network event, the VLAN in which the
+	// frame was transmitted. This could be the VLAN's numeric identifier or
+	// text description.
+	EgressVlan string `ecs:"egress_vlan"`
+
+	// From the observation point of a network event, the network interface
+	// into which frames or packets were received. For example, in the case of
+	// a switch or router this might be the port name (e.g. eth0, ge-0/1,
+	// GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+	IngressInterface string `ecs:"ingress_interface"`
+
+	// From the observation point of a network event, the VLAN in which the
+	// frame was received. This could be the VLAN's numeric identifier or text
+	// description.
+	IngressVlan string `ecs:"ingress_vlan"`
+
 	// Host IP address when the source IP address is the proxy.
 	ForwardedIP string `ecs:"forwarded_ip"`
 
@@ -88,8 +139,18 @@ type Network struct {
 	// their sum.
 	Bytes int64 `ecs:"bytes"`
 
+	// Calculated by dividing the total number of bits transferred during an
+	// arbitrary period of time by that period of time. By convention, this
+	// would likely be presented in bps (bits per second).
+	BitRate float64 `ecs:"bit_rate"`
+
 	// Total packets transferred in both directions.
 	// If `source.packets` and `destination.packets` are known,
 	// `network.packets` is their sum.
 	Packets int64 `ecs:"packets"`
+
+	// Calculated by dividing the total number of packets transferred during an
+	// arbitrary period of time by that period of time. By convention, this
+	// would likely be presented in pps (packets per second).
+	PacketRate float64 `ecs:"packet_rate"`
 }

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -33,8 +33,17 @@ type Source struct {
 	// Can be one or multiple IPv4 or IPv6 addresses.
 	IP string `ecs:"ip"`
 
+	// Count of the number of high-order bits that define an IPv4 or IPv6
+	// network address in a source network.
+	IPNetworkPrefix int64 `ecs:"ip.network_prefix"`
+
 	// Port of the source.
 	Port int64 `ecs:"port"`
+
+	// Text description for commonly used ports, e.g. dns, http, https, smtp.
+	// The field value must be normalized to lowercase for querying. See the
+	// documentation section "Implementing ECS".
+	PortName string `ecs:"port_name"`
 
 	// MAC address of the source.
 	MAC string `ecs:"mac"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -635,6 +635,17 @@ type: ip
 
 // ===============================================================
 
+| destination.ip.network_prefix
+| Count of the number of high-order bits that define an IPv4 or IPv6 network address in a destination network.
+
+type: long
+
+
+
+| core
+
+// ===============================================================
+
 | destination.mac
 | MAC address of the destination.
 
@@ -689,6 +700,19 @@ example: `12`
 type: long
 
 
+
+| core
+
+// ===============================================================
+
+| destination.port_name
+| Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS".
+
+type: keyword
+
+example: `http`
 
 | core
 
@@ -2471,6 +2495,17 @@ example: `aim`
 
 // ===============================================================
 
+| network.bit_rate
+| Calculated by dividing the total number of bits transferred during an arbitrary period of time by that period of time. By convention, this would likely be presented in bps (bits per second).
+
+type: float
+
+
+
+| core
+
+// ===============================================================
+
 | network.bytes
 | Total bytes transferred in both directions.
 
@@ -2479,6 +2514,17 @@ If `source.bytes` and `destination.bytes` are known, `network.bytes` is their su
 type: long
 
 example: `368`
+
+| core
+
+// ===============================================================
+
+| network.class_of_service
+| In the case of IPv4 packets this would correspond to the TOS (Type of Service) field. In the case of IPv6 packets this would correspond to the Traffic Class field.
+
+type: long
+
+
 
 | core
 
@@ -2526,12 +2572,67 @@ example: `inbound`
 
 // ===============================================================
 
+| network.dot1q_ctag
+| The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag Control Information) field as defined in IEEE 802.1Q. This could be the VLAN's numeric identifier or text description.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| network.dot1q_vlan
+| The VLAN identifier portion of the TCI (Tag Control Information) field of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's numeric identifier or text description.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| network.egress_interface
+| From the observation point of a network event, the network interface from which frames or packets were transmitted. For example, in the case of a switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| network.egress_vlan
+| From the observation point of a network event, the VLAN in which the frame was transmitted. This could be the VLAN's numeric identifier or text description.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
 | network.forwarded_ip
 | Host IP address when the source IP address is the proxy.
 
 type: ip
 
 example: `192.1.1.2`
+
+| core
+
+// ===============================================================
+
+| network.fragment_identification
+| The value of the fragment identification field from an IPv4 or IPv6 packet header.
+
+type: long
+
+
 
 | core
 
@@ -2548,6 +2649,39 @@ example: `6`
 
 // ===============================================================
 
+| network.icmp_type_code
+| This could be represented using a numeric value or a text description. For example, an ICMP echo request would have "type = 8" and "code = 0", which could be represented as "0x0800" or "ICMP Echo".
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| network.ingress_interface
+| From the observation point of a network event, the network interface into which frames or packets were received. For example, in the case of a switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
+| network.ingress_vlan
+| From the observation point of a network event, the VLAN in which the frame was received. This could be the VLAN's numeric identifier or text description.
+
+type: keyword
+
+
+
+| core
+
+// ===============================================================
+
 | network.name
 | Name given by operators to sections of their network.
 
@@ -2556,6 +2690,17 @@ type: keyword
 example: `Guest Wifi`
 
 | extended
+
+// ===============================================================
+
+| network.packet_rate
+| Calculated by dividing the total number of packets transferred during an arbitrary period of time by that period of time. By convention, this would likely be presented in pps (packets per second).
+
+type: float
+
+
+
+| core
 
 // ===============================================================
 
@@ -2580,6 +2725,17 @@ The field value must be normalized to lowercase for querying. See the documentat
 type: keyword
 
 example: `http`
+
+| core
+
+// ===============================================================
+
+| network.tcp_control_bits
+| This could be represented using a numeric value or text description. For example, a TCP syncrhonize flag could be represented as "0x0002" or "SYN".
+
+type: keyword
+
+
 
 | core
 
@@ -4150,6 +4306,17 @@ type: ip
 
 // ===============================================================
 
+| source.ip.network_prefix
+| Count of the number of high-order bits that define an IPv4 or IPv6 network address in a source network.
+
+type: long
+
+
+
+| core
+
+// ===============================================================
+
 | source.mac
 | MAC address of the source.
 
@@ -4204,6 +4371,19 @@ example: `12`
 type: long
 
 
+
+| core
+
+// ===============================================================
+
+| source.port_name
+| Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+The field value must be normalized to lowercase for querying. See the documentation section "Implementing ECS".
+
+type: keyword
+
+example: `http`
 
 | core
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -574,6 +574,12 @@
       description: 'IP address of the destination.
 
         Can be one or multiple IPv4 or IPv6 addresses.'
+    - name: ip.network_prefix
+      level: core
+      type: long
+      description: Count of the number of high-order bits that define an IPv4 or IPv6
+        network address in a destination network.
+      default_field: false
     - name: mac
       level: core
       type: keyword
@@ -603,6 +609,17 @@
       type: long
       format: string
       description: Port of the destination.
+    - name: port_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Text description for commonly used ports, e.g. dns, http, https,
+        smtp.
+
+        The field value must be normalized to lowercase for querying. See the documentation
+        section "Implementing ECS".'
+      example: http
+      default_field: false
     - name: registered_domain
       level: extended
       type: keyword
@@ -1915,6 +1932,13 @@
         The field value must be normalized to lowercase for querying. See the documentation
         section "Implementing ECS".'
       example: aim
+    - name: bit_rate
+      level: core
+      type: float
+      description: Calculated by dividing the total number of bits transferred during
+        an arbitrary period of time by that period of time. By convention, this would
+        likely be presented in bps (bits per second).
+      default_field: false
     - name: bytes
       level: core
       type: long
@@ -1924,6 +1948,13 @@
         If `source.bytes` and `destination.bytes` are known, `network.bytes` is their
         sum.'
       example: 368
+    - name: class_of_service
+      level: core
+      type: long
+      description: In the case of IPv4 packets this would correspond to the TOS (Type
+        of Service) field. In the case of IPv6 packets this would correspond to the
+        Traffic Class field.
+      default_field: false
     - name: community_id
       level: extended
       type: keyword
@@ -1945,11 +1976,50 @@
         \ monitoring context, populate this field from the point of view of your network\
         \ perimeter."
       example: inbound
+    - name: dot1q_ctag
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI
+        (Tag Control Information) field as defined in IEEE 802.1Q. This could be the
+        VLAN's numeric identifier or text description.
+      default_field: false
+    - name: dot1q_vlan
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The VLAN identifier portion of the TCI (Tag Control Information)
+        field of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's
+        numeric identifier or text description.
+      default_field: false
+    - name: egress_interface
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: From the observation point of a network event, the network interface
+        from which frames or packets were transmitted. For example, in the case of
+        a switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+        etc.), port description, or SNMP ifIndex (e.g. 501).
+      default_field: false
+    - name: egress_vlan
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: From the observation point of a network event, the VLAN in which
+        the frame was transmitted. This could be the VLAN's numeric identifier or
+        text description.
+      default_field: false
     - name: forwarded_ip
       level: core
       type: ip
       description: Host IP address when the source IP address is the proxy.
       example: 192.1.1.2
+    - name: fragment_identification
+      level: core
+      type: long
+      description: The value of the fragment identification field from an IPv4 or
+        IPv6 packet header.
+      default_field: false
     - name: iana_number
       level: extended
       type: keyword
@@ -1958,12 +2028,44 @@
         Standardized list of protocols. This aligns well with NetFlow and sFlow related
         logs which use the IANA Protocol Number.
       example: 6
+    - name: icmp_type_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: This could be represented using a numeric value or a text description.
+        For example, an ICMP echo request would have "type = 8" and "code = 0", which
+        could be represented as "0x0800" or "ICMP Echo".
+      default_field: false
+    - name: ingress_interface
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: From the observation point of a network event, the network interface
+        into which frames or packets were received. For example, in the case of a
+        switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+        etc.), port description, or SNMP ifIndex (e.g. 501).
+      default_field: false
+    - name: ingress_vlan
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: From the observation point of a network event, the VLAN in which
+        the frame was received. This could be the VLAN's numeric identifier or text
+        description.
+      default_field: false
     - name: name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Name given by operators to sections of their network.
       example: Guest Wifi
+    - name: packet_rate
+      level: core
+      type: float
+      description: Calculated by dividing the total number of packets transferred
+        during an arbitrary period of time by that period of time. By convention,
+        this would likely be presented in pps (packets per second).
+      default_field: false
     - name: packets
       level: core
       type: long
@@ -1981,6 +2083,13 @@
         The field value must be normalized to lowercase for querying. See the documentation
         section "Implementing ECS".'
       example: http
+    - name: tcp_control_bits
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: This could be represented using a numeric value or text description.
+        For example, a TCP syncrhonize flag could be represented as "0x0002" or "SYN".
+      default_field: false
     - name: transport
       level: core
       type: keyword
@@ -3257,6 +3366,12 @@
       description: 'IP address of the source.
 
         Can be one or multiple IPv4 or IPv6 addresses.'
+    - name: ip.network_prefix
+      level: core
+      type: long
+      description: Count of the number of high-order bits that define an IPv4 or IPv6
+        network address in a source network.
+      default_field: false
     - name: mac
       level: core
       type: keyword
@@ -3287,6 +3402,17 @@
       type: long
       format: string
       description: Port of the source.
+    - name: port_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Text description for commonly used ports, e.g. dns, http, https,
+        smtp.
+
+        The field value must be normalized to lowercase for querying. See the documentation
+        section "Implementing ECS".'
+      example: http
+      default_field: false
     - name: registered_domain
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -72,11 +72,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
 1.5.0-dev,true,destination,destination.geo.region_name,keyword,core,Quebec,Region name.
 1.5.0-dev,true,destination,destination.ip,ip,core,,IP address of the destination.
+1.5.0-dev,true,destination,destination.ip.network_prefix,long,core,,Network prefix bits of the destination IP address.
 1.5.0-dev,true,destination,destination.mac,keyword,core,,MAC address of the destination.
 1.5.0-dev,true,destination,destination.nat.ip,ip,extended,,Destination NAT ip
 1.5.0-dev,true,destination,destination.nat.port,long,extended,,Destination NAT Port
 1.5.0-dev,true,destination,destination.packets,long,core,12,Packets sent from the destination to the source.
 1.5.0-dev,true,destination,destination.port,long,core,,Port of the destination.
+1.5.0-dev,true,destination,destination.port_name,keyword,core,http,Text description for a destination port.
 1.5.0-dev,true,destination,destination.registered_domain,keyword,extended,google.com,"The highest registered destination domain, stripped of the subdomain."
 1.5.0-dev,true,destination,destination.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.5.0-dev,true,destination,destination.user.domain,keyword,extended,,Name of the directory the user is a member of.
@@ -239,14 +241,26 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,log,log.syslog.severity.code,long,extended,3,Syslog numeric severity of the event.
 1.5.0-dev,true,log,log.syslog.severity.name,keyword,extended,Error,Syslog text-based severity of the event.
 1.5.0-dev,true,network,network.application,keyword,extended,aim,Application level protocol name.
+1.5.0-dev,true,network,network.bit_rate,float,core,,Calculated network throughput in bits per some time period.
 1.5.0-dev,true,network,network.bytes,long,core,368,Total bytes transferred in both directions.
+1.5.0-dev,true,network,network.class_of_service,long,core,,Classification value for IP packets.
 1.5.0-dev,true,network,network.community_id,keyword,extended,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
 1.5.0-dev,true,network,network.direction,keyword,core,inbound,Direction of the network traffic.
+1.5.0-dev,true,network,network.dot1q_ctag,keyword,core,,The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag Control Information) field as defined in IEEE 802.1Q. This could be the VLAN's numeric identifier or text description.
+1.5.0-dev,true,network,network.dot1q_vlan,keyword,core,,The VLAN identifier portion of the TCI (Tag Control Information) field of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's numeric identifier or text description.
+1.5.0-dev,true,network,network.egress_interface,keyword,core,,Network interface from which frames or packets exited.
+1.5.0-dev,true,network,network.egress_vlan,keyword,core,,VLAN in which frames exited the observer.
 1.5.0-dev,true,network,network.forwarded_ip,ip,core,192.1.1.2,Host IP address when the source IP address is the proxy.
+1.5.0-dev,true,network,network.fragment_identification,long,core,,The value of the fragment identification field from an IPv4 or IPv6 packet header.
 1.5.0-dev,true,network,network.iana_number,keyword,extended,6,IANA Protocol Number.
+1.5.0-dev,true,network,network.icmp_type_code,keyword,core,,Type and code of an IPv4 ICMP messages.
+1.5.0-dev,true,network,network.ingress_interface,keyword,core,,Network interface into which frames or packets entered.
+1.5.0-dev,true,network,network.ingress_vlan,keyword,core,,VLAN in which frames entered the observer.
 1.5.0-dev,true,network,network.name,keyword,extended,Guest Wifi,Name given by operators to sections of their network.
+1.5.0-dev,true,network,network.packet_rate,float,core,,Calculated network throughput in packets per some time period.
 1.5.0-dev,true,network,network.packets,long,core,24,Total packets transferred in both directions.
 1.5.0-dev,true,network,network.protocol,keyword,core,http,L7 Network protocol name.
+1.5.0-dev,true,network,network.tcp_control_bits,keyword,core,,Control bits set in the TCP header.
 1.5.0-dev,true,network,network.transport,keyword,core,tcp,Protocol Name corresponding to the field `iana_number`.
 1.5.0-dev,true,network,network.type,keyword,core,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
 1.5.0-dev,true,observer,observer.geo.city_name,keyword,core,Montreal,City name.
@@ -415,11 +429,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,source,source.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
 1.5.0-dev,true,source,source.geo.region_name,keyword,core,Quebec,Region name.
 1.5.0-dev,true,source,source.ip,ip,core,,IP address of the source.
+1.5.0-dev,true,source,source.ip.network_prefix,long,core,,Network prefix bits of the source IP address.
 1.5.0-dev,true,source,source.mac,keyword,core,,MAC address of the source.
 1.5.0-dev,true,source,source.nat.ip,ip,extended,,Source NAT ip
 1.5.0-dev,true,source,source.nat.port,long,extended,,Source NAT port
 1.5.0-dev,true,source,source.packets,long,core,12,Packets sent from the source to the destination.
 1.5.0-dev,true,source,source.port,long,core,,Port of the source.
+1.5.0-dev,true,source,source.port_name,keyword,core,http,Text description for a source port.
 1.5.0-dev,true,source,source.registered_domain,keyword,extended,google.com,"The highest registered source domain, stripped of the subdomain."
 1.5.0-dev,true,source,source.top_level_domain,keyword,extended,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.5.0-dev,true,source,source.user.domain,keyword,extended,,Name of the directory the user is a member of.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -696,7 +696,7 @@ destination.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 7
+  order: 9
   short: Bytes sent from the destination to the source.
   type: long
 destination.domain:
@@ -706,7 +706,7 @@ destination.domain:
   ignore_above: 1024
   level: core
   name: domain
-  order: 4
+  order: 6
   short: Destination domain.
   type: keyword
 destination.geo.city_name:
@@ -821,6 +821,16 @@ destination.ip:
   order: 1
   short: IP address of the destination.
   type: ip
+destination.ip.network_prefix:
+  dashed_name: destination-ip-network-prefix
+  description: Count of the number of high-order bits that define an IPv4 or IPv6
+    network address in a destination network.
+  flat_name: destination.ip.network_prefix
+  level: core
+  name: ip.network_prefix
+  order: 2
+  short: Network prefix bits of the destination IP address.
+  type: long
 destination.mac:
   dashed_name: destination-mac
   description: MAC address of the destination.
@@ -828,7 +838,7 @@ destination.mac:
   ignore_above: 1024
   level: core
   name: mac
-  order: 3
+  order: 5
   short: MAC address of the destination.
   type: keyword
 destination.nat.ip:
@@ -840,7 +850,7 @@ destination.nat.ip:
   flat_name: destination.nat.ip
   level: extended
   name: nat.ip
-  order: 9
+  order: 11
   short: Destination NAT ip
   type: ip
 destination.nat.port:
@@ -852,7 +862,7 @@ destination.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 10
+  order: 12
   short: Destination NAT Port
   type: long
 destination.packets:
@@ -862,7 +872,7 @@ destination.packets:
   flat_name: destination.packets
   level: core
   name: packets
-  order: 8
+  order: 10
   short: Packets sent from the destination to the source.
   type: long
 destination.port:
@@ -872,9 +882,23 @@ destination.port:
   format: string
   level: core
   name: port
-  order: 2
+  order: 3
   short: Port of the destination.
   type: long
+destination.port_name:
+  dashed_name: destination-port-name
+  description: 'Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+    The field value must be normalized to lowercase for querying. See the documentation
+    section "Implementing ECS".'
+  example: http
+  flat_name: destination.port_name
+  ignore_above: 1024
+  level: core
+  name: port_name
+  order: 4
+  short: Text description for a destination port.
+  type: keyword
 destination.registered_domain:
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
@@ -889,7 +913,7 @@ destination.registered_domain:
   ignore_above: 1024
   level: extended
   name: registered_domain
-  order: 5
+  order: 7
   short: The highest registered destination domain, stripped of the subdomain.
   type: keyword
 destination.top_level_domain:
@@ -906,7 +930,7 @@ destination.top_level_domain:
   ignore_above: 1024
   level: extended
   name: top_level_domain
-  order: 6
+  order: 8
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 destination.user.domain:
@@ -3165,9 +3189,20 @@ network.application:
   ignore_above: 1024
   level: extended
   name: application
-  order: 4
+  order: 10
   short: Application level protocol name.
   type: keyword
+network.bit_rate:
+  dashed_name: network-bit-rate
+  description: Calculated by dividing the total number of bits transferred during
+    an arbitrary period of time by that period of time. By convention, this would
+    likely be presented in bps (bits per second).
+  flat_name: network.bit_rate
+  level: core
+  name: bit_rate
+  order: 20
+  short: Calculated network throughput in bits per some time period.
+  type: float
 network.bytes:
   dashed_name: network-bytes
   description: 'Total bytes transferred in both directions.
@@ -3179,8 +3214,19 @@ network.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 9
+  order: 19
   short: Total bytes transferred in both directions.
+  type: long
+network.class_of_service:
+  dashed_name: network-class-of-service
+  description: In the case of IPv4 packets this would correspond to the TOS (Type
+    of Service) field. In the case of IPv6 packets this would correspond to the Traffic
+    Class field.
+  flat_name: network.class_of_service
+  level: core
+  name: class_of_service
+  order: 4
+  short: Classification value for IP packets.
   type: long
 network.community_id:
   dashed_name: network-community-id
@@ -3193,7 +3239,7 @@ network.community_id:
   ignore_above: 1024
   level: extended
   name: community_id
-  order: 8
+  order: 18
   short: A hash of source and destination IPs and ports.
   type: keyword
 network.direction:
@@ -3208,8 +3254,60 @@ network.direction:
   ignore_above: 1024
   level: core
   name: direction
-  order: 6
+  order: 12
   short: Direction of the network traffic.
+  type: keyword
+network.dot1q_ctag:
+  dashed_name: network-dot1q-ctag
+  description: The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag
+    Control Information) field as defined in IEEE 802.1Q. This could be the VLAN's
+    numeric identifier or text description.
+  flat_name: network.dot1q_ctag
+  ignore_above: 1024
+  level: core
+  name: dot1q_ctag
+  order: 1
+  short: The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag Control
+    Information) field as defined in IEEE 802.1Q. This could be the VLAN's numeric
+    identifier or text description.
+  type: keyword
+network.dot1q_vlan:
+  dashed_name: network-dot1q-vlan
+  description: The VLAN identifier portion of the TCI (Tag Control Information) field
+    of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's numeric
+    identifier or text description.
+  flat_name: network.dot1q_vlan
+  ignore_above: 1024
+  level: core
+  name: dot1q_vlan
+  order: 2
+  short: The VLAN identifier portion of the TCI (Tag Control Information) field of
+    an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's numeric
+    identifier or text description.
+  type: keyword
+network.egress_interface:
+  dashed_name: network-egress-interface
+  description: From the observation point of a network event, the network interface
+    from which frames or packets were transmitted. For example, in the case of a switch
+    or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+    etc.), port description, or SNMP ifIndex (e.g. 501).
+  flat_name: network.egress_interface
+  ignore_above: 1024
+  level: core
+  name: egress_interface
+  order: 13
+  short: Network interface from which frames or packets exited.
+  type: keyword
+network.egress_vlan:
+  dashed_name: network-egress-vlan
+  description: From the observation point of a network event, the VLAN in which the
+    frame was transmitted. This could be the VLAN's numeric identifier or text description.
+  flat_name: network.egress_vlan
+  ignore_above: 1024
+  level: core
+  name: egress_vlan
+  order: 14
+  short: VLAN in which frames exited the observer.
   type: keyword
 network.forwarded_ip:
   dashed_name: network-forwarded-ip
@@ -3218,9 +3316,20 @@ network.forwarded_ip:
   flat_name: network.forwarded_ip
   level: core
   name: forwarded_ip
-  order: 7
+  order: 17
   short: Host IP address when the source IP address is the proxy.
   type: ip
+network.fragment_identification:
+  dashed_name: network-fragment-identification
+  description: The value of the fragment identification field from an IPv4 or IPv6
+    packet header.
+  flat_name: network.fragment_identification
+  level: core
+  name: fragment_identification
+  order: 8
+  short: The value of the fragment identification field from an IPv4 or IPv6 packet
+    header.
+  type: long
 network.iana_number:
   dashed_name: network-iana-number
   description: IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
@@ -3231,8 +3340,44 @@ network.iana_number:
   ignore_above: 1024
   level: extended
   name: iana_number
-  order: 2
+  order: 6
   short: IANA Protocol Number.
+  type: keyword
+network.icmp_type_code:
+  dashed_name: network-icmp-type-code
+  description: This could be represented using a numeric value or a text description.
+    For example, an ICMP echo request would have "type = 8" and "code = 0", which
+    could be represented as "0x0800" or "ICMP Echo".
+  flat_name: network.icmp_type_code
+  ignore_above: 1024
+  level: core
+  name: icmp_type_code
+  order: 5
+  short: Type and code of an IPv4 ICMP messages.
+  type: keyword
+network.ingress_interface:
+  dashed_name: network-ingress-interface
+  description: From the observation point of a network event, the network interface
+    into which frames or packets were received. For example, in the case of a switch
+    or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+    etc.), port description, or SNMP ifIndex (e.g. 501).
+  flat_name: network.ingress_interface
+  ignore_above: 1024
+  level: core
+  name: ingress_interface
+  order: 15
+  short: Network interface into which frames or packets entered.
+  type: keyword
+network.ingress_vlan:
+  dashed_name: network-ingress-vlan
+  description: From the observation point of a network event, the VLAN in which the
+    frame was received. This could be the VLAN's numeric identifier or text description.
+  flat_name: network.ingress_vlan
+  ignore_above: 1024
+  level: core
+  name: ingress_vlan
+  order: 16
+  short: VLAN in which frames entered the observer.
   type: keyword
 network.name:
   dashed_name: network-name
@@ -3245,6 +3390,17 @@ network.name:
   order: 0
   short: Name given by operators to sections of their network.
   type: keyword
+network.packet_rate:
+  dashed_name: network-packet-rate
+  description: Calculated by dividing the total number of packets transferred during
+    an arbitrary period of time by that period of time. By convention, this would
+    likely be presented in pps (packets per second).
+  flat_name: network.packet_rate
+  level: core
+  name: packet_rate
+  order: 22
+  short: Calculated network throughput in packets per some time period.
+  type: float
 network.packets:
   dashed_name: network-packets
   description: 'Total packets transferred in both directions.
@@ -3255,7 +3411,7 @@ network.packets:
   flat_name: network.packets
   level: core
   name: packets
-  order: 10
+  order: 21
   short: Total packets transferred in both directions.
   type: long
 network.protocol:
@@ -3269,8 +3425,19 @@ network.protocol:
   ignore_above: 1024
   level: core
   name: protocol
-  order: 5
+  order: 11
   short: L7 Network protocol name.
+  type: keyword
+network.tcp_control_bits:
+  dashed_name: network-tcp-control-bits
+  description: This could be represented using a numeric value or text description.
+    For example, a TCP syncrhonize flag could be represented as "0x0002" or "SYN".
+  flat_name: network.tcp_control_bits
+  ignore_above: 1024
+  level: core
+  name: tcp_control_bits
+  order: 9
+  short: Control bits set in the TCP header.
   type: keyword
 network.transport:
   dashed_name: network-transport
@@ -3284,7 +3451,7 @@ network.transport:
   ignore_above: 1024
   level: core
   name: transport
-  order: 3
+  order: 7
   short: Protocol Name corresponding to the field `iana_number`.
   type: keyword
 network.type:
@@ -3299,7 +3466,7 @@ network.type:
   ignore_above: 1024
   level: core
   name: type
-  order: 1
+  order: 3
   short: In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim,
     etc
   type: keyword
@@ -5065,7 +5232,7 @@ source.bytes:
   format: bytes
   level: core
   name: bytes
-  order: 7
+  order: 9
   short: Bytes sent from the source to the destination.
   type: long
 source.domain:
@@ -5075,7 +5242,7 @@ source.domain:
   ignore_above: 1024
   level: core
   name: domain
-  order: 4
+  order: 6
   short: Source domain.
   type: keyword
 source.geo.city_name:
@@ -5190,6 +5357,16 @@ source.ip:
   order: 1
   short: IP address of the source.
   type: ip
+source.ip.network_prefix:
+  dashed_name: source-ip-network-prefix
+  description: Count of the number of high-order bits that define an IPv4 or IPv6
+    network address in a source network.
+  flat_name: source.ip.network_prefix
+  level: core
+  name: ip.network_prefix
+  order: 2
+  short: Network prefix bits of the source IP address.
+  type: long
 source.mac:
   dashed_name: source-mac
   description: MAC address of the source.
@@ -5197,7 +5374,7 @@ source.mac:
   ignore_above: 1024
   level: core
   name: mac
-  order: 3
+  order: 5
   short: MAC address of the source.
   type: keyword
 source.nat.ip:
@@ -5209,7 +5386,7 @@ source.nat.ip:
   flat_name: source.nat.ip
   level: extended
   name: nat.ip
-  order: 9
+  order: 11
   short: Source NAT ip
   type: ip
 source.nat.port:
@@ -5222,7 +5399,7 @@ source.nat.port:
   format: string
   level: extended
   name: nat.port
-  order: 10
+  order: 12
   short: Source NAT port
   type: long
 source.packets:
@@ -5232,7 +5409,7 @@ source.packets:
   flat_name: source.packets
   level: core
   name: packets
-  order: 8
+  order: 10
   short: Packets sent from the source to the destination.
   type: long
 source.port:
@@ -5242,9 +5419,23 @@ source.port:
   format: string
   level: core
   name: port
-  order: 2
+  order: 3
   short: Port of the source.
   type: long
+source.port_name:
+  dashed_name: source-port-name
+  description: 'Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+    The field value must be normalized to lowercase for querying. See the documentation
+    section "Implementing ECS".'
+  example: http
+  flat_name: source.port_name
+  ignore_above: 1024
+  level: core
+  name: port_name
+  order: 4
+  short: Text description for a source port.
+  type: keyword
 source.registered_domain:
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
@@ -5259,7 +5450,7 @@ source.registered_domain:
   ignore_above: 1024
   level: extended
   name: registered_domain
-  order: 5
+  order: 7
   short: The highest registered source domain, stripped of the subdomain.
   type: keyword
 source.top_level_domain:
@@ -5276,7 +5467,7 @@ source.top_level_domain:
   ignore_above: 1024
   level: extended
   name: top_level_domain
-  order: 6
+  order: 8
   short: The effective top level domain (com, org, net, co.uk).
   type: keyword
 source.user.domain:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -848,7 +848,7 @@ destination:
       format: bytes
       level: core
       name: bytes
-      order: 7
+      order: 9
       short: Bytes sent from the destination to the source.
       type: long
     domain:
@@ -858,7 +858,7 @@ destination:
       ignore_above: 1024
       level: core
       name: domain
-      order: 4
+      order: 6
       short: Destination domain.
       type: keyword
     geo.city_name:
@@ -973,6 +973,16 @@ destination:
       order: 1
       short: IP address of the destination.
       type: ip
+    ip.network_prefix:
+      dashed_name: destination-ip-network-prefix
+      description: Count of the number of high-order bits that define an IPv4 or IPv6
+        network address in a destination network.
+      flat_name: destination.ip.network_prefix
+      level: core
+      name: ip.network_prefix
+      order: 2
+      short: Network prefix bits of the destination IP address.
+      type: long
     mac:
       dashed_name: destination-mac
       description: MAC address of the destination.
@@ -980,7 +990,7 @@ destination:
       ignore_above: 1024
       level: core
       name: mac
-      order: 3
+      order: 5
       short: MAC address of the destination.
       type: keyword
     nat.ip:
@@ -992,7 +1002,7 @@ destination:
       flat_name: destination.nat.ip
       level: extended
       name: nat.ip
-      order: 9
+      order: 11
       short: Destination NAT ip
       type: ip
     nat.port:
@@ -1004,7 +1014,7 @@ destination:
       format: string
       level: extended
       name: nat.port
-      order: 10
+      order: 12
       short: Destination NAT Port
       type: long
     packets:
@@ -1014,7 +1024,7 @@ destination:
       flat_name: destination.packets
       level: core
       name: packets
-      order: 8
+      order: 10
       short: Packets sent from the destination to the source.
       type: long
     port:
@@ -1024,9 +1034,24 @@ destination:
       format: string
       level: core
       name: port
-      order: 2
+      order: 3
       short: Port of the destination.
       type: long
+    port_name:
+      dashed_name: destination-port-name
+      description: 'Text description for commonly used ports, e.g. dns, http, https,
+        smtp.
+
+        The field value must be normalized to lowercase for querying. See the documentation
+        section "Implementing ECS".'
+      example: http
+      flat_name: destination.port_name
+      ignore_above: 1024
+      level: core
+      name: port_name
+      order: 4
+      short: Text description for a destination port.
+      type: keyword
     registered_domain:
       dashed_name: destination-registered-domain
       description: 'The highest registered destination domain, stripped of the subdomain.
@@ -1041,7 +1066,7 @@ destination:
       ignore_above: 1024
       level: extended
       name: registered_domain
-      order: 5
+      order: 7
       short: The highest registered destination domain, stripped of the subdomain.
       type: keyword
     top_level_domain:
@@ -1058,7 +1083,7 @@ destination:
       ignore_above: 1024
       level: extended
       name: top_level_domain
-      order: 6
+      order: 8
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:
@@ -3467,9 +3492,20 @@ network:
       ignore_above: 1024
       level: extended
       name: application
-      order: 4
+      order: 10
       short: Application level protocol name.
       type: keyword
+    bit_rate:
+      dashed_name: network-bit-rate
+      description: Calculated by dividing the total number of bits transferred during
+        an arbitrary period of time by that period of time. By convention, this would
+        likely be presented in bps (bits per second).
+      flat_name: network.bit_rate
+      level: core
+      name: bit_rate
+      order: 20
+      short: Calculated network throughput in bits per some time period.
+      type: float
     bytes:
       dashed_name: network-bytes
       description: 'Total bytes transferred in both directions.
@@ -3481,8 +3517,19 @@ network:
       format: bytes
       level: core
       name: bytes
-      order: 9
+      order: 19
       short: Total bytes transferred in both directions.
+      type: long
+    class_of_service:
+      dashed_name: network-class-of-service
+      description: In the case of IPv4 packets this would correspond to the TOS (Type
+        of Service) field. In the case of IPv6 packets this would correspond to the
+        Traffic Class field.
+      flat_name: network.class_of_service
+      level: core
+      name: class_of_service
+      order: 4
+      short: Classification value for IP packets.
       type: long
     community_id:
       dashed_name: network-community-id
@@ -3496,7 +3543,7 @@ network:
       ignore_above: 1024
       level: extended
       name: community_id
-      order: 8
+      order: 18
       short: A hash of source and destination IPs and ports.
       type: keyword
     direction:
@@ -3512,8 +3559,61 @@ network:
       ignore_above: 1024
       level: core
       name: direction
-      order: 6
+      order: 12
       short: Direction of the network traffic.
+      type: keyword
+    dot1q_ctag:
+      dashed_name: network-dot1q-ctag
+      description: The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI
+        (Tag Control Information) field as defined in IEEE 802.1Q. This could be the
+        VLAN's numeric identifier or text description.
+      flat_name: network.dot1q_ctag
+      ignore_above: 1024
+      level: core
+      name: dot1q_ctag
+      order: 1
+      short: The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag
+        Control Information) field as defined in IEEE 802.1Q. This could be the VLAN's
+        numeric identifier or text description.
+      type: keyword
+    dot1q_vlan:
+      dashed_name: network-dot1q-vlan
+      description: The VLAN identifier portion of the TCI (Tag Control Information)
+        field of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's
+        numeric identifier or text description.
+      flat_name: network.dot1q_vlan
+      ignore_above: 1024
+      level: core
+      name: dot1q_vlan
+      order: 2
+      short: The VLAN identifier portion of the TCI (Tag Control Information) field
+        of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's numeric
+        identifier or text description.
+      type: keyword
+    egress_interface:
+      dashed_name: network-egress-interface
+      description: From the observation point of a network event, the network interface
+        from which frames or packets were transmitted. For example, in the case of
+        a switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+        etc.), port description, or SNMP ifIndex (e.g. 501).
+      flat_name: network.egress_interface
+      ignore_above: 1024
+      level: core
+      name: egress_interface
+      order: 13
+      short: Network interface from which frames or packets exited.
+      type: keyword
+    egress_vlan:
+      dashed_name: network-egress-vlan
+      description: From the observation point of a network event, the VLAN in which
+        the frame was transmitted. This could be the VLAN's numeric identifier or
+        text description.
+      flat_name: network.egress_vlan
+      ignore_above: 1024
+      level: core
+      name: egress_vlan
+      order: 14
+      short: VLAN in which frames exited the observer.
       type: keyword
     forwarded_ip:
       dashed_name: network-forwarded-ip
@@ -3522,9 +3622,20 @@ network:
       flat_name: network.forwarded_ip
       level: core
       name: forwarded_ip
-      order: 7
+      order: 17
       short: Host IP address when the source IP address is the proxy.
       type: ip
+    fragment_identification:
+      dashed_name: network-fragment-identification
+      description: The value of the fragment identification field from an IPv4 or
+        IPv6 packet header.
+      flat_name: network.fragment_identification
+      level: core
+      name: fragment_identification
+      order: 8
+      short: The value of the fragment identification field from an IPv4 or IPv6 packet
+        header.
+      type: long
     iana_number:
       dashed_name: network-iana-number
       description: IANA Protocol Number (https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml).
@@ -3535,8 +3646,45 @@ network:
       ignore_above: 1024
       level: extended
       name: iana_number
-      order: 2
+      order: 6
       short: IANA Protocol Number.
+      type: keyword
+    icmp_type_code:
+      dashed_name: network-icmp-type-code
+      description: This could be represented using a numeric value or a text description.
+        For example, an ICMP echo request would have "type = 8" and "code = 0", which
+        could be represented as "0x0800" or "ICMP Echo".
+      flat_name: network.icmp_type_code
+      ignore_above: 1024
+      level: core
+      name: icmp_type_code
+      order: 5
+      short: Type and code of an IPv4 ICMP messages.
+      type: keyword
+    ingress_interface:
+      dashed_name: network-ingress-interface
+      description: From the observation point of a network event, the network interface
+        into which frames or packets were received. For example, in the case of a
+        switch or router this might be the port name (e.g. eth0, ge-0/1,  GigabitEthernet0/0,
+        etc.), port description, or SNMP ifIndex (e.g. 501).
+      flat_name: network.ingress_interface
+      ignore_above: 1024
+      level: core
+      name: ingress_interface
+      order: 15
+      short: Network interface into which frames or packets entered.
+      type: keyword
+    ingress_vlan:
+      dashed_name: network-ingress-vlan
+      description: From the observation point of a network event, the VLAN in which
+        the frame was received. This could be the VLAN's numeric identifier or text
+        description.
+      flat_name: network.ingress_vlan
+      ignore_above: 1024
+      level: core
+      name: ingress_vlan
+      order: 16
+      short: VLAN in which frames entered the observer.
       type: keyword
     name:
       dashed_name: network-name
@@ -3549,6 +3697,17 @@ network:
       order: 0
       short: Name given by operators to sections of their network.
       type: keyword
+    packet_rate:
+      dashed_name: network-packet-rate
+      description: Calculated by dividing the total number of packets transferred
+        during an arbitrary period of time by that period of time. By convention,
+        this would likely be presented in pps (packets per second).
+      flat_name: network.packet_rate
+      level: core
+      name: packet_rate
+      order: 22
+      short: Calculated network throughput in packets per some time period.
+      type: float
     packets:
       dashed_name: network-packets
       description: 'Total packets transferred in both directions.
@@ -3559,7 +3718,7 @@ network:
       flat_name: network.packets
       level: core
       name: packets
-      order: 10
+      order: 21
       short: Total packets transferred in both directions.
       type: long
     protocol:
@@ -3573,8 +3732,19 @@ network:
       ignore_above: 1024
       level: core
       name: protocol
-      order: 5
+      order: 11
       short: L7 Network protocol name.
+      type: keyword
+    tcp_control_bits:
+      dashed_name: network-tcp-control-bits
+      description: This could be represented using a numeric value or text description.
+        For example, a TCP syncrhonize flag could be represented as "0x0002" or "SYN".
+      flat_name: network.tcp_control_bits
+      ignore_above: 1024
+      level: core
+      name: tcp_control_bits
+      order: 9
+      short: Control bits set in the TCP header.
       type: keyword
     transport:
       dashed_name: network-transport
@@ -3588,7 +3758,7 @@ network:
       ignore_above: 1024
       level: core
       name: transport
-      order: 3
+      order: 7
       short: Protocol Name corresponding to the field `iana_number`.
       type: keyword
     type:
@@ -3603,7 +3773,7 @@ network:
       ignore_above: 1024
       level: core
       name: type
-      order: 1
+      order: 3
       short: In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec,
         pim, etc
       type: keyword
@@ -5537,7 +5707,7 @@ source:
       format: bytes
       level: core
       name: bytes
-      order: 7
+      order: 9
       short: Bytes sent from the source to the destination.
       type: long
     domain:
@@ -5547,7 +5717,7 @@ source:
       ignore_above: 1024
       level: core
       name: domain
-      order: 4
+      order: 6
       short: Source domain.
       type: keyword
     geo.city_name:
@@ -5662,6 +5832,16 @@ source:
       order: 1
       short: IP address of the source.
       type: ip
+    ip.network_prefix:
+      dashed_name: source-ip-network-prefix
+      description: Count of the number of high-order bits that define an IPv4 or IPv6
+        network address in a source network.
+      flat_name: source.ip.network_prefix
+      level: core
+      name: ip.network_prefix
+      order: 2
+      short: Network prefix bits of the source IP address.
+      type: long
     mac:
       dashed_name: source-mac
       description: MAC address of the source.
@@ -5669,7 +5849,7 @@ source:
       ignore_above: 1024
       level: core
       name: mac
-      order: 3
+      order: 5
       short: MAC address of the source.
       type: keyword
     nat.ip:
@@ -5681,7 +5861,7 @@ source:
       flat_name: source.nat.ip
       level: extended
       name: nat.ip
-      order: 9
+      order: 11
       short: Source NAT ip
       type: ip
     nat.port:
@@ -5694,7 +5874,7 @@ source:
       format: string
       level: extended
       name: nat.port
-      order: 10
+      order: 12
       short: Source NAT port
       type: long
     packets:
@@ -5704,7 +5884,7 @@ source:
       flat_name: source.packets
       level: core
       name: packets
-      order: 8
+      order: 10
       short: Packets sent from the source to the destination.
       type: long
     port:
@@ -5714,9 +5894,24 @@ source:
       format: string
       level: core
       name: port
-      order: 2
+      order: 3
       short: Port of the source.
       type: long
+    port_name:
+      dashed_name: source-port-name
+      description: 'Text description for commonly used ports, e.g. dns, http, https,
+        smtp.
+
+        The field value must be normalized to lowercase for querying. See the documentation
+        section "Implementing ECS".'
+      example: http
+      flat_name: source.port_name
+      ignore_above: 1024
+      level: core
+      name: port_name
+      order: 4
+      short: Text description for a source port.
+      type: keyword
     registered_domain:
       dashed_name: source-registered-domain
       description: 'The highest registered source domain, stripped of the subdomain.
@@ -5731,7 +5926,7 @@ source:
       ignore_above: 1024
       level: extended
       name: registered_domain
-      order: 5
+      order: 7
       short: The highest registered source domain, stripped of the subdomain.
       type: keyword
     top_level_domain:
@@ -5748,7 +5943,7 @@ source:
       ignore_above: 1024
       level: extended
       name: top_level_domain
-      order: 6
+      order: 8
       short: The effective top level domain (com, org, net, co.uk).
       type: keyword
     user.domain:

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -371,6 +371,11 @@
               }
             },
             "ip": {
+              "properties": {
+                "network_prefix": {
+                  "type": "long"
+                }
+              },
               "type": "ip"
             },
             "mac": {
@@ -392,6 +397,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "port_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "registered_domain": {
               "ignore_above": 1024,
@@ -1161,7 +1170,13 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "bit_rate": {
+              "type": "float"
+            },
             "bytes": {
+              "type": "long"
+            },
+            "class_of_service": {
               "type": "long"
             },
             "community_id": {
@@ -1172,10 +1187,41 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "dot1q_ctag": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "dot1q_vlan": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "egress_interface": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "egress_vlan": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "forwarded_ip": {
               "type": "ip"
             },
+            "fragment_identification": {
+              "type": "long"
+            },
             "iana_number": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "icmp_type_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingress_interface": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "ingress_vlan": {
               "ignore_above": 1024,
               "type": "keyword"
             },
@@ -1183,10 +1229,17 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "packet_rate": {
+              "type": "float"
+            },
             "packets": {
               "type": "long"
             },
             "protocol": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "tcp_control_bits": {
               "ignore_above": 1024,
               "type": "keyword"
             },
@@ -1977,6 +2030,11 @@
               }
             },
             "ip": {
+              "properties": {
+                "network_prefix": {
+                  "type": "long"
+                }
+              },
               "type": "ip"
             },
             "mac": {
@@ -1998,6 +2056,10 @@
             },
             "port": {
               "type": "long"
+            },
+            "port_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "registered_domain": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -370,6 +370,11 @@
             }
           },
           "ip": {
+            "properties": {
+              "network_prefix": {
+                "type": "long"
+              }
+            },
             "type": "ip"
           },
           "mac": {
@@ -391,6 +396,10 @@
           },
           "port": {
             "type": "long"
+          },
+          "port_name": {
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "registered_domain": {
             "ignore_above": 1024,
@@ -1160,7 +1169,13 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "bit_rate": {
+            "type": "float"
+          },
           "bytes": {
+            "type": "long"
+          },
+          "class_of_service": {
             "type": "long"
           },
           "community_id": {
@@ -1171,10 +1186,41 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "dot1q_ctag": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "dot1q_vlan": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "egress_interface": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "egress_vlan": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "forwarded_ip": {
             "type": "ip"
           },
+          "fragment_identification": {
+            "type": "long"
+          },
           "iana_number": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "icmp_type_code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "ingress_interface": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "ingress_vlan": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -1182,10 +1228,17 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "packet_rate": {
+            "type": "float"
+          },
           "packets": {
             "type": "long"
           },
           "protocol": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "tcp_control_bits": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -1976,6 +2029,11 @@
             }
           },
           "ip": {
+            "properties": {
+              "network_prefix": {
+                "type": "long"
+              }
+            },
             "type": "ip"
           },
           "mac": {
@@ -1997,6 +2055,10 @@
           },
           "port": {
             "type": "long"
+          },
+          "port_name": {
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "registered_domain": {
             "ignore_above": 1024,

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -31,12 +31,30 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: ip.network_prefix
+      level: core
+      type: long
+      short: Network prefix bits of the destination IP address.
+      description: Count of the number of high-order bits that define an IPv4
+        or IPv6 network address in a destination network.
+
     - name: port
       format: string
       level: core
       type: long
       description: >
         Port of the destination.
+
+    - name: port_name
+      level: core
+      type: keyword
+      short: Text description for a destination port.
+      description: >
+        Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+        The field value must be normalized to lowercase for querying.
+        See the documentation section "Implementing ECS".
+      example: http
 
     - name: mac
       level: core

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -17,6 +17,22 @@
         Name given by operators to sections of their network.
       example: Guest Wifi
 
+    - name: dot1q_ctag
+      level: core
+      type: keyword
+      description: >
+        The customer VLAN identifier in the C-TAG (Customer VLAN Tag) TCI (Tag
+        Control Information) field as defined in IEEE 802.1Q. This could be the
+        VLAN's numeric identifier or text description. 
+
+    - name: dot1q_vlan
+      level: core
+      type: keyword
+      description: >
+        The VLAN identifier portion of the TCI (Tag Control Information) field
+        of an Ethernet frame as defined in IEEE 802.1Q. This could be the VLAN's
+        numeric identifier or text description. 
+
     - name: type
       level: core
       type: keyword
@@ -27,6 +43,24 @@
         The field value must be normalized to lowercase for querying. See
         the documentation section "Implementing ECS".
       example: ipv4
+
+    - name: class_of_service
+      level: core
+      type: long
+      short: Classification value for IP packets.
+      description: >
+        In the case of IPv4 packets this would correspond to the TOS (Type of
+        Service) field. In the case of IPv6 packets this would correspond to
+        the Traffic Class field.
+
+    - name: icmp_type_code
+      level: core
+      type: keyword
+      short: Type and code of an IPv4 ICMP messages.
+      description: >
+        This could be represented using a numeric value or a text description.
+        For example, an ICMP echo request would have "type = 8" and "code = 0",
+        which could be represented as "0x0800" or "ICMP Echo".
 
     - name: iana_number
       level: extended
@@ -49,6 +83,22 @@
         The field value must be normalized to lowercase for querying. See
         the documentation section "Implementing ECS".
       example: tcp
+
+    - name: fragment_identification
+      level: core
+      type: long
+      description: >
+        The value of the fragment identification field from an IPv4 or IPv6
+        packet header.
+
+    - name: tcp_control_bits
+      level: core
+      type: keyword
+      short: Control bits set in the TCP header.
+      description: >
+        This could be represented using a numeric value or text description.
+        For example, a TCP syncrhonize flag could be represented as "0x0002" or
+        "SYN".
 
     - name: application
       level: extended
@@ -98,6 +148,44 @@
         populate this field from the point of view of your network perimeter.
       example: inbound
 
+    - name: egress_interface
+      level: core
+      type: keyword
+      short: Network interface from which frames or packets exited.
+      description: >
+        From the observation point of a network event, the network interface
+        from which frames or packets were transmitted. For example, in the case
+        of a switch or router this might be the port name (e.g. eth0, ge-0/1, 
+        GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+
+    - name: egress_vlan
+      level: core
+      type: keyword
+      short: VLAN in which frames exited the observer.
+      description: >
+        From the observation point of a network event, the VLAN in which the
+        frame was transmitted. This could be the VLAN's numeric identifier or
+        text description. 
+
+    - name: ingress_interface
+      level: core
+      type: keyword
+      short: Network interface into which frames or packets entered.
+      description: >
+        From the observation point of a network event, the network interface
+        into which frames or packets were received. For example, in the case
+        of a switch or router this might be the port name (e.g. eth0, ge-0/1, 
+        GigabitEthernet0/0, etc.), port description, or SNMP ifIndex (e.g. 501).
+
+    - name: ingress_vlan
+      level: core
+      type: keyword
+      short: VLAN in which frames entered the observer.
+      description: >
+        From the observation point of a network event, the VLAN in which the
+        frame was received. This could be the VLAN's numeric identifier or
+        text description. 
+
     - name: forwarded_ip
       level: core
       type: ip
@@ -129,6 +217,15 @@
         If `source.bytes` and `destination.bytes` are known, `network.bytes` is their sum.
       example: 368
 
+    - name: bit_rate
+      level: core
+      type: float
+      short: Calculated network throughput in bits per some time period.
+      description: >
+        Calculated by dividing the total number of bits transferred during an
+        arbitrary period of time by that period of time. By convention, this
+        would likely be presented in bps (bits per second).
+
     - name: packets
       level: core
       type: long
@@ -138,3 +235,12 @@
 
         If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
       example: 24
+
+    - name: packet_rate
+      level: core
+      type: float
+      short: Calculated network throughput in packets per some time period.
+      description: >
+        Calculated by dividing the total number of packets transferred during an
+        arbitrary period of time by that period of time. By convention, this
+        would likely be presented in pps (packets per second).

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -31,12 +31,30 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: ip.network_prefix
+      level: core
+      type: long
+      short: Network prefix bits of the source IP address.
+      description: Count of the number of high-order bits that define an IPv4
+        or IPv6 network address in a source network.
+
     - name: port
       format: string
       level: core
       type: long
       description: >
         Port of the source.
+
+    - name: port_name
+      level: core
+      type: keyword
+      short: Text description for a source port.
+      description: >
+        Text description for commonly used ports, e.g. dns, http, https, smtp.
+
+        The field value must be normalized to lowercase for querying.
+        See the documentation section "Implementing ECS".
+      example: http
 
     - name: mac
       level: core


### PR DESCRIPTION
Added 2 additional fields to both the destination and source field sets to capture IP network prefixes/masks and text descriptions of common network ports. Added 11 additional fields to the network field set to capture interface, VLAN (Virtual Local Area Network), ICMP, IP, and TCP information as well as bit rates and packet rates.