### PR TITLE
Allowing beats output files to be generated with --include and --subset

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -49,6 +49,7 @@ Thanks, you're awesome :-) -->
   slightly different results in different situations. #782
 * Fix incorrect listing of where field sets are nested in asciidoc,
   when they are nested deep. #784
+* Allow beats output to be generated when using `--include` or `--subset` flags. #814
 
 #### Added
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -64,9 +64,9 @@ def main():
 
     csv_generator.generate(flat, ecs_version, out_dir)
     es_template.generate(flat, ecs_version, out_dir)
+    beats.generate(nested, ecs_version, out_dir)
     if args.include or args.subset:
         exit()
-    beats.generate(nested, ecs_version, out_dir)
     asciidoc_fields.generate(intermediate_fields, ecs_version, docs_dir)
 
 


### PR DESCRIPTION
The beats output files are used to create the `fields.yml` mapping file for the endpoint package's mapping located here: https://github.com/elastic/package-registry/tree/master/dev/packages/example/endpoint-1.0.0/dataset/events/fields

The endpoint team needs the ability to generate the beats output while using the `--include` and `--subset` flags because we specify custom fields for our alerts and also leverage the subset functionality to limit the fields from ecs core.

The typical command I use to generate the `fields.yml` file is:
`python scripts/generator.py --out ../gen --include ../endpoint-app-team/custom_schemas --subset ../endpoint-app-team/custom_subsets/elastic_endpoint/events/* ../endpoint-app-team/custom_subsets/*.yml`