### PR TITLE
Shorthand subset notation

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Allow shorthand notation for including all subfields in subsets. #805
+
 #### Deprecated
 
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -37,6 +37,8 @@ def main():
                 with open(file) as f:
                     raw = yaml.safe_load(f.read())
                     ecs_helpers.recursive_merge_subset_dicts(subset, raw)
+        if not subset:
+            raise ValueError('Subset option specified but no subsets found')
         intermediate_fields = ecs_helpers.fields_subset(subset, intermediate_fields)
 
     (nested, flat) = schema_reader.generate_nested_flat(intermediate_fields)

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -76,10 +76,11 @@ def recursive_merge_subset_dicts(a, b):
     for key in b:
         if key not in a:
             a[key] = b[key]
-        elif isinstance(a[key]['fields'], dict) and isinstance(b[key]['fields'], dict):
-            recursive_merge_subset_dicts(a[key]['fields'], b[key]['fields'])
         elif 'fields' not in b[key] or b[key]['fields'] == '*':
             a[key]['fields'] = '*'
+        elif isinstance(a[key]['fields'], dict) and isinstance(b[key]['fields'], dict):
+            recursive_merge_subset_dicts(a[key]['fields'], b[key]['fields'])
+
 
 
 def yaml_ordereddict(dumper, data):

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -52,7 +52,11 @@ def safe_merge_dicts(a, b):
 
 def fields_subset(subset, fields):
     retained_fields = {}
+    allowed_options = ['fields']
     for key, val in subset.items():
+        for option in val:
+            if option not in allowed_options:
+                raise ValueError('Unsupported option found in subset: {}'.format(option))
         # A missing fields key is shorthand for including all subfields
         if 'fields' not in val or val['fields'] == '*':
             retained_fields[key] = fields[key]

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -63,15 +63,6 @@ def fields_subset(subset, fields):
     return retained_fields
 
 
-def get_reusable_fields(fields):
-    reusable_fields = {}
-    for key in fields:
-        if 'reusable' in fields[key]:
-            reusable_fields[key] = True
-        if 'fields' in fields[key]:
-            reusable_fields.update(get_reusable_fields(fields[key]['fields']))
-    return reusable_fields
-
 def recursive_merge_subset_dicts(a, b):
     for key in b:
         if key not in a:
@@ -80,7 +71,6 @@ def recursive_merge_subset_dicts(a, b):
             a[key]['fields'] = '*'
         elif isinstance(a[key]['fields'], dict) and isinstance(b[key]['fields'], dict):
             recursive_merge_subset_dicts(a[key]['fields'], b[key]['fields'])
-
 
 
 def yaml_ordereddict(dumper, data):

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -67,7 +67,7 @@ def recursive_merge_subset_dicts(a, b):
     for key in b:
         if key not in a:
             a[key] = b[key]
-        elif 'fields' not in b[key] or b[key]['fields'] == '*':
+        elif 'fields' not in a[key] or 'fields' not in b[key] or b[key]['fields'] == '*':
             a[key]['fields'] = '*'
         elif isinstance(a[key]['fields'], dict) and isinstance(b[key]['fields'], dict):
             recursive_merge_subset_dicts(a[key]['fields'], b[key]['fields'])

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -100,9 +100,7 @@ class TestECSHelpers(unittest.TestCase):
                     }
                 }
             },
-            'field2': {
-                'fields': '*'
-            }
+            'field2': {}
         }
         subset_b = {
             'field1': {


### PR DESCRIPTION
This PR makes the subset notation less cumbersome by including all subfields if the `fields` key is missing.  Instead of writing 
```
field1:
    fields: *
```
every time you want to include all subfields, you can instead write 
```
field1: {}
```
This still leaves the ability to specify other options for the field in the dictionary later on without breaking changes.