### PR TITLE
Changes search result IDs to be array of objects

### DIFF
--- a/code/go/ecs/search.go
+++ b/code/go/ecs/search.go
@@ -55,9 +55,20 @@ type Search struct {
 	// in the query response.
 	ResultsTotal int64 `ecs:"results.total"`
 
-	// A list of opaque document IDs representing the results that were shown
-	// to the user. This is effectively the impression list and it's size
-	// should be equal to `results.size`. This field can be empty when there
-	// are no results to return.
-	ResultsIds string `ecs:"results.ids"`
+	// A list of documents representing the results that were shown to the
+	// user. This is effectively the impression list and it's size should be
+	// equal to `results.size`. This field can be empty when there are no
+	// results to return.
+	ResultsDocument map[string]interface{} `ecs:"results.document"`
+
+	// An opaque document ID representing the result that was shown to the
+	// user. This ID should be unique within the index it was retrieved from.
+	// The combination of document ID and index should be globally unique.
+	ResultsDocumentID string `ecs:"results.document.id"`
+
+	// The name of the index that the result document was retrieved from. This
+	// can be considered as optional if all search results are always retrieved
+	// from same index. The combination of document ID and index should be
+	// globally unique.
+	ResultsDocumentIndex string `ecs:"results.document.index"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4982,17 +4982,43 @@ example: `where does the rain in Spain mainly fall`
 
 // ===============================================================
 
-| search.results.ids
-| A list of opaque document IDs representing the results that were shown to the user. This is effectively the impression list and it's size should be equal to `results.size`. This field can be empty when there are no results to return.
+| search.results.document
+| A list of documents representing the results that were shown to the user. This is effectively the impression list and it's size should be equal to `results.size`. This field can be empty when there are no results to return.
 
-type: keyword
+type: object
 
 
 Note: this field should contain an array of values.
 
 
 
+
+
+| extended
+
+// ===============================================================
+
+| search.results.document.id
+| An opaque document ID representing the result that was shown to the user. This ID should be unique within the index it was retrieved from. The combination of document ID and index should be globally unique.
+
+type: keyword
+
+
+
 example: `['user:82375akja9f', 'issue:2782630']`
+
+| extended
+
+// ===============================================================
+
+| search.results.document.index
+| The name of the index that the result document was retrieved from. This can be considered as optional if all search results are always retrieved from same index. The combination of document ID and index should be globally unique.
+
+type: keyword
+
+
+
+example: `['users', 'issues-032020']`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3582,17 +3582,37 @@
         user context, etc.
       example: where does the rain in Spain mainly fall
       default_field: false
-    - name: results.ids
+    - name: results.document
+      level: extended
+      type: object
+      object_type: keyword
+      description: A list of documents representing the results that were shown to
+        the user. This is effectively the impression list and it's size should be
+        equal to `results.size`. This field can be empty when there are no results
+        to return.
+      default_field: false
+    - name: results.document.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A list of opaque document IDs representing the results that were
-        shown to the user. This is effectively the impression list and it's size should
-        be equal to `results.size`. This field can be empty when there are no results
-        to return.
+      description: An opaque document ID representing the result that was shown to
+        the user. This ID should be unique within the index it was retrieved from.
+        The combination of document ID and index should be globally unique.
       example:
       - user:82375akja9f
       - issue:2782630
+      default_field: false
+    - name: results.document.index
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of the index that the result document was retrieved from.
+        This can be considered as optional if all search results are always retrieved
+        from same index. The combination of document ID and index should be globally
+        unique.
+      example:
+      - users
+      - issues-032020
       default_field: false
     - name: results.size
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -447,7 +447,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,search,search.query.id,keyword,extended,,2dc15175-de0d-44db-86d8-8a99f41b7a11,An opaque query identifier.
 1.6.0-dev,true,search,search.query.page,long,extended,,1,The page of search results being requested.
 1.6.0-dev,true,search,search.query.value,keyword,extended,,where does the rain in Spain mainly fall,The query string being searched on.
-1.6.0-dev,true,search,search.results.ids,keyword,extended,array,"['user:82375akja9f', 'issue:2782630']",A list of document IDs in the result set.
+1.6.0-dev,true,search,search.results.document,object,extended,array,,A list of documents in the result set.
+1.6.0-dev,true,search,search.results.document.id,keyword,extended,,"['user:82375akja9f', 'issue:2782630']",The ID of the retrieved document.
+1.6.0-dev,true,search,search.results.document.index,keyword,extended,,"['users', 'issues-032020']",The index the document was retrieved from.
 1.6.0-dev,true,search,search.results.size,long,extended,,10,The size of the result set displayed to the user.
 1.6.0-dev,true,search,search.results.total,long,extended,,134509,The total number of matches for this query.
 1.6.0-dev,true,server,server.address,keyword,extended,,,Server network address.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6200,22 +6200,51 @@ search.query.value:
   order: 1
   short: The query string being searched on.
   type: keyword
-search.results.ids:
-  dashed_name: search-results-ids
-  description: A list of opaque document IDs representing the results that were shown
-    to the user. This is effectively the impression list and it's size should be equal
-    to `results.size`. This field can be empty when there are no results to return.
+search.results.document:
+  dashed_name: search-results-document
+  description: A list of documents representing the results that were shown to the
+    user. This is effectively the impression list and it's size should be equal to
+    `results.size`. This field can be empty when there are no results to return.
+  flat_name: search.results.document
+  level: extended
+  name: results.document
+  normalize:
+  - array
+  object_type: keyword
+  order: 5
+  short: A list of documents in the result set.
+  type: object
+search.results.document.id:
+  dashed_name: search-results-document-id
+  description: An opaque document ID representing the result that was shown to the
+    user. This ID should be unique within the index it was retrieved from. The combination
+    of document ID and index should be globally unique.
   example:
   - user:82375akja9f
   - issue:2782630
-  flat_name: search.results.ids
+  flat_name: search.results.document.id
   ignore_above: 1024
   level: extended
-  name: results.ids
-  normalize:
-  - array
-  order: 5
-  short: A list of document IDs in the result set.
+  name: results.document.id
+  normalize: []
+  order: 6
+  short: The ID of the retrieved document.
+  type: keyword
+search.results.document.index:
+  dashed_name: search-results-document-index
+  description: The name of the index that the result document was retrieved from.
+    This can be considered as optional if all search results are always retrieved
+    from same index. The combination of document ID and index should be globally unique.
+  example:
+  - users
+  - issues-032020
+  flat_name: search.results.document.index
+  ignore_above: 1024
+  level: extended
+  name: results.document.index
+  normalize: []
+  order: 7
+  short: The index the document was retrieved from.
   type: keyword
 search.results.size:
   dashed_name: search-results-size

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6721,23 +6721,53 @@ search:
       order: 1
       short: The query string being searched on.
       type: keyword
-    results.ids:
-      dashed_name: search-results-ids
-      description: A list of opaque document IDs representing the results that were
-        shown to the user. This is effectively the impression list and it's size should
-        be equal to `results.size`. This field can be empty when there are no results
+    results.document:
+      dashed_name: search-results-document
+      description: A list of documents representing the results that were shown to
+        the user. This is effectively the impression list and it's size should be
+        equal to `results.size`. This field can be empty when there are no results
         to return.
+      flat_name: search.results.document
+      level: extended
+      name: results.document
+      normalize:
+      - array
+      object_type: keyword
+      order: 5
+      short: A list of documents in the result set.
+      type: object
+    results.document.id:
+      dashed_name: search-results-document-id
+      description: An opaque document ID representing the result that was shown to
+        the user. This ID should be unique within the index it was retrieved from.
+        The combination of document ID and index should be globally unique.
       example:
       - user:82375akja9f
       - issue:2782630
-      flat_name: search.results.ids
+      flat_name: search.results.document.id
       ignore_above: 1024
       level: extended
-      name: results.ids
-      normalize:
-      - array
-      order: 5
-      short: A list of document IDs in the result set.
+      name: results.document.id
+      normalize: []
+      order: 6
+      short: The ID of the retrieved document.
+      type: keyword
+    results.document.index:
+      dashed_name: search-results-document-index
+      description: The name of the index that the result document was retrieved from.
+        This can be considered as optional if all search results are always retrieved
+        from same index. The combination of document ID and index should be globally
+        unique.
+      example:
+      - users
+      - issues-032020
+      flat_name: search.results.document.index
+      ignore_above: 1024
+      level: extended
+      name: results.document.index
+      normalize: []
+      order: 7
+      short: The index the document was retrieved from.
       type: keyword
     results.size:
       dashed_name: search-results-size

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2132,9 +2132,18 @@
             },
             "results": {
               "properties": {
-                "ids": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                "document": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "index": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "object"
                 },
                 "size": {
                   "type": "long"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2131,9 +2131,18 @@
           },
           "results": {
             "properties": {
-              "ids": {
-                "ignore_above": 1024,
-                "type": "keyword"
+              "document": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "index": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                },
+                "type": "object"
               },
               "size": {
                 "type": "long"

--- a/schemas/search.yml
+++ b/schemas/search.yml
@@ -68,15 +68,35 @@
         in the query response.
       example: 134509
 
-    - name: results.ids
+    - name: results.document
       level: extended
-      type: keyword
+      type: object
       normalize:
         - array
-      short: A list of document IDs in the result set.
+      short: A list of documents in the result set.
       description: >
-        A list of opaque document IDs representing the results that were shown
-        to the user. This is effectively the impression list and it's size
-        should be equal to `results.size`. This field can be empty when there
-        are no results to return.
+        A list of documents representing the results that were shown to the
+        user. This is effectively the impression list and it's size should be
+        equal to `results.size`. This field can be empty when there are no
+        results to return.
+
+    - name: results.document.id
+      level: extended
+      type: keyword
+      short: The ID of the retrieved document.
+      description: >
+        An opaque document ID representing the result that was shown to the
+        user. This ID should be unique within the index it was retrieved from.
+        The combination of document ID and index should be globally unique.
       example: ["user:82375akja9f", "issue:2782630"]
+
+    - name: results.document.index
+      level: extended
+      type: keyword
+      short: The index the document was retrieved from.
+      description: >
+        The name of the index that the result document was retrieved from. This
+        can be considered as optional if all search results are always
+        retrieved from same index. The combination of document ID and index
+        should be globally unique.
+      example: ["users", "issues-032020"]


### PR DESCRIPTION
Search results were originally modelled as a list of document IDs. When
implementing query logging in Workplace Search, we realized that the
unique key for a document is actually index plus document ID since
queries can be executed across multiple indices and document IDs alone
are required to be unique only within an index. For metrics tasks, the
ID field could have encoded the index and ID, and most machine learning
tasks such as training data for learning-to-rank could also use this
scheme to keep the data structure simple. On the other side, the rank
evaluation API uses two fields to represent the unique keys of a
document. We are changing this schema primarily to be consistent with
other APIs such as rank evaluation, at the cost of adding some schema
complexity and potentially data structure overhead in raw events.

This PR is a request for comments and a discussion point to decide if
this is the right way to proceed vs the way we have currently implemented
this as an array of plain/opaque IDs.