### PR TITLE
Add entity_id for process and process.parent

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,7 @@ Thanks, you're awesome :-) -->
 #### Added
 * Added `dll.*` fields (#679)
 * Fieldset for PE metadata. #731
+* Globally unique identifier `entity_id` for `process` and `process.parent`. (#747)
 
 #### Improvements
 

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -39,6 +39,9 @@ type Process struct {
 	// examples of what could be used here are a process-generated UUID, Sysmon
 	// Process GUIDs, or a hash of some uniquely identifying components of a
 	// process.
+	// Constructing a globally unique identifier is a common practice to
+	// mitigate PID reuse as well as to identify a specific process over time,
+	// across multiple monitored hosts.
 	EntityID string `ecs:"entity_id"`
 
 	// Unique identifier for the process.
@@ -46,6 +49,9 @@ type Process struct {
 	// examples of what could be used here are a process-generated UUID, Sysmon
 	// Process GUIDs, or a hash of some uniquely identifying components of a
 	// process.
+	// Constructing a globally unique identifier is a common practice to
+	// mitigate PID reuse as well as to identify a specific process over time,
+	// across multiple monitored hosts.
 	ParentEntityID string `ecs:"parent.entity_id"`
 
 	// Process name.

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -34,6 +34,20 @@ type Process struct {
 	// Process id.
 	ParentPID int64 `ecs:"parent.pid"`
 
+	// Unique identifier for the process.
+	// The implementation of this is specified by the data source, but some
+	// examples of what could be used here are a process-generated UUID, Sysmon
+	// Process GUIDs, or a hash of some uniquely identifying components of a
+	// process.
+	EntityID string `ecs:"entity_id"`
+
+	// Unique identifier for the process.
+	// The implementation of this is specified by the data source, but some
+	// examples of what could be used here are a process-generated UUID, Sysmon
+	// Process GUIDs, or a hash of some uniquely identifying components of a
+	// process.
+	ParentEntityID string `ecs:"parent.entity_id"`
+
 	// Process name.
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3755,6 +3755,21 @@ example: `/usr/bin/ssh -l user 10.0.0.16`
 
 // ===============================================================
 
+| process.entity_id
+| Unique identifier for the process.
+
+The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
+
+type: keyword
+
+
+
+example: `c2c455d9f99375d`
+
+| extended
+
+// ===============================================================
+
 | process.executable
 | Absolute path to the process executable.
 
@@ -3859,6 +3874,21 @@ Multi-fields:
 
 
 example: `/usr/bin/ssh -l user 10.0.0.16`
+
+| extended
+
+// ===============================================================
+
+| process.parent.entity_id
+| Unique identifier for the process.
+
+The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
+
+type: keyword
+
+
+
+example: `c2c455d9f99375d`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3760,6 +3760,8 @@ example: `/usr/bin/ssh -l user 10.0.0.16`
 
 The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
 
+Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.
+
 type: keyword
 
 
@@ -3883,6 +3885,8 @@ example: `/usr/bin/ssh -l user 10.0.0.16`
 | Unique identifier for the process.
 
 The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
+
+Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2571,7 +2571,11 @@
 
         The implementation of this is specified by the data source, but some examples
         of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-        or a hash of some uniquely identifying components of a process.'
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
       example: c2c455d9f99375d
       default_field: false
     - name: executable
@@ -2672,7 +2676,11 @@
 
         The implementation of this is specified by the data source, but some examples
         of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-        or a hash of some uniquely identifying components of a process.'
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
       example: c2c455d9f99375d
       default_field: false
     - name: parent.executable

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2563,6 +2563,17 @@
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
       default_field: false
+    - name: entity_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.'
+      example: c2c455d9f99375d
+      default_field: false
     - name: executable
       level: extended
       type: keyword
@@ -2652,6 +2663,17 @@
 
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
+      default_field: false
+    - name: parent.entity_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.'
+      example: c2c455d9f99375d
       default_field: false
     - name: parent.executable
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -323,6 +323,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 1.5.0-dev,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.5.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.5.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.5.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.5.0-dev,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.5.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
@@ -336,6 +337,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.5.0-dev,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.5.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.5.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.5.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.5.0-dev,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.5.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4417,7 +4417,7 @@ process.args:
   name: args
   normalize:
   - array
-  order: 10
+  order: 12
   short: Array of process arguments.
   type: keyword
 process.args_count:
@@ -4432,7 +4432,7 @@ process.args_count:
   level: extended
   name: args_count
   normalize: []
-  order: 12
+  order: 14
   short: Length of the process.args array.
   type: long
 process.command_line:
@@ -4452,8 +4452,24 @@ process.command_line:
     type: text
   name: command_line
   normalize: []
-  order: 8
+  order: 10
   short: Full command line that started the process.
+  type: keyword
+process.entity_id:
+  dashed_name: process-entity-id
+  description: 'Unique identifier for the process.
+
+    The implementation of this is specified by the data source, but some examples
+    of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+    or a hash of some uniquely identifying components of a process.'
+  example: c2c455d9f99375d
+  flat_name: process.entity_id
+  ignore_above: 1024
+  level: extended
+  name: entity_id
+  normalize: []
+  order: 2
+  short: Unique identifier for the process.
   type: keyword
 process.executable:
   dashed_name: process-executable
@@ -4469,7 +4485,7 @@ process.executable:
     type: text
   name: executable
   normalize: []
-  order: 14
+  order: 16
   short: Absolute path to the process executable.
   type: keyword
 process.exit_code:
@@ -4483,7 +4499,7 @@ process.exit_code:
   level: extended
   name: exit_code
   normalize: []
-  order: 28
+  order: 30
   short: The exit code of the process.
   type: long
 process.hash.md5:
@@ -4550,7 +4566,7 @@ process.name:
     type: text
   name: name
   normalize: []
-  order: 2
+  order: 4
   short: Process name.
   type: keyword
 process.parent.args:
@@ -4569,7 +4585,7 @@ process.parent.args:
   name: parent.args
   normalize:
   - array
-  order: 11
+  order: 13
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -4584,7 +4600,7 @@ process.parent.args_count:
   level: extended
   name: parent.args_count
   normalize: []
-  order: 13
+  order: 15
   short: Length of the process.args array.
   type: long
 process.parent.command_line:
@@ -4604,8 +4620,24 @@ process.parent.command_line:
     type: text
   name: parent.command_line
   normalize: []
-  order: 9
+  order: 11
   short: Full command line that started the process.
+  type: keyword
+process.parent.entity_id:
+  dashed_name: process-parent-entity-id
+  description: 'Unique identifier for the process.
+
+    The implementation of this is specified by the data source, but some examples
+    of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+    or a hash of some uniquely identifying components of a process.'
+  example: c2c455d9f99375d
+  flat_name: process.parent.entity_id
+  ignore_above: 1024
+  level: extended
+  name: parent.entity_id
+  normalize: []
+  order: 3
+  short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
   dashed_name: process-parent-executable
@@ -4621,7 +4653,7 @@ process.parent.executable:
     type: text
   name: parent.executable
   normalize: []
-  order: 15
+  order: 17
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -4635,7 +4667,7 @@ process.parent.exit_code:
   level: extended
   name: parent.exit_code
   normalize: []
-  order: 29
+  order: 31
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -4702,7 +4734,7 @@ process.parent.name:
     type: text
   name: parent.name
   normalize: []
-  order: 3
+  order: 5
   short: Process name.
   type: keyword
 process.parent.pgid:
@@ -4713,7 +4745,7 @@ process.parent.pgid:
   level: extended
   name: parent.pgid
   normalize: []
-  order: 7
+  order: 9
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -4737,7 +4769,7 @@ process.parent.ppid:
   level: extended
   name: parent.ppid
   normalize: []
-  order: 5
+  order: 7
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -4748,7 +4780,7 @@ process.parent.start:
   level: extended
   name: parent.start
   normalize: []
-  order: 23
+  order: 25
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -4760,7 +4792,7 @@ process.parent.thread.id:
   level: extended
   name: parent.thread.id
   normalize: []
-  order: 19
+  order: 21
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -4772,7 +4804,7 @@ process.parent.thread.name:
   level: extended
   name: parent.thread.name
   normalize: []
-  order: 21
+  order: 23
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -4791,7 +4823,7 @@ process.parent.title:
     type: text
   name: parent.title
   normalize: []
-  order: 17
+  order: 19
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -4802,7 +4834,7 @@ process.parent.uptime:
   level: extended
   name: parent.uptime
   normalize: []
-  order: 25
+  order: 27
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -4819,7 +4851,7 @@ process.parent.working_directory:
     type: text
   name: parent.working_directory
   normalize: []
-  order: 27
+  order: 29
   short: The working directory of the process.
   type: keyword
 process.pe.company:
@@ -4895,7 +4927,7 @@ process.pgid:
   level: extended
   name: pgid
   normalize: []
-  order: 6
+  order: 8
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.pid:
@@ -4919,7 +4951,7 @@ process.ppid:
   level: extended
   name: ppid
   normalize: []
-  order: 4
+  order: 6
   short: Parent process' pid.
   type: long
 process.start:
@@ -4930,7 +4962,7 @@ process.start:
   level: extended
   name: start
   normalize: []
-  order: 22
+  order: 24
   short: The time the process started.
   type: date
 process.thread.id:
@@ -4942,7 +4974,7 @@ process.thread.id:
   level: extended
   name: thread.id
   normalize: []
-  order: 18
+  order: 20
   short: Thread ID.
   type: long
 process.thread.name:
@@ -4954,7 +4986,7 @@ process.thread.name:
   level: extended
   name: thread.name
   normalize: []
-  order: 20
+  order: 22
   short: Thread name.
   type: keyword
 process.title:
@@ -4973,7 +5005,7 @@ process.title:
     type: text
   name: title
   normalize: []
-  order: 16
+  order: 18
   short: Process title.
   type: keyword
 process.uptime:
@@ -4984,7 +5016,7 @@ process.uptime:
   level: extended
   name: uptime
   normalize: []
-  order: 24
+  order: 26
   short: Seconds the process has been up.
   type: long
 process.working_directory:
@@ -5001,7 +5033,7 @@ process.working_directory:
     type: text
   name: working_directory
   normalize: []
-  order: 26
+  order: 28
   short: The working directory of the process.
   type: keyword
 registry.data.bytes:

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4461,7 +4461,11 @@ process.entity_id:
 
     The implementation of this is specified by the data source, but some examples
     of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-    or a hash of some uniquely identifying components of a process.'
+    or a hash of some uniquely identifying components of a process.
+
+    Constructing a globally unique identifier is a common practice to mitigate PID
+    reuse as well as to identify a specific process over time, across multiple monitored
+    hosts.'
   example: c2c455d9f99375d
   flat_name: process.entity_id
   ignore_above: 1024
@@ -4629,7 +4633,11 @@ process.parent.entity_id:
 
     The implementation of this is specified by the data source, but some examples
     of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-    or a hash of some uniquely identifying components of a process.'
+    or a hash of some uniquely identifying components of a process.
+
+    Constructing a globally unique identifier is a common practice to mitigate PID
+    reuse as well as to identify a specific process over time, across multiple monitored
+    hosts.'
   example: c2c455d9f99375d
   flat_name: process.parent.entity_id
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4832,7 +4832,7 @@ process:
       name: args
       normalize:
       - array
-      order: 10
+      order: 12
       short: Array of process arguments.
       type: keyword
     args_count:
@@ -4847,7 +4847,7 @@ process:
       level: extended
       name: args_count
       normalize: []
-      order: 12
+      order: 14
       short: Length of the process.args array.
       type: long
     command_line:
@@ -4867,8 +4867,24 @@ process:
         type: text
       name: command_line
       normalize: []
-      order: 8
+      order: 10
       short: Full command line that started the process.
+      type: keyword
+    entity_id:
+      dashed_name: process-entity-id
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.'
+      example: c2c455d9f99375d
+      flat_name: process.entity_id
+      ignore_above: 1024
+      level: extended
+      name: entity_id
+      normalize: []
+      order: 2
+      short: Unique identifier for the process.
       type: keyword
     executable:
       dashed_name: process-executable
@@ -4884,7 +4900,7 @@ process:
         type: text
       name: executable
       normalize: []
-      order: 14
+      order: 16
       short: Absolute path to the process executable.
       type: keyword
     exit_code:
@@ -4898,7 +4914,7 @@ process:
       level: extended
       name: exit_code
       normalize: []
-      order: 28
+      order: 30
       short: The exit code of the process.
       type: long
     hash.md5:
@@ -4965,7 +4981,7 @@ process:
         type: text
       name: name
       normalize: []
-      order: 2
+      order: 4
       short: Process name.
       type: keyword
     parent.args:
@@ -4984,7 +5000,7 @@ process:
       name: parent.args
       normalize:
       - array
-      order: 11
+      order: 13
       short: Array of process arguments.
       type: keyword
     parent.args_count:
@@ -4999,7 +5015,7 @@ process:
       level: extended
       name: parent.args_count
       normalize: []
-      order: 13
+      order: 15
       short: Length of the process.args array.
       type: long
     parent.command_line:
@@ -5019,8 +5035,24 @@ process:
         type: text
       name: parent.command_line
       normalize: []
-      order: 9
+      order: 11
       short: Full command line that started the process.
+      type: keyword
+    parent.entity_id:
+      dashed_name: process-parent-entity-id
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.'
+      example: c2c455d9f99375d
+      flat_name: process.parent.entity_id
+      ignore_above: 1024
+      level: extended
+      name: parent.entity_id
+      normalize: []
+      order: 3
+      short: Unique identifier for the process.
       type: keyword
     parent.executable:
       dashed_name: process-parent-executable
@@ -5036,7 +5068,7 @@ process:
         type: text
       name: parent.executable
       normalize: []
-      order: 15
+      order: 17
       short: Absolute path to the process executable.
       type: keyword
     parent.exit_code:
@@ -5050,7 +5082,7 @@ process:
       level: extended
       name: parent.exit_code
       normalize: []
-      order: 29
+      order: 31
       short: The exit code of the process.
       type: long
     parent.hash.md5:
@@ -5117,7 +5149,7 @@ process:
         type: text
       name: parent.name
       normalize: []
-      order: 3
+      order: 5
       short: Process name.
       type: keyword
     parent.pgid:
@@ -5128,7 +5160,7 @@ process:
       level: extended
       name: parent.pgid
       normalize: []
-      order: 7
+      order: 9
       short: Identifier of the group of processes the process belongs to.
       type: long
     parent.pid:
@@ -5152,7 +5184,7 @@ process:
       level: extended
       name: parent.ppid
       normalize: []
-      order: 5
+      order: 7
       short: Parent process' pid.
       type: long
     parent.start:
@@ -5163,7 +5195,7 @@ process:
       level: extended
       name: parent.start
       normalize: []
-      order: 23
+      order: 25
       short: The time the process started.
       type: date
     parent.thread.id:
@@ -5175,7 +5207,7 @@ process:
       level: extended
       name: parent.thread.id
       normalize: []
-      order: 19
+      order: 21
       short: Thread ID.
       type: long
     parent.thread.name:
@@ -5187,7 +5219,7 @@ process:
       level: extended
       name: parent.thread.name
       normalize: []
-      order: 21
+      order: 23
       short: Thread name.
       type: keyword
     parent.title:
@@ -5206,7 +5238,7 @@ process:
         type: text
       name: parent.title
       normalize: []
-      order: 17
+      order: 19
       short: Process title.
       type: keyword
     parent.uptime:
@@ -5217,7 +5249,7 @@ process:
       level: extended
       name: parent.uptime
       normalize: []
-      order: 25
+      order: 27
       short: Seconds the process has been up.
       type: long
     parent.working_directory:
@@ -5234,7 +5266,7 @@ process:
         type: text
       name: parent.working_directory
       normalize: []
-      order: 27
+      order: 29
       short: The working directory of the process.
       type: keyword
     pe.company:
@@ -5310,7 +5342,7 @@ process:
       level: extended
       name: pgid
       normalize: []
-      order: 6
+      order: 8
       short: Identifier of the group of processes the process belongs to.
       type: long
     pid:
@@ -5334,7 +5366,7 @@ process:
       level: extended
       name: ppid
       normalize: []
-      order: 4
+      order: 6
       short: Parent process' pid.
       type: long
     start:
@@ -5345,7 +5377,7 @@ process:
       level: extended
       name: start
       normalize: []
-      order: 22
+      order: 24
       short: The time the process started.
       type: date
     thread.id:
@@ -5357,7 +5389,7 @@ process:
       level: extended
       name: thread.id
       normalize: []
-      order: 18
+      order: 20
       short: Thread ID.
       type: long
     thread.name:
@@ -5369,7 +5401,7 @@ process:
       level: extended
       name: thread.name
       normalize: []
-      order: 20
+      order: 22
       short: Thread name.
       type: keyword
     title:
@@ -5388,7 +5420,7 @@ process:
         type: text
       name: title
       normalize: []
-      order: 16
+      order: 18
       short: Process title.
       type: keyword
     uptime:
@@ -5399,7 +5431,7 @@ process:
       level: extended
       name: uptime
       normalize: []
-      order: 24
+      order: 26
       short: Seconds the process has been up.
       type: long
     working_directory:
@@ -5416,7 +5448,7 @@ process:
         type: text
       name: working_directory
       normalize: []
-      order: 26
+      order: 28
       short: The working directory of the process.
       type: keyword
   group: 2

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4876,7 +4876,11 @@ process:
 
         The implementation of this is specified by the data source, but some examples
         of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-        or a hash of some uniquely identifying components of a process.'
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
       example: c2c455d9f99375d
       flat_name: process.entity_id
       ignore_above: 1024
@@ -5044,7 +5048,11 @@ process:
 
         The implementation of this is specified by the data source, but some examples
         of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
-        or a hash of some uniquely identifying components of a process.'
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
       example: c2c455d9f99375d
       flat_name: process.parent.entity_id
       ignore_above: 1024

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1549,6 +1549,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "entity_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "executable": {
               "fields": {
                 "text": {
@@ -1608,6 +1612,10 @@
                       "type": "text"
                     }
                   },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "entity_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1548,6 +1548,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "entity_id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "executable": {
             "fields": {
               "text": {
@@ -1607,6 +1611,10 @@
                     "type": "text"
                   }
                 },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "entity_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -42,6 +42,31 @@
         Process id.
       example: 4242
 
+    - name: entity_id
+      level: extended
+      type: keyword
+      short: Unique identifier for the process.
+      description: >
+        Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some
+        examples of what could be used here are a process-generated UUID,
+        Sysmon Process GUIDs, or a hash of some uniquely identifying components
+        of a process.
+      example: c2c455d9f99375d
+
+    - name: parent.entity_id
+      level: extended
+      type: keyword
+      short: Unique identifier for the process.
+      description: >
+        Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some
+        examples of what could be used here are a process-generated UUID,
+        Sysmon Process GUIDs, or a hash of some uniquely identifying components
+        of a process.
+      example: c2c455d9f99375d
 
     - name: name
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -53,6 +53,10 @@
         examples of what could be used here are a process-generated UUID,
         Sysmon Process GUIDs, or a hash of some uniquely identifying components
         of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.
       example: c2c455d9f99375d
 
     - name: parent.entity_id
@@ -66,6 +70,10 @@
         examples of what could be used here are a process-generated UUID,
         Sysmon Process GUIDs, or a hash of some uniquely identifying components
         of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.
       example: c2c455d9f99375d
 
     - name: name


### PR DESCRIPTION
This implements the unique process identification field discussed in https://github.com/elastic/ecs/issues/672. We settled on allowing ECS users to use their own implementation-specific values in this field in order to support multiple types of data shippers that may have different requirements around the identifier generation. That said, there's still room for future discussion on some sort of standard generation algorithm that would allow us to correlate processes across multiple sources.

The name corresponds to what beats are already filling in for their unique identifier.