### PR TITLE
Categorization: Add new "iam" category and associated types "admin", "group", "user"

### DIFF
--- a/code/go/ecs/rule.go
+++ b/code/go/ecs/rule.go
@@ -57,4 +57,16 @@ type Rule struct {
 	// that's not available, it can also be a link to a more general page
 	// describing this type of alert.
 	Reference string `ecs:"reference"`
+
+	// Name, organization, or pseudonym of the author or authors who created
+	// the rule used to generate this event.
+	Author string `ecs:"author"`
+
+	// Name of the license under which the rule used to generate this event is
+	// made available.
+	LicenseType string `ecs:"license_type"`
+
+	// Reference URL to the license under which the rule used to generate this
+	// event is made available.
+	LicenseReference string `ecs:"license_reference"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1491,7 +1491,7 @@ Note: this field should contain an array of values.
 
 *Important*: The field value must be one of the following:
 
-authentication, database, driver, file, host, intrusion_detection, malware, package, process, web
+authentication, database, driver, file, iam, intrusion_detection, malware, package, process, web
 
 To learn more about when to use which value, visit the page
 <<ecs-allowed-values-event-category,allowed values for event.category>>
@@ -1819,7 +1819,7 @@ Note: this field should contain an array of values.
 
 *Important*: The field value must be one of the following:
 
-access, change, creation, deletion, end, error, info, installation, start
+access, admin, change, creation, deletion, end, error, group, info, installation, start, user
 
 To learn more about when to use which value, visit the page
 <<ecs-allowed-values-event-type,allowed values for event.type>>

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4551,6 +4551,22 @@ Examples of data sources that would populate the rule fields include: network ad
 
 // ===============================================================
 
+| rule.author
+| Name, organization, or pseudonym of the author or authors who created the rule used to generate this event.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `John R. Doe, Elastic, s3cst1ltsk1n`
+
+| extended
+
+// ===============================================================
+
 | rule.category
 | A categorization value keyword used by the entity using the rule for detection of this event.
 
@@ -4585,6 +4601,32 @@ type: keyword
 
 
 example: `101`
+
+| extended
+
+// ===============================================================
+
+| rule.license_reference
+| Reference URL to the license under which the rule used to generate this event is made available.
+
+type: keyword
+
+
+
+example: `https://www.apache.org/licenses/LICENSE-2.0.txt`
+
+| extended
+
+// ===============================================================
+
+| rule.license_type
+| Name of the license under which the rule used to generate this event is made available.
+
+type: keyword
+
+
+
+example: `Apache 2.0`
 
 | extended
 

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -142,7 +142,7 @@ that will require subsequent breaking changes.
 * <<ecs-event-category-database,database>>
 * <<ecs-event-category-driver,driver>>
 * <<ecs-event-category-file,file>>
-* <<ecs-event-category-host,host>>
+* <<ecs-event-category-iam,iam>>
 * <<ecs-event-category-intrusion_detection,intrusion_detection>>
 * <<ecs-event-category-malware,malware>>
 * <<ecs-event-category-package,package>>
@@ -208,21 +208,17 @@ change, creation, deletion, info
 
 
 [float]
-[[ecs-event-category-host]]
-==== host
+[[ecs-event-category-iam]]
+==== iam
 
-Use this category to visualize and analyze information such as host inventory or host lifecycle events.
-
-Most of the events in this category can usually be observed from the outside, such as from a hypervisor or a control plane's point of view. Some can also be seen from within, such as "start" or "end".
-
-Note that this category is for information about hosts themselves; it is not meant to capture activity "happening on a host".
+Identity and access management events relating to users, groups, and admin. Use this category to visualize and analyze iam-related logs and data from active directory, LDAP, Okta, Duo, and other IAM systems.
 
 
 
 
-*Expected event types for category host:*
+*Expected event types for category iam:*
 
-access, change, end, info, start
+admin, change, creation, deletion, group, info, user
 
 
 [float]
@@ -312,20 +308,33 @@ that will require subsequent breaking changes.
 *Allowed Values*
 
 * <<ecs-event-type-access,access>>
+* <<ecs-event-type-admin,admin>>
 * <<ecs-event-type-change,change>>
 * <<ecs-event-type-creation,creation>>
 * <<ecs-event-type-deletion,deletion>>
 * <<ecs-event-type-end,end>>
 * <<ecs-event-type-error,error>>
+* <<ecs-event-type-group,group>>
 * <<ecs-event-type-info,info>>
 * <<ecs-event-type-installation,installation>>
 * <<ecs-event-type-start,start>>
+* <<ecs-event-type-user,user>>
 
 [float]
 [[ecs-event-type-access]]
 ==== access
 
 The access event type is used for the subset of events within a category that indicate that something was accessed. Common examples include `event.category:database AND event.type:access`, or `event.category:file AND event.type:access`. Note for file access, both directory listings and file opens should be included in this subcategory. You can further distinguish access operations using the ECS `event.action` field.
+
+
+
+
+
+[float]
+[[ecs-event-type-admin]]
+==== admin
+
+The admin event type is used for the subset of events within a category that are related to admin objects. Common example: `event.category:iam AND event.type:admin`. You can further distinguish access operations using the ECS `event.action` field.
 
 
 
@@ -382,6 +391,16 @@ The error event type is used for the subset of events within a category that ind
 
 
 [float]
+[[ecs-event-type-group]]
+==== group
+
+The group event type is used for the subset of events within a category that are related to group objects. Common example: `event.category:iam AND event.type:group`. You can further distinguish access operations using the ECS `event.action` field.
+
+
+
+
+
+[float]
 [[ecs-event-type-info]]
 ==== info
 
@@ -406,6 +425,16 @@ The installation event type is used for the subset of events within a category t
 ==== start
 
 The start event type is used for the subset of events within a category that indicate something has started. A common example is `event.category:process AND event.type:start`.
+
+
+
+
+
+[float]
+[[ecs-event-type-user]]
+==== user
+
+The user event type is used for the subset of events within a category that are related to user objects. Common example: `event.category:iam AND event.type:user`. You can further distinguish access operations using the ECS `event.action` field.
 
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3236,6 +3236,14 @@
       etc.'
     type: group
     fields:
+    - name: author
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name, organization, or pseudonym of the author or authors who created
+        the rule used to generate this event.
+      example: John R. Doe, Elastic, s3cst1ltsk1n
+      default_field: false
     - name: category
       level: extended
       type: keyword
@@ -3258,6 +3266,22 @@
       description: A rule ID that is unique within the scope of an agent, observer,
         or other entity using the rule for detection of this event.
       example: 101
+      default_field: false
+    - name: license_reference
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Reference URL to the license under which the rule used to generate
+        this event is made available.
+      example: https://www.apache.org/licenses/LICENSE-2.0.txt
+      default_field: false
+    - name: license_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the license under which the rule used to generate this
+        event is made available.
+      example: Apache 2.0
       default_field: false
     - name: name
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -409,9 +409,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
 1.5.0-dev,true,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
 1.5.0-dev,true,related,related.user,keyword,extended,array,,All the user names seen on your event.
+1.5.0-dev,true,rule,rule.author,keyword,extended,array,"John R. Doe, Elastic, s3cst1ltsk1n",Rule author
 1.5.0-dev,true,rule,rule.category,keyword,extended,,Attempted Information Leak,Rule category
 1.5.0-dev,true,rule,rule.description,keyword,extended,,Block requests to public DNS over HTTPS / TLS protocols,Rule description
 1.5.0-dev,true,rule,rule.id,keyword,extended,,101,Rule ID
+1.5.0-dev,true,rule,rule.license_reference,keyword,extended,,https://www.apache.org/licenses/LICENSE-2.0.txt,Rule license reference URL
+1.5.0-dev,true,rule,rule.license_type,keyword,extended,,Apache 2.0,Rule license
 1.5.0-dev,true,rule,rule.name,keyword,extended,,BLOCK_DNS_over_TLS,Rule name
 1.5.0-dev,true,rule,rule.reference,keyword,extended,,https://en.wikipedia.org/wiki/DNS_over_TLS,Rule reference URL
 1.5.0-dev,true,rule,rule.ruleset,keyword,extended,,Standard_Protocol_Filters,Rule ruleset

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1821,24 +1821,20 @@ event.category:
     - deletion
     - info
     name: file
-  - description: 'Use this category to visualize and analyze information such as host
-      inventory or host lifecycle events.
-
-      Most of the events in this category can usually be observed from the outside,
-      such as from a hypervisor or a control plane''s point of view. Some can also
-      be seen from within, such as "start" or "end".
-
-      Note that this category is for information about hosts themselves; it is not
-      meant to capture activity "happening on a host".
+  - description: 'Identity and access management events relating to users, groups,
+      and admin. Use this category to visualize and analyze iam-related logs and data
+      from active directory, LDAP, Okta, Duo, and other IAM systems.
 
       '
     expected_event_types:
-    - access
+    - admin
     - change
-    - end
+    - creation
+    - deletion
+    - group
     - info
-    - start
-    name: host
+    - user
+    name: iam
   - description: 'Relating to intrusion detections from IDS/IPS systems and functions,
       both network and host-based. Use this category to visualize and analyze intrusion
       detection alerts from systems such as Snort, Suricata, and Palo Alto threat
@@ -2298,6 +2294,12 @@ event.type:
 
       '
     name: access
+  - description: 'The admin event type is used for the subset of events within a category
+      that are related to admin objects. Common example: `event.category:iam AND event.type:admin`.
+      You can further distinguish access operations using the ECS `event.action` field.
+
+      '
+    name: admin
   - description: 'The change event type is used for the subset of events within a
       category that indicate that something has changed. If semantics best describe
       an event as modified, then include them in this subcategory. Common examples
@@ -2333,6 +2335,12 @@ event.type:
 
       '
     name: error
+  - description: 'The group event type is used for the subset of events within a category
+      that are related to group objects. Common example: `event.category:iam AND event.type:group`.
+      You can further distinguish access operations using the ECS `event.action` field.
+
+      '
+    name: group
   - description: 'The info event type is used for the subset of events within a category
       that indicate that they are purely informational, and don''t report a state
       change, or any type of action. For example, an initial run of a file integrity
@@ -2356,6 +2364,12 @@ event.type:
 
       '
     name: start
+  - description: 'The user event type is used for the subset of events within a category
+      that are related to user objects. Common example: `event.category:iam AND event.type:user`.
+      You can further distinguish access operations using the ECS `event.action` field.
+
+      '
+    name: user
   dashed_name: event-type
   description: 'This is one of four ECS Categorization Fields, and indicates the third
     level in the ECS category hierarchy.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5541,6 +5541,20 @@ related.user:
   order: 1
   short: All the user names seen on your event.
   type: keyword
+rule.author:
+  dashed_name: rule-author
+  description: Name, organization, or pseudonym of the author or authors who created
+    the rule used to generate this event.
+  example: John R. Doe, Elastic, s3cst1ltsk1n
+  flat_name: rule.author
+  ignore_above: 1024
+  level: extended
+  name: author
+  normalize:
+  - array
+  order: 8
+  short: Rule author
+  type: keyword
 rule.category:
   dashed_name: rule-category
   description: A categorization value keyword used by the entity using the rule for
@@ -5578,6 +5592,32 @@ rule.id:
   normalize: []
   order: 0
   short: Rule ID
+  type: keyword
+rule.license_reference:
+  dashed_name: rule-license-reference
+  description: Reference URL to the license under which the rule used to generate
+    this event is made available.
+  example: https://www.apache.org/licenses/LICENSE-2.0.txt
+  flat_name: rule.license_reference
+  ignore_above: 1024
+  level: extended
+  name: license_reference
+  normalize: []
+  order: 10
+  short: Rule license reference URL
+  type: keyword
+rule.license_type:
+  dashed_name: rule-license-type
+  description: Name of the license under which the rule used to generate this event
+    is made available.
+  example: Apache 2.0
+  flat_name: rule.license_type
+  ignore_above: 1024
+  level: extended
+  name: license_type
+  normalize: []
+  order: 9
+  short: Rule license
   type: keyword
 rule.name:
   dashed_name: rule-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6014,6 +6014,20 @@ rule:
     admission control platforms, network or host IDS/IPS, network firewalls, web application
     firewalls, url filters, endpoint detection and response (EDR) systems, etc.'
   fields:
+    author:
+      dashed_name: rule-author
+      description: Name, organization, or pseudonym of the author or authors who created
+        the rule used to generate this event.
+      example: John R. Doe, Elastic, s3cst1ltsk1n
+      flat_name: rule.author
+      ignore_above: 1024
+      level: extended
+      name: author
+      normalize:
+      - array
+      order: 8
+      short: Rule author
+      type: keyword
     category:
       dashed_name: rule-category
       description: A categorization value keyword used by the entity using the rule
@@ -6051,6 +6065,32 @@ rule:
       normalize: []
       order: 0
       short: Rule ID
+      type: keyword
+    license_reference:
+      dashed_name: rule-license-reference
+      description: Reference URL to the license under which the rule used to generate
+        this event is made available.
+      example: https://www.apache.org/licenses/LICENSE-2.0.txt
+      flat_name: rule.license_reference
+      ignore_above: 1024
+      level: extended
+      name: license_reference
+      normalize: []
+      order: 10
+      short: Rule license reference URL
+      type: keyword
+    license_type:
+      dashed_name: rule-license-type
+      description: Name of the license under which the rule used to generate this
+        event is made available.
+      example: Apache 2.0
+      flat_name: rule.license_type
+      ignore_above: 1024
+      level: extended
+      name: license_type
+      normalize: []
+      order: 9
+      short: Rule license
       type: keyword
     name:
       dashed_name: rule-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2073,24 +2073,20 @@ event:
         - deletion
         - info
         name: file
-      - description: 'Use this category to visualize and analyze information such
-          as host inventory or host lifecycle events.
-
-          Most of the events in this category can usually be observed from the outside,
-          such as from a hypervisor or a control plane''s point of view. Some can
-          also be seen from within, such as "start" or "end".
-
-          Note that this category is for information about hosts themselves; it is
-          not meant to capture activity "happening on a host".
+      - description: 'Identity and access management events relating to users, groups,
+          and admin. Use this category to visualize and analyze iam-related logs and
+          data from active directory, LDAP, Okta, Duo, and other IAM systems.
 
           '
         expected_event_types:
-        - access
+        - admin
         - change
-        - end
+        - creation
+        - deletion
+        - group
         - info
-        - start
-        name: host
+        - user
+        name: iam
       - description: 'Relating to intrusion detections from IDS/IPS systems and functions,
           both network and host-based. Use this category to visualize and analyze
           intrusion detection alerts from systems such as Snort, Suricata, and Palo
@@ -2557,6 +2553,13 @@ event:
 
           '
         name: access
+      - description: 'The admin event type is used for the subset of events within
+          a category that are related to admin objects. Common example: `event.category:iam
+          AND event.type:admin`. You can further distinguish access operations using
+          the ECS `event.action` field.
+
+          '
+        name: admin
       - description: 'The change event type is used for the subset of events within
           a category that indicate that something has changed. If semantics best describe
           an event as modified, then include them in this subcategory. Common examples
@@ -2593,6 +2596,13 @@ event:
 
           '
         name: error
+      - description: 'The group event type is used for the subset of events within
+          a category that are related to group objects. Common example: `event.category:iam
+          AND event.type:group`. You can further distinguish access operations using
+          the ECS `event.action` field.
+
+          '
+        name: group
       - description: 'The info event type is used for the subset of events within
           a category that indicate that they are purely informational, and don''t
           report a state change, or any type of action. For example, an initial run
@@ -2617,6 +2627,13 @@ event:
 
           '
         name: start
+      - description: 'The user event type is used for the subset of events within
+          a category that are related to user objects. Common example: `event.category:iam
+          AND event.type:user`. You can further distinguish access operations using
+          the ECS `event.action` field.
+
+          '
+        name: user
       dashed_name: event-type
       description: 'This is one of four ECS Categorization Fields, and indicates the
         third level in the ECS category hierarchy.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1940,6 +1940,10 @@
         },
         "rule": {
           "properties": {
+            "author": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "category": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -1949,6 +1953,14 @@
               "type": "keyword"
             },
             "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "license_reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "license_type": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1939,6 +1939,10 @@
       },
       "rule": {
         "properties": {
+          "author": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "category": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -1948,6 +1952,14 @@
             "type": "keyword"
           },
           "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "license_reference": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "license_type": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -162,23 +162,19 @@
             - creation
             - deletion
             - info
-        - name: host
+        - name: iam
           description: >
-            Use this category to visualize and analyze information such as host inventory
-            or host lifecycle events.
-
-            Most of the events in this category can usually be observed from the outside,
-            such as from a hypervisor or a control plane's point of view. Some can also
-            be seen from within, such as "start" or "end".
-
-            Note that this category is for information about hosts themselves;
-            it is not meant to capture activity "happening on a host".
+            Identity and access management events relating to users, groups, and admin.
+            Use this category to visualize and analyze iam-related logs and data from active directory,
+            LDAP, Okta, Duo, and other IAM systems.
           expected_event_types:
-            - access
+            - admin
             - change
-            - end
+            - creation
+            - deletion
+            - group
             - info
-            - start
+            - user
         - name: intrusion_detection
           description: >
             Relating to intrusion detections from IDS/IPS systems and functions,
@@ -297,6 +293,13 @@
             Note for file access, both directory listings and file opens should be included
             in this subcategory. You can further distinguish access operations using the ECS
             `event.action` field.
+        - name: admin
+          description: >
+            The admin event type is used for the subset of events within a category
+            that are related to admin objects.
+            Common example: `event.category:iam AND event.type:admin`.
+            You can further distinguish access operations using the ECS
+            `event.action` field.
         - name: change
           description: >
             The change event type is used for the subset of events within a category
@@ -329,6 +332,13 @@
             Note that pipeline errors that occur during the event ingestion process
             should not use this `event.type` value. Instead, they should use
             `event.kind:pipeline_error`.
+        - name: group
+          description: >
+            The group event type is used for the subset of events within a category
+            that are related to group objects.
+            Common example: `event.category:iam AND event.type:group`.
+            You can further distinguish access operations using the ECS
+            `event.action` field.
         - name: info
           description: >
             The info event type is used for the subset of events within a category
@@ -349,6 +359,13 @@
             The start event type is used for the subset of events within a category
             that indicate something has started. A common example is
             `event.category:process AND event.type:start`.
+        - name: user
+          description: >
+            The user event type is used for the subset of events within a category
+            that are related to user objects.
+            Common example: `event.category:iam AND event.type:user`.
+            You can further distinguish access operations using the ECS
+            `event.action` field.
 
     - name: module
       level: core

--- a/schemas/rule.yml
+++ b/schemas/rule.yml
@@ -81,4 +81,31 @@
 
       example: https://en.wikipedia.org/wiki/DNS_over_TLS
 
+    - name: author
+      level: extended
+      type: keyword
+      short: Rule author
+      description: >
+        Name, organization, or pseudonym of the author or authors who created the rule used to generate this event.
 
+      example: John R. Doe, Elastic, s3cst1ltsk1n
+      normalize:
+        - array
+
+    - name: license_type
+      level: extended
+      type: keyword
+      short: Rule license
+      description: >
+        Name of the license under which the rule used to generate this event is made available.
+
+      example: Apache 2.0
+
+    - name: license_reference
+      level: extended
+      type: keyword
+      short: Rule license reference URL
+      description: >
+        Reference URL to the license under which the rule used to generate this event is made available.
+
+      example: https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
This new value of `event.category` is being added to properly categorize Identity and access management events relating to users, groups, and admin.

- [ ] `event.category:"iam"`

It is expected that this category would be used to visualize and analyze iam-related logs and data from sources such as active directory, LDAP, Okta, Duo, and other IAM systems.

There are three new values of `event.type` associated with this new addition.
- [ ] `event.type:"admin"`
- [ ] `event.type:"group"`
- [ ] `event.type:"user"`
