### PR TITLE
Backport #798 to 1.5: Missing changelog for #784

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -27,6 +27,9 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Fix incorrect listing of where field sets are nested in asciidoc,
+  when they are nested deep. #784
+
 #### Added
 
 #### Improvements


### PR DESCRIPTION
Backport of PR #798 to 1.5 branch.