### PR TITLE
Merge reusable location lists when merging schemas

### DIFF
--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -114,7 +114,15 @@ def merge_schema_fields(a, b):
                 raise ValueError('Schemas unmergeable: type {} does not match type {}'.format(a_type, b_type))
             elif a_type not in ['object', 'nested']:
                 print('Warning: dropping field {}, already defined'.format(key))
-            elif 'fields' in b[key]:
+                continue
+            # reusable should only be found at the top level of a fieldset
+            if 'reusable' in b[key]:
+                a[key].setdefault('reusable', {})
+                a[key]['reusable']['top_level'] = a[key]['reusable'].get(
+                    'top_level', False) or b[key]['reusable']['top_level']
+                a[key]['reusable'].setdefault('expected', [])
+                a[key]['reusable']['expected'].extend(b[key]['reusable']['expected'])
+            if 'fields' in b[key]:
                 a[key].setdefault('fields', {})
                 merge_schema_fields(a[key]['fields'], b[key]['fields'])
 

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -257,6 +257,10 @@ class TestSchemaReader(unittest.TestCase):
         fieldset1 = {
             'test_fieldset': {
                 'name': 'test_fieldset',
+                'reusable': {
+                    'top_level': False,
+                    'expected': ['location1, location2']
+                },
                 'fields': {
                     'test_field1': {
                         'field_details': {
@@ -278,6 +282,10 @@ class TestSchemaReader(unittest.TestCase):
         fieldset2 = {
             'test_fieldset': {
                 'name': 'test_fieldset',
+                'reusable': {
+                    'top_level': True,
+                    'expected': ['location3, location4']
+                },
                 'fields': {
                     'test_field1': {
                         'field_details': {
@@ -299,6 +307,10 @@ class TestSchemaReader(unittest.TestCase):
         expected = {
             'test_fieldset': {
                 'name': 'test_fieldset',
+                'reusable': {
+                    'top_level': True,
+                    'expected': ['location1, location2', 'location3, location4']
+                },
                 'fields': {
                     'test_field1': {
                         'field_details': {


### PR DESCRIPTION
This PR further enhances the generator's custom schema capabilities.  It allows custom schemas to extend the list of locations that a set of official ECS fields is are reused at.  For example, `hash` is a fieldset that would often be useful to include in custom schemas.  With this PR, users can define a custom schema file with name: hash and add more locations where `hash` should be reused in their custom schema.