### PR TITLE
Array definitions are missing for IP fields.

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -297,6 +297,9 @@ Can be one or multiple IPv4 or IPv6 addresses.
 type: ip
 
 
+Note: this field should contain an array of values.
+
+
 
 
 
@@ -805,6 +808,9 @@ type: keyword
 Can be one or multiple IPv4 or IPv6 addresses.
 
 type: ip
+
+
+Note: this field should contain an array of values.
 
 
 
@@ -5062,6 +5068,9 @@ Can be one or multiple IPv4 or IPv6 addresses.
 type: ip
 
 
+Note: this field should contain an array of values.
+
+
 
 
 
@@ -5397,6 +5406,9 @@ type: keyword
 Can be one or multiple IPv4 or IPv6 addresses.
 
 type: ip
+
+
+Note: this field should contain an array of values.
 
 
 

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -25,7 +25,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,client,client.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 1.6.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 1.6.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
-1.6.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
+1.6.0-dev,true,client,client.ip,ip,core,array,,IP address of the client.
 1.6.0-dev,true,client,client.mac,keyword,core,,,MAC address of the client.
 1.6.0-dev,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
 1.6.0-dev,true,client,client.nat.port,long,extended,,,Client NAT port
@@ -76,7 +76,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,destination,destination.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 1.6.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 1.6.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
-1.6.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
+1.6.0-dev,true,destination,destination.ip,ip,core,array,,IP address of the destination.
 1.6.0-dev,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 1.6.0-dev,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
 1.6.0-dev,true,destination,destination.nat.port,long,extended,,,Destination NAT Port
@@ -464,7 +464,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,server,server.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 1.6.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 1.6.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
-1.6.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
+1.6.0-dev,true,server,server.ip,ip,core,array,,IP address of the server.
 1.6.0-dev,true,server,server.mac,keyword,core,,,MAC address of the server.
 1.6.0-dev,true,server,server.nat.ip,ip,extended,,,Server NAT ip
 1.6.0-dev,true,server,server.nat.port,long,extended,,,Server NAT port
@@ -504,7 +504,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 1.6.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 1.6.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
-1.6.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
+1.6.0-dev,true,source,source.ip,ip,core,array,,IP address of the source.
 1.6.0-dev,true,source,source.mac,keyword,core,,,MAC address of the source.
 1.6.0-dev,true,source,source.nat.ip,ip,extended,,,Source NAT ip
 1.6.0-dev,true,source,source.nat.port,long,extended,,,Source NAT port

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -312,7 +312,8 @@ client.ip:
   flat_name: client.ip
   level: core
   name: ip
-  normalize: []
+  normalize:
+  - array
   order: 1
   short: IP address of the client.
   type: ip
@@ -956,7 +957,8 @@ destination.ip:
   flat_name: destination.ip
   level: core
   name: ip
-  normalize: []
+  normalize:
+  - array
   order: 1
   short: IP address of the destination.
   type: ip
@@ -6430,7 +6432,8 @@ server.ip:
   flat_name: server.ip
   level: core
   name: ip
-  normalize: []
+  normalize:
+  - array
   order: 1
   short: IP address of the server.
   type: ip
@@ -6965,7 +6968,8 @@ source.ip:
   flat_name: source.ip
   level: core
   name: ip
-  normalize: []
+  normalize:
+  - array
   order: 1
   short: IP address of the source.
   type: ip

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -424,7 +424,8 @@ client:
       flat_name: client.ip
       level: core
       name: ip
-      normalize: []
+      normalize:
+      - array
       order: 1
       short: IP address of the client.
       type: ip
@@ -1121,7 +1122,8 @@ destination:
       flat_name: destination.ip
       level: core
       name: ip
-      normalize: []
+      normalize:
+      - array
       order: 1
       short: IP address of the destination.
       type: ip
@@ -6976,7 +6978,8 @@ server:
       flat_name: server.ip
       level: core
       name: ip
-      normalize: []
+      normalize:
+      - array
       order: 1
       short: IP address of the server.
       type: ip
@@ -7539,7 +7542,8 @@ source:
       flat_name: source.ip
       level: core
       name: ip
-      normalize: []
+      normalize:
+      - array
       order: 1
       short: IP address of the source.
       type: ip

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -39,6 +39,8 @@
         IP address of the client.
 
         Can be one or multiple IPv4 or IPv6 addresses.
+      normalize:
+        - array
 
     - name: port
       format: string

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -30,6 +30,8 @@
         IP address of the destination.
 
         Can be one or multiple IPv4 or IPv6 addresses.
+      normalize:
+        - array
 
     - name: port
       format: string

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -39,6 +39,8 @@
         IP address of the server.
 
         Can be one or multiple IPv4 or IPv6 addresses.
+      normalize:
+        - array
 
     - name: port
       format: string

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -30,6 +30,8 @@
         IP address of the source.
 
         Can be one or multiple IPv4 or IPv6 addresses.
+      normalize:
+        - array
 
     - name: port
       format: string


### PR DESCRIPTION
- client.ip
- destination.ip
- server.ip
- source.ip

The schema indicates that these fields "Can be one or multiple IPv4 or IPv6 addresses." but are missing the normalize->array definition.

Fixes #786