### PR TITLE
Support nested type at top level of fieldsets

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -41,6 +41,7 @@ Thanks, you're awesome :-) -->
 * Allow the artifact generator to consider and output only a subset of fields. #737
 * Add support for reusing fields in places other than the top level of the destination fieldset. #739
 * Add support for specifying the directory to write the generated files. #748
+* Add support for field types other than `group` at the top level. #750
 
 #### Deprecated
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -11,7 +11,7 @@ YAML with a twist: Flattened field names equivalent to nested. E.g. `foo.bar: va
 - group (required for now): TBD. Just set it to 2, for now ;-)
 - description (required): Description of the field set
 - fields (required): YAML array as described below
-- type (ignored): at this level, should always be `group`
+- type (optional): at this level, type can be `group`, `object`, or `nested`
 - reusable (optional): YAML object composed of top_level and expected sub properties
 
 ## Field set

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -177,6 +177,15 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
                 nested_schema = nested_schema.setdefault('fields', {})
             nested_schema[schema['name']] = schema
 
+# Main
+
+
+def finalize_schemas(fields_nested):
+    for schema_name in fields_nested:
+        schema = fields_nested[schema_name]
+
+        schema_cleanup_values(schema)
+
 
 def assemble_reusables(fields_nested):
     # This happens as a second pass, so that all fieldsets have their
@@ -245,8 +254,7 @@ def cleanup_fields_recursive(fields, prefix):
 def load_schemas(files=ecs_files()):
     """Loads the given list of files"""
     fields_intermediate = load_schema_files(files)
-    for schema_name in fields_intermediate:
-        schema_cleanup_values(fields_intermediate[schema_name])
+    finalize_schemas(fields_intermediate)
     return fields_intermediate
 
 

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -69,7 +69,7 @@ def schema_cleanup_values(schema):
 
 
 def schema_set_default_values(schema):
-    schema['type'] = 'group'
+    dict_set_default(schema, 'type', 'group')
     dict_set_default(schema, 'group', 2)
     dict_set_default(schema, 'short', schema['description'])
     if "\n" in schema['short']:
@@ -86,6 +86,8 @@ def schema_set_fieldset_prefix(schema):
 def schema_fields_as_dictionary(schema):
     """Re-nest the array of field names as a dictionary of 'fieldname' => { field definition }"""
     field_array = schema.pop('fields')
+    if schema['type'] != 'group':
+        schema['field_details'] = schema.copy()
     schema['fields'] = {}
     for order, field in enumerate(field_array):
         field['order'] = order
@@ -175,15 +177,6 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
                 nested_schema = nested_schema.setdefault('fields', {})
             nested_schema[schema['name']] = schema
 
-# Main
-
-
-def finalize_schemas(fields_nested):
-    for schema_name in fields_nested:
-        schema = fields_nested[schema_name]
-
-        schema_cleanup_values(schema)
-
 
 def assemble_reusables(fields_nested):
     # This happens as a second pass, so that all fieldsets have their
@@ -252,7 +245,8 @@ def cleanup_fields_recursive(fields, prefix):
 def load_schemas(files=ecs_files()):
     """Loads the given list of files"""
     fields_intermediate = load_schema_files(files)
-    finalize_schemas(fields_intermediate)
+    for schema_name in fields_intermediate:
+        schema_cleanup_values(fields_intermediate[schema_name])
     return fields_intermediate
 
 

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -70,7 +70,8 @@ def schema_cleanup_values(schema):
 
 def schema_set_default_values(schema):
     dict_set_default(schema, 'type', 'group')
-    dict_set_default(schema, 'group', 2)
+    if schema['type'] == 'group':
+        dict_set_default(schema, 'group', 2)
     dict_set_default(schema, 'short', schema['description'])
     if "\n" in schema['short']:
         raise ValueError("Short descriptions must be single line.\nFieldset: {}\n{}".format(schema['name'], schema))


### PR DESCRIPTION
This PR adds support for specifying the type at the top level of a fieldset.  This is useful for cases where a fieldset needs to have the `nested` type, such as a `call_stack` fieldset that represents an array of stack frames.