### PR TITLE
Fix bug #495

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,9 @@ Thanks, you're awesome :-) -->
 
 #### Breaking changes
 
+* Removed field definitions at the root of documents for fieldsets that
+  had `reusable.top_level:false`. This PR affects `ecs_flat.yml`, the csv file
+  and the sample Elasticsearch templates. #495, #813
 * Removed the `order` attribute from the `ecs_nested.yml` and `ecs_flat.yml` files. #811
 
 #### Bugfixes

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -9,9 +9,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 1.6.0-dev,true,agent,agent.type,keyword,core,,filebeat,Type of the agent.
 1.6.0-dev,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
-1.6.0-dev,true,as,as.number,long,extended,,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
-1.6.0-dev,true,as,as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.6.0-dev,true,as,as.organization.name.text,text,extended,,Google LLC,Organization name.
 1.6.0-dev,true,client,client.address,keyword,extended,,,Client network address.
 1.6.0-dev,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system. The autonomous system number (ASN) uniquely identifies each network on the Internet.
 1.6.0-dev,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
@@ -52,11 +49,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
 1.6.0-dev,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 1.6.0-dev,true,cloud,cloud.region,keyword,extended,,us-east-1,Region in which this host is running.
-1.6.0-dev,true,code_signature,code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
-1.6.0-dev,true,code_signature,code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
-1.6.0-dev,true,code_signature,code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
-1.6.0-dev,true,code_signature,code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
-1.6.0-dev,true,code_signature,code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.6.0-dev,true,container,container.id,keyword,core,,,Unique container id.
 1.6.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 1.6.0-dev,true,container,container.image.tag,keyword,extended,array,,Container image tags.
@@ -202,21 +194,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
 1.6.0-dev,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.6.0-dev,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
-1.6.0-dev,true,geo,geo.city_name,keyword,core,,Montreal,City name.
-1.6.0-dev,true,geo,geo.continent_name,keyword,core,,North America,Name of the continent.
-1.6.0-dev,true,geo,geo.country_iso_code,keyword,core,,CA,Country ISO code.
-1.6.0-dev,true,geo,geo.country_name,keyword,core,,Canada,Country name.
-1.6.0-dev,true,geo,geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-1.6.0-dev,true,geo,geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-1.6.0-dev,true,geo,geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
-1.6.0-dev,true,geo,geo.region_name,keyword,core,,Quebec,Region name.
 1.6.0-dev,true,group,group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.6.0-dev,true,group,group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.6.0-dev,true,group,group.name,keyword,extended,,,Name of the group.
-1.6.0-dev,true,hash,hash.md5,keyword,extended,,,MD5 hash.
-1.6.0-dev,true,hash,hash.sha1,keyword,extended,,,SHA1 hash.
-1.6.0-dev,true,hash,hash.sha256,keyword,extended,,,SHA256 hash.
-1.6.0-dev,true,hash,hash.sha512,keyword,extended,,,SHA512 hash.
 1.6.0-dev,true,host,host.architecture,keyword,core,,x86_64,Operating system architecture.
 1.6.0-dev,true,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
 1.6.0-dev,true,host,host.geo.city_name,keyword,core,,Montreal,City name.
@@ -265,9 +245,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 1.6.0-dev,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
 1.6.0-dev,true,http,http.version,keyword,extended,,1.1,HTTP version.
-1.6.0-dev,true,interface,interface.alias,keyword,extended,,outside,Interface alias
-1.6.0-dev,true,interface,interface.id,keyword,extended,,10,Interface ID
-1.6.0-dev,true,interface,interface.name,keyword,extended,,eth0,Interface name
 1.6.0-dev,true,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 1.6.0-dev,true,log,log.level,keyword,core,,error,Log level of the log event.
 1.6.0-dev,true,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
@@ -339,14 +316,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 1.6.0-dev,true,organization,organization.name,keyword,extended,,,Organization name.
 1.6.0-dev,true,organization,organization.name.text,text,extended,,,Organization name.
-1.6.0-dev,true,os,os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
-1.6.0-dev,true,os,os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.6.0-dev,true,os,os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.6.0-dev,true,os,os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
-1.6.0-dev,true,os,os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.6.0-dev,true,os,os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
-1.6.0-dev,true,os,os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-1.6.0-dev,true,os,os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.6.0-dev,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 1.6.0-dev,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
 1.6.0-dev,true,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.
@@ -360,13 +329,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,package,package.size,long,extended,,62231,Package size in bytes.
 1.6.0-dev,true,package,package.type,keyword,extended,,rpm,Package type
 1.6.0-dev,true,package,package.version,keyword,extended,,1.12.9,Package version
-1.6.0-dev,true,pe,pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
-1.6.0-dev,true,pe,pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
-1.6.0-dev,true,pe,pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
-1.6.0-dev,true,pe,pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
-1.6.0-dev,true,pe,pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
-1.6.0-dev,true,pe,pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
-1.6.0-dev,true,pe,pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 1.6.0-dev,true,process,process.args,keyword,extended,array,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
 1.6.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 1.6.0-dev,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -605,8 +567,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.6.0-dev,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.6.0-dev,true,user_agent,user_agent.version,keyword,extended,,12.0,Version of the user agent.
-1.6.0-dev,true,vlan,vlan.id,keyword,extended,,10,VLAN ID as reported by the observer.
-1.6.0-dev,true,vlan,vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 1.6.0-dev,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
 1.6.0-dev,true,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
 1.6.0-dev,true,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -101,34 +101,6 @@ agent.version:
   normalize: []
   short: Version of the agent.
   type: keyword
-as.number:
-  dashed_name: as-number
-  description: Unique number allocated to the autonomous system. The autonomous system
-    number (ASN) uniquely identifies each network on the Internet.
-  example: 15169
-  flat_name: as.number
-  level: extended
-  name: number
-  normalize: []
-  short: Unique number allocated to the autonomous system. The autonomous system number
-    (ASN) uniquely identifies each network on the Internet.
-  type: long
-as.organization.name:
-  dashed_name: as-organization-name
-  description: Organization name.
-  example: Google LLC
-  flat_name: as.organization.name
-  ignore_above: 1024
-  level: extended
-  multi_fields:
-  - flat_name: as.organization.name.text
-    name: text
-    norms: false
-    type: text
-  name: organization.name
-  normalize: []
-  short: Organization name.
-  type: keyword
 client.address:
   dashed_name: client-address
   description: 'Some event client addresses are defined ambiguously. The event will
@@ -593,69 +565,6 @@ cloud.region:
   normalize: []
   short: Region in which this host is running.
   type: keyword
-code_signature.exists:
-  dashed_name: code-signature-exists
-  description: Boolean to capture if a signature is present.
-  example: 'true'
-  flat_name: code_signature.exists
-  level: core
-  name: exists
-  normalize: []
-  short: Boolean to capture if a signature is present.
-  type: boolean
-code_signature.status:
-  dashed_name: code-signature-status
-  description: 'Additional information about the certificate status.
-
-    This is useful for logging cryptographic errors with the certificate validity
-    or trust status. Leave unpopulated if the validity or trust of the certificate
-    was unchecked.'
-  example: ERROR_UNTRUSTED_ROOT
-  flat_name: code_signature.status
-  ignore_above: 1024
-  level: extended
-  name: status
-  normalize: []
-  short: Additional information about the certificate status.
-  type: keyword
-code_signature.subject_name:
-  dashed_name: code-signature-subject-name
-  description: Subject name of the code signer
-  example: Microsoft Corporation
-  flat_name: code_signature.subject_name
-  ignore_above: 1024
-  level: core
-  name: subject_name
-  normalize: []
-  short: Subject name of the code signer
-  type: keyword
-code_signature.trusted:
-  dashed_name: code-signature-trusted
-  description: 'Stores the trust status of the certificate chain.
-
-    Validating the trust of the certificate chain may be complicated, and this field
-    should only be populated by tools that actively check the status.'
-  example: 'true'
-  flat_name: code_signature.trusted
-  level: extended
-  name: trusted
-  normalize: []
-  short: Stores the trust status of the certificate chain.
-  type: boolean
-code_signature.valid:
-  dashed_name: code-signature-valid
-  description: 'Boolean to capture if the digital signature is verified against the
-    binary content.
-
-    Leave unpopulated if a certificate was unchecked.'
-  example: 'true'
-  flat_name: code_signature.valid
-  level: extended
-  name: valid
-  normalize: []
-  short: Boolean to capture if the digital signature is verified against the binary
-    content.
-  type: boolean
 container.id:
   dashed_name: container-id
   description: Unique container id.
@@ -2886,99 +2795,6 @@ file.uid:
   normalize: []
   short: The user ID (UID) or security identifier (SID) of the file owner.
   type: keyword
-geo.city_name:
-  dashed_name: geo-city-name
-  description: City name.
-  example: Montreal
-  flat_name: geo.city_name
-  ignore_above: 1024
-  level: core
-  name: city_name
-  normalize: []
-  short: City name.
-  type: keyword
-geo.continent_name:
-  dashed_name: geo-continent-name
-  description: Name of the continent.
-  example: North America
-  flat_name: geo.continent_name
-  ignore_above: 1024
-  level: core
-  name: continent_name
-  normalize: []
-  short: Name of the continent.
-  type: keyword
-geo.country_iso_code:
-  dashed_name: geo-country-iso-code
-  description: Country ISO code.
-  example: CA
-  flat_name: geo.country_iso_code
-  ignore_above: 1024
-  level: core
-  name: country_iso_code
-  normalize: []
-  short: Country ISO code.
-  type: keyword
-geo.country_name:
-  dashed_name: geo-country-name
-  description: Country name.
-  example: Canada
-  flat_name: geo.country_name
-  ignore_above: 1024
-  level: core
-  name: country_name
-  normalize: []
-  short: Country name.
-  type: keyword
-geo.location:
-  dashed_name: geo-location
-  description: Longitude and latitude.
-  example: '{ "lon": -73.614830, "lat": 45.505918 }'
-  flat_name: geo.location
-  level: core
-  name: location
-  normalize: []
-  short: Longitude and latitude.
-  type: geo_point
-geo.name:
-  dashed_name: geo-name
-  description: 'User-defined description of a location, at the level of granularity
-    they care about.
-
-    Could be the name of their data centers, the floor number, if this describes a
-    local physical entity, city names.
-
-    Not typically used in automated geolocation.'
-  example: boston-dc
-  flat_name: geo.name
-  ignore_above: 1024
-  level: extended
-  name: name
-  normalize: []
-  short: User-defined description of a location.
-  type: keyword
-geo.region_iso_code:
-  dashed_name: geo-region-iso-code
-  description: Region ISO code.
-  example: CA-QC
-  flat_name: geo.region_iso_code
-  ignore_above: 1024
-  level: core
-  name: region_iso_code
-  normalize: []
-  short: Region ISO code.
-  type: keyword
-geo.region_name:
-  dashed_name: geo-region-name
-  description: Region name.
-  example: Quebec
-  flat_name: geo.region_name
-  ignore_above: 1024
-  level: core
-  name: region_name
-  normalize: []
-  short: Region name.
-  type: keyword
 group.domain:
   dashed_name: group-domain
   description: 'Name of the directory the group is a member of.
@@ -3010,46 +2826,6 @@ group.name:
   name: name
   normalize: []
   short: Name of the group.
-  type: keyword
-hash.md5:
-  dashed_name: hash-md5
-  description: MD5 hash.
-  flat_name: hash.md5
-  ignore_above: 1024
-  level: extended
-  name: md5
-  normalize: []
-  short: MD5 hash.
-  type: keyword
-hash.sha1:
-  dashed_name: hash-sha1
-  description: SHA1 hash.
-  flat_name: hash.sha1
-  ignore_above: 1024
-  level: extended
-  name: sha1
-  normalize: []
-  short: SHA1 hash.
-  type: keyword
-hash.sha256:
-  dashed_name: hash-sha256
-  description: SHA256 hash.
-  flat_name: hash.sha256
-  ignore_above: 1024
-  level: extended
-  name: sha256
-  normalize: []
-  short: SHA256 hash.
-  type: keyword
-hash.sha512:
-  dashed_name: hash-sha512
-  description: SHA512 hash.
-  flat_name: hash.sha512
-  ignore_above: 1024
-  level: extended
-  name: sha512
-  normalize: []
-  short: SHA512 hash.
   type: keyword
 host.architecture:
   dashed_name: host-architecture
@@ -3583,40 +3359,6 @@ http.version:
   name: version
   normalize: []
   short: HTTP version.
-  type: keyword
-interface.alias:
-  dashed_name: interface-alias
-  description: Interface alias as reported by the system, typically used in firewall
-    implementations for e.g. inside, outside, or dmz logical interface naming.
-  example: outside
-  flat_name: interface.alias
-  ignore_above: 1024
-  level: extended
-  name: alias
-  normalize: []
-  short: Interface alias
-  type: keyword
-interface.id:
-  dashed_name: interface-id
-  description: Interface ID as reported by an observer (typically SNMP interface ID).
-  example: 10
-  flat_name: interface.id
-  ignore_above: 1024
-  level: extended
-  name: id
-  normalize: []
-  short: Interface ID
-  type: keyword
-interface.name:
-  dashed_name: interface-name
-  description: Interface name as reported by the system.
-  example: eth0
-  flat_name: interface.name
-  ignore_above: 1024
-  level: extended
-  name: name
-  normalize: []
-  short: Interface name
   type: keyword
 labels:
   dashed_name: labels
@@ -4532,82 +4274,6 @@ organization.name:
   normalize: []
   short: Organization name.
   type: keyword
-os.family:
-  dashed_name: os-family
-  description: OS family (such as redhat, debian, freebsd, windows).
-  example: debian
-  flat_name: os.family
-  ignore_above: 1024
-  level: extended
-  name: family
-  normalize: []
-  short: OS family (such as redhat, debian, freebsd, windows).
-  type: keyword
-os.full:
-  dashed_name: os-full
-  description: Operating system name, including the version or code name.
-  example: Mac OS Mojave
-  flat_name: os.full
-  ignore_above: 1024
-  level: extended
-  multi_fields:
-  - flat_name: os.full.text
-    name: text
-    norms: false
-    type: text
-  name: full
-  normalize: []
-  short: Operating system name, including the version or code name.
-  type: keyword
-os.kernel:
-  dashed_name: os-kernel
-  description: Operating system kernel version as a raw string.
-  example: 4.4.0-112-generic
-  flat_name: os.kernel
-  ignore_above: 1024
-  level: extended
-  name: kernel
-  normalize: []
-  short: Operating system kernel version as a raw string.
-  type: keyword
-os.name:
-  dashed_name: os-name
-  description: Operating system name, without the version.
-  example: Mac OS X
-  flat_name: os.name
-  ignore_above: 1024
-  level: extended
-  multi_fields:
-  - flat_name: os.name.text
-    name: text
-    norms: false
-    type: text
-  name: name
-  normalize: []
-  short: Operating system name, without the version.
-  type: keyword
-os.platform:
-  dashed_name: os-platform
-  description: Operating system platform (such centos, ubuntu, windows).
-  example: darwin
-  flat_name: os.platform
-  ignore_above: 1024
-  level: extended
-  name: platform
-  normalize: []
-  short: Operating system platform (such centos, ubuntu, windows).
-  type: keyword
-os.version:
-  dashed_name: os-version
-  description: Operating system version as a raw string.
-  example: 10.14.1
-  flat_name: os.version
-  ignore_above: 1024
-  level: extended
-  name: version
-  normalize: []
-  short: Operating system version as a raw string.
-  type: keyword
 package.architecture:
   dashed_name: package-architecture
   description: Package architecture.
@@ -4756,87 +4422,6 @@ package.version:
   name: version
   normalize: []
   short: Package version
-  type: keyword
-pe.architecture:
-  dashed_name: pe-architecture
-  description: CPU architecture target for the file.
-  example: x64
-  flat_name: pe.architecture
-  ignore_above: 1024
-  level: extended
-  name: architecture
-  normalize: []
-  short: CPU architecture target for the file.
-  type: keyword
-pe.company:
-  dashed_name: pe-company
-  description: Internal company name of the file, provided at compile-time.
-  example: Microsoft Corporation
-  flat_name: pe.company
-  ignore_above: 1024
-  level: extended
-  name: company
-  normalize: []
-  short: Internal company name of the file, provided at compile-time.
-  type: keyword
-pe.description:
-  dashed_name: pe-description
-  description: Internal description of the file, provided at compile-time.
-  example: Paint
-  flat_name: pe.description
-  ignore_above: 1024
-  level: extended
-  name: description
-  normalize: []
-  short: Internal description of the file, provided at compile-time.
-  type: keyword
-pe.file_version:
-  dashed_name: pe-file-version
-  description: Internal version of the file, provided at compile-time.
-  example: 6.3.9600.17415
-  flat_name: pe.file_version
-  ignore_above: 1024
-  level: extended
-  name: file_version
-  normalize: []
-  short: Process name.
-  type: keyword
-pe.imphash:
-  dashed_name: pe-imphash
-  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
-
-    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
-  example: 0c6803c4e922103c4dca5963aad36ddf
-  flat_name: pe.imphash
-  ignore_above: 1024
-  level: extended
-  name: imphash
-  normalize: []
-  short: A hash of the imports in a PE file.
-  type: keyword
-pe.original_file_name:
-  dashed_name: pe-original-file-name
-  description: Internal name of the file, provided at compile-time.
-  example: MSPAINT.EXE
-  flat_name: pe.original_file_name
-  ignore_above: 1024
-  level: extended
-  name: original_file_name
-  normalize: []
-  short: Internal name of the file, provided at compile-time.
-  type: keyword
-pe.product:
-  dashed_name: pe-product
-  description: Internal product name of the file, provided at compile-time.
-  example: "Microsoft\xAE Windows\xAE Operating System"
-  flat_name: pe.product
-  ignore_above: 1024
-  level: extended
-  name: product
-  normalize: []
-  short: Internal product name of the file, provided at compile-time.
   type: keyword
 process.args:
   dashed_name: process-args
@@ -7678,28 +7263,6 @@ user_agent.version:
   name: version
   normalize: []
   short: Version of the user agent.
-  type: keyword
-vlan.id:
-  dashed_name: vlan-id
-  description: VLAN ID as reported by the observer.
-  example: 10
-  flat_name: vlan.id
-  ignore_above: 1024
-  level: extended
-  name: id
-  normalize: []
-  short: VLAN ID as reported by the observer.
-  type: keyword
-vlan.name:
-  dashed_name: vlan-name
-  description: Optional VLAN name as reported by the observer.
-  example: outside
-  flat_name: vlan.name
-  ignore_above: 1024
-  level: extended
-  name: name
-  normalize: []
-  short: Optional VLAN name as reported by the observer.
   type: keyword
 vulnerability.category:
   dashed_name: vulnerability-category

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -55,27 +55,6 @@
             }
           }
         },
-        "as": {
-          "properties": {
-            "number": {
-              "type": "long"
-            },
-            "organization": {
-              "properties": {
-                "name": {
-                  "fields": {
-                    "text": {
-                      "norms": false,
-                      "type": "text"
-                    }
-                  },
-                  "ignore_above": 1024,
-                  "type": "keyword"
-                }
-              }
-            }
-          }
-        },
         "client": {
           "properties": {
             "address": {
@@ -275,27 +254,6 @@
             "region": {
               "ignore_above": 1024,
               "type": "keyword"
-            }
-          }
-        },
-        "code_signature": {
-          "properties": {
-            "exists": {
-              "type": "boolean"
-            },
-            "status": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "subject_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "trusted": {
-              "type": "boolean"
-            },
-            "valid": {
-              "type": "boolean"
             }
           }
         },
@@ -953,41 +911,6 @@
             }
           }
         },
-        "geo": {
-          "properties": {
-            "city_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "continent_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "country_iso_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "country_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "location": {
-              "type": "geo_point"
-            },
-            "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "region_iso_code": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "region_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
         "group": {
           "properties": {
             "domain": {
@@ -999,26 +922,6 @@
               "type": "keyword"
             },
             "name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "hash": {
-          "properties": {
-            "md5": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "sha1": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "sha256": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "sha512": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -1255,22 +1158,6 @@
               }
             },
             "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "interface": {
-          "properties": {
-            "alias": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -1638,46 +1525,6 @@
             }
           }
         },
-        "os": {
-          "properties": {
-            "family": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "full": {
-              "fields": {
-                "text": {
-                  "norms": false,
-                  "type": "text"
-                }
-              },
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "kernel": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
-              "fields": {
-                "text": {
-                  "norms": false,
-                  "type": "text"
-                }
-              },
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "platform": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
         "package": {
           "properties": {
             "architecture": {
@@ -1727,38 +1574,6 @@
               "type": "keyword"
             },
             "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "pe": {
-          "properties": {
-            "architecture": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "company": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "description": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "file_version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "imphash": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "original_file_name": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "product": {
               "ignore_above": 1024,
               "type": "keyword"
             }
@@ -2897,18 +2712,6 @@
               }
             },
             "version": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            }
-          }
-        },
-        "vlan": {
-          "properties": {
-            "id": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
-            "name": {
               "ignore_above": 1024,
               "type": "keyword"
             }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -54,27 +54,6 @@
           }
         }
       },
-      "as": {
-        "properties": {
-          "number": {
-            "type": "long"
-          },
-          "organization": {
-            "properties": {
-              "name": {
-                "fields": {
-                  "text": {
-                    "norms": false,
-                    "type": "text"
-                  }
-                },
-                "ignore_above": 1024,
-                "type": "keyword"
-              }
-            }
-          }
-        }
-      },
       "client": {
         "properties": {
           "address": {
@@ -274,27 +253,6 @@
           "region": {
             "ignore_above": 1024,
             "type": "keyword"
-          }
-        }
-      },
-      "code_signature": {
-        "properties": {
-          "exists": {
-            "type": "boolean"
-          },
-          "status": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "subject_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "trusted": {
-            "type": "boolean"
-          },
-          "valid": {
-            "type": "boolean"
           }
         }
       },
@@ -952,41 +910,6 @@
           }
         }
       },
-      "geo": {
-        "properties": {
-          "city_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "continent_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "country_iso_code": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "country_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "location": {
-            "type": "geo_point"
-          },
-          "name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "region_iso_code": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "region_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
       "group": {
         "properties": {
           "domain": {
@@ -998,26 +921,6 @@
             "type": "keyword"
           },
           "name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "hash": {
-        "properties": {
-          "md5": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "sha1": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "sha256": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "sha512": {
             "ignore_above": 1024,
             "type": "keyword"
           }
@@ -1254,22 +1157,6 @@
             }
           },
           "version": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "interface": {
-        "properties": {
-          "alias": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "id": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "name": {
             "ignore_above": 1024,
             "type": "keyword"
           }
@@ -1637,46 +1524,6 @@
           }
         }
       },
-      "os": {
-        "properties": {
-          "family": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "full": {
-            "fields": {
-              "text": {
-                "norms": false,
-                "type": "text"
-              }
-            },
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "kernel": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "name": {
-            "fields": {
-              "text": {
-                "norms": false,
-                "type": "text"
-              }
-            },
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "platform": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "version": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
       "package": {
         "properties": {
           "architecture": {
@@ -1726,38 +1573,6 @@
             "type": "keyword"
           },
           "version": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "pe": {
-        "properties": {
-          "architecture": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "company": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "description": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "file_version": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "imphash": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "original_file_name": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "product": {
             "ignore_above": 1024,
             "type": "keyword"
           }
@@ -2896,18 +2711,6 @@
             }
           },
           "version": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "vlan": {
-        "properties": {
-          "id": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "name": {
             "ignore_above": 1024,
             "type": "keyword"
           }

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -13,6 +13,9 @@ from generators import ecs_helpers
 
 def main():
     args = argument_parser()
+    # Get rid of empty include
+    if args.include and [''] == args.include:
+        args.include.clear()
 
     ecs_version = read_version()
     print('Running generator. ECS version ' + ecs_version)

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -248,10 +248,8 @@ def remove_non_root_reusables(fields_nested):
     fields = {}
     for (name, field) in fields_nested.items():
         if 'reusable' not in field or ('reusable' in field and field['reusable']['top_level']):
-                fields[name] = field
+            fields[name] = field
     return fields
-
-
 
 
 def flatten_fields(fields, key_prefix):

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -240,7 +240,18 @@ def generate_partially_flattened_fields(fields_nested):
 
 
 def generate_fully_flattened_fields(fields_nested):
-    return flatten_fields(fields_nested, "")
+    flattened = flatten_fields(remove_non_root_reusables(fields_nested), "")
+    return flattened
+
+
+def remove_non_root_reusables(fields_nested):
+    fields = {}
+    for (name, field) in fields_nested.items():
+        if 'reusable' not in field or ('reusable' in field and field['reusable']['top_level']):
+                fields[name] = field
+    return fields
+
+
 
 
 def flatten_fields(fields, key_prefix):


### PR DESCRIPTION
Most reusable field sets in ECS are **not** expected at the root of the documents. As of ECS 1.5.0:

| reusable field set | expected at root |
| --- | --- |
| `as` | no |
| `code_signature` | no |
| `geo` | no |
| `group` | yes |
| `hash` | no |
| `interface` | no |
| `os` | no |
| `pe` | no |
| `user` | yes |
| `vlan` | no |

Unfortunately, ever since the introduction of reusable fields, these field sets remained defined at the root nonetheless, for some of the generated artifacts.

The official documentation correctly mentions which field sets were expected at the root and which weren't. This issue however affected the following artifacts:

* 'ecs_flat.yml'
* the csv
* the Elasticsearch sample templates
* Beats field definition file

This PR does not affect the Beats field definitions for now. Even if they weren't meant to be defined there, we first need confirmation whether they've actually been used.

This PR only fixes the issue for the first 3 artifacts.

Note about 'ecs_nested.yml': this file mixes two types of information. Information about field sets, and information about field definitions. Consumers of this file must make sure to check the attribute `reusable.top_level`. You should skip defining fields at the root for any field sets where `reusable.top_level: false`.