### PR TITLE
log.syslog can contain multiple objects, hence requires the array definition.

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3014,6 +3014,9 @@ example: `Sep 19 08:26:10 localhost My log`
 type: object
 
 
+Note: this field should contain an array of values.
+
+
 
 
 

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -269,7 +269,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The file which originated the log event.
 1.6.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 1.6.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
-1.6.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata
+1.6.0-dev,true,log,log.syslog,object,extended,array,,Syslog metadata
 1.6.0-dev,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 1.6.0-dev,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
 1.6.0-dev,true,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3936,7 +3936,8 @@ log.syslog:
   flat_name: log.syslog
   level: extended
   name: syslog
-  normalize: []
+  normalize:
+  - array
   object_type: keyword
   order: 6
   short: Syslog metadata

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4308,7 +4308,8 @@ log:
       flat_name: log.syslog
       level: extended
       name: syslog
-      normalize: []
+      normalize:
+      - array
       object_type: keyword
       order: 6
       short: Syslog metadata

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -90,6 +90,8 @@
       description: >
         The Syslog metadata of the event, if the event was transmitted via Syslog.
         Please see RFCs 5424 or 3164.
+      normalize:
+        - array
 
     - name: syslog.severity.code
       level: extended


### PR DESCRIPTION
This was locally overridden in the .NET client.

Fixes #780 

@webmat - please can you re-run the generator before approval? Thanks.