### PR TITLE
Allow generation of a subset of ECS and custom schema fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -35,7 +35,7 @@ Thanks, you're awesome :-) -->
 
 * ECS scripts now use Python 3.6+. #674
 * schema_reader.py now reliably supports chaining reusable fieldsets together. #722
-* A subset of fields to render can be defined. #737
+* Allow the artifact generator to consider and output only a subset of fields. #737
 
 #### Deprecated
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -35,6 +35,7 @@ Thanks, you're awesome :-) -->
 
 * ECS scripts now use Python 3.6+. #674
 * schema_reader.py now reliably supports chaining reusable fieldsets together. #722
+* A subset of fields to render can be defined. #737
 
 #### Deprecated
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -10,6 +10,7 @@ from generators import beats
 from generators import asciidoc_fields
 from generators import ecs_helpers
 
+
 def fields_subset(subset, fields):
     retained_fields = {}
     for key, val in subset.items():
@@ -19,6 +20,7 @@ def fields_subset(subset, fields):
         elif val == '*':
             retained_fields[key] = fields[key]
     return retained_fields
+
 
 def main():
     args = argument_parser()

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -11,17 +11,6 @@ from generators import asciidoc_fields
 from generators import ecs_helpers
 
 
-def fields_subset(subset, fields):
-    retained_fields = {}
-    for key, val in subset.items():
-        if isinstance(val, dict):
-            retained_fields[key] = fields[key]
-            retained_fields[key]['fields'] = fields_subset(val, fields[key]['fields'])
-        elif val == '*':
-            retained_fields[key] = fields[key]
-    return retained_fields
-
-
 def main():
     args = argument_parser()
 
@@ -48,7 +37,7 @@ def main():
             with open(file) as f:
                 raw = yaml.safe_load(f.read())
                 ecs_helpers.recursive_merge_subset_dicts(subset, raw)
-        intermediate_fields = fields_subset(subset, intermediate_fields)
+        intermediate_fields = ecs_helpers.fields_subset(subset, intermediate_fields)
 
     (nested, flat) = schema_reader.generate_nested_flat(intermediate_fields)
     intermediate_files.generate(nested, flat)

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -18,7 +18,7 @@ def main():
 
     # Load the default schemas
     print('Loading default schemas')
-    (nested, flat) = schema_reader.load_schemas()
+    intermediate_fields = schema_reader.load_schemas()
 
     # Maybe load user specified directory of schemas
     if args.include:
@@ -26,12 +26,10 @@ def main():
 
         print('Loading user defined schemas: {0}'.format(include_glob))
 
-        (custom_nested, custom_flat) = schema_reader.load_schemas(sorted(glob.glob(include_glob)))
+        intermediate_custom = schema_reader.load_schemas(sorted(glob.glob(include_glob)))
+        schema_reader.merge_schema_fields(intermediate_fields, intermediate_custom, True)
 
-        # Merge without allowing user schemas to overwrite default schemas
-        nested = ecs_helpers.safe_merge_dicts(nested, custom_nested)
-        flat = ecs_helpers.safe_merge_dicts(flat, custom_flat)
-
+    (nested, flat) = schema_reader.generate_nested_flat(intermediate_fields)
     intermediate_files.generate(nested, flat)
     if args.intermediate_only:
         exit()

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -40,9 +40,13 @@ def main():
         schema_reader.merge_schema_fields(intermediate_fields, intermediate_custom)
 
     if args.subset:
-        with open(args.subset) as f:
-            raw = yaml.safe_load(f.read())
-            intermediate_fields = fields_subset(raw, intermediate_fields)
+        subset = {}
+        files = args.subset.split(' ')
+        for file in files:
+            with open(file) as f:
+                raw = yaml.safe_load(f.read())
+                ecs_helpers.recursive_merge_subset_dicts(subset, raw)
+        intermediate_fields = fields_subset(subset, intermediate_fields)
 
     (nested, flat) = schema_reader.generate_nested_flat(intermediate_fields)
     intermediate_files.generate(nested, flat)

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -32,8 +32,7 @@ def main():
 
     if args.subset:
         subset = {}
-        files = args.subset.split(' ')
-        for file in files:
+        for file in glob.glob(args.subset):
             with open(file) as f:
                 raw = yaml.safe_load(f.read())
                 ecs_helpers.recursive_merge_subset_dicts(subset, raw)

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -46,6 +46,8 @@ def argument_parser():
                         help='generate intermediary files only')
     parser.add_argument('--include', action='store',
                         help='include user specified directory of custom field definitions')
+    parser.add_argument('--subset', action='store',
+                        help='render a subset of the schema')
     return parser.parse_args()
 
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -32,10 +32,11 @@ def main():
 
     if args.subset:
         subset = {}
-        for file in glob.glob(args.subset):
-            with open(file) as f:
-                raw = yaml.safe_load(f.read())
-                ecs_helpers.recursive_merge_subset_dicts(subset, raw)
+        for arg in args.subset:
+            for file in glob.glob(arg):
+                with open(file) as f:
+                    raw = yaml.safe_load(f.read())
+                    ecs_helpers.recursive_merge_subset_dicts(subset, raw)
         intermediate_fields = ecs_helpers.fields_subset(subset, intermediate_fields)
 
     (nested, flat) = schema_reader.generate_nested_flat(intermediate_fields)
@@ -55,7 +56,7 @@ def argument_parser():
                         help='generate intermediary files only')
     parser.add_argument('--include', action='store',
                         help='include user specified directory of custom field definitions')
-    parser.add_argument('--subset', action='store',
+    parser.add_argument('--subset', nargs='+',
                         help='render a subset of the schema')
     return parser.parse_args()
 

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -49,6 +49,15 @@ def safe_merge_dicts(a, b):
     return c
 
 
+def recursive_merge_subset_dicts(a, b):
+    for key in b:
+        if key not in a:
+            a[key] = b[key]
+        elif isinstance(a[key], dict) and isinstance(b[key], dict):
+            recursive_merge_subset_dicts(a[key], b[key])
+        elif b[key] == "*":
+            a[key] = b[key]
+
 def yaml_ordereddict(dumper, data):
     # YAML representation of an OrderedDict will be like a dictionary, but
     # respecting the order of the dictionary.

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -58,6 +58,7 @@ def recursive_merge_subset_dicts(a, b):
         elif b[key] == "*":
             a[key] = b[key]
 
+
 def yaml_ordereddict(dumper, data):
     # YAML representation of an OrderedDict will be like a dictionary, but
     # respecting the order of the dictionary.

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -52,10 +52,12 @@ def safe_merge_dicts(a, b):
 def fields_subset(subset, fields):
     retained_fields = {}
     for key, val in subset.items():
-        if isinstance(val, dict):
+        # Every field must have a 'fields' key or the schema is invalid
+        if isinstance(val['fields'], dict):
+            # Copy the full field over so we get all the options, then replace the 'fields' with the right subset
             retained_fields[key] = fields[key]
-            retained_fields[key]['fields'] = fields_subset(val, fields[key]['fields'])
-        elif val == '*':
+            retained_fields[key]['fields'] = fields_subset(val['fields'], fields[key]['fields'])
+        elif val['fields'] == '*':
             retained_fields[key] = fields[key]
     return retained_fields
 
@@ -64,10 +66,10 @@ def recursive_merge_subset_dicts(a, b):
     for key in b:
         if key not in a:
             a[key] = b[key]
-        elif isinstance(a[key], dict) and isinstance(b[key], dict):
-            recursive_merge_subset_dicts(a[key], b[key])
-        elif b[key] == "*":
-            a[key] = b[key]
+        elif isinstance(a[key]['fields'], dict) and isinstance(b[key]['fields'], dict):
+            recursive_merge_subset_dicts(a[key]['fields'], b[key]['fields'])
+        elif b[key]['fields'] == "*":
+            a[key]['fields'] = b[key]['fields']
 
 
 def yaml_ordereddict(dumper, data):

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -49,6 +49,17 @@ def safe_merge_dicts(a, b):
     return c
 
 
+def fields_subset(subset, fields):
+    retained_fields = {}
+    for key, val in subset.items():
+        if isinstance(val, dict):
+            retained_fields[key] = fields[key]
+            retained_fields[key]['fields'] = fields_subset(val, fields[key]['fields'])
+        elif val == '*':
+            retained_fields[key] = fields[key]
+    return retained_fields
+
+
 def recursive_merge_subset_dicts(a, b):
     for key in b:
         if key not in a:

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -100,14 +100,12 @@ def merge_schema_fields(a, b):
             a_type = a[key].get('field_details', {}).get('type', 'object')
             b_type = b[key].get('field_details', {}).get('type', 'object')
             if a_type != b_type:
-                print('Schemas unmergeable: type {} does not match type {}'.format(a_type, b_type))
-                exit()
+                raise ValueError('Schemas unmergeable: type {} does not match type {}'.format(a_type, b_type))
             elif a_type not in ['object', 'nested']:
                 print('Warning: dropping field {}, already defined'.format(key))
-            else:
-                if 'fields' in b[key]:
-                    a[key].setdefault('fields', {})
-                    merge_schema_fields(a[key]['fields'], b[key]['fields'], False)
+            elif 'fields' in b[key]:
+                a[key].setdefault('fields', {})
+                merge_schema_fields(a[key]['fields'], b[key]['fields'])
 
 
 def field_set_defaults(field):

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -92,7 +92,7 @@ def schema_fields_as_dictionary(schema):
         nested_schema[nested_levels[-1]]['field_details'] = field
 
 
-def merge_schema_fields(a, b, is_top_level):
+def merge_schema_fields(a, b):
     for key in b:
         if key not in a:
             a[key] = b[key]

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -105,9 +105,6 @@ def merge_schema_fields(a, b, is_top_level):
             elif a_type not in ['object', 'nested']:
                 print('Warning: dropping field {}, already defined'.format(key))
             else:
-                if 'reusable' in a[key] and not is_top_level:
-                    print('Error: can not add fields to reusable fieldset when already nested')
-                    exit()
                 if 'fields' in b[key]:
                     a[key].setdefault('fields', {})
                     merge_schema_fields(a[key]['fields'], b[key]['fields'], False)

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -97,7 +97,7 @@ def merge_schema_fields(a, b):
         if key not in a:
             a[key] = b[key]
         else:
-            a_type = a[key].get('field_details', {}).get('type', 'object') 
+            a_type = a[key].get('field_details', {}).get('type', 'object')
             b_type = b[key].get('field_details', {}).get('type', 'object')
             if a_type != b_type:
                 print('Schemas unmergeable: type {} does not match type {}'.format(a_type, b_type))
@@ -161,6 +161,7 @@ def finalize_schemas(fields_nested):
         schema = fields_nested[schema_name]
 
         schema_cleanup_values(schema)
+
 
 def assemble_reusables(fields_nested):
     # This happens as a second pass, so that all fieldsets have their
@@ -231,6 +232,7 @@ def load_schemas(files=ecs_files()):
     fields_intermediate = load_schema_files(files)
     finalize_schemas(fields_intermediate)
     return fields_intermediate
+
 
 def generate_nested_flat(fields_intermediate):
     assemble_reusables(fields_intermediate)

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -86,18 +86,66 @@ class TestECSHelpers(unittest.TestCase):
 
     def test_recursive_subset_merge(self):
         subset_a = {
-            'field1': {'subfield1': {'subsubfield1': '*'}, 'subfield2': '*'},
-            'field2': '*'
+            'field1': {
+                'fields': {
+                    'subfield1': {
+                        'fields': {
+                            'subsubfield1': {
+                                'fields': '*'
+                            }
+                        }
+                    },
+                    'subfield2': {
+                        'fields': '*'
+                    }
+                }
+            },
+            'field2': {
+                'fields': '*'
+            }
         }
         subset_b = {
-            'field1': {'subfield1': '*', 'subfield3': '*'},
-            'field2': {'subfield2': '*'},
-            'field3': '*'
+            'field1': {
+                'fields': {
+                    'subfield1': {
+                        'fields': '*'
+                    },
+                    'subfield3': {
+                        'fields': '*'
+                    }
+                }
+            },
+            'field2': {
+                'fields': {
+                    'subfield2': {
+                        'fields': '*'
+                    }
+                }
+            },
+            'field3': {
+                'fields': '*'
+            }
         }
         expected = {
-            'field1': {'subfield1': '*', 'subfield2': '*', 'subfield3': '*'},
-            'field2': '*',
-            'field3': '*'
+            'field1': {
+                'fields': {
+                    'subfield1': {
+                        'fields': '*'
+                    },
+                    'subfield2': {
+                        'fields': '*'
+                    },
+                    'subfield3': {
+                        'fields': '*'
+                    }
+                }
+            },
+            'field2': {
+                'fields': '*'
+            },
+            'field3': {
+                'fields': '*'
+            }
         }
         ecs_helpers.recursive_merge_subset_dicts(subset_a, subset_b)
         self.assertEqual(subset_a, expected)
@@ -126,7 +174,11 @@ class TestECSHelpers(unittest.TestCase):
         }
         subset = {
             'test_fieldset': {
-                'test_field1': '*'
+                'fields': {
+                    'test_field1': {
+                        'fields': '*'
+                    }
+                }
             }
         }
         expected = {

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -84,6 +84,68 @@ class TestECSHelpers(unittest.TestCase):
         split_list = ecs_helpers.list_split_by(lst, 3)
         self.assertEqual(split_list, [['ecs', 'has', 'a'], ['meme', 'now']])
 
+    def test_recursive_subset_merge(self):
+        subset_a = {
+            'field1': {'subfield1': {'subsubfield1': '*'}, 'subfield2': '*'},
+            'field2': '*'
+        }
+        subset_b = {
+            'field1': {'subfield1': '*', 'subfield3': '*'},
+            'field2': {'subfield2': '*'},
+            'field3': '*'
+        }
+        expected = {
+            'field1': {'subfield1': '*', 'subfield2': '*', 'subfield3': '*'},
+            'field2': '*',
+            'field3': '*'
+        }
+        ecs_helpers.recursive_merge_subset_dicts(subset_a, subset_b)
+        self.assertEqual(subset_a, expected)
+
+    def test_fields_subset(self):
+        fields = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    },
+                    'test_field2': {
+                        'field_details': {
+                            'name': 'test_field2',
+                            'type': 'keyword',
+                            'description': 'Another test field'
+                        }
+                    }
+                }
+            }
+        }
+        subset = {
+            'test_fieldset': {
+                'test_field1': '*'
+            }
+        }
+        expected = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    }
+                }
+            }
+        }
+        actual = ecs_helpers.fields_subset(subset, fields)
+        self.assertEqual(actual, expected)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from scripts import schema_reader
 
 
-(nested, flat) = schema_reader.load_schemas()
+(nested, flat) = schema_reader.generate_nested_flat(schema_reader.load_schemas())
 
 
 class TestEcsSpec(unittest.TestCase):

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -250,6 +250,112 @@ class TestSchemaReader(unittest.TestCase):
         }
         self.assertEqual(fields, expected)
 
+    def test_merge_schema_fields(self):
+        fieldset1 = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    },
+                    'test_field2': {
+                        'field_details': {
+                            'name': 'test_field2',
+                            'type': 'keyword',
+                            'description': 'Another test field'
+                        }
+                    }
+                }
+            }
+        }
+        fieldset2 = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field with matching type but custom description'
+                        }
+                    },
+                    'test_field3': {
+                        'field_details': {
+                            'name': 'test_field3',
+                            'type': 'keyword',
+                            'description': 'A third test field'
+                        }
+                    }
+                }
+            }
+        }
+        expected = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    },
+                    'test_field2': {
+                        'field_details': {
+                            'name': 'test_field2',
+                            'type': 'keyword',
+                            'description': 'Another test field'
+                        }
+                    },
+                    'test_field3': {
+                        'field_details': {
+                            'name': 'test_field3',
+                            'type': 'keyword',
+                            'description': 'A third test field'
+                        }
+                    }
+                }
+            }
+        }
+        schema_reader.merge_schema_fields(fieldset1, fieldset2)
+        self.assertEqual(fieldset1, expected)
+
+    def test_merge_schema_fields_fail(self):
+        fieldset1 = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    }
+                }
+            }
+        }
+        fieldset2 = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'long',
+                            'description': 'A conflicting field'
+                        }
+                    }
+                }
+            }
+        }
+        with self.assertRaises(ValueError):
+            schema_reader.merge_schema_fields(fieldset1, fieldset2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -253,7 +253,6 @@ class TestSchemaReader(unittest.TestCase):
         }
         self.assertEqual(fields, expected)
 
-
     def test_merge_schema_fields(self):
         fieldset1 = {
             'test_fieldset': {

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -82,7 +82,7 @@ class TestSchemaReader(unittest.TestCase):
 
     def test_load_schemas_with_empty_list_loads_nothing(self):
         result = schema_reader.load_schemas([])
-        self.assertEqual(result, ({}, {}))
+        self.assertEqual(result, ({}))
 
     def test_flatten_fields(self):
         fields = {


### PR DESCRIPTION
This PR extends prior work on the intermediate data format introduced in https://github.com/elastic/ecs/pull/722 and provides a way to specify a subset of the full set of ECS fields plus any fields defined by a custom schema and render only that subset to the generated files.  This would be particularly useful when multiple types of documents will be stored in the same index: one monolithic set of fields can be defined using the official ECS fields in addition to a custom schema that encompass every possible field for the documents, and the --subset parameter can be used to define which fields exist in each type of document.

An example subset document is
```---
host: "*"
base:
  "@timestamp": "*"
agent:
  id: "*"
  name: "*"
event: "*"
```
This subset includes every field in `host`, `@timestamp` from `base`, `id` and `name` from `agent`, and every field in `event`.  The format supports an arbitrary level of nesting as well.

Finally, multiple subsets can be provided at once and they will be automatically merged together to produce the set of fields which is the union of all the subsets.  This creates the exact mapping that is needed to support the set of documents.