### PR TITLE
Add environment field

### DIFF
--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -11,6 +11,15 @@
   type: group
   fields:
 
+    - name: environment
+      level: extended
+      type: keyword
+      short: The environment in which the service is running
+      description: >
+        The environment in which the service is running.
+        To avoid clashing names (e.g. prd or prod) please write the name in full, e.g. production.
+      example: production
+
     - name: id
       level: core
       type: keyword


### PR DESCRIPTION
Many companies need to specify the environment in the log messages themselves. Service seems like the appropriate place for this field to me. Would you please consider adding an environment field to allow easily isolating logs from the appropriate environment?