### PR TITLE
Add `log.file.path` to capture the log file path, following Filebeat convention.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -10,6 +10,8 @@ Thanks, you're awesome :-) -->
 
 ### Schema Changes
 
+* Added `log.file.path` to capture the log file an event came from. #802
+
 #### Breaking changes
 
 #### Bugfixes

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -34,6 +34,11 @@ type Log struct {
 	// Some examples are `warn`, `err`, `i`, `informational`.
 	Level string `ecs:"level"`
 
+	// Full path to the log file this event came from, including the file name.
+	// It should include the drive letter, when appropriate.
+	// If the event wasn't read from a log file, do not populate this field.
+	FilePath string `ecs:"file.path"`
+
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.
 	// In contrast to the `message` field which can contain an extracted part
@@ -49,7 +54,9 @@ type Log struct {
 	Logger string `ecs:"logger"`
 
 	// The name of the file containing the source code which originated the log
-	// event. Note that this is not the name of the log file.
+	// event.
+	// Note that this field is not meant to capture the log file. The correct
+	// field to capture the log file is `log.file.path`.
 	OriginFileName string `ecs:"origin.file.name"`
 
 	// The line number of the file containing the source code which originated

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2922,6 +2922,21 @@ The details specific to your event source are typically not logged under `log.*`
 
 // ===============================================================
 
+| log.file.path
+| Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.
+
+If the event wasn't read from a log file, do not populate this field.
+
+type: keyword
+
+
+
+example: `/var/log/fun-times.log`
+
+| extended
+
+// ===============================================================
+
 | log.level
 | Original log level of the log event.
 
@@ -2966,7 +2981,9 @@ example: `42`
 // ===============================================================
 
 | log.origin.file.name
-| The name of the file containing the source code which originated the log event. Note that this is not the name of the log file.
+| The name of the file containing the source code which originated the log event.
+
+Note that this field is not meant to capture the log file. The correct field to capture the log file is `log.file.path`.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2122,6 +2122,16 @@
       but rather in `event.*` or in other ECS fields.'
     type: group
     fields:
+    - name: file.path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Full path to the log file this event came from, including the
+        file name. It should include the drive letter, when appropriate.
+
+        If the event wasn''t read from a log file, do not populate this field.'
+      example: /var/log/fun-times.log
+      default_field: false
     - name: level
       level: core
       type: keyword
@@ -2151,8 +2161,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The name of the file containing the source code which originated
-        the log event. Note that this is not the name of the log file.
+      description: 'The name of the file containing the source code which originated
+        the log event.
+
+        Note that this field is not meant to capture the log file. The correct field
+        to capture the log file is `log.file.path`.'
       example: Bootstrap.java
     - name: origin.function
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -263,10 +263,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,interface,interface.alias,keyword,extended,,outside,Interface alias
 1.6.0-dev,true,interface,interface.id,keyword,extended,,10,Interface ID
 1.6.0-dev,true,interface,interface.name,keyword,extended,,eth0,Interface name
+1.6.0-dev,true,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 1.6.0-dev,true,log,log.level,keyword,core,,error,Log level of the log event.
 1.6.0-dev,true,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
 1.6.0-dev,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
-1.6.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The file which originated the log event.
+1.6.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 1.6.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 1.6.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
 1.6.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3838,6 +3838,21 @@ labels:
   order: 2
   short: Custom key/value pairs.
   type: object
+log.file.path:
+  dashed_name: log-file-path
+  description: 'Full path to the log file this event came from, including the file
+    name. It should include the drive letter, when appropriate.
+
+    If the event wasn''t read from a log file, do not populate this field.'
+  example: /var/log/fun-times.log
+  flat_name: log.file.path
+  ignore_above: 1024
+  level: extended
+  name: file.path
+  normalize: []
+  order: 1
+  short: Full path to the log file this event came from.
+  type: keyword
 log.level:
   dashed_name: log-level
   description: 'Original log level of the log event.
@@ -3866,7 +3881,7 @@ log.logger:
   level: core
   name: logger
   normalize: []
-  order: 2
+  order: 3
   short: Name of the logger.
   type: keyword
 log.origin.file.line:
@@ -3878,21 +3893,24 @@ log.origin.file.line:
   level: extended
   name: origin.file.line
   normalize: []
-  order: 4
+  order: 5
   short: The line number of the file which originated the log event.
   type: integer
 log.origin.file.name:
   dashed_name: log-origin-file-name
-  description: The name of the file containing the source code which originated the
-    log event. Note that this is not the name of the log file.
+  description: 'The name of the file containing the source code which originated the
+    log event.
+
+    Note that this field is not meant to capture the log file. The correct field to
+    capture the log file is `log.file.path`.'
   example: Bootstrap.java
   flat_name: log.origin.file.name
   ignore_above: 1024
   level: extended
   name: origin.file.name
   normalize: []
-  order: 3
-  short: The file which originated the log event.
+  order: 4
+  short: The code file which originated the log event.
   type: keyword
 log.origin.function:
   dashed_name: log-origin-function
@@ -3903,7 +3921,7 @@ log.origin.function:
   level: extended
   name: origin.function
   normalize: []
-  order: 5
+  order: 6
   short: The function which originated the log event.
   type: keyword
 log.original:
@@ -3926,7 +3944,7 @@ log.original:
   level: core
   name: original
   normalize: []
-  order: 1
+  order: 2
   short: Original log message with light interpretation only (encoding, newlines).
   type: keyword
 log.syslog:
@@ -3938,7 +3956,7 @@ log.syslog:
   name: syslog
   normalize: []
   object_type: keyword
-  order: 6
+  order: 7
   short: Syslog metadata
   type: object
 log.syslog.facility.code:
@@ -3953,7 +3971,7 @@ log.syslog.facility.code:
   level: extended
   name: syslog.facility.code
   normalize: []
-  order: 9
+  order: 10
   short: Syslog numeric facility of the event.
   type: long
 log.syslog.facility.name:
@@ -3965,7 +3983,7 @@ log.syslog.facility.name:
   level: extended
   name: syslog.facility.name
   normalize: []
-  order: 10
+  order: 11
   short: Syslog text-based facility of the event.
   type: keyword
 log.syslog.priority:
@@ -3980,7 +3998,7 @@ log.syslog.priority:
   level: extended
   name: syslog.priority
   normalize: []
-  order: 11
+  order: 12
   short: Syslog priority of the event.
   type: long
 log.syslog.severity.code:
@@ -3996,7 +4014,7 @@ log.syslog.severity.code:
   level: extended
   name: syslog.severity.code
   normalize: []
-  order: 7
+  order: 8
   short: Syslog numeric severity of the event.
   type: long
 log.syslog.severity.name:
@@ -4013,7 +4031,7 @@ log.syslog.severity.name:
   level: extended
   name: syslog.severity.name
   normalize: []
-  order: 8
+  order: 9
   short: Syslog text-based severity of the event.
   type: keyword
 message:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4210,6 +4210,21 @@ log:
     The details specific to your event source are typically not logged under `log.*`,
     but rather in `event.*` or in other ECS fields.'
   fields:
+    file.path:
+      dashed_name: log-file-path
+      description: 'Full path to the log file this event came from, including the
+        file name. It should include the drive letter, when appropriate.
+
+        If the event wasn''t read from a log file, do not populate this field.'
+      example: /var/log/fun-times.log
+      flat_name: log.file.path
+      ignore_above: 1024
+      level: extended
+      name: file.path
+      normalize: []
+      order: 1
+      short: Full path to the log file this event came from.
+      type: keyword
     level:
       dashed_name: log-level
       description: 'Original log level of the log event.
@@ -4238,7 +4253,7 @@ log:
       level: core
       name: logger
       normalize: []
-      order: 2
+      order: 3
       short: Name of the logger.
       type: keyword
     origin.file.line:
@@ -4250,21 +4265,24 @@ log:
       level: extended
       name: origin.file.line
       normalize: []
-      order: 4
+      order: 5
       short: The line number of the file which originated the log event.
       type: integer
     origin.file.name:
       dashed_name: log-origin-file-name
-      description: The name of the file containing the source code which originated
-        the log event. Note that this is not the name of the log file.
+      description: 'The name of the file containing the source code which originated
+        the log event.
+
+        Note that this field is not meant to capture the log file. The correct field
+        to capture the log file is `log.file.path`.'
       example: Bootstrap.java
       flat_name: log.origin.file.name
       ignore_above: 1024
       level: extended
       name: origin.file.name
       normalize: []
-      order: 3
-      short: The file which originated the log event.
+      order: 4
+      short: The code file which originated the log event.
       type: keyword
     origin.function:
       dashed_name: log-origin-function
@@ -4275,7 +4293,7 @@ log:
       level: extended
       name: origin.function
       normalize: []
-      order: 5
+      order: 6
       short: The function which originated the log event.
       type: keyword
     original:
@@ -4298,7 +4316,7 @@ log:
       level: core
       name: original
       normalize: []
-      order: 1
+      order: 2
       short: Original log message with light interpretation only (encoding, newlines).
       type: keyword
     syslog:
@@ -4310,7 +4328,7 @@ log:
       name: syslog
       normalize: []
       object_type: keyword
-      order: 6
+      order: 7
       short: Syslog metadata
       type: object
     syslog.facility.code:
@@ -4325,7 +4343,7 @@ log:
       level: extended
       name: syslog.facility.code
       normalize: []
-      order: 9
+      order: 10
       short: Syslog numeric facility of the event.
       type: long
     syslog.facility.name:
@@ -4337,7 +4355,7 @@ log:
       level: extended
       name: syslog.facility.name
       normalize: []
-      order: 10
+      order: 11
       short: Syslog text-based facility of the event.
       type: keyword
     syslog.priority:
@@ -4352,7 +4370,7 @@ log:
       level: extended
       name: syslog.priority
       normalize: []
-      order: 11
+      order: 12
       short: Syslog priority of the event.
       type: long
     syslog.severity.code:
@@ -4368,7 +4386,7 @@ log:
       level: extended
       name: syslog.severity.code
       normalize: []
-      order: 7
+      order: 8
       short: Syslog numeric severity of the event.
       type: long
     syslog.severity.name:
@@ -4385,7 +4403,7 @@ log:
       level: extended
       name: syslog.severity.name
       normalize: []
-      order: 8
+      order: 9
       short: Syslog text-based severity of the event.
       type: keyword
   group: 2

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1257,6 +1257,14 @@
         },
         "log": {
           "properties": {
+            "file": {
+              "properties": {
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "level": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1256,6 +1256,14 @@
       },
       "log": {
         "properties": {
+          "file": {
+            "properties": {
+              "path": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "level": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -29,6 +29,18 @@
         Some examples are `warn`, `err`, `i`, `informational`.
       example: error
 
+    - name: file.path
+      level: extended
+      type: keyword
+      short: Full path to the log file this event came from.
+      description: >
+        Full path to the log file this event came from, including the file name.
+        It should include the drive letter, when appropriate.
+
+        If the event wasn't read from a log file, do not populate this field.
+      example: "/var/log/fun-times.log"
+
+
     - name: original
       level: core
       type: keyword
@@ -61,10 +73,12 @@
       level: extended
       type: keyword
       example: Bootstrap.java
-      short: The file which originated the log event.
+      short: The code file which originated the log event.
       description: >
         The name of the file containing the source code which originated the log event.
-        Note that this is not the name of the log file.
+
+        Note that this field is not meant to capture the log file.
+        The correct field to capture the log file is `log.file.path`.
 
     - name: origin.file.line
       level: extended


### PR DESCRIPTION
A few points to note about this PR:

* This is not nesting all of `file.*` at `log.file.*`, this is adding a single field only: `log.file.path`. If I remember correctly, it's the first time we do this.
  * If there's a need for more `file.*` fields we could add them, but so far that need has not arisen.
* This approach also made it possible to tailor the field description to this specific use case.
* Where `file.path` has a `text` multi-field which may be useful for threat hunting in arbitrary file paths, `log.file.path` does not. The thinking is that these log files are controlled by operators and aren't "user data" in which we're likely to do threat hunting. This is something we can add later if needed.
* This PR also adjusts the field description for `log.origin.file.name` to disambiguate: `log.origin.file.*` are fields to capture source code file details, in application logging use cases.

Closes #770