### PR TITLE
Correct docs reference to observer.interface

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3543,8 +3543,14 @@ type: keyword
 // ===============================================================
 
 
-| <<ecs-interface,observer.interface.*>>
-| Fields to describe observer interface information.
+| <<ecs-interface,observer.ingress.interface.*>>
+| Fields to describe observer ingress interface information.
+
+// ===============================================================
+
+
+| <<ecs-interface,observer.egress.interface.*>>
+| Fields to describe observer egress interface information.
 
 // ===============================================================
 


### PR DESCRIPTION
Interface docs mention that interface can be nested under observer as `observer.interface`, which doesn't exists. The correct nesting is `observer.ingress.interface` and `observer.egress.interface`.

