### PR TITLE
Add event.reference field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -19,6 +19,8 @@ Thanks, you're awesome :-) -->
 * Fieldset for PE metadata. #731
 * Globally unique identifier `entity_id` for `process` and `process.parent`. (#747)
 
+* Added field event.reference to hold link to additional event info/actions. (#757)
+
 #### Improvements
 
 * Temporary workaround for Beats templates' `default_field` growing too big. #687

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -19,7 +19,7 @@ Thanks, you're awesome :-) -->
 * Fieldset for PE metadata. #731
 * Globally unique identifier `entity_id` for `process` and `process.parent`. (#747)
 
-* Added field event.reference to hold link to additional event info/actions. (#757)
+* Added fields `event.reference` and `event.url` to hold link to additional event info/actions. (#757)
 
 #### Improvements
 

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -187,9 +187,14 @@ type Event struct {
 	Ingested time.Time `ecs:"ingested"`
 
 	// Reference URL linking to additional information about this event.
-	// This URL can link to either a static definition of the general event, or
-	// to another system where in-depth investigation of the specific occurence
-	// of this event can take place. Alert events, indicated by
-	// `event.kind:alert`, are a common use case for this field.
+	// This URL links to a static definition of the this event Alert events,
+	// indicated by `event.kind:alert`, are a common use case for this field.
 	Reference string `ecs:"reference"`
+
+	// URL linking to an external system to continue investigtion of this
+	// event.
+	// This URL links to another system where in-depth investigation of the
+	// specific occurence of this event can take place. Alert events, indicated
+	// by `event.kind:alert`, are a common use case for this field.
+	Url string `ecs:"url"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -187,9 +187,9 @@ type Event struct {
 	Ingested time.Time `ecs:"ingested"`
 
 	// Reference URL linking to additional information about this event.
-	// This URL can link to another system where additional or in-depth
-	// investigation the specific occurance of this event can take place. Alert
-	// events, indicated by `event.kind:alert`, are a common use case for this
-	// field.
+	// This URL can link to either a static definition of the general event, or
+	// to another system where in-depth investigation of the specific occurence
+	// of this event can take place. Alert events, indicated by
+	// `event.kind:alert`, are a common use case for this field.
 	Reference string `ecs:"reference"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -185,4 +185,11 @@ type Event struct {
 	// chronologically look like this: `@timestamp` < `event.created` <
 	// `event.ingested`.
 	Ingested time.Time `ecs:"ingested"`
+
+	// Reference URL linking to additional information about this event.
+	// This URL can link to another system where additional or in-depth
+	// investigation the specific occurance of this event can take place. Alert
+	// events, indicated by `event.kind:alert`, are a common use case for this
+	// field.
+	Reference string `ecs:"reference"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -187,11 +187,11 @@ type Event struct {
 	Ingested time.Time `ecs:"ingested"`
 
 	// Reference URL linking to additional information about this event.
-	// This URL links to a static definition of the this event Alert events,
+	// This URL links to a static definition of the this event. Alert events,
 	// indicated by `event.kind:alert`, are a common use case for this field.
 	Reference string `ecs:"reference"`
 
-	// URL linking to an external system to continue investigtion of this
+	// URL linking to an external system to continue investigation of this
 	// event.
 	// This URL links to another system where in-depth investigation of the
 	// specific occurence of this event can take place. Alert events, indicated

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1717,13 +1717,13 @@ example: `kernel`
 | event.reference
 | Reference URL linking to additional information about this event.
 
-This URL can link to either a static definition of the general event, or to another system where in-depth investigation of the specific occurence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+This URL links to a static definition of the this event Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
 type: keyword
 
 
 
-example: `https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
+example: `https://system.vendor.com/event/#0001234`
 
 | extended
 
@@ -1841,6 +1841,21 @@ To learn more about when to use which value, visit the page
 
 
 | core
+
+// ===============================================================
+
+| event.url
+| URL linking to an external system to continue investigtion of this event.
+
+This URL links to another system where in-depth investigation of the specific occurence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+type: keyword
+
+
+
+example: `https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
+
+| extended
 
 // ===============================================================
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1714,6 +1714,21 @@ example: `kernel`
 
 // ===============================================================
 
+| event.reference
+| Reference URL linking to additional information about this event.
+
+This URL can link to another system where additional or in-depth investigation the specific occurance of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+type: keyword
+
+
+
+example: `https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
+
+| extended
+
+// ===============================================================
+
 | event.risk_score
 | Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1717,7 +1717,7 @@ example: `kernel`
 | event.reference
 | Reference URL linking to additional information about this event.
 
-This URL can link to another system where additional or in-depth investigation the specific occurance of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+This URL can link to either a static definition of the general event, or to another system where in-depth investigation of the specific occurence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1717,7 +1717,7 @@ example: `kernel`
 | event.reference
 | Reference URL linking to additional information about this event.
 
-This URL links to a static definition of the this event Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+This URL links to a static definition of the this event. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
 type: keyword
 
@@ -1845,7 +1845,7 @@ To learn more about when to use which value, visit the page
 // ===============================================================
 
 | event.url
-| URL linking to an external system to continue investigtion of this event.
+| URL linking to an external system to continue investigation of this event.
 
 This URL links to another system where in-depth investigation of the specific occurence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1291,9 +1291,10 @@
       ignore_above: 1024
       description: 'Reference URL linking to additional information about this event.
 
-        This URL can link to another system where additional or in-depth investigation
-        the specific occurance of this event can take place. Alert events, indicated
-        by `event.kind:alert`, are a common use case for this field.'
+        This URL can link to either a static definition of the general event, or to
+        another system where in-depth investigation of the specific occurence of this
+        event can take place. Alert events, indicated by `event.kind:alert`, are a
+        common use case for this field.'
       example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       default_field: false
     - name: risk_score

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1285,6 +1285,17 @@
         the event (e.g. Sysmon, httpd), or of a subsystem of the operating system
         (kernel, Microsoft-Windows-Security-Auditing).'
       example: kernel
+    - name: reference
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Reference URL linking to additional information about this event.
+
+        This URL can link to another system where additional or in-depth investigation
+        the specific occurance of this event can take place. Alert events, indicated
+        by `event.kind:alert`, are a common use case for this field.'
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      default_field: false
     - name: risk_score
       level: core
       type: float

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1291,7 +1291,7 @@
       ignore_above: 1024
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event Alert events, indicated
+        This URL links to a static definition of the this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.vendor.com/event/#0001234
       default_field: false
@@ -1363,7 +1363,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'URL linking to an external system to continue investigtion of
+      description: 'URL linking to an external system to continue investigation of
         this event.
 
         This URL links to another system where in-depth investigation of the specific

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1291,11 +1291,9 @@
       ignore_above: 1024
       description: 'Reference URL linking to additional information about this event.
 
-        This URL can link to either a static definition of the general event, or to
-        another system where in-depth investigation of the specific occurence of this
-        event can take place. Alert events, indicated by `event.kind:alert`, are a
-        common use case for this field.'
-      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+        This URL links to a static definition of the this event Alert events, indicated
+        by `event.kind:alert`, are a common use case for this field.'
+      example: https://system.vendor.com/event/#0001234
       default_field: false
     - name: risk_score
       level: core
@@ -1361,6 +1359,18 @@
 
         This field is an array. This will allow proper categorization of some events
         that fall in multiple event types.'
+    - name: url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'URL linking to an external system to continue investigtion of
+        this event.
+
+        This URL links to another system where in-depth investigation of the specific
+        occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+        are a common use case for this field.'
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      default_field: false
   - name: file
     title: File
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -151,7 +151,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 1.5.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest categorization field in the hierarchy.
 1.5.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
-1.5.0-dev,true,event,event.reference,keyword,extended,,https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event reference URL
+1.5.0-dev,true,event,event.reference,keyword,extended,,https://system.vendor.com/event/#0001234,Event reference URL
 1.5.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.5.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 1.5.0-dev,true,event,event.sequence,long,extended,,,Sequence number of the event.
@@ -159,6 +159,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
 1.5.0-dev,true,event,event.timezone,keyword,extended,,,Event time zone.
 1.5.0-dev,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
+1.5.0-dev,true,event,event.url,keyword,extended,,https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 1.5.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.5.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 1.5.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -151,6 +151,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 1.5.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest categorization field in the hierarchy.
 1.5.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
+1.5.0-dev,true,event,event.reference,keyword,extended,,https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event reference URL
 1.5.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.5.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 1.5.0-dev,true,event,event.sequence,long,extended,,,Sequence number of the event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2202,9 +2202,10 @@ event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.
 
-    This URL can link to another system where additional or in-depth investigation
-    the specific occurance of this event can take place. Alert events, indicated by
-    `event.kind:alert`, are a common use case for this field.'
+    This URL can link to either a static definition of the general event, or to another
+    system where in-depth investigation of the specific occurence of this event can
+    take place. Alert events, indicated by `event.kind:alert`, are a common use case
+    for this field.'
   example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
   flat_name: event.reference
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2202,11 +2202,9 @@ event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.
 
-    This URL can link to either a static definition of the general event, or to another
-    system where in-depth investigation of the specific occurence of this event can
-    take place. Alert events, indicated by `event.kind:alert`, are a common use case
-    for this field.'
-  example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+    This URL links to a static definition of the this event Alert events, indicated
+    by `event.kind:alert`, are a common use case for this field.'
+  example: https://system.vendor.com/event/#0001234
   flat_name: event.reference
   ignore_above: 1024
   level: extended
@@ -2391,6 +2389,23 @@ event.type:
   - array
   order: 6
   short: Event type. The third categorization field in the hierarchy.
+  type: keyword
+event.url:
+  dashed_name: event-url
+  description: 'URL linking to an external system to continue investigtion of this
+    event.
+
+    This URL links to another system where in-depth investigation of the specific
+    occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+    are a common use case for this field.'
+  example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+  flat_name: event.url
+  ignore_above: 1024
+  level: extended
+  name: url
+  normalize: []
+  order: 23
+  short: Event investigation URL
   type: keyword
 file.accessed:
   dashed_name: file-accessed

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2202,7 +2202,7 @@ event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.
 
-    This URL links to a static definition of the this event Alert events, indicated
+    This URL links to a static definition of the this event. Alert events, indicated
     by `event.kind:alert`, are a common use case for this field.'
   example: https://system.vendor.com/event/#0001234
   flat_name: event.reference
@@ -2392,7 +2392,7 @@ event.type:
   type: keyword
 event.url:
   dashed_name: event-url
-  description: 'URL linking to an external system to continue investigtion of this
+  description: 'URL linking to an external system to continue investigation of this
     event.
 
     This URL links to another system where in-depth investigation of the specific

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2198,6 +2198,22 @@ event.provider:
   order: 9
   short: Source of the event.
   type: keyword
+event.reference:
+  dashed_name: event-reference
+  description: 'Reference URL linking to additional information about this event.
+
+    This URL can link to another system where additional or in-depth investigation
+    the specific occurance of this event can take place. Alert events, indicated by
+    `event.kind:alert`, are a common use case for this field.'
+  example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+  flat_name: event.reference
+  ignore_above: 1024
+  level: extended
+  name: reference
+  normalize: []
+  order: 22
+  short: Event reference URL
+  type: keyword
 event.risk_score:
   dashed_name: event-risk-score
   description: Risk score or priority of the event (e.g. security solutions). Use

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2461,7 +2461,7 @@ event:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event Alert events, indicated
+        This URL links to a static definition of the this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.vendor.com/event/#0001234
       flat_name: event.reference
@@ -2653,7 +2653,7 @@ event:
       type: keyword
     url:
       dashed_name: event-url
-      description: 'URL linking to an external system to continue investigtion of
+      description: 'URL linking to an external system to continue investigation of
         this event.
 
         This URL links to another system where in-depth investigation of the specific

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2457,6 +2457,22 @@ event:
       order: 9
       short: Source of the event.
       type: keyword
+    reference:
+      dashed_name: event-reference
+      description: 'Reference URL linking to additional information about this event.
+
+        This URL can link to another system where additional or in-depth investigation
+        the specific occurance of this event can take place. Alert events, indicated
+        by `event.kind:alert`, are a common use case for this field.'
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      flat_name: event.reference
+      ignore_above: 1024
+      level: extended
+      name: reference
+      normalize: []
+      order: 22
+      short: Event reference URL
+      type: keyword
     risk_score:
       dashed_name: event-risk-score
       description: Risk score or priority of the event (e.g. security solutions).

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2461,9 +2461,10 @@ event:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.
 
-        This URL can link to another system where additional or in-depth investigation
-        the specific occurance of this event can take place. Alert events, indicated
-        by `event.kind:alert`, are a common use case for this field.'
+        This URL can link to either a static definition of the general event, or to
+        another system where in-depth investigation of the specific occurence of this
+        event can take place. Alert events, indicated by `event.kind:alert`, are a
+        common use case for this field.'
       example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       flat_name: event.reference
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2461,11 +2461,9 @@ event:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.
 
-        This URL can link to either a static definition of the general event, or to
-        another system where in-depth investigation of the specific occurence of this
-        event can take place. Alert events, indicated by `event.kind:alert`, are a
-        common use case for this field.'
-      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+        This URL links to a static definition of the this event Alert events, indicated
+        by `event.kind:alert`, are a common use case for this field.'
+      example: https://system.vendor.com/event/#0001234
       flat_name: event.reference
       ignore_above: 1024
       level: extended
@@ -2652,6 +2650,23 @@ event:
       - array
       order: 6
       short: Event type. The third categorization field in the hierarchy.
+      type: keyword
+    url:
+      dashed_name: event-url
+      description: 'URL linking to an external system to continue investigtion of
+        this event.
+
+        This URL links to another system where in-depth investigation of the specific
+        occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+        are a common use case for this field.'
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      flat_name: event.url
+      ignore_above: 1024
+      level: extended
+      name: url
+      normalize: []
+      order: 23
+      short: Event investigation URL
       type: keyword
   group: 2
   name: event

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -762,6 +762,10 @@
             "type": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "url": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         },

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -736,6 +736,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "reference": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "risk_score": {
               "type": "float"
             },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -761,6 +761,10 @@
           "type": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "url": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -735,6 +735,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "reference": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "risk_score": {
             "type": "float"
           },

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -549,7 +549,19 @@
       description: >
         Reference URL linking to additional information about this event.
 
-        This URL can link to either a static definition of the general event, or to another
+        This URL links to a static definition of the this event
+        Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+      example: https://system.vendor.com/event/#0001234
+
+    - name: url
+      level: extended
+      type: keyword
+      short: Event investigation URL
+      description: >
+        URL linking to an external system to continue investigtion of this event.
+
+        This URL links to another
         system where in-depth investigation of the specific occurence of this event can take place.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -549,7 +549,7 @@
       description: >
         Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event
+        This URL links to a static definition of the this event.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
       example: https://system.vendor.com/event/#0001234
@@ -559,7 +559,7 @@
       type: keyword
       short: Event investigation URL
       description: >
-        URL linking to an external system to continue investigtion of this event.
+        URL linking to an external system to continue investigation of this event.
 
         This URL links to another
         system where in-depth investigation of the specific occurence of this event can take place.

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -549,8 +549,8 @@
       description: >
         Reference URL linking to additional information about this event.
 
-        This URL can link to another system where additional or in-depth
-        investigation the specific occurance of this event can take place.
+        This URL can link to either a static definition of the general event, or to another
+        system where in-depth investigation of the specific occurence of this event can take place.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
       example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -541,3 +541,16 @@
 
         In normal conditions, assuming no tampering, the timestamps should
         chronologically look like this: `@timestamp` < `event.created` < `event.ingested`.
+
+    - name: reference
+      level: extended
+      type: keyword
+      short: Event reference URL
+      description: >
+        Reference URL linking to additional information about this event.
+
+        This URL can link to another system where additional or in-depth
+        investigation the specific occurance of this event can take place.
+        Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+
+      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe


### PR DESCRIPTION
ECS already has a `rule.reference` field to contain a reference URL to additional information about a rule used to generate an event/alert. The URL can point to the vendor’s documentation about the rule, or if that’s not available, it can also be a link to a more general page describing this type of alert.

However some systems provide not only a reference to the rule that created the event, but also to the specific instance of the event or alert itself.

This URL can link to another system where additional or in-depth investigation the specific occurrence of this event can take place.  Alert events, indicated by `event.kind:alert`, are a common use case for this field.

example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe

This new field `event.reference` is for storing such URL's.

- [x] Add event.reference field
- [x] Add event.url field
