### PR TITLE
Add array definition to user.id

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6423,6 +6423,9 @@ type: keyword
 type: keyword
 
 
+Note: this field should contain an array of values.
+
+
 
 
 

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -41,7 +41,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,client,client.user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,client,client.user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
@@ -92,7 +92,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,destination,destination.user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,destination,destination.user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -245,7 +245,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,host,host.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,host,host.user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,host,host.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,host,host.user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,host,host.user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,host,host.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,host,host.user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
@@ -480,7 +480,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,server,server.user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,server,server.user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -520,7 +520,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,source,source.user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,source,source.user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
@@ -585,7 +585,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,user,user.group.name,keyword,extended,,,Name of the group.
 1.6.0-dev,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
-1.6.0-dev,true,user,user.id,keyword,core,,,Unique identifiers of the user.
+1.6.0-dev,true,user,user.id,keyword,core,array,,Unique identifiers of the user.
 1.6.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -517,7 +517,8 @@ client.user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.
@@ -1160,7 +1161,8 @@ destination.user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.
@@ -3625,7 +3627,8 @@ host.user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.
@@ -6635,7 +6638,8 @@ server.user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.
@@ -7170,7 +7174,8 @@ source.user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.
@@ -8057,7 +8062,8 @@ user.id:
   ignore_above: 1024
   level: core
   name: id
-  normalize: []
+  normalize:
+  - array
   order: 0
   original_fieldset: user
   short: Unique identifiers of the user.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -629,7 +629,8 @@ client:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       original_fieldset: user
       short: Unique identifiers of the user.
@@ -1325,7 +1326,8 @@ destination:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       original_fieldset: user
       short: Unique identifiers of the user.
@@ -3968,7 +3970,8 @@ host:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       original_fieldset: user
       short: Unique identifiers of the user.
@@ -7181,7 +7184,8 @@ server:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       original_fieldset: user
       short: Unique identifiers of the user.
@@ -7744,7 +7748,8 @@ source:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       original_fieldset: user
       short: Unique identifiers of the user.
@@ -8689,7 +8694,8 @@ user:
       ignore_above: 1024
       level: core
       name: id
-      normalize: []
+      normalize:
+      - array
       order: 0
       short: Unique identifiers of the user.
       type: keyword

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -26,6 +26,8 @@
       type: keyword
       description: >
         Unique identifiers of the user.
+      normalize:
+        - array
 
     - name: name
       level: core


### PR DESCRIPTION
The following *.user.id fields are missing the normalize->array definitions:

- user.id
- client.user.id
- destination.user.id
- host.user.id
- server.user.id
- source.user.id

The descriptions "Unique identifiers of the user." indicates this can contain more than one id.

Fixes #777

@webmat - please run generator and check! Thank you.