### PR TITLE
Handle nestings better and refactor asciidoc generation

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Add full path names to reused fieldsets in `nestings` array in ecs_nested.yml. #803
+
 #### Deprecated
 
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -440,6 +440,12 @@ example: `co.uk`
 // ===============================================================
 
 
+| <<ecs-group,client.user.group.*>>
+| User's group relevant to the event.
+
+// ===============================================================
+
+
 |=====
 
 [[ecs-cloud]]
@@ -946,6 +952,12 @@ example: `co.uk`
 
 | <<ecs-user,destination.user.*>>
 | Fields to describe the user relevant to the event.
+
+// ===============================================================
+
+
+| <<ecs-group,destination.user.group.*>>
+| User's group relevant to the event.
 
 // ===============================================================
 
@@ -2677,6 +2689,12 @@ example: `1325`
 
 | <<ecs-user,host.user.*>>
 | Fields to describe the user relevant to the event.
+
+// ===============================================================
+
+
+| <<ecs-group,host.user.group.*>>
+| User's group relevant to the event.
 
 // ===============================================================
 
@@ -5235,6 +5253,12 @@ example: `co.uk`
 // ===============================================================
 
 
+| <<ecs-group,server.user.group.*>>
+| User's group relevant to the event.
+
+// ===============================================================
+
+
 |=====
 
 [[ecs-service]]
@@ -5568,6 +5592,12 @@ example: `co.uk`
 
 | <<ecs-user,source.user.*>>
 | Fields to describe the user relevant to the event.
+
+// ===============================================================
+
+
+| <<ecs-group,source.user.group.*>>
+| User's group relevant to the event.
 
 // ===============================================================
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -102,7 +102,6 @@ as.number:
   name: number
   normalize: []
   order: 0
-  original_fieldset: as
   short: Unique number allocated to the autonomous system. The autonomous system number
     (ASN) uniquely identifies each network on the Internet.
   type: long
@@ -121,7 +120,6 @@ as.organization.name:
   name: organization.name
   normalize: []
   order: 1
-  original_fieldset: as
   short: Organization name.
   type: keyword
 client.address:
@@ -636,7 +634,6 @@ code_signature.exists:
   name: exists
   normalize: []
   order: 0
-  original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
 code_signature.status:
@@ -653,7 +650,6 @@ code_signature.status:
   name: status
   normalize: []
   order: 4
-  original_fieldset: code_signature
   short: Additional information about the certificate status.
   type: keyword
 code_signature.subject_name:
@@ -666,7 +662,6 @@ code_signature.subject_name:
   name: subject_name
   normalize: []
   order: 1
-  original_fieldset: code_signature
   short: Subject name of the code signer
   type: keyword
 code_signature.trusted:
@@ -681,7 +676,6 @@ code_signature.trusted:
   name: trusted
   normalize: []
   order: 3
-  original_fieldset: code_signature
   short: Stores the trust status of the certificate chain.
   type: boolean
 code_signature.valid:
@@ -696,7 +690,6 @@ code_signature.valid:
   name: valid
   normalize: []
   order: 2
-  original_fieldset: code_signature
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
@@ -3021,7 +3014,6 @@ geo.city_name:
   name: city_name
   normalize: []
   order: 4
-  original_fieldset: geo
   short: City name.
   type: keyword
 geo.continent_name:
@@ -3034,7 +3026,6 @@ geo.continent_name:
   name: continent_name
   normalize: []
   order: 1
-  original_fieldset: geo
   short: Name of the continent.
   type: keyword
 geo.country_iso_code:
@@ -3047,7 +3038,6 @@ geo.country_iso_code:
   name: country_iso_code
   normalize: []
   order: 5
-  original_fieldset: geo
   short: Country ISO code.
   type: keyword
 geo.country_name:
@@ -3060,7 +3050,6 @@ geo.country_name:
   name: country_name
   normalize: []
   order: 2
-  original_fieldset: geo
   short: Country name.
   type: keyword
 geo.location:
@@ -3072,7 +3061,6 @@ geo.location:
   name: location
   normalize: []
   order: 0
-  original_fieldset: geo
   short: Longitude and latitude.
   type: geo_point
 geo.name:
@@ -3091,7 +3079,6 @@ geo.name:
   name: name
   normalize: []
   order: 7
-  original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
 geo.region_iso_code:
@@ -3104,7 +3091,6 @@ geo.region_iso_code:
   name: region_iso_code
   normalize: []
   order: 6
-  original_fieldset: geo
   short: Region ISO code.
   type: keyword
 geo.region_name:
@@ -3117,7 +3103,6 @@ geo.region_name:
   name: region_name
   normalize: []
   order: 3
-  original_fieldset: geo
   short: Region name.
   type: keyword
 group.domain:
@@ -3131,7 +3116,6 @@ group.domain:
   name: domain
   normalize: []
   order: 2
-  original_fieldset: group
   short: Name of the directory the group is a member of.
   type: keyword
 group.id:
@@ -3143,7 +3127,6 @@ group.id:
   name: id
   normalize: []
   order: 0
-  original_fieldset: group
   short: Unique identifier for the group on the system/platform.
   type: keyword
 group.name:
@@ -3155,7 +3138,6 @@ group.name:
   name: name
   normalize: []
   order: 1
-  original_fieldset: group
   short: Name of the group.
   type: keyword
 hash.md5:
@@ -3167,7 +3149,6 @@ hash.md5:
   name: md5
   normalize: []
   order: 0
-  original_fieldset: hash
   short: MD5 hash.
   type: keyword
 hash.sha1:
@@ -3179,7 +3160,6 @@ hash.sha1:
   name: sha1
   normalize: []
   order: 1
-  original_fieldset: hash
   short: SHA1 hash.
   type: keyword
 hash.sha256:
@@ -3191,7 +3171,6 @@ hash.sha256:
   name: sha256
   normalize: []
   order: 2
-  original_fieldset: hash
   short: SHA256 hash.
   type: keyword
 hash.sha512:
@@ -3203,7 +3182,6 @@ hash.sha512:
   name: sha512
   normalize: []
   order: 3
-  original_fieldset: hash
   short: SHA512 hash.
   type: keyword
 host.architecture:
@@ -3792,7 +3770,6 @@ interface.alias:
   name: alias
   normalize: []
   order: 2
-  original_fieldset: interface
   short: Interface alias
   type: keyword
 interface.id:
@@ -3805,7 +3782,6 @@ interface.id:
   name: id
   normalize: []
   order: 0
-  original_fieldset: interface
   short: Interface ID
   type: keyword
 interface.name:
@@ -3818,7 +3794,6 @@ interface.name:
   name: name
   normalize: []
   order: 1
-  original_fieldset: interface
   short: Interface name
   type: keyword
 labels:
@@ -4797,7 +4772,6 @@ os.family:
   name: family
   normalize: []
   order: 3
-  original_fieldset: os
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 os.full:
@@ -4815,7 +4789,6 @@ os.full:
   name: full
   normalize: []
   order: 2
-  original_fieldset: os
   short: Operating system name, including the version or code name.
   type: keyword
 os.kernel:
@@ -4828,7 +4801,6 @@ os.kernel:
   name: kernel
   normalize: []
   order: 5
-  original_fieldset: os
   short: Operating system kernel version as a raw string.
   type: keyword
 os.name:
@@ -4846,7 +4818,6 @@ os.name:
   name: name
   normalize: []
   order: 1
-  original_fieldset: os
   short: Operating system name, without the version.
   type: keyword
 os.platform:
@@ -4859,7 +4830,6 @@ os.platform:
   name: platform
   normalize: []
   order: 0
-  original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
 os.version:
@@ -4872,7 +4842,6 @@ os.version:
   name: version
   normalize: []
   order: 4
-  original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
 package.architecture:
@@ -5047,7 +5016,6 @@ pe.company:
   name: company
   normalize: []
   order: 4
-  original_fieldset: pe
   short: Internal company name of the file, provided at compile-time.
   type: keyword
 pe.description:
@@ -5060,7 +5028,6 @@ pe.description:
   name: description
   normalize: []
   order: 2
-  original_fieldset: pe
   short: Internal description of the file, provided at compile-time.
   type: keyword
 pe.file_version:
@@ -5073,7 +5040,6 @@ pe.file_version:
   name: file_version
   normalize: []
   order: 1
-  original_fieldset: pe
   short: Process name.
   type: keyword
 pe.original_file_name:
@@ -5086,7 +5052,6 @@ pe.original_file_name:
   name: original_file_name
   normalize: []
   order: 0
-  original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
   type: keyword
 pe.product:
@@ -5099,7 +5064,6 @@ pe.product:
   name: product
   normalize: []
   order: 3
-  original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
 process.args:
@@ -7963,7 +7927,6 @@ user.domain:
   name: domain
   normalize: []
   order: 5
-  original_fieldset: user
   short: Name of the directory the user is a member of.
   type: keyword
 user.email:
@@ -7975,7 +7938,6 @@ user.email:
   name: email
   normalize: []
   order: 3
-  original_fieldset: user
   short: User email address.
   type: keyword
 user.full_name:
@@ -7993,7 +7955,6 @@ user.full_name:
   name: full_name
   normalize: []
   order: 2
-  original_fieldset: user
   short: User's full name, if available.
   type: keyword
 user.group.domain:
@@ -8047,7 +8008,6 @@ user.hash:
   name: hash
   normalize: []
   order: 4
-  original_fieldset: user
   short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
@@ -8059,7 +8019,6 @@ user.id:
   name: id
   normalize: []
   order: 0
-  original_fieldset: user
   short: Unique identifiers of the user.
   type: keyword
 user.name:
@@ -8077,7 +8036,6 @@ user.name:
   name: name
   normalize: []
   order: 1
-  original_fieldset: user
   short: Short name or login of the user.
   type: keyword
 user_agent.device.name:
@@ -8232,7 +8190,6 @@ vlan.id:
   name: id
   normalize: []
   order: 0
-  original_fieldset: vlan
   short: VLAN ID as reported by the observer.
   type: keyword
 vlan.name:
@@ -8245,7 +8202,6 @@ vlan.name:
   name: name
   normalize: []
   order: 1
-  original_fieldset: vlan
   short: Optional VLAN name as reported by the observer.
   type: keyword
 vulnerability.category:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -655,9 +655,9 @@ client:
   group: 2
   name: client
   nestings:
-  - as
-  - geo
-  - user
+  - client.as
+  - client.geo
+  - client.user
   prefix: client.
   short: Fields about the client side of a network connection, used with server.
   title: Client
@@ -1351,9 +1351,9 @@ destination:
   group: 2
   name: destination
   nestings:
-  - as
-  - geo
-  - user
+  - destination.as
+  - destination.geo
+  - destination.user
   prefix: destination.
   short: Fields about the destination side of a network connection, used with source.
   title: Destination
@@ -1587,9 +1587,9 @@ dll:
   group: 2
   name: dll
   nestings:
-  - code_signature
-  - hash
-  - pe
+  - dll.code_signature
+  - dll.hash
+  - dll.pe
   prefix: dll.
   short: These fields contain information about code libraries dynamically loaded
     into processes.
@@ -3296,9 +3296,9 @@ file:
   group: 2
   name: file
   nestings:
-  - code_signature
-  - hash
-  - pe
+  - file.code_signature
+  - file.hash
+  - file.pe
   prefix: file.
   short: Fields describing files.
   title: File
@@ -3994,9 +3994,9 @@ host:
   group: 2
   name: host
   nestings:
-  - geo
-  - os
-  - user
+  - host.geo
+  - host.os
+  - host.user
   prefix: host.
   short: Fields describing the relevant computing instance.
   title: Host
@@ -4637,7 +4637,8 @@ network:
   group: 2
   name: network
   nestings:
-  - vlan
+  - network.inner.vlan
+  - network.vlan
   prefix: network.
   short: Fields describing the communication path over which the event happened.
   title: Network
@@ -5158,10 +5159,12 @@ observer:
   group: 2
   name: observer
   nestings:
-  - geo
-  - interface
-  - os
-  - vlan
+  - observer.egress.interface
+  - observer.egress.vlan
+  - observer.geo
+  - observer.ingress.interface
+  - observer.ingress.vlan
+  - observer.os
   prefix: observer.
   short: Fields describing an entity observing the event from outside the host.
   title: Observer
@@ -6354,9 +6357,11 @@ process:
   group: 2
   name: process
   nestings:
-  - code_signature
-  - hash
-  - pe
+  - process.code_signature
+  - process.hash
+  - process.parent.code_signature
+  - process.parent.hash
+  - process.pe
   prefix: process.
   short: These fields contain information about a process.
   title: Process
@@ -7207,9 +7212,9 @@ server:
   group: 2
   name: server
   nestings:
-  - as
-  - geo
-  - user
+  - server.as
+  - server.geo
+  - server.user
   prefix: server.
   short: Fields about the server side of a network connection, used with client.
   title: Server
@@ -7770,9 +7775,9 @@ source:
   group: 2
   name: source
   nestings:
-  - as
-  - geo
-  - user
+  - source.as
+  - source.geo
+  - source.user
   prefix: source.
   short: Fields about the source side of a network connection, used with destination.
   title: Source
@@ -8713,7 +8718,7 @@ user:
   group: 2
   name: user
   nestings:
-  - group
+  - user.group
   prefix: user.
   reusable:
     expected:
@@ -8876,7 +8881,7 @@ user_agent:
   group: 2
   name: user_agent
   nestings:
-  - os
+  - user_agent.os
   prefix: user_agent.
   short: Fields to describe a browser user_agent string.
   title: User agent

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -658,6 +658,7 @@ client:
   - client.as
   - client.geo
   - client.user
+  - client.user.group
   prefix: client.
   short: Fields about the client side of a network connection, used with server.
   title: Client
@@ -1354,6 +1355,7 @@ destination:
   - destination.as
   - destination.geo
   - destination.user
+  - destination.user.group
   prefix: destination.
   short: Fields about the destination side of a network connection, used with source.
   title: Destination
@@ -3997,6 +3999,7 @@ host:
   - host.geo
   - host.os
   - host.user
+  - host.user.group
   prefix: host.
   short: Fields describing the relevant computing instance.
   title: Host
@@ -7215,6 +7218,7 @@ server:
   - server.as
   - server.geo
   - server.user
+  - server.user.group
   prefix: server.
   short: Fields about the server side of a network connection, used with client.
   title: Server
@@ -7778,6 +7782,7 @@ source:
   - source.as
   - source.geo
   - source.user
+  - source.user.group
   prefix: source.
   short: Fields about the source side of a network connection, used with destination.
   title: Source

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -57,6 +57,8 @@ def main():
 
     csv_generator.generate(flat, ecs_version, out_dir)
     es_template.generate(flat, ecs_version, out_dir)
+    if args.include or args.subset:
+        exit()
     beats.generate(nested, ecs_version, out_dir)
     asciidoc_fields.generate(intermediate_fields, ecs_version, docs_dir)
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -58,7 +58,7 @@ def main():
     csv_generator.generate(flat, ecs_version, out_dir)
     es_template.generate(flat, ecs_version, out_dir)
     beats.generate(nested, ecs_version, out_dir)
-    asciidoc_fields.generate(nested, flat, ecs_version, docs_dir)
+    asciidoc_fields.generate(intermediate_fields, ecs_version, docs_dir)
 
 
 def argument_parser():

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -73,7 +73,6 @@ def render_fields(fields):
     return text
 
 
-
 def render_asciidoc_paragraphs(string):
     '''Simply double the \n'''
     return string.replace("\n", "\n\n")
@@ -316,7 +315,8 @@ def page_field_values(intermediate_nested):
     section_text = values_section_header()
     category_fields = ['event.kind', 'event.category', 'event.type', 'event.outcome']
     for cat_field in category_fields:
-        section_text += render_field_values_page(ecs_helpers.get_nested_field(cat_field, intermediate_nested)['field_details'])
+        section_text += render_field_values_page(ecs_helpers.get_nested_field(cat_field,
+                                                                              intermediate_nested)['field_details'])
     return section_text
 
 

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -2,10 +2,10 @@ from os.path import join
 from generators import ecs_helpers
 
 
-def generate(ecs_nested, ecs_flat, ecs_version, out_dir):
-    save_asciidoc(join(out_dir, 'fields.asciidoc'), page_field_index(ecs_nested, ecs_version))
-    save_asciidoc(join(out_dir, 'field-details.asciidoc'), page_field_details(ecs_nested))
-    save_asciidoc(join(out_dir, 'field-values.asciidoc'), page_field_values(ecs_flat))
+def generate(intermediate_nested, ecs_version, out_dir):
+    save_asciidoc(join(out_dir, 'fields.asciidoc'), page_field_index(intermediate_nested, ecs_version))
+    save_asciidoc(join(out_dir, 'field-details.asciidoc'), page_field_details(intermediate_nested))
+    save_asciidoc(join(out_dir, 'field-values.asciidoc'), page_field_values(intermediate_nested))
 
 # Helpers
 
@@ -20,9 +20,9 @@ def save_asciidoc(file, text):
 # Field Index
 
 
-def page_field_index(ecs_nested, ecs_version):
+def page_field_index(intermediate_nested, ecs_version):
     page_text = index_header(ecs_version)
-    for fieldset in ecs_helpers.dict_sorted_by_keys(ecs_nested, ['group', 'name']):
+    for fieldset in ecs_helpers.dict_sorted_by_keys(intermediate_nested, ['group', 'name']):
         page_text += render_field_index_row(fieldset)
     page_text += table_footer()
     page_text += index_footer()
@@ -39,30 +39,39 @@ def render_field_index_row(fieldset):
 
 # Field Details Page
 
-def page_field_details(ecs_nested):
+def page_field_details(intermediate_nested):
     page_text = ''
-    for fieldset in ecs_helpers.dict_sorted_by_keys(ecs_nested, ['group', 'name']):
-        page_text += render_fieldset(fieldset, ecs_nested)
+    for fieldset in ecs_helpers.dict_sorted_by_keys(intermediate_nested, ['group', 'name']):
+        page_text += render_fieldset(fieldset, intermediate_nested)
     return page_text
 
 
-def render_fieldset(fieldset, ecs_nested):
+def render_fieldset(fieldset, intermediate_nested):
     text = field_details_table_header().format(
         fieldset_title=fieldset['title'],
         fieldset_name=fieldset['name'],
         fieldset_description=render_asciidoc_paragraphs(fieldset['description'])
     )
 
-    for field in ecs_helpers.dict_sorted_by_keys(fieldset['fields'], 'flat_name'):
-        # Skip fields nested in this field set
-        if 'original_fieldset' not in field:
-            text += render_field_details_row(field)
+    text += render_fields(fieldset['fields'])
 
     text += table_footer()
 
-    text += render_fieldset_reuse_section(fieldset, ecs_nested)
+    text += render_fieldset_reuse_section(fieldset, intermediate_nested)
 
     return text
+
+
+def render_fields(fields):
+    text = ''
+    for field_name, field in sorted(fields.items()):
+        # Skip fields nested in this field set
+        if 'field_details' in field and 'original_fieldset' not in field['field_details']:
+            text += render_field_details_row(field['field_details'])
+        if 'fields' in field:
+            text += render_fields(field['fields'])
+    return text
+
 
 
 def render_asciidoc_paragraphs(string):
@@ -109,7 +118,7 @@ def render_field_details_row(field):
     return text
 
 
-def render_fieldset_reuse_section(fieldset, ecs_nested):
+def render_fieldset_reuse_section(fieldset, intermediate_nested):
     '''Render the section on where field set can be nested, and which field sets can be nested here'''
     if not ('nestings' in fieldset or 'reusable' in fieldset):
         return ''
@@ -124,18 +133,12 @@ def render_fieldset_reuse_section(fieldset, ecs_nested):
         )
         rows = []
         for nested_fs_name in fieldset['nestings']:
-            ecs = ecs_nested[nested_fs_name]
-            if 'reusable' in ecs:
-                target_fields = filter(lambda x: x == fieldset['name'] or x.startswith(
-                    fieldset['name'] + '.'), ecs['reusable']['expected'])
-            else:
-                target_fields = [fieldset['name']]
-            for field in target_fields:
-                rows.append({
-                    'flat_nesting': "{}.{}.*".format(field, nested_fs_name),
-                    'name': nested_fs_name,
-                    'short': ecs['short']
-                })
+            ecs = ecs_helpers.get_nested_field(nested_fs_name, intermediate_nested)
+            rows.append({
+                'flat_nesting': "{}.*".format(nested_fs_name),
+                'name': nested_fs_name.split('.')[-1],
+                'short': ecs['short']
+            })
         for row in sorted(rows, key=lambda x: x['flat_nesting']):
             text += render_nesting_row(row)
         text += table_footer()
@@ -309,11 +312,11 @@ def nestings_row():
 # Allowed values section
 
 
-def page_field_values(ecs_flat):
+def page_field_values(intermediate_nested):
     section_text = values_section_header()
     category_fields = ['event.kind', 'event.category', 'event.type', 'event.outcome']
     for cat_field in category_fields:
-        section_text += render_field_values_page(ecs_flat[cat_field])
+        section_text += render_field_values_page(ecs_helpers.get_nested_field(cat_field, intermediate_nested)['field_details'])
     return section_text
 
 

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -133,3 +133,11 @@ def list_split_by(lst, size):
     for i in range(0, len(lst), size):
         acc.append(lst[i:i + size])
     return acc
+
+
+def get_nested_field(fieldname, field_dict):
+    fields = fieldname.split('.')
+    nested_field = field_dict[fields[0]]
+    for field in fields[1:]:
+        nested_field = nested_field['fields'][field]
+    return nested_field

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -136,6 +136,7 @@ def list_split_by(lst, size):
 
 
 def get_nested_field(fieldname, field_dict):
+    """Takes a field name in dot notation and a dictionary of fields and finds the field in the dictionary"""
     fields = fieldname.split('.')
     nested_field = field_dict[fields[0]]
     for field in fields[1:]:

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -173,6 +173,7 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
 
 
 def find_nestings(fields, prefix):
+    """Recursively finds all reusable fields in the fields dictionary."""
     nestings = []
     for field_name, field in fields.items():
         if 'reusable' in field:

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -172,9 +172,9 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
             nested_schema[schema['name']] = schema
 
 
-def find_nestings(fields_nested, prefix):
+def find_nestings(fields, prefix):
     nestings = []
-    for field_name, field in fields_nested.items():
+    for field_name, field in fields.items():
         if 'reusable' in field:
             nestings.append(prefix + field_name)
         if 'fields' in field:

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -198,6 +198,38 @@ class TestECSHelpers(unittest.TestCase):
         actual = ecs_helpers.fields_subset(subset, fields)
         self.assertEqual(actual, expected)
 
+    def test_get_nested_field(self):
+        fields = {
+            'test_fieldset': {
+                'name': 'test_fieldset',
+                'fields': {
+                    'test_field1': {
+                        'field_details': {
+                            'name': 'test_field1',
+                            'type': 'keyword',
+                            'description': 'A test field'
+                        }
+                    },
+                    'test_field2': {
+                        'field_details': {
+                            'name': 'test_field2',
+                            'type': 'keyword',
+                            'description': 'Another test field'
+                        }
+                    }
+                }
+            }
+        }
+        nested_field_name = 'test_fieldset.test_field1'
+        expected = {
+            'field_details': {
+                'name': 'test_field1',
+                'type': 'keyword',
+                'description': 'A test field'
+            }
+        }
+        actual = ecs_helpers.get_nested_field(nested_field_name, fields)
+        self.assertEqual(actual, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -231,5 +231,6 @@ class TestECSHelpers(unittest.TestCase):
         actual = ecs_helpers.get_nested_field(nested_field_name, fields)
         self.assertEqual(actual, expected)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -120,43 +120,6 @@ class TestSchemaReader(unittest.TestCase):
         }
         self.assertEqual(flat_fields, expected)
 
-    def test_flatten_fields_reusable(self):
-        fields = {
-            'top_level': {
-                'field_details': {
-                    'name': 'top_level'
-                },
-                'fields': {
-                    'nested_field': {
-                        'reusable': {
-                            'top_level': False,
-                            'expected': [
-                                'top_level'
-                            ]
-                        },
-                        'fields': {
-                            'double_nested_field': {
-                                'field_details': {
-                                    'name': 'double_nested_field'
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        flat_fields = schema_reader.flatten_fields(fields, "")
-        expected = {
-            'top_level': {
-                'name': 'top_level'
-            },
-            'top_level.nested_field.double_nested_field': {
-                'name': 'double_nested_field',
-                'original_fieldset': 'nested_field'
-            }
-        }
-        self.assertEqual(flat_fields, expected)
-
     def test_cleanup_fields_recursive(self):
         """Reuse a fieldset under two other fieldsets and check that the flat names are properly generated."""
         reusable = {
@@ -215,6 +178,7 @@ class TestSchemaReader(unittest.TestCase):
                                     'ignore_above': 1024,
                                     'short': 'A test field',
                                     'normalize': [],
+                                    'original_fieldset': 'reusable_fieldset'
                                 }
                             }
                         }
@@ -243,7 +207,7 @@ class TestSchemaReader(unittest.TestCase):
                                     'ignore_above': 1024,
                                     'short': 'A test field',
                                     'normalize': [],
-
+                                    'original_fieldset': 'reusable_fieldset'
                                 }
                             }
                         }

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -431,6 +431,44 @@ class TestSchemaReader(unittest.TestCase):
         with self.assertRaises(ValueError):
             schema_reader.duplicate_reusable_fieldsets(fieldset['reusable_fieldset2'], fieldset)
 
+    def test_find_nestings(self):
+        field = {
+            'sub_field': {
+                'reusable': {
+                    'top_level': True,
+                    'expected': [
+                        'some_other_field'
+                    ]
+                },
+                'fields': {
+                    'reusable_fieldset1': {
+                        'name': 'reusable_fieldset1',
+                        'reusable': {
+                            'top_level': False,
+                            'expected': [
+                                'sub_field'
+                            ]
+                        },
+                        'fields': {
+                            'nested_reusable_field': {
+                                'reusable': {
+                                    'top_level': False,
+                                    'expected': 'sub_field.nested_reusable_field'
+                                },
+                                'field_details': {
+                                    'name': 'reusable_field',
+                                    'type': 'keyword',
+                                    'description': 'A test field'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        expected = ['sub_field.reusable_fieldset1', 'sub_field.reusable_fieldset1.nested_reusable_field']
+        self.assertEqual(schema_reader.find_nestings(field['sub_field']['fields'], 'sub_field.'), expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #796 

A few related fixes in this PR:
- `nestings` array now contains the full path to reused fields within a fieldset, rather than just containing the name of the reused fieldset.  This better identifies places where a fieldset is reused multiple times within another set.
- Moved the `original_fieldset` logic from into the function where reused fields are converted from references to copies.  This makes the ecs_flat and ecs_nested files more consistent - `original_fieldset` was showing up in reusable fields even at the top level in ecs_flat.  However, it was supposed to be identifying places where a field was actually being reused.
- Refactor ascii doc generation to use intermediate field data structure instead of both the flat and nested structures.  This makes the logic easier to follow imo by reducing the number of transformations the data goes through.