### PR TITLE
switch to python3 venv module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,9 @@ addons:
   apt:
     update: true
     packages:
-      - xsltproc
       - libxml2-utils
+      - python3-venv
+      - xsltproc
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ test: ve
 .PHONY: ve
 ve: build/ve/bin/activate
 build/ve/bin/activate: scripts/requirements.txt
-	@test -d build/ve || virtualenv -p python3 build/ve
+	@test -d build/ve || python3 -mvenv build/ve
 	@build/ve/bin/pip install -Ur scripts/requirements.txt
 	@touch build/ve/bin/activate
 


### PR DESCRIPTION
Removing `virtualenv` requirement.  Python3 is already a requirement in contributing.