### PR TITLE
Enhance description of event.outcome field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -23,7 +23,6 @@ Thanks, you're awesome :-) -->
 
 * Temporary workaround for Beats templates' `default_field` growing too big. #687
 * Identify which fields should contain arrays of values, rather than scalar values. #727, #661
-
 * Updated definition of `event.outcome` based on community feedback #759
 
 #### Deprecated

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,8 @@ Thanks, you're awesome :-) -->
 * Temporary workaround for Beats templates' `default_field` growing too big. #687
 * Identify which fields should contain arrays of values, rather than scalar values. #727, #661
 
+* Updated definition of `event.outcome` based on community feedback #759
+
 #### Deprecated
 
 

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -78,14 +78,14 @@ type Event struct {
 	// Note that when a single transaction is described in multiple events,
 	// each event may populate different values of `event.outcome`, according
 	// to their perspective.
-	// Also note that in the case of a compount event (a single event that
+	// Also note that in the case of a compound event (a single event that
 	// contains multiple logical events), this field should be populated with
 	// the value that best captures the overall success or failure from the
 	// perspective of the event producer.
 	// Further note that not all events will have an associated outcome. For
 	// example, this field is generally not populated for metric events, events
-	// with `event.type:info`, or any events for  which an outcome does not
-	// make logical sense.
+	// with `event.type:info`, or any events for which an outcome does not make
+	// logical sense.
 	Outcome string `ecs:"outcome"`
 
 	// This is one of four ECS Categorization Fields, and indicates the third

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -73,10 +73,19 @@ type Event struct {
 
 	// This is one of four ECS Categorization Fields, and indicates the lowest
 	// level in the ECS category hierarchy.
-	// `event.outcome` simply denotes whether the event represent a success or
-	// a failure. Note that not all events will have an associated outcome. For
-	// example, this field is generally not populated for metric events or
-	// events with `event.type:info`.
+	// `event.outcome` simply denotes whether the event represents a success or
+	// a failure from the perspective of the entity that produced the event.
+	// Note that when a single transaction is described in multiple events,
+	// each event may populate different values of `event.outcome`, according
+	// to their perspective.
+	// Also note that in the case of a compount event (a single event that
+	// contains multiple logical events), this field should be populated with
+	// the value that best captures the overall success or failure from the
+	// perspective of the event producer.
+	// Further note that not all events will have an associated outcome. For
+	// example, this field is generally not populated for metric events, events
+	// with `event.type:info`, or any events for  which an outcome does not
+	// make logical sense.
 	Outcome string `ecs:"outcome"`
 
 	// This is one of four ECS Categorization Fields, and indicates the third

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1680,7 +1680,13 @@ example: `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&
 | event.outcome
 | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
 
-`event.outcome` simply denotes whether the event represent a success or a failure. Note that not all events will have an associated outcome. For example, this field is generally not populated for metric events or events with `event.type:info`.
+`event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+Also note that in the case of a compount event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for  which an outcome does not make logical sense.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1684,9 +1684,9 @@ example: `Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&
 
 Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
 
-Also note that in the case of a compount event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
 
-Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for  which an outcome does not make logical sense.
+Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.
 
 type: keyword
 

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -416,7 +416,13 @@ The start event type is used for the subset of events within a category that ind
 
 This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
 
-`event.outcome` simply denotes whether the event represent a success or a failure. Note that not all events will have an associated outcome. For example, this field is generally not populated for metric events or events with `event.type:info`.
+`event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+Also note that in the case of a compount event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for  which an outcome does not make logical sense.
 
 WARNING: After the beta period for categorization, only the allowed categorization
 values listed in the ECS repository and official ECS documentation should be considered
@@ -443,7 +449,7 @@ Indicates that this event describes a failed result. A common example is `event.
 [[ecs-event-outcome-success]]
 ==== success
 
-Indicates that this event describes a successful result.  A common example is `event.category:file AND event.type:create AND event.outcome:success` to indicate that a file was successfully created.
+Indicates that this event describes a successful result. A common example is `event.category:file AND event.type:create AND event.outcome:success` to indicate that a file was successfully created.
 
 
 
@@ -453,7 +459,7 @@ Indicates that this event describes a successful result.  A common example is `e
 [[ecs-event-outcome-unknown]]
 ==== unknown
 
-Indicates that this event describes only an attempt for which the result is unknown. For example, if the event contains information only about a request in an entity transaction that usually results in a response, populating `event.outcome:unknown` is appropriate.
+Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about a request in an entity transaction that usually results in a response, populating `event.outcome:unknown` in the request event is appropriate.
 
 
 

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -420,9 +420,9 @@ This is one of four ECS Categorization Fields, and indicates the lowest level in
 
 Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
 
-Also note that in the case of a compount event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
 
-Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for  which an outcome does not make logical sense.
+Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.
 
 WARNING: After the beta period for categorization, only the allowed categorization
 values listed in the ECS repository and official ECS documentation should be considered
@@ -459,7 +459,7 @@ Indicates that this event describes a successful result. A common example is `ev
 [[ecs-event-outcome-unknown]]
 ==== unknown
 
-Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about a request in an entity transaction that usually results in a response, populating `event.outcome:unknown` in the request event is appropriate.
+Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about the request side of a transaction that results in a response, populating `event.outcome:unknown` in the request event is appropriate. The unknown value should not be used when an outcome doesn't make logical sense for the event. In such cases `event.outcome` should not be populated.
 
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1277,14 +1277,14 @@
         event may populate different values of `event.outcome`, according to their
         perspective.
 
-        Also note that in the case of a compount event (a single event that contains
+        Also note that in the case of a compound event (a single event that contains
         multiple logical events), this field should be populated with the value that
         best captures the overall success or failure from the perspective of the event
         producer.
 
         Further note that not all events will have an associated outcome. For example,
         this field is generally not populated for metric events, events with `event.type:info`,
-        or any events for  which an outcome does not make logical sense.'
+        or any events for which an outcome does not make logical sense.'
       example: success
     - name: provider
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1270,9 +1270,21 @@
       description: 'This is one of four ECS Categorization Fields, and indicates the
         lowest level in the ECS category hierarchy.
 
-        `event.outcome` simply denotes whether the event represent a success or a
-        failure. Note that not all events will have an associated outcome. For example,
-        this field is generally not populated for metric events or events with `event.type:info`.'
+        `event.outcome` simply denotes whether the event represents a success or a
+        failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each
+        event may populate different values of `event.outcome`, according to their
+        perspective.
+
+        Also note that in the case of a compount event (a single event that contains
+        multiple logical events), this field should be populated with the value that
+        best captures the overall success or failure from the perspective of the event
+        producer.
+
+        Further note that not all events will have an associated outcome. For example,
+        this field is generally not populated for metric events, events with `event.type:info`,
+        or any events for  which an outcome does not make logical sense.'
       example: success
     - name: provider
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -149,7 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.5.0-dev,true,event,event.kind,keyword,core,,alert,The kind of the event. The highest categorization field in the hierarchy.
 1.5.0-dev,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
 1.5.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
-1.5.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest categorization field in the hierarchy.
+1.5.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 1.5.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
 1.5.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.5.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2161,9 +2161,11 @@ event.outcome:
     name: success
   - description: 'Indicates that this event describes only an attempt for which the
       result is unknown from the perspective of the event producer. For example, if
-      the event contains information only about a request in an entity transaction
-      that usually results in a response, populating `event.outcome:unknown` in the
-      request event is appropriate.
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn''t
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
 
       '
     name: unknown
@@ -2177,13 +2179,13 @@ event.outcome:
     Note that when a single transaction is described in multiple events, each event
     may populate different values of `event.outcome`, according to their perspective.
 
-    Also note that in the case of a compount event (a single event that contains multiple
+    Also note that in the case of a compound event (a single event that contains multiple
     logical events), this field should be populated with the value that best captures
     the overall success or failure from the perspective of the event producer.
 
     Further note that not all events will have an associated outcome. For example,
     this field is generally not populated for metric events, events with `event.type:info`,
-    or any events for  which an outcome does not make logical sense.'
+    or any events for which an outcome does not make logical sense.'
   example: success
   flat_name: event.outcome
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2153,16 +2153,17 @@ event.outcome:
 
       '
     name: failure
-  - description: 'Indicates that this event describes a successful result.  A common
+  - description: 'Indicates that this event describes a successful result. A common
       example is `event.category:file AND event.type:create AND event.outcome:success`
       to indicate that a file was successfully created.
 
       '
     name: success
   - description: 'Indicates that this event describes only an attempt for which the
-      result is unknown. For example, if the event contains information only about
-      a request in an entity transaction that usually results in a response, populating
-      `event.outcome:unknown` is appropriate.
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about a request in an entity transaction
+      that usually results in a response, populating `event.outcome:unknown` in the
+      request event is appropriate.
 
       '
     name: unknown
@@ -2170,9 +2171,19 @@ event.outcome:
   description: 'This is one of four ECS Categorization Fields, and indicates the lowest
     level in the ECS category hierarchy.
 
-    `event.outcome` simply denotes whether the event represent a success or a failure.
-    Note that not all events will have an associated outcome. For example, this field
-    is generally not populated for metric events or events with `event.type:info`.'
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compount event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for  which an outcome does not make logical sense.'
   example: success
   flat_name: event.outcome
   ignore_above: 1024
@@ -2180,7 +2191,7 @@ event.outcome:
   name: outcome
   normalize: []
   order: 5
-  short: The outcome of the event. The lowest categorization field in the hierarchy.
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
   type: keyword
 event.provider:
   dashed_name: event-provider

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2411,16 +2411,17 @@ event:
 
           '
         name: failure
-      - description: 'Indicates that this event describes a successful result.  A
-          common example is `event.category:file AND event.type:create AND event.outcome:success`
+      - description: 'Indicates that this event describes a successful result. A common
+          example is `event.category:file AND event.type:create AND event.outcome:success`
           to indicate that a file was successfully created.
 
           '
         name: success
       - description: 'Indicates that this event describes only an attempt for which
-          the result is unknown. For example, if the event contains information only
-          about a request in an entity transaction that usually results in a response,
-          populating `event.outcome:unknown` is appropriate.
+          the result is unknown from the perspective of the event producer. For example,
+          if the event contains information only about a request in an entity transaction
+          that usually results in a response, populating `event.outcome:unknown` in
+          the request event is appropriate.
 
           '
         name: unknown
@@ -2428,9 +2429,21 @@ event:
       description: 'This is one of four ECS Categorization Fields, and indicates the
         lowest level in the ECS category hierarchy.
 
-        `event.outcome` simply denotes whether the event represent a success or a
-        failure. Note that not all events will have an associated outcome. For example,
-        this field is generally not populated for metric events or events with `event.type:info`.'
+        `event.outcome` simply denotes whether the event represents a success or a
+        failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each
+        event may populate different values of `event.outcome`, according to their
+        perspective.
+
+        Also note that in the case of a compount event (a single event that contains
+        multiple logical events), this field should be populated with the value that
+        best captures the overall success or failure from the perspective of the event
+        producer.
+
+        Further note that not all events will have an associated outcome. For example,
+        this field is generally not populated for metric events, events with `event.type:info`,
+        or any events for  which an outcome does not make logical sense.'
       example: success
       flat_name: event.outcome
       ignore_above: 1024
@@ -2438,7 +2451,8 @@ event:
       name: outcome
       normalize: []
       order: 5
-      short: The outcome of the event. The lowest categorization field in the hierarchy.
+      short: The outcome of the event. The lowest level categorization field in the
+        hierarchy.
       type: keyword
     provider:
       dashed_name: event-provider

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2419,9 +2419,11 @@ event:
         name: success
       - description: 'Indicates that this event describes only an attempt for which
           the result is unknown from the perspective of the event producer. For example,
-          if the event contains information only about a request in an entity transaction
-          that usually results in a response, populating `event.outcome:unknown` in
-          the request event is appropriate.
+          if the event contains information only about the request side of a transaction
+          that results in a response, populating `event.outcome:unknown` in the request
+          event is appropriate. The unknown value should not be used when an outcome
+          doesn''t make logical sense for the event. In such cases `event.outcome`
+          should not be populated.
 
           '
         name: unknown
@@ -2436,14 +2438,14 @@ event:
         event may populate different values of `event.outcome`, according to their
         perspective.
 
-        Also note that in the case of a compount event (a single event that contains
+        Also note that in the case of a compound event (a single event that contains
         multiple logical events), this field should be populated with the value that
         best captures the overall success or failure from the perspective of the event
         producer.
 
         Further note that not all events will have an associated outcome. For example,
         this field is generally not populated for metric events, events with `event.type:info`,
-        or any events for  which an outcome does not make logical sense.'
+        or any events for which an outcome does not make logical sense.'
       example: success
       flat_name: event.outcome
       ignore_above: 1024

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -244,14 +244,24 @@
     - name: outcome
       level: core
       type: keyword
-      short: The outcome of the event. The lowest categorization field in the hierarchy.
+      short: The outcome of the event. The lowest level categorization field in the hierarchy.
       description: >
         This is one of four ECS Categorization Fields, and indicates the
         lowest level in the ECS category hierarchy.
 
-        `event.outcome` simply denotes whether the event represent a success or a failure.
-        Note that not all events will have an associated outcome. For example, this field is
-        generally not populated for metric events or events with `event.type:info`.
+        `event.outcome` simply denotes whether the event represents a success or a failure from
+        the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may
+        populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compount event (a single event that contains multiple logical events),
+        this field should be populated with the value that best captures the overall success or failure from
+        the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is
+        generally not populated for metric events, events with `event.type:info`, or any events for 
+        which an outcome does not make logical sense.
       example: success
       allowed_values:
         - name: failure
@@ -261,15 +271,16 @@
             to indicate that a file access was attempted, but was not successful.
         - name: success
           description: >
-            Indicates that this event describes a successful result.  A common example is
+            Indicates that this event describes a successful result. A common example is
             `event.category:file AND event.type:create AND event.outcome:success`
             to indicate that a file was successfully created.
         - name: unknown
           description: >
             Indicates that this event describes only an attempt for which the result
-            is unknown. For example, if the event contains information only about a
-            request in an entity transaction that usually results in a response,
-            populating `event.outcome:unknown` is appropriate.
+            is unknown from the perspective of the event producer. For example, if the
+            event contains information only about a request in an entity transaction that
+            usually results in a response, populating `event.outcome:unknown` in the request
+            event is appropriate.
 
     - name: type
       level: core

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -255,12 +255,12 @@
         Note that when a single transaction is described in multiple events, each event may
         populate different values of `event.outcome`, according to their perspective.
 
-        Also note that in the case of a compount event (a single event that contains multiple logical events),
+        Also note that in the case of a compound event (a single event that contains multiple logical events),
         this field should be populated with the value that best captures the overall success or failure from
         the perspective of the event producer.
 
         Further note that not all events will have an associated outcome. For example, this field is
-        generally not populated for metric events, events with `event.type:info`, or any events for 
+        generally not populated for metric events, events with `event.type:info`, or any events for
         which an outcome does not make logical sense.
       example: success
       allowed_values:
@@ -277,10 +277,12 @@
         - name: unknown
           description: >
             Indicates that this event describes only an attempt for which the result
-            is unknown from the perspective of the event producer. For example, if the
-            event contains information only about a request in an entity transaction that
-            usually results in a response, populating `event.outcome:unknown` in the request
-            event is appropriate.
+            is unknown from the perspective of the event producer.
+            For example, if the event contains information only about the request side
+            of a transaction that results in a response, populating `event.outcome:unknown`
+            in the request event is appropriate.
+            The unknown value should not be used when an outcome doesn't make logical sense for
+            the event. In such cases `event.outcome` should not be populated.
 
     - name: type
       level: core


### PR DESCRIPTION
Since publishing ECS 1.4, where the ECS categorization fields were introduced, the `event.outcome` field has generated the most questions about its definition, use, and consistency.

This PR significantly expands the definitions and example usage of event.outcome based on the feedback from the community.

No field names or allowed values are changed with this PR.