### PR TITLE
Remove misleading wording about multiple IPs in src/dst or cli/srv

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -22,6 +22,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Clarified misleading wording about multiple IPs in src/dst or cli/srv. #804
+
 #### Deprecated
 
 

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -40,8 +40,7 @@ type Client struct {
 	// one it is.
 	Address string `ecs:"address"`
 
-	// IP address of the client.
-	// Can be one or multiple IPv4 or IPv6 addresses.
+	// IP address of the client (IPv4 or IPv6).
 	IP string `ecs:"ip"`
 
 	// Port of the client.

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -29,8 +29,7 @@ type Destination struct {
 	// one it is.
 	Address string `ecs:"address"`
 
-	// IP address of the destination.
-	// Can be one or multiple IPv4 or IPv6 addresses.
+	// IP address of the destination (IPv4 or IPv6).
 	IP string `ecs:"ip"`
 
 	// Port of the destination.

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -40,8 +40,7 @@ type Server struct {
 	// one it is.
 	Address string `ecs:"address"`
 
-	// IP address of the server.
-	// Can be one or multiple IPv4 or IPv6 addresses.
+	// IP address of the server (IPv4 or IPv6).
 	IP string `ecs:"ip"`
 
 	// Port of the server.

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -29,8 +29,7 @@ type Source struct {
 	// one it is.
 	Address string `ecs:"address"`
 
-	// IP address of the source.
-	// Can be one or multiple IPv4 or IPv6 addresses.
+	// IP address of the source (IPv4 or IPv6).
 	IP string `ecs:"ip"`
 
 	// Port of the source.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -290,9 +290,7 @@ type: keyword
 // ===============================================================
 
 | client.ip
-| IP address of the client.
-
-Can be one or multiple IPv4 or IPv6 addresses.
+| IP address of the client (IPv4 or IPv6).
 
 type: ip
 
@@ -800,9 +798,7 @@ type: keyword
 // ===============================================================
 
 | destination.ip
-| IP address of the destination.
-
-Can be one or multiple IPv4 or IPv6 addresses.
+| IP address of the destination (IPv4 or IPv6).
 
 type: ip
 
@@ -5088,9 +5084,7 @@ type: keyword
 // ===============================================================
 
 | server.ip
-| IP address of the server.
-
-Can be one or multiple IPv4 or IPv6 addresses.
+| IP address of the server (IPv4 or IPv6).
 
 type: ip
 
@@ -5425,9 +5419,7 @@ type: keyword
 // ===============================================================
 
 | source.ip
-| IP address of the source.
-
-Can be one or multiple IPv4 or IPv6 addresses.
+| IP address of the source (IPv4 or IPv6).
 
 type: ip
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -248,9 +248,7 @@
     - name: ip
       level: core
       type: ip
-      description: 'IP address of the client.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the client (IPv4 or IPv6).
     - name: mac
       level: core
       type: keyword
@@ -617,9 +615,7 @@
     - name: ip
       level: core
       type: ip
-      description: 'IP address of the destination.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the destination (IPv4 or IPv6).
     - name: mac
       level: core
       type: keyword
@@ -3724,9 +3720,7 @@
     - name: ip
       level: core
       type: ip
-      description: 'IP address of the server.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the server (IPv4 or IPv6).
     - name: mac
       level: core
       type: keyword
@@ -4035,9 +4029,7 @@
     - name: ip
       level: core
       type: ip
-      description: 'IP address of the source.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the source (IPv4 or IPv6).
     - name: mac
       level: core
       type: keyword

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -306,9 +306,7 @@ client.geo.region_name:
   type: keyword
 client.ip:
   dashed_name: client-ip
-  description: 'IP address of the client.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the client (IPv4 or IPv6).
   flat_name: client.ip
   level: core
   name: ip
@@ -950,9 +948,7 @@ destination.geo.region_name:
   type: keyword
 destination.ip:
   dashed_name: destination-ip
-  description: 'IP address of the destination.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the destination (IPv4 or IPv6).
   flat_name: destination.ip
   level: core
   name: ip
@@ -6425,9 +6421,7 @@ server.geo.region_name:
   type: keyword
 server.ip:
   dashed_name: server-ip
-  description: 'IP address of the server.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the server (IPv4 or IPv6).
   flat_name: server.ip
   level: core
   name: ip
@@ -6960,9 +6954,7 @@ source.geo.region_name:
   type: keyword
 source.ip:
   dashed_name: source-ip
-  description: 'IP address of the source.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the source (IPv4 or IPv6).
   flat_name: source.ip
   level: core
   name: ip

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -418,9 +418,7 @@ client:
       type: keyword
     ip:
       dashed_name: client-ip
-      description: 'IP address of the client.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the client (IPv4 or IPv6).
       flat_name: client.ip
       level: core
       name: ip
@@ -1115,9 +1113,7 @@ destination:
       type: keyword
     ip:
       dashed_name: destination-ip
-      description: 'IP address of the destination.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the destination (IPv4 or IPv6).
       flat_name: destination.ip
       level: core
       name: ip
@@ -6971,9 +6967,7 @@ server:
       type: keyword
     ip:
       dashed_name: server-ip
-      description: 'IP address of the server.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the server (IPv4 or IPv6).
       flat_name: server.ip
       level: core
       name: ip
@@ -7534,9 +7528,7 @@ source:
       type: keyword
     ip:
       dashed_name: source-ip
-      description: 'IP address of the source.
-
-        Can be one or multiple IPv4 or IPv6 addresses.'
+      description: IP address of the source (IPv4 or IPv6).
       flat_name: source.ip
       level: core
       name: ip

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -36,9 +36,7 @@
       type: ip
       short: IP address of the client.
       description: >
-        IP address of the client.
-
-        Can be one or multiple IPv4 or IPv6 addresses.
+        IP address of the client (IPv4 or IPv6).
 
     - name: port
       format: string

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -27,9 +27,7 @@
       type: ip
       short: IP address of the destination.
       description: >
-        IP address of the destination.
-
-        Can be one or multiple IPv4 or IPv6 addresses.
+        IP address of the destination (IPv4 or IPv6).
 
     - name: port
       format: string

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -36,9 +36,7 @@
       type: ip
       short: IP address of the server.
       description: >
-        IP address of the server.
-
-        Can be one or multiple IPv4 or IPv6 addresses.
+        IP address of the server (IPv4 or IPv6).
 
     - name: port
       format: string

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -27,9 +27,7 @@
       type: ip
       short: IP address of the source.
       description: >
-        IP address of the source.
-
-        Can be one or multiple IPv4 or IPv6 addresses.
+        IP address of the source (IPv4 or IPv6).
 
     - name: port
       format: string


### PR DESCRIPTION
These fields are meant to be a single IP, not "one or more" IP addresses.

Closes #786