### PR TITLE
Initial discussion for email object

### DIFF
--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -1,0 +1,58 @@
+---
+- name: email
+  group: 2
+  title: Email
+  short: Fields describing emails.
+  description: >
+     A file is defined as a set of information that has been created on, or has existed on a filesystem.
+
+     File objects can be associated with host events, network events,
+     and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services).
+     File fields provide details about the affected file associated with the event or metric.
+  type: group
+  fields:
+
+  - name: id
+    level: core
+    type: keyword
+    description: ID of the email
+
+  - name: subject
+    level: core
+    type: keyword
+    description: Subject of the email
+
+  - name: from
+    level: core
+    type: keyword
+    description: should be an array with email and fullname
+
+  - name: to
+    level: core
+    type: keyword
+    description: should be an array of dicts with email and fullname
+
+  - name: cc
+    level: core
+    type: keyword
+    description: should be an array of dicts with email and fullname
+
+  - name: reply-to
+    level: core
+    type: keyword
+    description: should be an array of dicts with email and fullname
+
+  - name: attachments
+    level: extended
+    type: file
+    description: should be an array of attached files
+    normalize:
+      - array
+
+# Additional notes/fields:
+# message-id: event.id could be used
+# delivered to: destination.host could be used
+# received by: should be an array of hosts
+# spam grade:
+# spf check
+# authentication

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -9,6 +9,10 @@
      File objects can be associated with host events, network events,
      and/or file events (e.g., those produced by File Integrity Monitoring [FIM] products or services).
      File fields provide details about the affected file associated with the event or metric.
+  reusable:
+    top_level: true
+    expected:
+      - email
   type: group
   fields:
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -9,6 +9,10 @@
     ECS host.* fields should be populated with details about the host on which
     the event happened, or from which the measurement was taken.
     Host types include hardware, virtual machines, Docker containers, and Kubernetes nodes.
+  reusable:
+    top_level: true
+    expected:
+      - email
   type: group
   fields:
 
@@ -90,4 +94,3 @@
         For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name.
         For Linux this could be the domain of the host's LDAP provider.
       example: CONTOSO
-


### PR DESCRIPTION
I would like to start a discussion about adding an object for emails or not.
MTA logs could fit in events, but a more detailed log need a specific object.

Questions:
- Makes sense for you? How do you translate MTA logs to ECS schema?
- Can I define an array of objects? Examples: "to" is an array of dicts (address, full name), and attachments would be an array of files.
- Suggested fields to add?

Feel free to comment.