### PR TITLE
Defined observer zones and interfaces

### DIFF
--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -85,4 +85,7 @@ type Client struct {
 	// internet).
 	// Typically connections traversing load balancers, firewalls, or routers.
 	NatPort int64 `ecs:"nat.port"`
+
+	// Security zone facing the client.
+	Zone string `ecs:"zone"`
 }

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -73,4 +73,7 @@ type Destination struct {
 	// Port the source session is translated to by NAT Device.
 	// Typically used with load balancers, firewalls, or routers.
 	NatPort int64 `ecs:"nat.port"`
+
+	// Security zone facing the destination.
+	Zone string `ecs:"zone"`
 }

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -71,10 +71,4 @@ type Observer struct {
 	// `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM
 	// server`.
 	Type string `ecs:"type"`
-
-	// Ingress zone of the observer.
-	ZoneIn string `ecs:"zone.in"`
-
-	// Egress zone of the observer.
-	ZoneOut string `ecs:"zone.out"`
 }

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -35,6 +35,12 @@ type Observer struct {
 	// MAC address of the observer
 	MAC string `ecs:"mac"`
 
+	// Ingress interface of the observer.
+	InterfaceIn string `ecs:"interface.in"`
+
+	// Egress interface of the observer.
+	InterfaceOut string `ecs:"interface.out"`
+
 	// IP address of the observer.
 	IP string `ecs:"ip"`
 
@@ -65,4 +71,10 @@ type Observer struct {
 	// `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM
 	// server`.
 	Type string `ecs:"type"`
+
+	// Ingress zone of the observer.
+	ZoneIn string `ecs:"zone.in"`
+
+	// Egress zone of the observer.
+	ZoneOut string `ecs:"zone.out"`
 }

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -85,4 +85,7 @@ type Server struct {
 	// private DMZ)
 	// Typically used with load balancers, firewalls, or routers.
 	NatPort int64 `ecs:"nat.port"`
+
+	// Security zone facing the server.
+	Zone string `ecs:"zone"`
 }

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -74,4 +74,7 @@ type Source struct {
 	// internet)
 	// Typically used with load balancers, firewalls, or routers.
 	NatPort int64 `ecs:"nat.port"`
+
+	// Security zone facing the source.
+	Zone string `ecs:"zone"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2639,6 +2639,28 @@ type: keyword
 
 // ===============================================================
 
+| observer.interface.in
+| Ingress interface of the observer.
+
+type: keyword
+
+example: `eth0`
+
+| extended
+
+// ===============================================================
+
+| observer.interface.out
+| Egress interface of the observer.
+
+type: keyword
+
+example: `eth1`
+
+| extended
+
+// ===============================================================
+
 | observer.ip
 | IP address of the observer.
 
@@ -2730,6 +2752,28 @@ type: keyword
 
 
 | core
+
+// ===============================================================
+
+| observer.zone.in
+| Ingress zone of the observer.
+
+type: keyword
+
+example: `wan`
+
+| extended
+
+// ===============================================================
+
+| observer.zone.out
+| Egress zone of the observer.
+
+type: keyword
+
+example: `dmz`
+
+| extended
 
 // ===============================================================
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -358,6 +358,17 @@ example: `co.uk`
 
 // ===============================================================
 
+| client.zone
+| Security zone facing the client.
+
+type: keyword
+
+example: `dmz`
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -717,6 +728,17 @@ This value can be determined precisely with a list like the public suffix list (
 type: keyword
 
 example: `co.uk`
+
+| extended
+
+// ===============================================================
+
+| destination.zone
+| Security zone facing the destination.
+
+type: keyword
+
+example: `dmz`
 
 | extended
 
@@ -2755,28 +2777,6 @@ type: keyword
 
 // ===============================================================
 
-| observer.zone.in
-| Ingress zone of the observer.
-
-type: keyword
-
-example: `wan`
-
-| extended
-
-// ===============================================================
-
-| observer.zone.out
-| Egress zone of the observer.
-
-type: keyword
-
-example: `dmz`
-
-| extended
-
-// ===============================================================
-
 |=====
 
 ==== Field Reuse
@@ -3980,6 +3980,17 @@ example: `co.uk`
 
 // ===============================================================
 
+| server.zone
+| Security zone facing the server.
+
+type: keyword
+
+example: `dmz`
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse
@@ -4276,6 +4287,17 @@ This value can be determined precisely with a list like the public suffix list (
 type: keyword
 
 example: `co.uk`
+
+| extended
+
+// ===============================================================
+
+| source.zone
+| Security zone facing the source.
+
+type: keyword
+
+example: `dmz`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2076,6 +2076,20 @@
       type: keyword
       ignore_above: 1024
       description: Hostname of the observer.
+    - name: interface.in
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Ingress interface of the observer.
+      example: eth0
+      default_field: false
+    - name: interface.out
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Egress interface of the observer.
+      example: eth1
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -2173,6 +2187,20 @@
       type: keyword
       ignore_above: 1024
       description: Observer version.
+    - name: zone.in
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Ingress zone of the observer.
+      example: wan
+      default_field: false
+    - name: zone.out
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Egress zone of the observer.
+      example: dmz
+      default_field: false
   - name: organization
     title: Organization
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -372,6 +372,13 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Security zone facing the client.
+      example: dmz
+      default_field: false
   - name: cloud
     title: Cloud
     group: 2
@@ -692,6 +699,13 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Security zone facing the destination.
+      example: dmz
+      default_field: false
   - name: dns
     title: DNS
     group: 2
@@ -2187,20 +2201,6 @@
       type: keyword
       ignore_above: 1024
       description: Observer version.
-    - name: zone.in
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Ingress zone of the observer.
-      example: wan
-      default_field: false
-    - name: zone.out
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Egress zone of the observer.
-      example: dmz
-      default_field: false
   - name: organization
     title: Organization
     group: 2
@@ -3093,6 +3093,13 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Security zone facing the server.
+      example: dmz
+      default_field: false
   - name: service
     title: Service
     group: 2
@@ -3404,6 +3411,13 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Security zone facing the source.
+      example: dmz
+      default_field: false
   - name: threat
     title: Threat
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -258,6 +258,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,CA-QC,Region ISO code.
 1.5.0-dev,true,observer,observer.geo.region_name,keyword,core,Quebec,Region name.
 1.5.0-dev,true,observer,observer.hostname,keyword,core,,Hostname of the observer.
+1.5.0-dev,true,observer,observer.interface.in,keyword,extended,eth0,Ingress interface of the observer.
+1.5.0-dev,true,observer,observer.interface.out,keyword,extended,eth1,Egress interface of the observer.
 1.5.0-dev,true,observer,observer.ip,ip,core,,IP address of the observer.
 1.5.0-dev,true,observer,observer.mac,keyword,core,,MAC address of the observer
 1.5.0-dev,true,observer,observer.name,keyword,extended,1_proxySG,Custom name of the observer.
@@ -274,6 +276,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
 1.5.0-dev,true,observer,observer.vendor,keyword,core,Symantec,Vendor name of the observer.
 1.5.0-dev,true,observer,observer.version,keyword,core,,Observer version.
+1.5.0-dev,true,observer,observer.zone.in,keyword,extended,wan,Ingress zone of the observer.
+1.5.0-dev,true,observer,observer.zone.out,keyword,extended,dmz,Egress zone of the observer.
 1.5.0-dev,true,organization,organization.id,keyword,extended,,Unique identifier for the organization.
 1.5.0-dev,true,organization,organization.name,keyword,extended,,Organization name.
 1.5.0-dev,true,organization,organization.name.text,text,extended,,Organization name.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -44,6 +44,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,client,client.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,client,client.user.name,keyword,core,albert,Short name or login of the user.
 1.5.0-dev,true,client,client.user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,client,client.zone,keyword,extended,dmz,Security zone facing the client.
 1.5.0-dev,true,cloud,cloud.account.id,keyword,extended,666777888999,The cloud account or organization id.
 1.5.0-dev,true,cloud,cloud.availability_zone,keyword,extended,us-east-1c,Availability zone in which this host is running.
 1.5.0-dev,true,cloud,cloud.instance.id,keyword,extended,i-1234567890abcdef0,Instance ID of the host machine.
@@ -90,6 +91,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,destination,destination.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,destination,destination.user.name,keyword,core,albert,Short name or login of the user.
 1.5.0-dev,true,destination,destination.user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,destination,destination.zone,keyword,extended,dmz,Security zone facing the destination.
 1.5.0-dev,true,dns,dns.answers,object,extended,,Array of DNS answers.
 1.5.0-dev,true,dns,dns.answers.class,keyword,extended,IN,The class of DNS data contained in this resource record.
 1.5.0-dev,true,dns,dns.answers.data,keyword,extended,10.10.10.10,The data describing the resource.
@@ -276,8 +278,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,observer,observer.type,keyword,core,firewall,The type of the observer the data is coming from.
 1.5.0-dev,true,observer,observer.vendor,keyword,core,Symantec,Vendor name of the observer.
 1.5.0-dev,true,observer,observer.version,keyword,core,,Observer version.
-1.5.0-dev,true,observer,observer.zone.in,keyword,extended,wan,Ingress zone of the observer.
-1.5.0-dev,true,observer,observer.zone.out,keyword,extended,dmz,Egress zone of the observer.
 1.5.0-dev,true,organization,organization.id,keyword,extended,,Unique identifier for the organization.
 1.5.0-dev,true,organization,organization.name,keyword,extended,,Organization name.
 1.5.0-dev,true,organization,organization.name.text,text,extended,,Organization name.
@@ -397,6 +397,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,server,server.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,server,server.user.name,keyword,core,albert,Short name or login of the user.
 1.5.0-dev,true,server,server.user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,server,server.zone,keyword,extended,dmz,Security zone facing the server.
 1.5.0-dev,true,service,service.ephemeral_id,keyword,extended,8a4f500f,Ephemeral identifier of this service.
 1.5.0-dev,true,service,service.id,keyword,core,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 1.5.0-dev,true,service,service.name,keyword,core,elasticsearch-metrics,Name of the service.
@@ -437,6 +438,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Example,Description
 1.5.0-dev,true,source,source.user.id,keyword,core,,One or multiple unique identifiers of the user.
 1.5.0-dev,true,source,source.user.name,keyword,core,albert,Short name or login of the user.
 1.5.0-dev,true,source,source.user.name.text,text,core,albert,Short name or login of the user.
+1.5.0-dev,true,source,source.zone,keyword,extended,dmz,Security zone facing the source.
 1.5.0-dev,true,threat,threat.framework,keyword,extended,MITRE ATT&CK,Threat classification framework.
 1.5.0-dev,true,threat,threat.tactic.id,keyword,extended,TA0040,Threat tactic id.
 1.5.0-dev,true,threat,threat.tactic.name,keyword,extended,impact,Threat tactic.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -502,6 +502,17 @@ client.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+client.zone:
+  dashed_name: client-zone
+  description: Security zone facing the client.
+  example: dmz
+  flat_name: client.zone
+  ignore_above: 1024
+  level: extended
+  name: zone
+  order: 11
+  short: Security zone facing the client.
+  type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
   description: 'The cloud account or organization id used to identify different entities
@@ -1027,6 +1038,17 @@ destination.user.name:
   order: 1
   original_fieldset: user
   short: Short name or login of the user.
+  type: keyword
+destination.zone:
+  dashed_name: destination-zone
+  description: Security zone facing the destination.
+  example: dmz
+  flat_name: destination.zone
+  ignore_above: 1024
+  level: extended
+  name: zone
+  order: 11
+  short: Security zone facing the destination.
   type: keyword
 dns.answers:
   dashed_name: dns-answers
@@ -3609,28 +3631,6 @@ observer.version:
   order: 8
   short: Observer version.
   type: keyword
-observer.zone.in:
-  dashed_name: observer-zone-in
-  description: Ingress zone of the observer.
-  example: wan
-  flat_name: observer.zone.in
-  ignore_above: 1024
-  level: extended
-  name: zone.in
-  order: 11
-  short: Ingress zone of the observer.
-  type: keyword
-observer.zone.out:
-  dashed_name: observer-zone-out
-  description: Egress zone of the observer.
-  example: dmz
-  flat_name: observer.zone.out
-  ignore_above: 1024
-  level: extended
-  name: zone.out
-  order: 12
-  short: Egress zone of the observer.
-  type: keyword
 organization.id:
   dashed_name: organization-id
   description: Unique identifier for the organization.
@@ -4944,6 +4944,17 @@ server.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+server.zone:
+  dashed_name: server-zone
+  description: Security zone facing the server.
+  example: dmz
+  flat_name: server.zone
+  ignore_above: 1024
+  level: extended
+  name: zone
+  order: 11
+  short: Security zone facing the server.
+  type: keyword
 service.ephemeral_id:
   dashed_name: service-ephemeral-id
   description: 'Ephemeral identifier of this service (if one exists).
@@ -5441,6 +5452,17 @@ source.user.name:
   order: 1
   original_fieldset: user
   short: Short name or login of the user.
+  type: keyword
+source.zone:
+  dashed_name: source-zone
+  description: Security zone facing the source.
+  example: dmz
+  flat_name: source.zone
+  ignore_above: 1024
+  level: extended
+  name: zone
+  order: 11
+  short: Security zone facing the source.
   type: keyword
 tags:
   dashed_name: tags

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3411,8 +3411,30 @@ observer.hostname:
   ignore_above: 1024
   level: core
   name: hostname
-  order: 2
+  order: 4
   short: Hostname of the observer.
+  type: keyword
+observer.interface.in:
+  dashed_name: observer-interface-in
+  description: Ingress interface of the observer.
+  example: eth0
+  flat_name: observer.interface.in
+  ignore_above: 1024
+  level: extended
+  name: interface.in
+  order: 1
+  short: Ingress interface of the observer.
+  type: keyword
+observer.interface.out:
+  dashed_name: observer-interface-out
+  description: Egress interface of the observer.
+  example: eth1
+  flat_name: observer.interface.out
+  ignore_above: 1024
+  level: extended
+  name: interface.out
+  order: 2
+  short: Egress interface of the observer.
   type: keyword
 observer.ip:
   dashed_name: observer-ip
@@ -3420,7 +3442,7 @@ observer.ip:
   flat_name: observer.ip
   level: core
   name: ip
-  order: 1
+  order: 3
   short: IP address of the observer.
   type: ip
 observer.mac:
@@ -3446,7 +3468,7 @@ observer.name:
   ignore_above: 1024
   level: extended
   name: name
-  order: 3
+  order: 5
   short: Custom name of the observer.
   type: keyword
 observer.os.family:
@@ -3539,7 +3561,7 @@ observer.product:
   ignore_above: 1024
   level: extended
   name: product
-  order: 4
+  order: 6
   short: The product name of the observer.
   type: keyword
 observer.serial_number:
@@ -3549,7 +3571,7 @@ observer.serial_number:
   ignore_above: 1024
   level: extended
   name: serial_number
-  order: 7
+  order: 9
   short: Observer serial number.
   type: keyword
 observer.type:
@@ -3563,7 +3585,7 @@ observer.type:
   ignore_above: 1024
   level: core
   name: type
-  order: 8
+  order: 10
   short: The type of the observer the data is coming from.
   type: keyword
 observer.vendor:
@@ -3574,7 +3596,7 @@ observer.vendor:
   ignore_above: 1024
   level: core
   name: vendor
-  order: 5
+  order: 7
   short: Vendor name of the observer.
   type: keyword
 observer.version:
@@ -3584,8 +3606,30 @@ observer.version:
   ignore_above: 1024
   level: core
   name: version
-  order: 6
+  order: 8
   short: Observer version.
+  type: keyword
+observer.zone.in:
+  dashed_name: observer-zone-in
+  description: Ingress zone of the observer.
+  example: wan
+  flat_name: observer.zone.in
+  ignore_above: 1024
+  level: extended
+  name: zone.in
+  order: 11
+  short: Ingress zone of the observer.
+  type: keyword
+observer.zone.out:
+  dashed_name: observer-zone-out
+  description: Egress zone of the observer.
+  example: dmz
+  flat_name: observer.zone.out
+  ignore_above: 1024
+  level: extended
+  name: zone.out
+  order: 12
+  short: Egress zone of the observer.
   type: keyword
 organization.id:
   dashed_name: organization-id

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3735,8 +3735,30 @@ observer:
       ignore_above: 1024
       level: core
       name: hostname
-      order: 2
+      order: 4
       short: Hostname of the observer.
+      type: keyword
+    interface.in:
+      dashed_name: observer-interface-in
+      description: Ingress interface of the observer.
+      example: eth0
+      flat_name: observer.interface.in
+      ignore_above: 1024
+      level: extended
+      name: interface.in
+      order: 1
+      short: Ingress interface of the observer.
+      type: keyword
+    interface.out:
+      dashed_name: observer-interface-out
+      description: Egress interface of the observer.
+      example: eth1
+      flat_name: observer.interface.out
+      ignore_above: 1024
+      level: extended
+      name: interface.out
+      order: 2
+      short: Egress interface of the observer.
       type: keyword
     ip:
       dashed_name: observer-ip
@@ -3744,7 +3766,7 @@ observer:
       flat_name: observer.ip
       level: core
       name: ip
-      order: 1
+      order: 3
       short: IP address of the observer.
       type: ip
     mac:
@@ -3770,7 +3792,7 @@ observer:
       ignore_above: 1024
       level: extended
       name: name
-      order: 3
+      order: 5
       short: Custom name of the observer.
       type: keyword
     os.family:
@@ -3863,7 +3885,7 @@ observer:
       ignore_above: 1024
       level: extended
       name: product
-      order: 4
+      order: 6
       short: The product name of the observer.
       type: keyword
     serial_number:
@@ -3873,7 +3895,7 @@ observer:
       ignore_above: 1024
       level: extended
       name: serial_number
-      order: 7
+      order: 9
       short: Observer serial number.
       type: keyword
     type:
@@ -3887,7 +3909,7 @@ observer:
       ignore_above: 1024
       level: core
       name: type
-      order: 8
+      order: 10
       short: The type of the observer the data is coming from.
       type: keyword
     vendor:
@@ -3898,7 +3920,7 @@ observer:
       ignore_above: 1024
       level: core
       name: vendor
-      order: 5
+      order: 7
       short: Vendor name of the observer.
       type: keyword
     version:
@@ -3908,8 +3930,30 @@ observer:
       ignore_above: 1024
       level: core
       name: version
-      order: 6
+      order: 8
       short: Observer version.
+      type: keyword
+    zone.in:
+      dashed_name: observer-zone-in
+      description: Ingress zone of the observer.
+      example: wan
+      flat_name: observer.zone.in
+      ignore_above: 1024
+      level: extended
+      name: zone.in
+      order: 11
+      short: Ingress zone of the observer.
+      type: keyword
+    zone.out:
+      dashed_name: observer-zone-out
+      description: Egress zone of the observer.
+      example: dmz
+      flat_name: observer.zone.out
+      ignore_above: 1024
+      level: extended
+      name: zone.out
+      order: 12
+      short: Egress zone of the observer.
       type: keyword
   group: 2
   name: observer

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -612,6 +612,17 @@ client:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    zone:
+      dashed_name: client-zone
+      description: Security zone facing the client.
+      example: dmz
+      flat_name: client.zone
+      ignore_above: 1024
+      level: extended
+      name: zone
+      order: 11
+      short: Security zone facing the client.
+      type: keyword
   group: 2
   name: client
   nestings:
@@ -1179,6 +1190,17 @@ destination:
       order: 1
       original_fieldset: user
       short: Short name or login of the user.
+      type: keyword
+    zone:
+      dashed_name: destination-zone
+      description: Security zone facing the destination.
+      example: dmz
+      flat_name: destination.zone
+      ignore_above: 1024
+      level: extended
+      name: zone
+      order: 11
+      short: Security zone facing the destination.
       type: keyword
   group: 2
   name: destination
@@ -3933,28 +3955,6 @@ observer:
       order: 8
       short: Observer version.
       type: keyword
-    zone.in:
-      dashed_name: observer-zone-in
-      description: Ingress zone of the observer.
-      example: wan
-      flat_name: observer.zone.in
-      ignore_above: 1024
-      level: extended
-      name: zone.in
-      order: 11
-      short: Ingress zone of the observer.
-      type: keyword
-    zone.out:
-      dashed_name: observer-zone-out
-      description: Egress zone of the observer.
-      example: dmz
-      flat_name: observer.zone.out
-      ignore_above: 1024
-      level: extended
-      name: zone.out
-      order: 12
-      short: Egress zone of the observer.
-      type: keyword
   group: 2
   name: observer
   nestings:
@@ -5388,6 +5388,17 @@ server:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    zone:
+      dashed_name: server-zone
+      description: Security zone facing the server.
+      example: dmz
+      flat_name: server.zone
+      ignore_above: 1024
+      level: extended
+      name: zone
+      order: 11
+      short: Security zone facing the server.
+      type: keyword
   group: 2
   name: server
   nestings:
@@ -5913,6 +5924,17 @@ source:
       order: 1
       original_fieldset: user
       short: Short name or login of the user.
+      type: keyword
+    zone:
+      dashed_name: source-zone
+      description: Security zone facing the source.
+      example: dmz
+      flat_name: source.zone
+      ignore_above: 1024
+      level: extended
+      name: zone
+      order: 11
+      short: Security zone facing the source.
       type: keyword
   group: 2
   name: source

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -223,6 +223,10 @@
                   "type": "keyword"
                 }
               }
+            },
+            "zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -456,6 +460,10 @@
                   "type": "keyword"
                 }
               }
+            },
+            "zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -1323,18 +1331,6 @@
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
-            },
-            "zone": {
-              "properties": {
-                "in": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                },
-                "out": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
             }
           }
         },
@@ -1892,6 +1888,10 @@
                   "type": "keyword"
                 }
               }
+            },
+            "zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },
@@ -2086,6 +2086,10 @@
                   "type": "keyword"
                 }
               }
+            },
+            "zone": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1241,6 +1241,18 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "interface": {
+              "properties": {
+                "in": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "out": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "ip": {
               "type": "ip"
             },
@@ -1311,6 +1323,18 @@
             "version": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "zone": {
+              "properties": {
+                "in": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "out": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -222,6 +222,10 @@
                 "type": "keyword"
               }
             }
+          },
+          "zone": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -455,6 +459,10 @@
                 "type": "keyword"
               }
             }
+          },
+          "zone": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -1322,18 +1330,6 @@
           "version": {
             "ignore_above": 1024,
             "type": "keyword"
-          },
-          "zone": {
-            "properties": {
-              "in": {
-                "ignore_above": 1024,
-                "type": "keyword"
-              },
-              "out": {
-                "ignore_above": 1024,
-                "type": "keyword"
-              }
-            }
           }
         }
       },
@@ -1891,6 +1887,10 @@
                 "type": "keyword"
               }
             }
+          },
+          "zone": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -2085,6 +2085,10 @@
                 "type": "keyword"
               }
             }
+          },
+          "zone": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1240,6 +1240,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "interface": {
+            "properties": {
+              "in": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "out": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "ip": {
             "type": "ip"
           },
@@ -1310,6 +1322,18 @@
           "version": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "zone": {
+            "properties": {
+              "in": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "out": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -121,3 +121,10 @@
         Translated port of source based NAT sessions (e.g. internal client to internet).
 
         Typically connections traversing load balancers, firewalls, or routers.
+
+    - name: zone
+      level: extended
+      type: keyword
+      description: >
+        Security zone facing the client.
+      example: dmz

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -112,3 +112,10 @@
         Port the source session is translated to by NAT Device.
 
         Typically used with load balancers, firewalls, or routers.
+
+    - name: zone
+      level: extended
+      type: keyword
+      description: >
+        Security zone facing the destination.
+      example: dmz

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -100,17 +100,3 @@
         There is no predefined list of observer types. Some examples are
         `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`.
       example: firewall
-
-    - name: zone.in
-      level: extended
-      type: keyword
-      description: >
-        Ingress zone of the observer.
-      example: wan
-
-    - name: zone.out
-      level: extended
-      type: keyword
-      description: >
-        Egress zone of the observer.
-      example: dmz

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -23,6 +23,20 @@
       description: >
         MAC address of the observer
 
+    - name: interface.in
+      level: extended
+      type: keyword
+      description: >
+        Ingress interface of the observer.
+      example: eth0
+
+    - name: interface.out
+      level: extended
+      type: keyword
+      description: >
+        Egress interface of the observer.
+      example: eth1
+
     - name: ip
       level: core
       type: ip
@@ -86,3 +100,17 @@
         There is no predefined list of observer types. Some examples are
         `forwarder`, `firewall`, `ids`, `ips`, `proxy`, `poller`, `sensor`, `APM server`.
       example: firewall
+
+    - name: zone.in
+      level: extended
+      type: keyword
+      description: >
+        Ingress zone of the observer.
+      example: wan
+
+    - name: zone.out
+      level: extended
+      type: keyword
+      description: >
+        Egress zone of the observer.
+      example: dmz

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -121,3 +121,10 @@
         Translated port of destination based NAT sessions (e.g. internet to private DMZ)
 
         Typically used with load balancers, firewalls, or routers.
+
+    - name: zone
+      level: extended
+      type: keyword
+      description: >
+        Security zone facing the server.
+      example: dmz

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -112,3 +112,10 @@
         Translated port of source based NAT sessions. (e.g. internal client to internet)
 
         Typically used with load balancers, firewalls, or routers.
+
+    - name: zone
+      level: extended
+      type: keyword
+      description: >
+        Security zone facing the source.
+      example: dmz


### PR DESCRIPTION
Hi,

referring to network flows passing through a firewall, I think we should track ingress and egress security zones and interfaces.
I think we can have two different approaches:
* zones/interfaces are defined on the observer schema, and I think that's more correct
* zones/interfaces are defined on the client/server/source/destination schema
In the latter case, zones/interfaces are still references observer (i.e. firewall) objects.
Any thoughts?