### PR TITLE
Add a protobuf generator to ECS

### DIFF
--- a/generated/protobuf/cached-fields.yaml
+++ b/generated/protobuf/cached-fields.yaml
@@ -872,7 +872,7 @@ dns.answers:
   name: answers
   scope: dns
   tag: 1
-  type: map <string, string>
+  type: Answers
 dns.answers.class:
   deprecated: false
   key: dns.answers.class
@@ -1999,7 +1999,7 @@ log.syslog:
   name: syslog
   scope: log
   tag: 6
-  type: map <string, string>
+  type: Syslog
 log.syslog.facility:
   deprecated: false
   key: log.syslog.facility
@@ -2111,7 +2111,7 @@ network.inner:
   name: inner
   scope: network
   tag: 7
-  type: map <string, string>
+  type: Inner
 network.inner.vlan:
   deprecated: false
   key: network.inner.vlan
@@ -2202,7 +2202,7 @@ observer.egress:
   name: egress
   scope: observer
   tag: 1
-  type: map <string, string>
+  type: Egress
 observer.egress.interface:
   deprecated: false
   key: observer.egress.interface
@@ -2335,7 +2335,7 @@ observer.ingress:
   name: ingress
   scope: observer
   tag: 4
-  type: map <string, string>
+  type: Ingress
 observer.ingress.interface:
   deprecated: false
   key: observer.ingress.interface

--- a/generated/protobuf/cached-fields.yaml
+++ b/generated/protobuf/cached-fields.yaml
@@ -424,7 +424,7 @@ container.image.tag:
   name: tag
   scope: container.image
   tag: 2
-  type: string
+  type: repeated string
 container.labels:
   deprecated: false
   key: container.labels
@@ -914,7 +914,7 @@ dns.header_flags:
   name: header_flags
   scope: dns
   tag: 2
-  type: string
+  type: repeated string
 dns.id:
   deprecated: false
   key: dns.id
@@ -984,7 +984,7 @@ dns.resolved_ip:
   name: resolved_ip
   scope: dns
   tag: 6
-  type: string
+  type: repeated string
 dns.response_code:
   deprecated: false
   key: dns.response_code
@@ -1075,7 +1075,7 @@ event.category:
   name: category
   scope: event
   tag: 2
-  type: string
+  type: repeated string
 event.code:
   deprecated: false
   key: event.code
@@ -1222,7 +1222,7 @@ event.type:
   name: type
   scope: event
   tag: 23
-  type: string
+  type: repeated string
 event.url:
   deprecated: false
   key: event.url
@@ -1250,7 +1250,7 @@ file.attributes:
   name: attributes
   scope: file
   tag: 2
-  type: string
+  type: repeated string
 file.code_signature:
   deprecated: false
   key: file.code_signature
@@ -1649,14 +1649,14 @@ host.ip:
   name: ip
   scope: host
   tag: 6
-  type: string
+  type: repeated string
 host.mac:
   deprecated: false
   key: host.mac
   name: mac
   scope: host
   tag: 7
-  type: string
+  type: repeated string
 host.name:
   deprecated: false
   key: host.name
@@ -2398,14 +2398,14 @@ observer.ip:
   name: ip
   scope: observer
   tag: 5
-  type: string
+  type: repeated string
 observer.mac:
   deprecated: false
   key: observer.mac
   name: mac
   scope: observer
   tag: 6
-  type: string
+  type: repeated string
 observer.name:
   deprecated: false
   key: observer.name
@@ -2629,7 +2629,7 @@ process.args:
   name: args
   scope: process
   tag: 1
-  type: string
+  type: repeated string
 process.args_count:
   deprecated: false
   key: process.args_count
@@ -2762,7 +2762,7 @@ process.parent.args:
   name: args
   scope: process.parent
   tag: 1
-  type: string
+  type: repeated string
 process.parent.args_count:
   deprecated: false
   key: process.parent.args_count
@@ -3105,7 +3105,7 @@ registry.data.strings:
   name: strings
   scope: registry.data
   tag: 2
-  type: string
+  type: repeated string
 registry.data.type:
   deprecated: false
   key: registry.data.type
@@ -3154,21 +3154,21 @@ related.hash:
   name: hash
   scope: related
   tag: 1
-  type: string
+  type: repeated string
 related.ip:
   deprecated: false
   key: related.ip
   name: ip
   scope: related
   tag: 2
-  type: string
+  type: repeated string
 related.user:
   deprecated: false
   key: related.user
   name: user
   scope: related
   tag: 3
-  type: string
+  type: repeated string
 rule:
   deprecated: false
   key: rule
@@ -3182,7 +3182,7 @@ rule.author:
   name: author
   scope: rule
   tag: 1
-  type: string
+  type: repeated string
 rule.category:
   deprecated: false
   key: rule.category
@@ -3833,7 +3833,7 @@ tags:
   name: tags
   scope: ''
   tag: 29
-  type: string
+  type: repeated string
 threat:
   deprecated: false
   key: threat
@@ -3861,21 +3861,21 @@ threat.tactic.id:
   name: id
   scope: threat.tactic
   tag: 1
-  type: string
+  type: repeated string
 threat.tactic.name:
   deprecated: false
   key: threat.tactic.name
   name: name
   scope: threat.tactic
   tag: 2
-  type: string
+  type: repeated string
 threat.tactic.reference:
   deprecated: false
   key: threat.tactic.reference
   name: reference
   scope: threat.tactic
   tag: 3
-  type: string
+  type: repeated string
 threat.technique:
   deprecated: false
   key: threat.technique
@@ -3889,21 +3889,21 @@ threat.technique.id:
   name: id
   scope: threat.technique
   tag: 1
-  type: string
+  type: repeated string
 threat.technique.name:
   deprecated: false
   key: threat.technique.name
   name: name
   scope: threat.technique
   tag: 2
-  type: string
+  type: repeated string
 threat.technique.reference:
   deprecated: false
   key: threat.technique.reference
   name: reference
   scope: threat.technique
   tag: 3
-  type: string
+  type: repeated string
 timestamp:
   deprecated: false
   key: timestamp
@@ -3945,7 +3945,7 @@ tls.client.certificate_chain:
   name: certificate_chain
   scope: tls.client
   tag: 2
-  type: string
+  type: repeated string
 tls.client.hash:
   deprecated: false
   key: tls.client.hash
@@ -4022,7 +4022,7 @@ tls.client.supported_ciphers:
   name: supported_ciphers
   scope: tls.client
   tag: 10
-  type: string
+  type: repeated string
 tls.curve:
   deprecated: false
   key: tls.curve
@@ -4071,7 +4071,7 @@ tls.server.certificate_chain:
   name: certificate_chain
   scope: tls.server
   tag: 2
-  type: string
+  type: repeated string
 tls.server.hash:
   deprecated: false
   key: tls.server.hash
@@ -4456,7 +4456,7 @@ vulnerability.category:
   name: category
   scope: vulnerability
   tag: 1
-  type: string
+  type: repeated string
 vulnerability.classification:
   deprecated: false
   key: vulnerability.classification

--- a/generated/protobuf/cached-fields.yaml
+++ b/generated/protobuf/cached-fields.yaml
@@ -54,40 +54,12 @@ agent.version:
   scope: agent
   tag: 6
   type: string
-as:
-  deprecated: false
-  key: as
-  name: as
-  scope: ''
-  tag: 2
-  type: As
-as.number:
-  deprecated: false
-  key: as.number
-  name: number
-  scope: as
-  tag: 1
-  type: int64
-as.organization:
-  deprecated: false
-  key: as.organization
-  name: organization
-  scope: as
-  tag: 2
-  type: Organization
-as.organization.name:
-  deprecated: false
-  key: as.organization.name
-  name: name
-  scope: as.organization
-  tag: 1
-  type: string
 client:
   deprecated: false
   key: client
   name: client
   scope: ''
-  tag: 3
+  tag: 2
   type: Client
 client.address:
   deprecated: false
@@ -346,7 +318,7 @@ cloud:
   key: cloud
   name: cloud
   scope: ''
-  tag: 4
+  tag: 3
   type: Cloud
 cloud.account:
   deprecated: false
@@ -418,54 +390,12 @@ cloud.region:
   scope: cloud
   tag: 6
   type: string
-code_signature:
-  deprecated: false
-  key: code_signature
-  name: code_signature
-  scope: ''
-  tag: 5
-  type: CodeSignature
-code_signature.exists:
-  deprecated: false
-  key: code_signature.exists
-  name: exists
-  scope: code_signature
-  tag: 1
-  type: bool
-code_signature.status:
-  deprecated: false
-  key: code_signature.status
-  name: status
-  scope: code_signature
-  tag: 2
-  type: string
-code_signature.subject_name:
-  deprecated: false
-  key: code_signature.subject_name
-  name: subject_name
-  scope: code_signature
-  tag: 3
-  type: string
-code_signature.trusted:
-  deprecated: false
-  key: code_signature.trusted
-  name: trusted
-  scope: code_signature
-  tag: 4
-  type: bool
-code_signature.valid:
-  deprecated: false
-  key: code_signature.valid
-  name: valid
-  scope: code_signature
-  tag: 5
-  type: bool
 container:
   deprecated: false
   key: container
   name: container
   scope: ''
-  tag: 6
+  tag: 4
   type: Container
 container.id:
   deprecated: false
@@ -521,7 +451,7 @@ destination:
   key: destination
   name: destination
   scope: ''
-  tag: 7
+  tag: 5
   type: Destination
 destination.address:
   deprecated: false
@@ -780,7 +710,7 @@ dll:
   key: dll
   name: dll
   scope: ''
-  tag: 8
+  tag: 6
   type: Dll
 dll.code_signature:
   deprecated: false
@@ -934,7 +864,7 @@ dns:
   key: dns
   name: dns
   scope: ''
-  tag: 9
+  tag: 7
   type: Dns
 dns.answers:
   deprecated: false
@@ -1074,7 +1004,7 @@ ecs:
   key: ecs
   name: ecs
   scope: ''
-  tag: 10
+  tag: 8
   type: Ecs
 ecs.version:
   deprecated: false
@@ -1088,7 +1018,7 @@ error:
   key: error
   name: error
   scope: ''
-  tag: 11
+  tag: 9
   type: Error
 error.code:
   deprecated: false
@@ -1130,7 +1060,7 @@ event:
   key: event
   name: event
   scope: ''
-  tag: 12
+  tag: 10
   type: Event
 event.action:
   deprecated: false
@@ -1305,7 +1235,7 @@ file:
   key: file
   name: file
   scope: ''
-  tag: 13
+  tag: 11
   type: File
 file.accessed:
   deprecated: false
@@ -1587,75 +1517,12 @@ file.uid:
   scope: file
   tag: 24
   type: string
-geo:
-  deprecated: false
-  key: geo
-  name: geo
-  scope: ''
-  tag: 14
-  type: Geo
-geo.city_name:
-  deprecated: false
-  key: geo.city_name
-  name: city_name
-  scope: geo
-  tag: 1
-  type: string
-geo.continent_name:
-  deprecated: false
-  key: geo.continent_name
-  name: continent_name
-  scope: geo
-  tag: 2
-  type: string
-geo.country_iso_code:
-  deprecated: false
-  key: geo.country_iso_code
-  name: country_iso_code
-  scope: geo
-  tag: 3
-  type: string
-geo.country_name:
-  deprecated: false
-  key: geo.country_name
-  name: country_name
-  scope: geo
-  tag: 4
-  type: string
-geo.location:
-  deprecated: false
-  key: geo.location
-  name: location
-  scope: geo
-  tag: 5
-  type: string
-geo.name:
-  deprecated: false
-  key: geo.name
-  name: name
-  scope: geo
-  tag: 6
-  type: string
-geo.region_iso_code:
-  deprecated: false
-  key: geo.region_iso_code
-  name: region_iso_code
-  scope: geo
-  tag: 7
-  type: string
-geo.region_name:
-  deprecated: false
-  key: geo.region_name
-  name: region_name
-  scope: geo
-  tag: 8
-  type: string
 group:
   deprecated: false
   key: group
   name: group
   scope: ''
-  tag: 15
+  tag: 12
   type: Group
 group.domain:
   deprecated: false
@@ -1678,47 +1545,12 @@ group.name:
   scope: group
   tag: 3
   type: string
-hash:
-  deprecated: false
-  key: hash
-  name: hash
-  scope: ''
-  tag: 16
-  type: Hash
-hash.md5:
-  deprecated: false
-  key: hash.md5
-  name: md5
-  scope: hash
-  tag: 1
-  type: string
-hash.sha1:
-  deprecated: false
-  key: hash.sha1
-  name: sha1
-  scope: hash
-  tag: 2
-  type: string
-hash.sha256:
-  deprecated: false
-  key: hash.sha256
-  name: sha256
-  scope: hash
-  tag: 3
-  type: string
-hash.sha512:
-  deprecated: false
-  key: hash.sha512
-  name: sha512
-  scope: hash
-  tag: 4
-  type: string
 host:
   deprecated: false
   key: host
   name: host
   scope: ''
-  tag: 17
+  tag: 13
   type: Host
 host.architecture:
   deprecated: false
@@ -1977,7 +1809,7 @@ http:
   key: http
   name: http
   scope: ''
-  tag: 18
+  tag: 14
   type: Http
 http.request:
   deprecated: false
@@ -2077,47 +1909,19 @@ http.version:
   scope: http
   tag: 3
   type: string
-interface:
-  deprecated: false
-  key: interface
-  name: interface
-  scope: ''
-  tag: 19
-  type: Interface
-interface.alias:
-  deprecated: false
-  key: interface.alias
-  name: alias
-  scope: interface
-  tag: 1
-  type: string
-interface.id:
-  deprecated: false
-  key: interface.id
-  name: id
-  scope: interface
-  tag: 2
-  type: string
-interface.name:
-  deprecated: false
-  key: interface.name
-  name: name
-  scope: interface
-  tag: 3
-  type: string
 labels:
   deprecated: false
   key: labels
   name: labels
   scope: ''
-  tag: 20
+  tag: 15
   type: map <string, string>
 log:
   deprecated: false
   key: log
   name: log
   scope: ''
-  tag: 21
+  tag: 16
   type: Log
 log.file:
   deprecated: false
@@ -2250,14 +2054,14 @@ message:
   key: message
   name: message
   scope: ''
-  tag: 22
+  tag: 17
   type: string
 network:
   deprecated: false
   key: network
   name: network
   scope: ''
-  tag: 23
+  tag: 18
   type: Network
 network.application:
   deprecated: false
@@ -2390,7 +2194,7 @@ observer:
   key: observer
   name: observer
   scope: ''
-  tag: 24
+  tag: 19
   type: Observer
 observer.egress:
   deprecated: false
@@ -2698,7 +2502,7 @@ organization:
   key: organization
   name: organization
   scope: ''
-  tag: 25
+  tag: 20
   type: Organization
 organization.id:
   deprecated: false
@@ -2714,61 +2518,12 @@ organization.name:
   scope: organization
   tag: 2
   type: string
-os:
-  deprecated: false
-  key: os
-  name: os
-  scope: ''
-  tag: 26
-  type: Os
-os.family:
-  deprecated: false
-  key: os.family
-  name: family
-  scope: os
-  tag: 1
-  type: string
-os.full:
-  deprecated: false
-  key: os.full
-  name: full
-  scope: os
-  tag: 2
-  type: string
-os.kernel:
-  deprecated: false
-  key: os.kernel
-  name: kernel
-  scope: os
-  tag: 3
-  type: string
-os.name:
-  deprecated: false
-  key: os.name
-  name: name
-  scope: os
-  tag: 4
-  type: string
-os.platform:
-  deprecated: false
-  key: os.platform
-  name: platform
-  scope: os
-  tag: 5
-  type: string
-os.version:
-  deprecated: false
-  key: os.version
-  name: version
-  scope: os
-  tag: 6
-  type: string
 package:
   deprecated: false
   key: package
   name: package
   scope: ''
-  tag: 27
+  tag: 21
   type: Package
 package.architecture:
   deprecated: false
@@ -2861,68 +2616,12 @@ package.version:
   scope: package
   tag: 13
   type: string
-pe:
-  deprecated: false
-  key: pe
-  name: pe
-  scope: ''
-  tag: 28
-  type: Pe
-pe.architecture:
-  deprecated: false
-  key: pe.architecture
-  name: architecture
-  scope: pe
-  tag: 1
-  type: string
-pe.company:
-  deprecated: false
-  key: pe.company
-  name: company
-  scope: pe
-  tag: 2
-  type: string
-pe.description:
-  deprecated: false
-  key: pe.description
-  name: description
-  scope: pe
-  tag: 3
-  type: string
-pe.file_version:
-  deprecated: false
-  key: pe.file_version
-  name: file_version
-  scope: pe
-  tag: 4
-  type: string
-pe.imphash:
-  deprecated: false
-  key: pe.imphash
-  name: imphash
-  scope: pe
-  tag: 5
-  type: string
-pe.original_file_name:
-  deprecated: false
-  key: pe.original_file_name
-  name: original_file_name
-  scope: pe
-  tag: 6
-  type: string
-pe.product:
-  deprecated: false
-  key: pe.product
-  name: product
-  scope: pe
-  tag: 7
-  type: string
 process:
   deprecated: false
   key: process
   name: process
   scope: ''
-  tag: 29
+  tag: 22
   type: Process
 process.args:
   deprecated: false
@@ -3384,7 +3083,7 @@ registry:
   key: registry
   name: registry
   scope: ''
-  tag: 30
+  tag: 23
   type: Registry
 registry.data:
   deprecated: false
@@ -3447,7 +3146,7 @@ related:
   key: related
   name: related
   scope: ''
-  tag: 31
+  tag: 24
   type: Related
 related.hash:
   deprecated: false
@@ -3475,7 +3174,7 @@ rule:
   key: rule
   name: rule
   scope: ''
-  tag: 32
+  tag: 25
   type: Rule
 rule.author:
   deprecated: false
@@ -3552,7 +3251,7 @@ server:
   key: server
   name: server
   scope: ''
-  tag: 33
+  tag: 26
   type: Server
 server.address:
   deprecated: false
@@ -3811,7 +3510,7 @@ service:
   key: service
   name: service
   scope: ''
-  tag: 34
+  tag: 27
   type: Service
 service.ephemeral_id:
   deprecated: false
@@ -3874,7 +3573,7 @@ source:
   key: source
   name: source
   scope: ''
-  tag: 35
+  tag: 28
   type: Source
 source.address:
   deprecated: false
@@ -4133,14 +3832,14 @@ tags:
   key: tags
   name: tags
   scope: ''
-  tag: 36
+  tag: 29
   type: string
 threat:
   deprecated: false
   key: threat
   name: threat
   scope: ''
-  tag: 37
+  tag: 30
   type: Threat
 threat.framework:
   deprecated: false
@@ -4210,14 +3909,14 @@ timestamp:
   key: timestamp
   name: timestamp
   scope: ''
-  tag: 38
+  tag: 31
   type: string
 tls:
   deprecated: false
   key: tls
   name: tls
   scope: ''
-  tag: 39
+  tag: 32
   type: Tls
 tls.cipher:
   deprecated: false
@@ -4455,7 +4154,7 @@ trace:
   key: trace
   name: trace
   scope: ''
-  tag: 40
+  tag: 33
   type: Trace
 trace.id:
   deprecated: false
@@ -4469,7 +4168,7 @@ transaction:
   key: transaction
   name: transaction
   scope: ''
-  tag: 41
+  tag: 34
   type: Transaction
 transaction.id:
   deprecated: false
@@ -4483,7 +4182,7 @@ url:
   key: url
   name: url
   scope: ''
-  tag: 42
+  tag: 35
   type: Url
 url.domain:
   deprecated: false
@@ -4581,7 +4280,7 @@ user:
   key: user
   name: user
   scope: ''
-  tag: 43
+  tag: 36
   type: User
 user.domain:
   deprecated: false
@@ -4658,7 +4357,7 @@ user_agent:
   key: user_agent
   name: user_agent
   scope: ''
-  tag: 44
+  tag: 37
   type: UserAgent
 user_agent.device:
   deprecated: false
@@ -4744,33 +4443,12 @@ user_agent.version:
   scope: user_agent
   tag: 5
   type: string
-vlan:
-  deprecated: false
-  key: vlan
-  name: vlan
-  scope: ''
-  tag: 45
-  type: Vlan
-vlan.id:
-  deprecated: false
-  key: vlan.id
-  name: id
-  scope: vlan
-  tag: 1
-  type: string
-vlan.name:
-  deprecated: false
-  key: vlan.name
-  name: name
-  scope: vlan
-  tag: 2
-  type: string
 vulnerability:
   deprecated: false
   key: vulnerability
   name: vulnerability
   scope: ''
-  tag: 46
+  tag: 38
   type: Vulnerability
 vulnerability.category:
   deprecated: false

--- a/generated/protobuf/cached-fields.yaml
+++ b/generated/protobuf/cached-fields.yaml
@@ -1,0 +1,4879 @@
+agent:
+  deprecated: false
+  key: agent
+  name: agent
+  scope: ''
+  tag: 1
+  type: Agent
+agent.build:
+  deprecated: false
+  key: agent.build
+  name: build
+  scope: agent
+  tag: 1
+  type: Build
+agent.build.original:
+  deprecated: false
+  key: agent.build.original
+  name: original
+  scope: agent.build
+  tag: 1
+  type: string
+agent.ephemeral_id:
+  deprecated: false
+  key: agent.ephemeral_id
+  name: ephemeral_id
+  scope: agent
+  tag: 2
+  type: string
+agent.id:
+  deprecated: false
+  key: agent.id
+  name: id
+  scope: agent
+  tag: 3
+  type: string
+agent.name:
+  deprecated: false
+  key: agent.name
+  name: name
+  scope: agent
+  tag: 4
+  type: string
+agent.type:
+  deprecated: false
+  key: agent.type
+  name: type
+  scope: agent
+  tag: 5
+  type: string
+agent.version:
+  deprecated: false
+  key: agent.version
+  name: version
+  scope: agent
+  tag: 6
+  type: string
+as:
+  deprecated: false
+  key: as
+  name: as
+  scope: ''
+  tag: 2
+  type: As
+as.number:
+  deprecated: false
+  key: as.number
+  name: number
+  scope: as
+  tag: 1
+  type: int64
+as.organization:
+  deprecated: false
+  key: as.organization
+  name: organization
+  scope: as
+  tag: 2
+  type: Organization
+as.organization.name:
+  deprecated: false
+  key: as.organization.name
+  name: name
+  scope: as.organization
+  tag: 1
+  type: string
+client:
+  deprecated: false
+  key: client
+  name: client
+  scope: ''
+  tag: 3
+  type: Client
+client.address:
+  deprecated: false
+  key: client.address
+  name: address
+  scope: client
+  tag: 1
+  type: string
+client.as:
+  deprecated: false
+  key: client.as
+  name: as
+  scope: client
+  tag: 2
+  type: As
+client.as.number:
+  deprecated: false
+  key: client.as.number
+  name: number
+  scope: client.as
+  tag: 1
+  type: int64
+client.as.organization:
+  deprecated: false
+  key: client.as.organization
+  name: organization
+  scope: client.as
+  tag: 2
+  type: Organization
+client.as.organization.name:
+  deprecated: false
+  key: client.as.organization.name
+  name: name
+  scope: client.as.organization
+  tag: 1
+  type: string
+client.bytes:
+  deprecated: false
+  key: client.bytes
+  name: bytes
+  scope: client
+  tag: 3
+  type: int64
+client.domain:
+  deprecated: false
+  key: client.domain
+  name: domain
+  scope: client
+  tag: 4
+  type: string
+client.geo:
+  deprecated: false
+  key: client.geo
+  name: geo
+  scope: client
+  tag: 5
+  type: Geo
+client.geo.city_name:
+  deprecated: false
+  key: client.geo.city_name
+  name: city_name
+  scope: client.geo
+  tag: 1
+  type: string
+client.geo.continent_name:
+  deprecated: false
+  key: client.geo.continent_name
+  name: continent_name
+  scope: client.geo
+  tag: 2
+  type: string
+client.geo.country_iso_code:
+  deprecated: false
+  key: client.geo.country_iso_code
+  name: country_iso_code
+  scope: client.geo
+  tag: 3
+  type: string
+client.geo.country_name:
+  deprecated: false
+  key: client.geo.country_name
+  name: country_name
+  scope: client.geo
+  tag: 4
+  type: string
+client.geo.location:
+  deprecated: false
+  key: client.geo.location
+  name: location
+  scope: client.geo
+  tag: 5
+  type: string
+client.geo.name:
+  deprecated: false
+  key: client.geo.name
+  name: name
+  scope: client.geo
+  tag: 6
+  type: string
+client.geo.region_iso_code:
+  deprecated: false
+  key: client.geo.region_iso_code
+  name: region_iso_code
+  scope: client.geo
+  tag: 7
+  type: string
+client.geo.region_name:
+  deprecated: false
+  key: client.geo.region_name
+  name: region_name
+  scope: client.geo
+  tag: 8
+  type: string
+client.ip:
+  deprecated: false
+  key: client.ip
+  name: ip
+  scope: client
+  tag: 6
+  type: string
+client.mac:
+  deprecated: false
+  key: client.mac
+  name: mac
+  scope: client
+  tag: 7
+  type: string
+client.nat:
+  deprecated: false
+  key: client.nat
+  name: nat
+  scope: client
+  tag: 8
+  type: Nat
+client.nat.ip:
+  deprecated: false
+  key: client.nat.ip
+  name: ip
+  scope: client.nat
+  tag: 1
+  type: string
+client.nat.port:
+  deprecated: false
+  key: client.nat.port
+  name: port
+  scope: client.nat
+  tag: 2
+  type: int64
+client.packets:
+  deprecated: false
+  key: client.packets
+  name: packets
+  scope: client
+  tag: 9
+  type: int64
+client.port:
+  deprecated: false
+  key: client.port
+  name: port
+  scope: client
+  tag: 10
+  type: int64
+client.registered_domain:
+  deprecated: false
+  key: client.registered_domain
+  name: registered_domain
+  scope: client
+  tag: 11
+  type: string
+client.top_level_domain:
+  deprecated: false
+  key: client.top_level_domain
+  name: top_level_domain
+  scope: client
+  tag: 12
+  type: string
+client.user:
+  deprecated: false
+  key: client.user
+  name: user
+  scope: client
+  tag: 13
+  type: User
+client.user.domain:
+  deprecated: false
+  key: client.user.domain
+  name: domain
+  scope: client.user
+  tag: 1
+  type: string
+client.user.email:
+  deprecated: false
+  key: client.user.email
+  name: email
+  scope: client.user
+  tag: 2
+  type: string
+client.user.full_name:
+  deprecated: false
+  key: client.user.full_name
+  name: full_name
+  scope: client.user
+  tag: 3
+  type: string
+client.user.group:
+  deprecated: false
+  key: client.user.group
+  name: group
+  scope: client.user
+  tag: 4
+  type: Group
+client.user.group.domain:
+  deprecated: false
+  key: client.user.group.domain
+  name: domain
+  scope: client.user.group
+  tag: 1
+  type: string
+client.user.group.id:
+  deprecated: false
+  key: client.user.group.id
+  name: id
+  scope: client.user.group
+  tag: 2
+  type: string
+client.user.group.name:
+  deprecated: false
+  key: client.user.group.name
+  name: name
+  scope: client.user.group
+  tag: 3
+  type: string
+client.user.hash:
+  deprecated: false
+  key: client.user.hash
+  name: hash
+  scope: client.user
+  tag: 5
+  type: string
+client.user.id:
+  deprecated: false
+  key: client.user.id
+  name: id
+  scope: client.user
+  tag: 6
+  type: string
+client.user.name:
+  deprecated: false
+  key: client.user.name
+  name: name
+  scope: client.user
+  tag: 7
+  type: string
+cloud:
+  deprecated: false
+  key: cloud
+  name: cloud
+  scope: ''
+  tag: 4
+  type: Cloud
+cloud.account:
+  deprecated: false
+  key: cloud.account
+  name: account
+  scope: cloud
+  tag: 1
+  type: Account
+cloud.account.id:
+  deprecated: false
+  key: cloud.account.id
+  name: id
+  scope: cloud.account
+  tag: 1
+  type: string
+cloud.availability_zone:
+  deprecated: false
+  key: cloud.availability_zone
+  name: availability_zone
+  scope: cloud
+  tag: 2
+  type: string
+cloud.instance:
+  deprecated: false
+  key: cloud.instance
+  name: instance
+  scope: cloud
+  tag: 3
+  type: Instance
+cloud.instance.id:
+  deprecated: false
+  key: cloud.instance.id
+  name: id
+  scope: cloud.instance
+  tag: 1
+  type: string
+cloud.instance.name:
+  deprecated: false
+  key: cloud.instance.name
+  name: name
+  scope: cloud.instance
+  tag: 2
+  type: string
+cloud.machine:
+  deprecated: false
+  key: cloud.machine
+  name: machine
+  scope: cloud
+  tag: 4
+  type: Machine
+cloud.machine.type:
+  deprecated: false
+  key: cloud.machine.type
+  name: type
+  scope: cloud.machine
+  tag: 1
+  type: string
+cloud.provider:
+  deprecated: false
+  key: cloud.provider
+  name: provider
+  scope: cloud
+  tag: 5
+  type: string
+cloud.region:
+  deprecated: false
+  key: cloud.region
+  name: region
+  scope: cloud
+  tag: 6
+  type: string
+code_signature:
+  deprecated: false
+  key: code_signature
+  name: code_signature
+  scope: ''
+  tag: 5
+  type: CodeSignature
+code_signature.exists:
+  deprecated: false
+  key: code_signature.exists
+  name: exists
+  scope: code_signature
+  tag: 1
+  type: bool
+code_signature.status:
+  deprecated: false
+  key: code_signature.status
+  name: status
+  scope: code_signature
+  tag: 2
+  type: string
+code_signature.subject_name:
+  deprecated: false
+  key: code_signature.subject_name
+  name: subject_name
+  scope: code_signature
+  tag: 3
+  type: string
+code_signature.trusted:
+  deprecated: false
+  key: code_signature.trusted
+  name: trusted
+  scope: code_signature
+  tag: 4
+  type: bool
+code_signature.valid:
+  deprecated: false
+  key: code_signature.valid
+  name: valid
+  scope: code_signature
+  tag: 5
+  type: bool
+container:
+  deprecated: false
+  key: container
+  name: container
+  scope: ''
+  tag: 6
+  type: Container
+container.id:
+  deprecated: false
+  key: container.id
+  name: id
+  scope: container
+  tag: 1
+  type: string
+container.image:
+  deprecated: false
+  key: container.image
+  name: image
+  scope: container
+  tag: 2
+  type: Image
+container.image.name:
+  deprecated: false
+  key: container.image.name
+  name: name
+  scope: container.image
+  tag: 1
+  type: string
+container.image.tag:
+  deprecated: false
+  key: container.image.tag
+  name: tag
+  scope: container.image
+  tag: 2
+  type: string
+container.labels:
+  deprecated: false
+  key: container.labels
+  name: labels
+  scope: container
+  tag: 3
+  type: map <string, string>
+container.name:
+  deprecated: false
+  key: container.name
+  name: name
+  scope: container
+  tag: 4
+  type: string
+container.runtime:
+  deprecated: false
+  key: container.runtime
+  name: runtime
+  scope: container
+  tag: 5
+  type: string
+destination:
+  deprecated: false
+  key: destination
+  name: destination
+  scope: ''
+  tag: 7
+  type: Destination
+destination.address:
+  deprecated: false
+  key: destination.address
+  name: address
+  scope: destination
+  tag: 1
+  type: string
+destination.as:
+  deprecated: false
+  key: destination.as
+  name: as
+  scope: destination
+  tag: 2
+  type: As
+destination.as.number:
+  deprecated: false
+  key: destination.as.number
+  name: number
+  scope: destination.as
+  tag: 1
+  type: int64
+destination.as.organization:
+  deprecated: false
+  key: destination.as.organization
+  name: organization
+  scope: destination.as
+  tag: 2
+  type: Organization
+destination.as.organization.name:
+  deprecated: false
+  key: destination.as.organization.name
+  name: name
+  scope: destination.as.organization
+  tag: 1
+  type: string
+destination.bytes:
+  deprecated: false
+  key: destination.bytes
+  name: bytes
+  scope: destination
+  tag: 3
+  type: int64
+destination.domain:
+  deprecated: false
+  key: destination.domain
+  name: domain
+  scope: destination
+  tag: 4
+  type: string
+destination.geo:
+  deprecated: false
+  key: destination.geo
+  name: geo
+  scope: destination
+  tag: 5
+  type: Geo
+destination.geo.city_name:
+  deprecated: false
+  key: destination.geo.city_name
+  name: city_name
+  scope: destination.geo
+  tag: 1
+  type: string
+destination.geo.continent_name:
+  deprecated: false
+  key: destination.geo.continent_name
+  name: continent_name
+  scope: destination.geo
+  tag: 2
+  type: string
+destination.geo.country_iso_code:
+  deprecated: false
+  key: destination.geo.country_iso_code
+  name: country_iso_code
+  scope: destination.geo
+  tag: 3
+  type: string
+destination.geo.country_name:
+  deprecated: false
+  key: destination.geo.country_name
+  name: country_name
+  scope: destination.geo
+  tag: 4
+  type: string
+destination.geo.location:
+  deprecated: false
+  key: destination.geo.location
+  name: location
+  scope: destination.geo
+  tag: 5
+  type: string
+destination.geo.name:
+  deprecated: false
+  key: destination.geo.name
+  name: name
+  scope: destination.geo
+  tag: 6
+  type: string
+destination.geo.region_iso_code:
+  deprecated: false
+  key: destination.geo.region_iso_code
+  name: region_iso_code
+  scope: destination.geo
+  tag: 7
+  type: string
+destination.geo.region_name:
+  deprecated: false
+  key: destination.geo.region_name
+  name: region_name
+  scope: destination.geo
+  tag: 8
+  type: string
+destination.ip:
+  deprecated: false
+  key: destination.ip
+  name: ip
+  scope: destination
+  tag: 6
+  type: string
+destination.mac:
+  deprecated: false
+  key: destination.mac
+  name: mac
+  scope: destination
+  tag: 7
+  type: string
+destination.nat:
+  deprecated: false
+  key: destination.nat
+  name: nat
+  scope: destination
+  tag: 8
+  type: Nat
+destination.nat.ip:
+  deprecated: false
+  key: destination.nat.ip
+  name: ip
+  scope: destination.nat
+  tag: 1
+  type: string
+destination.nat.port:
+  deprecated: false
+  key: destination.nat.port
+  name: port
+  scope: destination.nat
+  tag: 2
+  type: int64
+destination.packets:
+  deprecated: false
+  key: destination.packets
+  name: packets
+  scope: destination
+  tag: 9
+  type: int64
+destination.port:
+  deprecated: false
+  key: destination.port
+  name: port
+  scope: destination
+  tag: 10
+  type: int64
+destination.registered_domain:
+  deprecated: false
+  key: destination.registered_domain
+  name: registered_domain
+  scope: destination
+  tag: 11
+  type: string
+destination.top_level_domain:
+  deprecated: false
+  key: destination.top_level_domain
+  name: top_level_domain
+  scope: destination
+  tag: 12
+  type: string
+destination.user:
+  deprecated: false
+  key: destination.user
+  name: user
+  scope: destination
+  tag: 13
+  type: User
+destination.user.domain:
+  deprecated: false
+  key: destination.user.domain
+  name: domain
+  scope: destination.user
+  tag: 1
+  type: string
+destination.user.email:
+  deprecated: false
+  key: destination.user.email
+  name: email
+  scope: destination.user
+  tag: 2
+  type: string
+destination.user.full_name:
+  deprecated: false
+  key: destination.user.full_name
+  name: full_name
+  scope: destination.user
+  tag: 3
+  type: string
+destination.user.group:
+  deprecated: false
+  key: destination.user.group
+  name: group
+  scope: destination.user
+  tag: 4
+  type: Group
+destination.user.group.domain:
+  deprecated: false
+  key: destination.user.group.domain
+  name: domain
+  scope: destination.user.group
+  tag: 1
+  type: string
+destination.user.group.id:
+  deprecated: false
+  key: destination.user.group.id
+  name: id
+  scope: destination.user.group
+  tag: 2
+  type: string
+destination.user.group.name:
+  deprecated: false
+  key: destination.user.group.name
+  name: name
+  scope: destination.user.group
+  tag: 3
+  type: string
+destination.user.hash:
+  deprecated: false
+  key: destination.user.hash
+  name: hash
+  scope: destination.user
+  tag: 5
+  type: string
+destination.user.id:
+  deprecated: false
+  key: destination.user.id
+  name: id
+  scope: destination.user
+  tag: 6
+  type: string
+destination.user.name:
+  deprecated: false
+  key: destination.user.name
+  name: name
+  scope: destination.user
+  tag: 7
+  type: string
+dll:
+  deprecated: false
+  key: dll
+  name: dll
+  scope: ''
+  tag: 8
+  type: Dll
+dll.code_signature:
+  deprecated: false
+  key: dll.code_signature
+  name: code_signature
+  scope: dll
+  tag: 1
+  type: CodeSignature
+dll.code_signature.exists:
+  deprecated: false
+  key: dll.code_signature.exists
+  name: exists
+  scope: dll.code_signature
+  tag: 1
+  type: bool
+dll.code_signature.status:
+  deprecated: false
+  key: dll.code_signature.status
+  name: status
+  scope: dll.code_signature
+  tag: 2
+  type: string
+dll.code_signature.subject_name:
+  deprecated: false
+  key: dll.code_signature.subject_name
+  name: subject_name
+  scope: dll.code_signature
+  tag: 3
+  type: string
+dll.code_signature.trusted:
+  deprecated: false
+  key: dll.code_signature.trusted
+  name: trusted
+  scope: dll.code_signature
+  tag: 4
+  type: bool
+dll.code_signature.valid:
+  deprecated: false
+  key: dll.code_signature.valid
+  name: valid
+  scope: dll.code_signature
+  tag: 5
+  type: bool
+dll.hash:
+  deprecated: false
+  key: dll.hash
+  name: hash
+  scope: dll
+  tag: 2
+  type: Hash
+dll.hash.md5:
+  deprecated: false
+  key: dll.hash.md5
+  name: md5
+  scope: dll.hash
+  tag: 1
+  type: string
+dll.hash.sha1:
+  deprecated: false
+  key: dll.hash.sha1
+  name: sha1
+  scope: dll.hash
+  tag: 2
+  type: string
+dll.hash.sha256:
+  deprecated: false
+  key: dll.hash.sha256
+  name: sha256
+  scope: dll.hash
+  tag: 3
+  type: string
+dll.hash.sha512:
+  deprecated: false
+  key: dll.hash.sha512
+  name: sha512
+  scope: dll.hash
+  tag: 4
+  type: string
+dll.name:
+  deprecated: false
+  key: dll.name
+  name: name
+  scope: dll
+  tag: 3
+  type: string
+dll.path:
+  deprecated: false
+  key: dll.path
+  name: path
+  scope: dll
+  tag: 4
+  type: string
+dll.pe:
+  deprecated: false
+  key: dll.pe
+  name: pe
+  scope: dll
+  tag: 5
+  type: Pe
+dll.pe.architecture:
+  deprecated: false
+  key: dll.pe.architecture
+  name: architecture
+  scope: dll.pe
+  tag: 1
+  type: string
+dll.pe.company:
+  deprecated: false
+  key: dll.pe.company
+  name: company
+  scope: dll.pe
+  tag: 2
+  type: string
+dll.pe.description:
+  deprecated: false
+  key: dll.pe.description
+  name: description
+  scope: dll.pe
+  tag: 3
+  type: string
+dll.pe.file_version:
+  deprecated: false
+  key: dll.pe.file_version
+  name: file_version
+  scope: dll.pe
+  tag: 4
+  type: string
+dll.pe.imphash:
+  deprecated: false
+  key: dll.pe.imphash
+  name: imphash
+  scope: dll.pe
+  tag: 5
+  type: string
+dll.pe.original_file_name:
+  deprecated: false
+  key: dll.pe.original_file_name
+  name: original_file_name
+  scope: dll.pe
+  tag: 6
+  type: string
+dll.pe.product:
+  deprecated: false
+  key: dll.pe.product
+  name: product
+  scope: dll.pe
+  tag: 7
+  type: string
+dns:
+  deprecated: false
+  key: dns
+  name: dns
+  scope: ''
+  tag: 9
+  type: Dns
+dns.answers:
+  deprecated: false
+  key: dns.answers
+  name: answers
+  scope: dns
+  tag: 1
+  type: map <string, string>
+dns.answers.class:
+  deprecated: false
+  key: dns.answers.class
+  name: class
+  scope: dns.answers
+  tag: 1
+  type: string
+dns.answers.data:
+  deprecated: false
+  key: dns.answers.data
+  name: data
+  scope: dns.answers
+  tag: 2
+  type: string
+dns.answers.name:
+  deprecated: false
+  key: dns.answers.name
+  name: name
+  scope: dns.answers
+  tag: 3
+  type: string
+dns.answers.ttl:
+  deprecated: false
+  key: dns.answers.ttl
+  name: ttl
+  scope: dns.answers
+  tag: 4
+  type: int64
+dns.answers.type:
+  deprecated: false
+  key: dns.answers.type
+  name: type
+  scope: dns.answers
+  tag: 5
+  type: string
+dns.header_flags:
+  deprecated: false
+  key: dns.header_flags
+  name: header_flags
+  scope: dns
+  tag: 2
+  type: string
+dns.id:
+  deprecated: false
+  key: dns.id
+  name: id
+  scope: dns
+  tag: 3
+  type: string
+dns.op_code:
+  deprecated: false
+  key: dns.op_code
+  name: op_code
+  scope: dns
+  tag: 4
+  type: string
+dns.question:
+  deprecated: false
+  key: dns.question
+  name: question
+  scope: dns
+  tag: 5
+  type: Question
+dns.question.class:
+  deprecated: false
+  key: dns.question.class
+  name: class
+  scope: dns.question
+  tag: 1
+  type: string
+dns.question.name:
+  deprecated: false
+  key: dns.question.name
+  name: name
+  scope: dns.question
+  tag: 2
+  type: string
+dns.question.registered_domain:
+  deprecated: false
+  key: dns.question.registered_domain
+  name: registered_domain
+  scope: dns.question
+  tag: 3
+  type: string
+dns.question.subdomain:
+  deprecated: false
+  key: dns.question.subdomain
+  name: subdomain
+  scope: dns.question
+  tag: 4
+  type: string
+dns.question.top_level_domain:
+  deprecated: false
+  key: dns.question.top_level_domain
+  name: top_level_domain
+  scope: dns.question
+  tag: 5
+  type: string
+dns.question.type:
+  deprecated: false
+  key: dns.question.type
+  name: type
+  scope: dns.question
+  tag: 6
+  type: string
+dns.resolved_ip:
+  deprecated: false
+  key: dns.resolved_ip
+  name: resolved_ip
+  scope: dns
+  tag: 6
+  type: string
+dns.response_code:
+  deprecated: false
+  key: dns.response_code
+  name: response_code
+  scope: dns
+  tag: 7
+  type: string
+dns.type:
+  deprecated: false
+  key: dns.type
+  name: type
+  scope: dns
+  tag: 8
+  type: string
+ecs:
+  deprecated: false
+  key: ecs
+  name: ecs
+  scope: ''
+  tag: 10
+  type: Ecs
+ecs.version:
+  deprecated: false
+  key: ecs.version
+  name: version
+  scope: ecs
+  tag: 1
+  type: string
+error:
+  deprecated: false
+  key: error
+  name: error
+  scope: ''
+  tag: 11
+  type: Error
+error.code:
+  deprecated: false
+  key: error.code
+  name: code
+  scope: error
+  tag: 1
+  type: string
+error.id:
+  deprecated: false
+  key: error.id
+  name: id
+  scope: error
+  tag: 2
+  type: string
+error.message:
+  deprecated: false
+  key: error.message
+  name: message
+  scope: error
+  tag: 3
+  type: string
+error.stack_trace:
+  deprecated: false
+  key: error.stack_trace
+  name: stack_trace
+  scope: error
+  tag: 4
+  type: string
+error.type:
+  deprecated: false
+  key: error.type
+  name: type
+  scope: error
+  tag: 5
+  type: string
+event:
+  deprecated: false
+  key: event
+  name: event
+  scope: ''
+  tag: 12
+  type: Event
+event.action:
+  deprecated: false
+  key: event.action
+  name: action
+  scope: event
+  tag: 1
+  type: string
+event.category:
+  deprecated: false
+  key: event.category
+  name: category
+  scope: event
+  tag: 2
+  type: string
+event.code:
+  deprecated: false
+  key: event.code
+  name: code
+  scope: event
+  tag: 3
+  type: string
+event.created:
+  deprecated: false
+  key: event.created
+  name: created
+  scope: event
+  tag: 4
+  type: string
+event.dataset:
+  deprecated: false
+  key: event.dataset
+  name: dataset
+  scope: event
+  tag: 5
+  type: string
+event.duration:
+  deprecated: false
+  key: event.duration
+  name: duration
+  scope: event
+  tag: 6
+  type: int64
+event.end:
+  deprecated: false
+  key: event.end
+  name: end
+  scope: event
+  tag: 7
+  type: string
+event.hash:
+  deprecated: false
+  key: event.hash
+  name: hash
+  scope: event
+  tag: 8
+  type: string
+event.id:
+  deprecated: false
+  key: event.id
+  name: id
+  scope: event
+  tag: 9
+  type: string
+event.ingested:
+  deprecated: false
+  key: event.ingested
+  name: ingested
+  scope: event
+  tag: 10
+  type: string
+event.kind:
+  deprecated: false
+  key: event.kind
+  name: kind
+  scope: event
+  tag: 11
+  type: string
+event.module:
+  deprecated: false
+  key: event.module
+  name: module
+  scope: event
+  tag: 12
+  type: string
+event.original:
+  deprecated: false
+  key: event.original
+  name: original
+  scope: event
+  tag: 13
+  type: string
+event.outcome:
+  deprecated: false
+  key: event.outcome
+  name: outcome
+  scope: event
+  tag: 14
+  type: string
+event.provider:
+  deprecated: false
+  key: event.provider
+  name: provider
+  scope: event
+  tag: 15
+  type: string
+event.reference:
+  deprecated: false
+  key: event.reference
+  name: reference
+  scope: event
+  tag: 16
+  type: string
+event.risk_score:
+  deprecated: false
+  key: event.risk_score
+  name: risk_score
+  scope: event
+  tag: 17
+  type: float
+event.risk_score_norm:
+  deprecated: false
+  key: event.risk_score_norm
+  name: risk_score_norm
+  scope: event
+  tag: 18
+  type: float
+event.sequence:
+  deprecated: false
+  key: event.sequence
+  name: sequence
+  scope: event
+  tag: 19
+  type: int64
+event.severity:
+  deprecated: false
+  key: event.severity
+  name: severity
+  scope: event
+  tag: 20
+  type: int64
+event.start:
+  deprecated: false
+  key: event.start
+  name: start
+  scope: event
+  tag: 21
+  type: string
+event.timezone:
+  deprecated: false
+  key: event.timezone
+  name: timezone
+  scope: event
+  tag: 22
+  type: string
+event.type:
+  deprecated: false
+  key: event.type
+  name: type
+  scope: event
+  tag: 23
+  type: string
+event.url:
+  deprecated: false
+  key: event.url
+  name: url
+  scope: event
+  tag: 24
+  type: string
+file:
+  deprecated: false
+  key: file
+  name: file
+  scope: ''
+  tag: 13
+  type: File
+file.accessed:
+  deprecated: false
+  key: file.accessed
+  name: accessed
+  scope: file
+  tag: 1
+  type: string
+file.attributes:
+  deprecated: false
+  key: file.attributes
+  name: attributes
+  scope: file
+  tag: 2
+  type: string
+file.code_signature:
+  deprecated: false
+  key: file.code_signature
+  name: code_signature
+  scope: file
+  tag: 3
+  type: CodeSignature
+file.code_signature.exists:
+  deprecated: false
+  key: file.code_signature.exists
+  name: exists
+  scope: file.code_signature
+  tag: 1
+  type: bool
+file.code_signature.status:
+  deprecated: false
+  key: file.code_signature.status
+  name: status
+  scope: file.code_signature
+  tag: 2
+  type: string
+file.code_signature.subject_name:
+  deprecated: false
+  key: file.code_signature.subject_name
+  name: subject_name
+  scope: file.code_signature
+  tag: 3
+  type: string
+file.code_signature.trusted:
+  deprecated: false
+  key: file.code_signature.trusted
+  name: trusted
+  scope: file.code_signature
+  tag: 4
+  type: bool
+file.code_signature.valid:
+  deprecated: false
+  key: file.code_signature.valid
+  name: valid
+  scope: file.code_signature
+  tag: 5
+  type: bool
+file.created:
+  deprecated: false
+  key: file.created
+  name: created
+  scope: file
+  tag: 4
+  type: string
+file.ctime:
+  deprecated: false
+  key: file.ctime
+  name: ctime
+  scope: file
+  tag: 5
+  type: string
+file.device:
+  deprecated: false
+  key: file.device
+  name: device
+  scope: file
+  tag: 6
+  type: string
+file.directory:
+  deprecated: false
+  key: file.directory
+  name: directory
+  scope: file
+  tag: 7
+  type: string
+file.drive_letter:
+  deprecated: false
+  key: file.drive_letter
+  name: drive_letter
+  scope: file
+  tag: 8
+  type: string
+file.extension:
+  deprecated: false
+  key: file.extension
+  name: extension
+  scope: file
+  tag: 9
+  type: string
+file.gid:
+  deprecated: false
+  key: file.gid
+  name: gid
+  scope: file
+  tag: 10
+  type: string
+file.group:
+  deprecated: false
+  key: file.group
+  name: group
+  scope: file
+  tag: 11
+  type: string
+file.hash:
+  deprecated: false
+  key: file.hash
+  name: hash
+  scope: file
+  tag: 12
+  type: Hash
+file.hash.md5:
+  deprecated: false
+  key: file.hash.md5
+  name: md5
+  scope: file.hash
+  tag: 1
+  type: string
+file.hash.sha1:
+  deprecated: false
+  key: file.hash.sha1
+  name: sha1
+  scope: file.hash
+  tag: 2
+  type: string
+file.hash.sha256:
+  deprecated: false
+  key: file.hash.sha256
+  name: sha256
+  scope: file.hash
+  tag: 3
+  type: string
+file.hash.sha512:
+  deprecated: false
+  key: file.hash.sha512
+  name: sha512
+  scope: file.hash
+  tag: 4
+  type: string
+file.inode:
+  deprecated: false
+  key: file.inode
+  name: inode
+  scope: file
+  tag: 13
+  type: string
+file.mime_type:
+  deprecated: false
+  key: file.mime_type
+  name: mime_type
+  scope: file
+  tag: 14
+  type: string
+file.mode:
+  deprecated: false
+  key: file.mode
+  name: mode
+  scope: file
+  tag: 15
+  type: string
+file.mtime:
+  deprecated: false
+  key: file.mtime
+  name: mtime
+  scope: file
+  tag: 16
+  type: string
+file.name:
+  deprecated: false
+  key: file.name
+  name: name
+  scope: file
+  tag: 17
+  type: string
+file.owner:
+  deprecated: false
+  key: file.owner
+  name: owner
+  scope: file
+  tag: 18
+  type: string
+file.path:
+  deprecated: false
+  key: file.path
+  name: path
+  scope: file
+  tag: 19
+  type: string
+file.pe:
+  deprecated: false
+  key: file.pe
+  name: pe
+  scope: file
+  tag: 20
+  type: Pe
+file.pe.architecture:
+  deprecated: false
+  key: file.pe.architecture
+  name: architecture
+  scope: file.pe
+  tag: 1
+  type: string
+file.pe.company:
+  deprecated: false
+  key: file.pe.company
+  name: company
+  scope: file.pe
+  tag: 2
+  type: string
+file.pe.description:
+  deprecated: false
+  key: file.pe.description
+  name: description
+  scope: file.pe
+  tag: 3
+  type: string
+file.pe.file_version:
+  deprecated: false
+  key: file.pe.file_version
+  name: file_version
+  scope: file.pe
+  tag: 4
+  type: string
+file.pe.imphash:
+  deprecated: false
+  key: file.pe.imphash
+  name: imphash
+  scope: file.pe
+  tag: 5
+  type: string
+file.pe.original_file_name:
+  deprecated: false
+  key: file.pe.original_file_name
+  name: original_file_name
+  scope: file.pe
+  tag: 6
+  type: string
+file.pe.product:
+  deprecated: false
+  key: file.pe.product
+  name: product
+  scope: file.pe
+  tag: 7
+  type: string
+file.size:
+  deprecated: false
+  key: file.size
+  name: size
+  scope: file
+  tag: 21
+  type: int64
+file.target_path:
+  deprecated: false
+  key: file.target_path
+  name: target_path
+  scope: file
+  tag: 22
+  type: string
+file.type:
+  deprecated: false
+  key: file.type
+  name: type
+  scope: file
+  tag: 23
+  type: string
+file.uid:
+  deprecated: false
+  key: file.uid
+  name: uid
+  scope: file
+  tag: 24
+  type: string
+geo:
+  deprecated: false
+  key: geo
+  name: geo
+  scope: ''
+  tag: 14
+  type: Geo
+geo.city_name:
+  deprecated: false
+  key: geo.city_name
+  name: city_name
+  scope: geo
+  tag: 1
+  type: string
+geo.continent_name:
+  deprecated: false
+  key: geo.continent_name
+  name: continent_name
+  scope: geo
+  tag: 2
+  type: string
+geo.country_iso_code:
+  deprecated: false
+  key: geo.country_iso_code
+  name: country_iso_code
+  scope: geo
+  tag: 3
+  type: string
+geo.country_name:
+  deprecated: false
+  key: geo.country_name
+  name: country_name
+  scope: geo
+  tag: 4
+  type: string
+geo.location:
+  deprecated: false
+  key: geo.location
+  name: location
+  scope: geo
+  tag: 5
+  type: string
+geo.name:
+  deprecated: false
+  key: geo.name
+  name: name
+  scope: geo
+  tag: 6
+  type: string
+geo.region_iso_code:
+  deprecated: false
+  key: geo.region_iso_code
+  name: region_iso_code
+  scope: geo
+  tag: 7
+  type: string
+geo.region_name:
+  deprecated: false
+  key: geo.region_name
+  name: region_name
+  scope: geo
+  tag: 8
+  type: string
+group:
+  deprecated: false
+  key: group
+  name: group
+  scope: ''
+  tag: 15
+  type: Group
+group.domain:
+  deprecated: false
+  key: group.domain
+  name: domain
+  scope: group
+  tag: 1
+  type: string
+group.id:
+  deprecated: false
+  key: group.id
+  name: id
+  scope: group
+  tag: 2
+  type: string
+group.name:
+  deprecated: false
+  key: group.name
+  name: name
+  scope: group
+  tag: 3
+  type: string
+hash:
+  deprecated: false
+  key: hash
+  name: hash
+  scope: ''
+  tag: 16
+  type: Hash
+hash.md5:
+  deprecated: false
+  key: hash.md5
+  name: md5
+  scope: hash
+  tag: 1
+  type: string
+hash.sha1:
+  deprecated: false
+  key: hash.sha1
+  name: sha1
+  scope: hash
+  tag: 2
+  type: string
+hash.sha256:
+  deprecated: false
+  key: hash.sha256
+  name: sha256
+  scope: hash
+  tag: 3
+  type: string
+hash.sha512:
+  deprecated: false
+  key: hash.sha512
+  name: sha512
+  scope: hash
+  tag: 4
+  type: string
+host:
+  deprecated: false
+  key: host
+  name: host
+  scope: ''
+  tag: 17
+  type: Host
+host.architecture:
+  deprecated: false
+  key: host.architecture
+  name: architecture
+  scope: host
+  tag: 1
+  type: string
+host.domain:
+  deprecated: false
+  key: host.domain
+  name: domain
+  scope: host
+  tag: 2
+  type: string
+host.geo:
+  deprecated: false
+  key: host.geo
+  name: geo
+  scope: host
+  tag: 3
+  type: Geo
+host.geo.city_name:
+  deprecated: false
+  key: host.geo.city_name
+  name: city_name
+  scope: host.geo
+  tag: 1
+  type: string
+host.geo.continent_name:
+  deprecated: false
+  key: host.geo.continent_name
+  name: continent_name
+  scope: host.geo
+  tag: 2
+  type: string
+host.geo.country_iso_code:
+  deprecated: false
+  key: host.geo.country_iso_code
+  name: country_iso_code
+  scope: host.geo
+  tag: 3
+  type: string
+host.geo.country_name:
+  deprecated: false
+  key: host.geo.country_name
+  name: country_name
+  scope: host.geo
+  tag: 4
+  type: string
+host.geo.location:
+  deprecated: false
+  key: host.geo.location
+  name: location
+  scope: host.geo
+  tag: 5
+  type: string
+host.geo.name:
+  deprecated: false
+  key: host.geo.name
+  name: name
+  scope: host.geo
+  tag: 6
+  type: string
+host.geo.region_iso_code:
+  deprecated: false
+  key: host.geo.region_iso_code
+  name: region_iso_code
+  scope: host.geo
+  tag: 7
+  type: string
+host.geo.region_name:
+  deprecated: false
+  key: host.geo.region_name
+  name: region_name
+  scope: host.geo
+  tag: 8
+  type: string
+host.hostname:
+  deprecated: false
+  key: host.hostname
+  name: hostname
+  scope: host
+  tag: 4
+  type: string
+host.id:
+  deprecated: false
+  key: host.id
+  name: id
+  scope: host
+  tag: 5
+  type: string
+host.ip:
+  deprecated: false
+  key: host.ip
+  name: ip
+  scope: host
+  tag: 6
+  type: string
+host.mac:
+  deprecated: false
+  key: host.mac
+  name: mac
+  scope: host
+  tag: 7
+  type: string
+host.name:
+  deprecated: false
+  key: host.name
+  name: name
+  scope: host
+  tag: 8
+  type: string
+host.os:
+  deprecated: false
+  key: host.os
+  name: os
+  scope: host
+  tag: 9
+  type: Os
+host.os.family:
+  deprecated: false
+  key: host.os.family
+  name: family
+  scope: host.os
+  tag: 1
+  type: string
+host.os.full:
+  deprecated: false
+  key: host.os.full
+  name: full
+  scope: host.os
+  tag: 2
+  type: string
+host.os.kernel:
+  deprecated: false
+  key: host.os.kernel
+  name: kernel
+  scope: host.os
+  tag: 3
+  type: string
+host.os.name:
+  deprecated: false
+  key: host.os.name
+  name: name
+  scope: host.os
+  tag: 4
+  type: string
+host.os.platform:
+  deprecated: false
+  key: host.os.platform
+  name: platform
+  scope: host.os
+  tag: 5
+  type: string
+host.os.version:
+  deprecated: false
+  key: host.os.version
+  name: version
+  scope: host.os
+  tag: 6
+  type: string
+host.type:
+  deprecated: false
+  key: host.type
+  name: type
+  scope: host
+  tag: 10
+  type: string
+host.uptime:
+  deprecated: false
+  key: host.uptime
+  name: uptime
+  scope: host
+  tag: 11
+  type: int64
+host.user:
+  deprecated: false
+  key: host.user
+  name: user
+  scope: host
+  tag: 12
+  type: User
+host.user.domain:
+  deprecated: false
+  key: host.user.domain
+  name: domain
+  scope: host.user
+  tag: 1
+  type: string
+host.user.email:
+  deprecated: false
+  key: host.user.email
+  name: email
+  scope: host.user
+  tag: 2
+  type: string
+host.user.full_name:
+  deprecated: false
+  key: host.user.full_name
+  name: full_name
+  scope: host.user
+  tag: 3
+  type: string
+host.user.group:
+  deprecated: false
+  key: host.user.group
+  name: group
+  scope: host.user
+  tag: 4
+  type: Group
+host.user.group.domain:
+  deprecated: false
+  key: host.user.group.domain
+  name: domain
+  scope: host.user.group
+  tag: 1
+  type: string
+host.user.group.id:
+  deprecated: false
+  key: host.user.group.id
+  name: id
+  scope: host.user.group
+  tag: 2
+  type: string
+host.user.group.name:
+  deprecated: false
+  key: host.user.group.name
+  name: name
+  scope: host.user.group
+  tag: 3
+  type: string
+host.user.hash:
+  deprecated: false
+  key: host.user.hash
+  name: hash
+  scope: host.user
+  tag: 5
+  type: string
+host.user.id:
+  deprecated: false
+  key: host.user.id
+  name: id
+  scope: host.user
+  tag: 6
+  type: string
+host.user.name:
+  deprecated: false
+  key: host.user.name
+  name: name
+  scope: host.user
+  tag: 7
+  type: string
+http:
+  deprecated: false
+  key: http
+  name: http
+  scope: ''
+  tag: 18
+  type: Http
+http.request:
+  deprecated: false
+  key: http.request
+  name: request
+  scope: http
+  tag: 1
+  type: Request
+http.request.body:
+  deprecated: false
+  key: http.request.body
+  name: body
+  scope: http.request
+  tag: 1
+  type: Body
+http.request.body.bytes:
+  deprecated: false
+  key: http.request.body.bytes
+  name: bytes
+  scope: http.request.body
+  tag: 1
+  type: int64
+http.request.body.content:
+  deprecated: false
+  key: http.request.body.content
+  name: content
+  scope: http.request.body
+  tag: 2
+  type: string
+http.request.bytes:
+  deprecated: false
+  key: http.request.bytes
+  name: bytes
+  scope: http.request
+  tag: 2
+  type: int64
+http.request.method:
+  deprecated: false
+  key: http.request.method
+  name: method
+  scope: http.request
+  tag: 3
+  type: string
+http.request.referrer:
+  deprecated: false
+  key: http.request.referrer
+  name: referrer
+  scope: http.request
+  tag: 4
+  type: string
+http.response:
+  deprecated: false
+  key: http.response
+  name: response
+  scope: http
+  tag: 2
+  type: Response
+http.response.body:
+  deprecated: false
+  key: http.response.body
+  name: body
+  scope: http.response
+  tag: 1
+  type: Body
+http.response.body.bytes:
+  deprecated: false
+  key: http.response.body.bytes
+  name: bytes
+  scope: http.response.body
+  tag: 1
+  type: int64
+http.response.body.content:
+  deprecated: false
+  key: http.response.body.content
+  name: content
+  scope: http.response.body
+  tag: 2
+  type: string
+http.response.bytes:
+  deprecated: false
+  key: http.response.bytes
+  name: bytes
+  scope: http.response
+  tag: 2
+  type: int64
+http.response.status_code:
+  deprecated: false
+  key: http.response.status_code
+  name: status_code
+  scope: http.response
+  tag: 3
+  type: int64
+http.version:
+  deprecated: false
+  key: http.version
+  name: version
+  scope: http
+  tag: 3
+  type: string
+interface:
+  deprecated: false
+  key: interface
+  name: interface
+  scope: ''
+  tag: 19
+  type: Interface
+interface.alias:
+  deprecated: false
+  key: interface.alias
+  name: alias
+  scope: interface
+  tag: 1
+  type: string
+interface.id:
+  deprecated: false
+  key: interface.id
+  name: id
+  scope: interface
+  tag: 2
+  type: string
+interface.name:
+  deprecated: false
+  key: interface.name
+  name: name
+  scope: interface
+  tag: 3
+  type: string
+labels:
+  deprecated: false
+  key: labels
+  name: labels
+  scope: ''
+  tag: 20
+  type: map <string, string>
+log:
+  deprecated: false
+  key: log
+  name: log
+  scope: ''
+  tag: 21
+  type: Log
+log.file:
+  deprecated: false
+  key: log.file
+  name: file
+  scope: log
+  tag: 1
+  type: File
+log.file.path:
+  deprecated: false
+  key: log.file.path
+  name: path
+  scope: log.file
+  tag: 1
+  type: string
+log.level:
+  deprecated: false
+  key: log.level
+  name: level
+  scope: log
+  tag: 2
+  type: string
+log.logger:
+  deprecated: false
+  key: log.logger
+  name: logger
+  scope: log
+  tag: 3
+  type: string
+log.origin:
+  deprecated: false
+  key: log.origin
+  name: origin
+  scope: log
+  tag: 4
+  type: Origin
+log.origin.file:
+  deprecated: false
+  key: log.origin.file
+  name: file
+  scope: log.origin
+  tag: 1
+  type: File
+log.origin.file.line:
+  deprecated: false
+  key: log.origin.file.line
+  name: line
+  scope: log.origin.file
+  tag: 1
+  type: int32
+log.origin.file.name:
+  deprecated: false
+  key: log.origin.file.name
+  name: name
+  scope: log.origin.file
+  tag: 2
+  type: string
+log.origin.function:
+  deprecated: false
+  key: log.origin.function
+  name: function
+  scope: log.origin
+  tag: 2
+  type: string
+log.original:
+  deprecated: false
+  key: log.original
+  name: original
+  scope: log
+  tag: 5
+  type: string
+log.syslog:
+  deprecated: false
+  key: log.syslog
+  name: syslog
+  scope: log
+  tag: 6
+  type: map <string, string>
+log.syslog.facility:
+  deprecated: false
+  key: log.syslog.facility
+  name: facility
+  scope: log.syslog
+  tag: 1
+  type: Facility
+log.syslog.facility.code:
+  deprecated: false
+  key: log.syslog.facility.code
+  name: code
+  scope: log.syslog.facility
+  tag: 1
+  type: int64
+log.syslog.facility.name:
+  deprecated: false
+  key: log.syslog.facility.name
+  name: name
+  scope: log.syslog.facility
+  tag: 2
+  type: string
+log.syslog.priority:
+  deprecated: false
+  key: log.syslog.priority
+  name: priority
+  scope: log.syslog
+  tag: 2
+  type: int64
+log.syslog.severity:
+  deprecated: false
+  key: log.syslog.severity
+  name: severity
+  scope: log.syslog
+  tag: 3
+  type: Severity
+log.syslog.severity.code:
+  deprecated: false
+  key: log.syslog.severity.code
+  name: code
+  scope: log.syslog.severity
+  tag: 1
+  type: int64
+log.syslog.severity.name:
+  deprecated: false
+  key: log.syslog.severity.name
+  name: name
+  scope: log.syslog.severity
+  tag: 2
+  type: string
+message:
+  deprecated: false
+  key: message
+  name: message
+  scope: ''
+  tag: 22
+  type: string
+network:
+  deprecated: false
+  key: network
+  name: network
+  scope: ''
+  tag: 23
+  type: Network
+network.application:
+  deprecated: false
+  key: network.application
+  name: application
+  scope: network
+  tag: 1
+  type: string
+network.bytes:
+  deprecated: false
+  key: network.bytes
+  name: bytes
+  scope: network
+  tag: 2
+  type: int64
+network.community_id:
+  deprecated: false
+  key: network.community_id
+  name: community_id
+  scope: network
+  tag: 3
+  type: string
+network.direction:
+  deprecated: false
+  key: network.direction
+  name: direction
+  scope: network
+  tag: 4
+  type: string
+network.forwarded_ip:
+  deprecated: false
+  key: network.forwarded_ip
+  name: forwarded_ip
+  scope: network
+  tag: 5
+  type: string
+network.iana_number:
+  deprecated: false
+  key: network.iana_number
+  name: iana_number
+  scope: network
+  tag: 6
+  type: string
+network.inner:
+  deprecated: false
+  key: network.inner
+  name: inner
+  scope: network
+  tag: 7
+  type: map <string, string>
+network.inner.vlan:
+  deprecated: false
+  key: network.inner.vlan
+  name: vlan
+  scope: network.inner
+  tag: 1
+  type: Vlan
+network.inner.vlan.id:
+  deprecated: false
+  key: network.inner.vlan.id
+  name: id
+  scope: network.inner.vlan
+  tag: 1
+  type: string
+network.inner.vlan.name:
+  deprecated: false
+  key: network.inner.vlan.name
+  name: name
+  scope: network.inner.vlan
+  tag: 2
+  type: string
+network.name:
+  deprecated: false
+  key: network.name
+  name: name
+  scope: network
+  tag: 8
+  type: string
+network.packets:
+  deprecated: false
+  key: network.packets
+  name: packets
+  scope: network
+  tag: 9
+  type: int64
+network.protocol:
+  deprecated: false
+  key: network.protocol
+  name: protocol
+  scope: network
+  tag: 10
+  type: string
+network.transport:
+  deprecated: false
+  key: network.transport
+  name: transport
+  scope: network
+  tag: 11
+  type: string
+network.type:
+  deprecated: false
+  key: network.type
+  name: type
+  scope: network
+  tag: 12
+  type: string
+network.vlan:
+  deprecated: false
+  key: network.vlan
+  name: vlan
+  scope: network
+  tag: 13
+  type: Vlan
+network.vlan.id:
+  deprecated: false
+  key: network.vlan.id
+  name: id
+  scope: network.vlan
+  tag: 1
+  type: string
+network.vlan.name:
+  deprecated: false
+  key: network.vlan.name
+  name: name
+  scope: network.vlan
+  tag: 2
+  type: string
+observer:
+  deprecated: false
+  key: observer
+  name: observer
+  scope: ''
+  tag: 24
+  type: Observer
+observer.egress:
+  deprecated: false
+  key: observer.egress
+  name: egress
+  scope: observer
+  tag: 1
+  type: map <string, string>
+observer.egress.interface:
+  deprecated: false
+  key: observer.egress.interface
+  name: interface
+  scope: observer.egress
+  tag: 1
+  type: Interface
+observer.egress.interface.alias:
+  deprecated: false
+  key: observer.egress.interface.alias
+  name: alias
+  scope: observer.egress.interface
+  tag: 1
+  type: string
+observer.egress.interface.id:
+  deprecated: false
+  key: observer.egress.interface.id
+  name: id
+  scope: observer.egress.interface
+  tag: 2
+  type: string
+observer.egress.interface.name:
+  deprecated: false
+  key: observer.egress.interface.name
+  name: name
+  scope: observer.egress.interface
+  tag: 3
+  type: string
+observer.egress.vlan:
+  deprecated: false
+  key: observer.egress.vlan
+  name: vlan
+  scope: observer.egress
+  tag: 2
+  type: Vlan
+observer.egress.vlan.id:
+  deprecated: false
+  key: observer.egress.vlan.id
+  name: id
+  scope: observer.egress.vlan
+  tag: 1
+  type: string
+observer.egress.vlan.name:
+  deprecated: false
+  key: observer.egress.vlan.name
+  name: name
+  scope: observer.egress.vlan
+  tag: 2
+  type: string
+observer.egress.zone:
+  deprecated: false
+  key: observer.egress.zone
+  name: zone
+  scope: observer.egress
+  tag: 3
+  type: string
+observer.geo:
+  deprecated: false
+  key: observer.geo
+  name: geo
+  scope: observer
+  tag: 2
+  type: Geo
+observer.geo.city_name:
+  deprecated: false
+  key: observer.geo.city_name
+  name: city_name
+  scope: observer.geo
+  tag: 1
+  type: string
+observer.geo.continent_name:
+  deprecated: false
+  key: observer.geo.continent_name
+  name: continent_name
+  scope: observer.geo
+  tag: 2
+  type: string
+observer.geo.country_iso_code:
+  deprecated: false
+  key: observer.geo.country_iso_code
+  name: country_iso_code
+  scope: observer.geo
+  tag: 3
+  type: string
+observer.geo.country_name:
+  deprecated: false
+  key: observer.geo.country_name
+  name: country_name
+  scope: observer.geo
+  tag: 4
+  type: string
+observer.geo.location:
+  deprecated: false
+  key: observer.geo.location
+  name: location
+  scope: observer.geo
+  tag: 5
+  type: string
+observer.geo.name:
+  deprecated: false
+  key: observer.geo.name
+  name: name
+  scope: observer.geo
+  tag: 6
+  type: string
+observer.geo.region_iso_code:
+  deprecated: false
+  key: observer.geo.region_iso_code
+  name: region_iso_code
+  scope: observer.geo
+  tag: 7
+  type: string
+observer.geo.region_name:
+  deprecated: false
+  key: observer.geo.region_name
+  name: region_name
+  scope: observer.geo
+  tag: 8
+  type: string
+observer.hostname:
+  deprecated: false
+  key: observer.hostname
+  name: hostname
+  scope: observer
+  tag: 3
+  type: string
+observer.ingress:
+  deprecated: false
+  key: observer.ingress
+  name: ingress
+  scope: observer
+  tag: 4
+  type: map <string, string>
+observer.ingress.interface:
+  deprecated: false
+  key: observer.ingress.interface
+  name: interface
+  scope: observer.ingress
+  tag: 1
+  type: Interface
+observer.ingress.interface.alias:
+  deprecated: false
+  key: observer.ingress.interface.alias
+  name: alias
+  scope: observer.ingress.interface
+  tag: 1
+  type: string
+observer.ingress.interface.id:
+  deprecated: false
+  key: observer.ingress.interface.id
+  name: id
+  scope: observer.ingress.interface
+  tag: 2
+  type: string
+observer.ingress.interface.name:
+  deprecated: false
+  key: observer.ingress.interface.name
+  name: name
+  scope: observer.ingress.interface
+  tag: 3
+  type: string
+observer.ingress.vlan:
+  deprecated: false
+  key: observer.ingress.vlan
+  name: vlan
+  scope: observer.ingress
+  tag: 2
+  type: Vlan
+observer.ingress.vlan.id:
+  deprecated: false
+  key: observer.ingress.vlan.id
+  name: id
+  scope: observer.ingress.vlan
+  tag: 1
+  type: string
+observer.ingress.vlan.name:
+  deprecated: false
+  key: observer.ingress.vlan.name
+  name: name
+  scope: observer.ingress.vlan
+  tag: 2
+  type: string
+observer.ingress.zone:
+  deprecated: false
+  key: observer.ingress.zone
+  name: zone
+  scope: observer.ingress
+  tag: 3
+  type: string
+observer.ip:
+  deprecated: false
+  key: observer.ip
+  name: ip
+  scope: observer
+  tag: 5
+  type: string
+observer.mac:
+  deprecated: false
+  key: observer.mac
+  name: mac
+  scope: observer
+  tag: 6
+  type: string
+observer.name:
+  deprecated: false
+  key: observer.name
+  name: name
+  scope: observer
+  tag: 7
+  type: string
+observer.os:
+  deprecated: false
+  key: observer.os
+  name: os
+  scope: observer
+  tag: 8
+  type: Os
+observer.os.family:
+  deprecated: false
+  key: observer.os.family
+  name: family
+  scope: observer.os
+  tag: 1
+  type: string
+observer.os.full:
+  deprecated: false
+  key: observer.os.full
+  name: full
+  scope: observer.os
+  tag: 2
+  type: string
+observer.os.kernel:
+  deprecated: false
+  key: observer.os.kernel
+  name: kernel
+  scope: observer.os
+  tag: 3
+  type: string
+observer.os.name:
+  deprecated: false
+  key: observer.os.name
+  name: name
+  scope: observer.os
+  tag: 4
+  type: string
+observer.os.platform:
+  deprecated: false
+  key: observer.os.platform
+  name: platform
+  scope: observer.os
+  tag: 5
+  type: string
+observer.os.version:
+  deprecated: false
+  key: observer.os.version
+  name: version
+  scope: observer.os
+  tag: 6
+  type: string
+observer.product:
+  deprecated: false
+  key: observer.product
+  name: product
+  scope: observer
+  tag: 9
+  type: string
+observer.serial_number:
+  deprecated: false
+  key: observer.serial_number
+  name: serial_number
+  scope: observer
+  tag: 10
+  type: string
+observer.type:
+  deprecated: false
+  key: observer.type
+  name: type
+  scope: observer
+  tag: 11
+  type: string
+observer.vendor:
+  deprecated: false
+  key: observer.vendor
+  name: vendor
+  scope: observer
+  tag: 12
+  type: string
+observer.version:
+  deprecated: false
+  key: observer.version
+  name: version
+  scope: observer
+  tag: 13
+  type: string
+organization:
+  deprecated: false
+  key: organization
+  name: organization
+  scope: ''
+  tag: 25
+  type: Organization
+organization.id:
+  deprecated: false
+  key: organization.id
+  name: id
+  scope: organization
+  tag: 1
+  type: string
+organization.name:
+  deprecated: false
+  key: organization.name
+  name: name
+  scope: organization
+  tag: 2
+  type: string
+os:
+  deprecated: false
+  key: os
+  name: os
+  scope: ''
+  tag: 26
+  type: Os
+os.family:
+  deprecated: false
+  key: os.family
+  name: family
+  scope: os
+  tag: 1
+  type: string
+os.full:
+  deprecated: false
+  key: os.full
+  name: full
+  scope: os
+  tag: 2
+  type: string
+os.kernel:
+  deprecated: false
+  key: os.kernel
+  name: kernel
+  scope: os
+  tag: 3
+  type: string
+os.name:
+  deprecated: false
+  key: os.name
+  name: name
+  scope: os
+  tag: 4
+  type: string
+os.platform:
+  deprecated: false
+  key: os.platform
+  name: platform
+  scope: os
+  tag: 5
+  type: string
+os.version:
+  deprecated: false
+  key: os.version
+  name: version
+  scope: os
+  tag: 6
+  type: string
+package:
+  deprecated: false
+  key: package
+  name: package
+  scope: ''
+  tag: 27
+  type: Package
+package.architecture:
+  deprecated: false
+  key: package.architecture
+  name: architecture
+  scope: package
+  tag: 1
+  type: string
+package.build_version:
+  deprecated: false
+  key: package.build_version
+  name: build_version
+  scope: package
+  tag: 2
+  type: string
+package.checksum:
+  deprecated: false
+  key: package.checksum
+  name: checksum
+  scope: package
+  tag: 3
+  type: string
+package.description:
+  deprecated: false
+  key: package.description
+  name: description
+  scope: package
+  tag: 4
+  type: string
+package.install_scope:
+  deprecated: false
+  key: package.install_scope
+  name: install_scope
+  scope: package
+  tag: 5
+  type: string
+package.installed:
+  deprecated: false
+  key: package.installed
+  name: installed
+  scope: package
+  tag: 6
+  type: string
+package.license:
+  deprecated: false
+  key: package.license
+  name: license
+  scope: package
+  tag: 7
+  type: string
+package.name:
+  deprecated: false
+  key: package.name
+  name: name
+  scope: package
+  tag: 8
+  type: string
+package.path:
+  deprecated: false
+  key: package.path
+  name: path
+  scope: package
+  tag: 9
+  type: string
+package.reference:
+  deprecated: false
+  key: package.reference
+  name: reference
+  scope: package
+  tag: 10
+  type: string
+package.size:
+  deprecated: false
+  key: package.size
+  name: size
+  scope: package
+  tag: 11
+  type: int64
+package.type:
+  deprecated: false
+  key: package.type
+  name: type
+  scope: package
+  tag: 12
+  type: string
+package.version:
+  deprecated: false
+  key: package.version
+  name: version
+  scope: package
+  tag: 13
+  type: string
+pe:
+  deprecated: false
+  key: pe
+  name: pe
+  scope: ''
+  tag: 28
+  type: Pe
+pe.architecture:
+  deprecated: false
+  key: pe.architecture
+  name: architecture
+  scope: pe
+  tag: 1
+  type: string
+pe.company:
+  deprecated: false
+  key: pe.company
+  name: company
+  scope: pe
+  tag: 2
+  type: string
+pe.description:
+  deprecated: false
+  key: pe.description
+  name: description
+  scope: pe
+  tag: 3
+  type: string
+pe.file_version:
+  deprecated: false
+  key: pe.file_version
+  name: file_version
+  scope: pe
+  tag: 4
+  type: string
+pe.imphash:
+  deprecated: false
+  key: pe.imphash
+  name: imphash
+  scope: pe
+  tag: 5
+  type: string
+pe.original_file_name:
+  deprecated: false
+  key: pe.original_file_name
+  name: original_file_name
+  scope: pe
+  tag: 6
+  type: string
+pe.product:
+  deprecated: false
+  key: pe.product
+  name: product
+  scope: pe
+  tag: 7
+  type: string
+process:
+  deprecated: false
+  key: process
+  name: process
+  scope: ''
+  tag: 29
+  type: Process
+process.args:
+  deprecated: false
+  key: process.args
+  name: args
+  scope: process
+  tag: 1
+  type: string
+process.args_count:
+  deprecated: false
+  key: process.args_count
+  name: args_count
+  scope: process
+  tag: 2
+  type: int64
+process.code_signature:
+  deprecated: false
+  key: process.code_signature
+  name: code_signature
+  scope: process
+  tag: 3
+  type: CodeSignature
+process.code_signature.exists:
+  deprecated: false
+  key: process.code_signature.exists
+  name: exists
+  scope: process.code_signature
+  tag: 1
+  type: bool
+process.code_signature.status:
+  deprecated: false
+  key: process.code_signature.status
+  name: status
+  scope: process.code_signature
+  tag: 2
+  type: string
+process.code_signature.subject_name:
+  deprecated: false
+  key: process.code_signature.subject_name
+  name: subject_name
+  scope: process.code_signature
+  tag: 3
+  type: string
+process.code_signature.trusted:
+  deprecated: false
+  key: process.code_signature.trusted
+  name: trusted
+  scope: process.code_signature
+  tag: 4
+  type: bool
+process.code_signature.valid:
+  deprecated: false
+  key: process.code_signature.valid
+  name: valid
+  scope: process.code_signature
+  tag: 5
+  type: bool
+process.command_line:
+  deprecated: false
+  key: process.command_line
+  name: command_line
+  scope: process
+  tag: 4
+  type: string
+process.entity_id:
+  deprecated: false
+  key: process.entity_id
+  name: entity_id
+  scope: process
+  tag: 5
+  type: string
+process.executable:
+  deprecated: false
+  key: process.executable
+  name: executable
+  scope: process
+  tag: 6
+  type: string
+process.exit_code:
+  deprecated: false
+  key: process.exit_code
+  name: exit_code
+  scope: process
+  tag: 7
+  type: int64
+process.hash:
+  deprecated: false
+  key: process.hash
+  name: hash
+  scope: process
+  tag: 8
+  type: Hash
+process.hash.md5:
+  deprecated: false
+  key: process.hash.md5
+  name: md5
+  scope: process.hash
+  tag: 1
+  type: string
+process.hash.sha1:
+  deprecated: false
+  key: process.hash.sha1
+  name: sha1
+  scope: process.hash
+  tag: 2
+  type: string
+process.hash.sha256:
+  deprecated: false
+  key: process.hash.sha256
+  name: sha256
+  scope: process.hash
+  tag: 3
+  type: string
+process.hash.sha512:
+  deprecated: false
+  key: process.hash.sha512
+  name: sha512
+  scope: process.hash
+  tag: 4
+  type: string
+process.name:
+  deprecated: false
+  key: process.name
+  name: name
+  scope: process
+  tag: 9
+  type: string
+process.parent:
+  deprecated: false
+  key: process.parent
+  name: parent
+  scope: process
+  tag: 10
+  type: Parent
+process.parent.args:
+  deprecated: false
+  key: process.parent.args
+  name: args
+  scope: process.parent
+  tag: 1
+  type: string
+process.parent.args_count:
+  deprecated: false
+  key: process.parent.args_count
+  name: args_count
+  scope: process.parent
+  tag: 2
+  type: int64
+process.parent.code_signature:
+  deprecated: false
+  key: process.parent.code_signature
+  name: code_signature
+  scope: process.parent
+  tag: 3
+  type: CodeSignature
+process.parent.code_signature.exists:
+  deprecated: false
+  key: process.parent.code_signature.exists
+  name: exists
+  scope: process.parent.code_signature
+  tag: 1
+  type: bool
+process.parent.code_signature.status:
+  deprecated: false
+  key: process.parent.code_signature.status
+  name: status
+  scope: process.parent.code_signature
+  tag: 2
+  type: string
+process.parent.code_signature.subject_name:
+  deprecated: false
+  key: process.parent.code_signature.subject_name
+  name: subject_name
+  scope: process.parent.code_signature
+  tag: 3
+  type: string
+process.parent.code_signature.trusted:
+  deprecated: false
+  key: process.parent.code_signature.trusted
+  name: trusted
+  scope: process.parent.code_signature
+  tag: 4
+  type: bool
+process.parent.code_signature.valid:
+  deprecated: false
+  key: process.parent.code_signature.valid
+  name: valid
+  scope: process.parent.code_signature
+  tag: 5
+  type: bool
+process.parent.command_line:
+  deprecated: false
+  key: process.parent.command_line
+  name: command_line
+  scope: process.parent
+  tag: 4
+  type: string
+process.parent.entity_id:
+  deprecated: false
+  key: process.parent.entity_id
+  name: entity_id
+  scope: process.parent
+  tag: 5
+  type: string
+process.parent.executable:
+  deprecated: false
+  key: process.parent.executable
+  name: executable
+  scope: process.parent
+  tag: 6
+  type: string
+process.parent.exit_code:
+  deprecated: false
+  key: process.parent.exit_code
+  name: exit_code
+  scope: process.parent
+  tag: 7
+  type: int64
+process.parent.hash:
+  deprecated: false
+  key: process.parent.hash
+  name: hash
+  scope: process.parent
+  tag: 8
+  type: Hash
+process.parent.hash.md5:
+  deprecated: false
+  key: process.parent.hash.md5
+  name: md5
+  scope: process.parent.hash
+  tag: 1
+  type: string
+process.parent.hash.sha1:
+  deprecated: false
+  key: process.parent.hash.sha1
+  name: sha1
+  scope: process.parent.hash
+  tag: 2
+  type: string
+process.parent.hash.sha256:
+  deprecated: false
+  key: process.parent.hash.sha256
+  name: sha256
+  scope: process.parent.hash
+  tag: 3
+  type: string
+process.parent.hash.sha512:
+  deprecated: false
+  key: process.parent.hash.sha512
+  name: sha512
+  scope: process.parent.hash
+  tag: 4
+  type: string
+process.parent.name:
+  deprecated: false
+  key: process.parent.name
+  name: name
+  scope: process.parent
+  tag: 9
+  type: string
+process.parent.pgid:
+  deprecated: false
+  key: process.parent.pgid
+  name: pgid
+  scope: process.parent
+  tag: 10
+  type: int64
+process.parent.pid:
+  deprecated: false
+  key: process.parent.pid
+  name: pid
+  scope: process.parent
+  tag: 11
+  type: int64
+process.parent.ppid:
+  deprecated: false
+  key: process.parent.ppid
+  name: ppid
+  scope: process.parent
+  tag: 12
+  type: int64
+process.parent.start:
+  deprecated: false
+  key: process.parent.start
+  name: start
+  scope: process.parent
+  tag: 13
+  type: string
+process.parent.thread:
+  deprecated: false
+  key: process.parent.thread
+  name: thread
+  scope: process.parent
+  tag: 14
+  type: Thread
+process.parent.thread.id:
+  deprecated: false
+  key: process.parent.thread.id
+  name: id
+  scope: process.parent.thread
+  tag: 1
+  type: int64
+process.parent.thread.name:
+  deprecated: false
+  key: process.parent.thread.name
+  name: name
+  scope: process.parent.thread
+  tag: 2
+  type: string
+process.parent.title:
+  deprecated: false
+  key: process.parent.title
+  name: title
+  scope: process.parent
+  tag: 15
+  type: string
+process.parent.uptime:
+  deprecated: false
+  key: process.parent.uptime
+  name: uptime
+  scope: process.parent
+  tag: 16
+  type: int64
+process.parent.working_directory:
+  deprecated: false
+  key: process.parent.working_directory
+  name: working_directory
+  scope: process.parent
+  tag: 17
+  type: string
+process.pe:
+  deprecated: false
+  key: process.pe
+  name: pe
+  scope: process
+  tag: 11
+  type: Pe
+process.pe.architecture:
+  deprecated: false
+  key: process.pe.architecture
+  name: architecture
+  scope: process.pe
+  tag: 1
+  type: string
+process.pe.company:
+  deprecated: false
+  key: process.pe.company
+  name: company
+  scope: process.pe
+  tag: 2
+  type: string
+process.pe.description:
+  deprecated: false
+  key: process.pe.description
+  name: description
+  scope: process.pe
+  tag: 3
+  type: string
+process.pe.file_version:
+  deprecated: false
+  key: process.pe.file_version
+  name: file_version
+  scope: process.pe
+  tag: 4
+  type: string
+process.pe.imphash:
+  deprecated: false
+  key: process.pe.imphash
+  name: imphash
+  scope: process.pe
+  tag: 5
+  type: string
+process.pe.original_file_name:
+  deprecated: false
+  key: process.pe.original_file_name
+  name: original_file_name
+  scope: process.pe
+  tag: 6
+  type: string
+process.pe.product:
+  deprecated: false
+  key: process.pe.product
+  name: product
+  scope: process.pe
+  tag: 7
+  type: string
+process.pgid:
+  deprecated: false
+  key: process.pgid
+  name: pgid
+  scope: process
+  tag: 12
+  type: int64
+process.pid:
+  deprecated: false
+  key: process.pid
+  name: pid
+  scope: process
+  tag: 13
+  type: int64
+process.ppid:
+  deprecated: false
+  key: process.ppid
+  name: ppid
+  scope: process
+  tag: 14
+  type: int64
+process.start:
+  deprecated: false
+  key: process.start
+  name: start
+  scope: process
+  tag: 15
+  type: string
+process.thread:
+  deprecated: false
+  key: process.thread
+  name: thread
+  scope: process
+  tag: 16
+  type: Thread
+process.thread.id:
+  deprecated: false
+  key: process.thread.id
+  name: id
+  scope: process.thread
+  tag: 1
+  type: int64
+process.thread.name:
+  deprecated: false
+  key: process.thread.name
+  name: name
+  scope: process.thread
+  tag: 2
+  type: string
+process.title:
+  deprecated: false
+  key: process.title
+  name: title
+  scope: process
+  tag: 17
+  type: string
+process.uptime:
+  deprecated: false
+  key: process.uptime
+  name: uptime
+  scope: process
+  tag: 18
+  type: int64
+process.working_directory:
+  deprecated: false
+  key: process.working_directory
+  name: working_directory
+  scope: process
+  tag: 19
+  type: string
+registry:
+  deprecated: false
+  key: registry
+  name: registry
+  scope: ''
+  tag: 30
+  type: Registry
+registry.data:
+  deprecated: false
+  key: registry.data
+  name: data
+  scope: registry
+  tag: 1
+  type: Data
+registry.data.bytes:
+  deprecated: false
+  key: registry.data.bytes
+  name: bytes
+  scope: registry.data
+  tag: 1
+  type: string
+registry.data.strings:
+  deprecated: false
+  key: registry.data.strings
+  name: strings
+  scope: registry.data
+  tag: 2
+  type: string
+registry.data.type:
+  deprecated: false
+  key: registry.data.type
+  name: type
+  scope: registry.data
+  tag: 3
+  type: string
+registry.hive:
+  deprecated: false
+  key: registry.hive
+  name: hive
+  scope: registry
+  tag: 2
+  type: string
+registry.key:
+  deprecated: false
+  key: registry.key
+  name: key
+  scope: registry
+  tag: 3
+  type: string
+registry.path:
+  deprecated: false
+  key: registry.path
+  name: path
+  scope: registry
+  tag: 4
+  type: string
+registry.value:
+  deprecated: false
+  key: registry.value
+  name: value
+  scope: registry
+  tag: 5
+  type: string
+related:
+  deprecated: false
+  key: related
+  name: related
+  scope: ''
+  tag: 31
+  type: Related
+related.hash:
+  deprecated: false
+  key: related.hash
+  name: hash
+  scope: related
+  tag: 1
+  type: string
+related.ip:
+  deprecated: false
+  key: related.ip
+  name: ip
+  scope: related
+  tag: 2
+  type: string
+related.user:
+  deprecated: false
+  key: related.user
+  name: user
+  scope: related
+  tag: 3
+  type: string
+rule:
+  deprecated: false
+  key: rule
+  name: rule
+  scope: ''
+  tag: 32
+  type: Rule
+rule.author:
+  deprecated: false
+  key: rule.author
+  name: author
+  scope: rule
+  tag: 1
+  type: string
+rule.category:
+  deprecated: false
+  key: rule.category
+  name: category
+  scope: rule
+  tag: 2
+  type: string
+rule.description:
+  deprecated: false
+  key: rule.description
+  name: description
+  scope: rule
+  tag: 3
+  type: string
+rule.id:
+  deprecated: false
+  key: rule.id
+  name: id
+  scope: rule
+  tag: 4
+  type: string
+rule.license:
+  deprecated: false
+  key: rule.license
+  name: license
+  scope: rule
+  tag: 5
+  type: string
+rule.name:
+  deprecated: false
+  key: rule.name
+  name: name
+  scope: rule
+  tag: 6
+  type: string
+rule.reference:
+  deprecated: false
+  key: rule.reference
+  name: reference
+  scope: rule
+  tag: 7
+  type: string
+rule.ruleset:
+  deprecated: false
+  key: rule.ruleset
+  name: ruleset
+  scope: rule
+  tag: 8
+  type: string
+rule.uuid:
+  deprecated: false
+  key: rule.uuid
+  name: uuid
+  scope: rule
+  tag: 9
+  type: string
+rule.version:
+  deprecated: false
+  key: rule.version
+  name: version
+  scope: rule
+  tag: 10
+  type: string
+server:
+  deprecated: false
+  key: server
+  name: server
+  scope: ''
+  tag: 33
+  type: Server
+server.address:
+  deprecated: false
+  key: server.address
+  name: address
+  scope: server
+  tag: 1
+  type: string
+server.as:
+  deprecated: false
+  key: server.as
+  name: as
+  scope: server
+  tag: 2
+  type: As
+server.as.number:
+  deprecated: false
+  key: server.as.number
+  name: number
+  scope: server.as
+  tag: 1
+  type: int64
+server.as.organization:
+  deprecated: false
+  key: server.as.organization
+  name: organization
+  scope: server.as
+  tag: 2
+  type: Organization
+server.as.organization.name:
+  deprecated: false
+  key: server.as.organization.name
+  name: name
+  scope: server.as.organization
+  tag: 1
+  type: string
+server.bytes:
+  deprecated: false
+  key: server.bytes
+  name: bytes
+  scope: server
+  tag: 3
+  type: int64
+server.domain:
+  deprecated: false
+  key: server.domain
+  name: domain
+  scope: server
+  tag: 4
+  type: string
+server.geo:
+  deprecated: false
+  key: server.geo
+  name: geo
+  scope: server
+  tag: 5
+  type: Geo
+server.geo.city_name:
+  deprecated: false
+  key: server.geo.city_name
+  name: city_name
+  scope: server.geo
+  tag: 1
+  type: string
+server.geo.continent_name:
+  deprecated: false
+  key: server.geo.continent_name
+  name: continent_name
+  scope: server.geo
+  tag: 2
+  type: string
+server.geo.country_iso_code:
+  deprecated: false
+  key: server.geo.country_iso_code
+  name: country_iso_code
+  scope: server.geo
+  tag: 3
+  type: string
+server.geo.country_name:
+  deprecated: false
+  key: server.geo.country_name
+  name: country_name
+  scope: server.geo
+  tag: 4
+  type: string
+server.geo.location:
+  deprecated: false
+  key: server.geo.location
+  name: location
+  scope: server.geo
+  tag: 5
+  type: string
+server.geo.name:
+  deprecated: false
+  key: server.geo.name
+  name: name
+  scope: server.geo
+  tag: 6
+  type: string
+server.geo.region_iso_code:
+  deprecated: false
+  key: server.geo.region_iso_code
+  name: region_iso_code
+  scope: server.geo
+  tag: 7
+  type: string
+server.geo.region_name:
+  deprecated: false
+  key: server.geo.region_name
+  name: region_name
+  scope: server.geo
+  tag: 8
+  type: string
+server.ip:
+  deprecated: false
+  key: server.ip
+  name: ip
+  scope: server
+  tag: 6
+  type: string
+server.mac:
+  deprecated: false
+  key: server.mac
+  name: mac
+  scope: server
+  tag: 7
+  type: string
+server.nat:
+  deprecated: false
+  key: server.nat
+  name: nat
+  scope: server
+  tag: 8
+  type: Nat
+server.nat.ip:
+  deprecated: false
+  key: server.nat.ip
+  name: ip
+  scope: server.nat
+  tag: 1
+  type: string
+server.nat.port:
+  deprecated: false
+  key: server.nat.port
+  name: port
+  scope: server.nat
+  tag: 2
+  type: int64
+server.packets:
+  deprecated: false
+  key: server.packets
+  name: packets
+  scope: server
+  tag: 9
+  type: int64
+server.port:
+  deprecated: false
+  key: server.port
+  name: port
+  scope: server
+  tag: 10
+  type: int64
+server.registered_domain:
+  deprecated: false
+  key: server.registered_domain
+  name: registered_domain
+  scope: server
+  tag: 11
+  type: string
+server.top_level_domain:
+  deprecated: false
+  key: server.top_level_domain
+  name: top_level_domain
+  scope: server
+  tag: 12
+  type: string
+server.user:
+  deprecated: false
+  key: server.user
+  name: user
+  scope: server
+  tag: 13
+  type: User
+server.user.domain:
+  deprecated: false
+  key: server.user.domain
+  name: domain
+  scope: server.user
+  tag: 1
+  type: string
+server.user.email:
+  deprecated: false
+  key: server.user.email
+  name: email
+  scope: server.user
+  tag: 2
+  type: string
+server.user.full_name:
+  deprecated: false
+  key: server.user.full_name
+  name: full_name
+  scope: server.user
+  tag: 3
+  type: string
+server.user.group:
+  deprecated: false
+  key: server.user.group
+  name: group
+  scope: server.user
+  tag: 4
+  type: Group
+server.user.group.domain:
+  deprecated: false
+  key: server.user.group.domain
+  name: domain
+  scope: server.user.group
+  tag: 1
+  type: string
+server.user.group.id:
+  deprecated: false
+  key: server.user.group.id
+  name: id
+  scope: server.user.group
+  tag: 2
+  type: string
+server.user.group.name:
+  deprecated: false
+  key: server.user.group.name
+  name: name
+  scope: server.user.group
+  tag: 3
+  type: string
+server.user.hash:
+  deprecated: false
+  key: server.user.hash
+  name: hash
+  scope: server.user
+  tag: 5
+  type: string
+server.user.id:
+  deprecated: false
+  key: server.user.id
+  name: id
+  scope: server.user
+  tag: 6
+  type: string
+server.user.name:
+  deprecated: false
+  key: server.user.name
+  name: name
+  scope: server.user
+  tag: 7
+  type: string
+service:
+  deprecated: false
+  key: service
+  name: service
+  scope: ''
+  tag: 34
+  type: Service
+service.ephemeral_id:
+  deprecated: false
+  key: service.ephemeral_id
+  name: ephemeral_id
+  scope: service
+  tag: 1
+  type: string
+service.id:
+  deprecated: false
+  key: service.id
+  name: id
+  scope: service
+  tag: 2
+  type: string
+service.name:
+  deprecated: false
+  key: service.name
+  name: name
+  scope: service
+  tag: 3
+  type: string
+service.node:
+  deprecated: false
+  key: service.node
+  name: node
+  scope: service
+  tag: 4
+  type: Node
+service.node.name:
+  deprecated: false
+  key: service.node.name
+  name: name
+  scope: service.node
+  tag: 1
+  type: string
+service.state:
+  deprecated: false
+  key: service.state
+  name: state
+  scope: service
+  tag: 5
+  type: string
+service.type:
+  deprecated: false
+  key: service.type
+  name: type
+  scope: service
+  tag: 6
+  type: string
+service.version:
+  deprecated: false
+  key: service.version
+  name: version
+  scope: service
+  tag: 7
+  type: string
+source:
+  deprecated: false
+  key: source
+  name: source
+  scope: ''
+  tag: 35
+  type: Source
+source.address:
+  deprecated: false
+  key: source.address
+  name: address
+  scope: source
+  tag: 1
+  type: string
+source.as:
+  deprecated: false
+  key: source.as
+  name: as
+  scope: source
+  tag: 2
+  type: As
+source.as.number:
+  deprecated: false
+  key: source.as.number
+  name: number
+  scope: source.as
+  tag: 1
+  type: int64
+source.as.organization:
+  deprecated: false
+  key: source.as.organization
+  name: organization
+  scope: source.as
+  tag: 2
+  type: Organization
+source.as.organization.name:
+  deprecated: false
+  key: source.as.organization.name
+  name: name
+  scope: source.as.organization
+  tag: 1
+  type: string
+source.bytes:
+  deprecated: false
+  key: source.bytes
+  name: bytes
+  scope: source
+  tag: 3
+  type: int64
+source.domain:
+  deprecated: false
+  key: source.domain
+  name: domain
+  scope: source
+  tag: 4
+  type: string
+source.geo:
+  deprecated: false
+  key: source.geo
+  name: geo
+  scope: source
+  tag: 5
+  type: Geo
+source.geo.city_name:
+  deprecated: false
+  key: source.geo.city_name
+  name: city_name
+  scope: source.geo
+  tag: 1
+  type: string
+source.geo.continent_name:
+  deprecated: false
+  key: source.geo.continent_name
+  name: continent_name
+  scope: source.geo
+  tag: 2
+  type: string
+source.geo.country_iso_code:
+  deprecated: false
+  key: source.geo.country_iso_code
+  name: country_iso_code
+  scope: source.geo
+  tag: 3
+  type: string
+source.geo.country_name:
+  deprecated: false
+  key: source.geo.country_name
+  name: country_name
+  scope: source.geo
+  tag: 4
+  type: string
+source.geo.location:
+  deprecated: false
+  key: source.geo.location
+  name: location
+  scope: source.geo
+  tag: 5
+  type: string
+source.geo.name:
+  deprecated: false
+  key: source.geo.name
+  name: name
+  scope: source.geo
+  tag: 6
+  type: string
+source.geo.region_iso_code:
+  deprecated: false
+  key: source.geo.region_iso_code
+  name: region_iso_code
+  scope: source.geo
+  tag: 7
+  type: string
+source.geo.region_name:
+  deprecated: false
+  key: source.geo.region_name
+  name: region_name
+  scope: source.geo
+  tag: 8
+  type: string
+source.ip:
+  deprecated: false
+  key: source.ip
+  name: ip
+  scope: source
+  tag: 6
+  type: string
+source.mac:
+  deprecated: false
+  key: source.mac
+  name: mac
+  scope: source
+  tag: 7
+  type: string
+source.nat:
+  deprecated: false
+  key: source.nat
+  name: nat
+  scope: source
+  tag: 8
+  type: Nat
+source.nat.ip:
+  deprecated: false
+  key: source.nat.ip
+  name: ip
+  scope: source.nat
+  tag: 1
+  type: string
+source.nat.port:
+  deprecated: false
+  key: source.nat.port
+  name: port
+  scope: source.nat
+  tag: 2
+  type: int64
+source.packets:
+  deprecated: false
+  key: source.packets
+  name: packets
+  scope: source
+  tag: 9
+  type: int64
+source.port:
+  deprecated: false
+  key: source.port
+  name: port
+  scope: source
+  tag: 10
+  type: int64
+source.registered_domain:
+  deprecated: false
+  key: source.registered_domain
+  name: registered_domain
+  scope: source
+  tag: 11
+  type: string
+source.top_level_domain:
+  deprecated: false
+  key: source.top_level_domain
+  name: top_level_domain
+  scope: source
+  tag: 12
+  type: string
+source.user:
+  deprecated: false
+  key: source.user
+  name: user
+  scope: source
+  tag: 13
+  type: User
+source.user.domain:
+  deprecated: false
+  key: source.user.domain
+  name: domain
+  scope: source.user
+  tag: 1
+  type: string
+source.user.email:
+  deprecated: false
+  key: source.user.email
+  name: email
+  scope: source.user
+  tag: 2
+  type: string
+source.user.full_name:
+  deprecated: false
+  key: source.user.full_name
+  name: full_name
+  scope: source.user
+  tag: 3
+  type: string
+source.user.group:
+  deprecated: false
+  key: source.user.group
+  name: group
+  scope: source.user
+  tag: 4
+  type: Group
+source.user.group.domain:
+  deprecated: false
+  key: source.user.group.domain
+  name: domain
+  scope: source.user.group
+  tag: 1
+  type: string
+source.user.group.id:
+  deprecated: false
+  key: source.user.group.id
+  name: id
+  scope: source.user.group
+  tag: 2
+  type: string
+source.user.group.name:
+  deprecated: false
+  key: source.user.group.name
+  name: name
+  scope: source.user.group
+  tag: 3
+  type: string
+source.user.hash:
+  deprecated: false
+  key: source.user.hash
+  name: hash
+  scope: source.user
+  tag: 5
+  type: string
+source.user.id:
+  deprecated: false
+  key: source.user.id
+  name: id
+  scope: source.user
+  tag: 6
+  type: string
+source.user.name:
+  deprecated: false
+  key: source.user.name
+  name: name
+  scope: source.user
+  tag: 7
+  type: string
+tags:
+  deprecated: false
+  key: tags
+  name: tags
+  scope: ''
+  tag: 36
+  type: string
+threat:
+  deprecated: false
+  key: threat
+  name: threat
+  scope: ''
+  tag: 37
+  type: Threat
+threat.framework:
+  deprecated: false
+  key: threat.framework
+  name: framework
+  scope: threat
+  tag: 1
+  type: string
+threat.tactic:
+  deprecated: false
+  key: threat.tactic
+  name: tactic
+  scope: threat
+  tag: 2
+  type: Tactic
+threat.tactic.id:
+  deprecated: false
+  key: threat.tactic.id
+  name: id
+  scope: threat.tactic
+  tag: 1
+  type: string
+threat.tactic.name:
+  deprecated: false
+  key: threat.tactic.name
+  name: name
+  scope: threat.tactic
+  tag: 2
+  type: string
+threat.tactic.reference:
+  deprecated: false
+  key: threat.tactic.reference
+  name: reference
+  scope: threat.tactic
+  tag: 3
+  type: string
+threat.technique:
+  deprecated: false
+  key: threat.technique
+  name: technique
+  scope: threat
+  tag: 3
+  type: Technique
+threat.technique.id:
+  deprecated: false
+  key: threat.technique.id
+  name: id
+  scope: threat.technique
+  tag: 1
+  type: string
+threat.technique.name:
+  deprecated: false
+  key: threat.technique.name
+  name: name
+  scope: threat.technique
+  tag: 2
+  type: string
+threat.technique.reference:
+  deprecated: false
+  key: threat.technique.reference
+  name: reference
+  scope: threat.technique
+  tag: 3
+  type: string
+timestamp:
+  deprecated: false
+  key: timestamp
+  name: timestamp
+  scope: ''
+  tag: 38
+  type: string
+tls:
+  deprecated: false
+  key: tls
+  name: tls
+  scope: ''
+  tag: 39
+  type: Tls
+tls.cipher:
+  deprecated: false
+  key: tls.cipher
+  name: cipher
+  scope: tls
+  tag: 1
+  type: string
+tls.client:
+  deprecated: false
+  key: tls.client
+  name: client
+  scope: tls
+  tag: 2
+  type: Client
+tls.client.certificate:
+  deprecated: false
+  key: tls.client.certificate
+  name: certificate
+  scope: tls.client
+  tag: 1
+  type: string
+tls.client.certificate_chain:
+  deprecated: false
+  key: tls.client.certificate_chain
+  name: certificate_chain
+  scope: tls.client
+  tag: 2
+  type: string
+tls.client.hash:
+  deprecated: false
+  key: tls.client.hash
+  name: hash
+  scope: tls.client
+  tag: 3
+  type: Hash
+tls.client.hash.md5:
+  deprecated: false
+  key: tls.client.hash.md5
+  name: md5
+  scope: tls.client.hash
+  tag: 1
+  type: string
+tls.client.hash.sha1:
+  deprecated: false
+  key: tls.client.hash.sha1
+  name: sha1
+  scope: tls.client.hash
+  tag: 2
+  type: string
+tls.client.hash.sha256:
+  deprecated: false
+  key: tls.client.hash.sha256
+  name: sha256
+  scope: tls.client.hash
+  tag: 3
+  type: string
+tls.client.issuer:
+  deprecated: false
+  key: tls.client.issuer
+  name: issuer
+  scope: tls.client
+  tag: 4
+  type: string
+tls.client.ja3:
+  deprecated: false
+  key: tls.client.ja3
+  name: ja3
+  scope: tls.client
+  tag: 5
+  type: string
+tls.client.not_after:
+  deprecated: false
+  key: tls.client.not_after
+  name: not_after
+  scope: tls.client
+  tag: 6
+  type: string
+tls.client.not_before:
+  deprecated: false
+  key: tls.client.not_before
+  name: not_before
+  scope: tls.client
+  tag: 7
+  type: string
+tls.client.server_name:
+  deprecated: false
+  key: tls.client.server_name
+  name: server_name
+  scope: tls.client
+  tag: 8
+  type: string
+tls.client.subject:
+  deprecated: false
+  key: tls.client.subject
+  name: subject
+  scope: tls.client
+  tag: 9
+  type: string
+tls.client.supported_ciphers:
+  deprecated: false
+  key: tls.client.supported_ciphers
+  name: supported_ciphers
+  scope: tls.client
+  tag: 10
+  type: string
+tls.curve:
+  deprecated: false
+  key: tls.curve
+  name: curve
+  scope: tls
+  tag: 3
+  type: string
+tls.established:
+  deprecated: false
+  key: tls.established
+  name: established
+  scope: tls
+  tag: 4
+  type: bool
+tls.next_protocol:
+  deprecated: false
+  key: tls.next_protocol
+  name: next_protocol
+  scope: tls
+  tag: 5
+  type: string
+tls.resumed:
+  deprecated: false
+  key: tls.resumed
+  name: resumed
+  scope: tls
+  tag: 6
+  type: bool
+tls.server:
+  deprecated: false
+  key: tls.server
+  name: server
+  scope: tls
+  tag: 7
+  type: Server
+tls.server.certificate:
+  deprecated: false
+  key: tls.server.certificate
+  name: certificate
+  scope: tls.server
+  tag: 1
+  type: string
+tls.server.certificate_chain:
+  deprecated: false
+  key: tls.server.certificate_chain
+  name: certificate_chain
+  scope: tls.server
+  tag: 2
+  type: string
+tls.server.hash:
+  deprecated: false
+  key: tls.server.hash
+  name: hash
+  scope: tls.server
+  tag: 3
+  type: Hash
+tls.server.hash.md5:
+  deprecated: false
+  key: tls.server.hash.md5
+  name: md5
+  scope: tls.server.hash
+  tag: 1
+  type: string
+tls.server.hash.sha1:
+  deprecated: false
+  key: tls.server.hash.sha1
+  name: sha1
+  scope: tls.server.hash
+  tag: 2
+  type: string
+tls.server.hash.sha256:
+  deprecated: false
+  key: tls.server.hash.sha256
+  name: sha256
+  scope: tls.server.hash
+  tag: 3
+  type: string
+tls.server.issuer:
+  deprecated: false
+  key: tls.server.issuer
+  name: issuer
+  scope: tls.server
+  tag: 4
+  type: string
+tls.server.ja3s:
+  deprecated: false
+  key: tls.server.ja3s
+  name: ja3s
+  scope: tls.server
+  tag: 5
+  type: string
+tls.server.not_after:
+  deprecated: false
+  key: tls.server.not_after
+  name: not_after
+  scope: tls.server
+  tag: 6
+  type: string
+tls.server.not_before:
+  deprecated: false
+  key: tls.server.not_before
+  name: not_before
+  scope: tls.server
+  tag: 7
+  type: string
+tls.server.subject:
+  deprecated: false
+  key: tls.server.subject
+  name: subject
+  scope: tls.server
+  tag: 8
+  type: string
+tls.version:
+  deprecated: false
+  key: tls.version
+  name: version
+  scope: tls
+  tag: 8
+  type: string
+tls.version_protocol:
+  deprecated: false
+  key: tls.version_protocol
+  name: version_protocol
+  scope: tls
+  tag: 9
+  type: string
+trace:
+  deprecated: false
+  key: trace
+  name: trace
+  scope: ''
+  tag: 40
+  type: Trace
+trace.id:
+  deprecated: false
+  key: trace.id
+  name: id
+  scope: trace
+  tag: 1
+  type: string
+transaction:
+  deprecated: false
+  key: transaction
+  name: transaction
+  scope: ''
+  tag: 41
+  type: Transaction
+transaction.id:
+  deprecated: false
+  key: transaction.id
+  name: id
+  scope: transaction
+  tag: 1
+  type: string
+url:
+  deprecated: false
+  key: url
+  name: url
+  scope: ''
+  tag: 42
+  type: Url
+url.domain:
+  deprecated: false
+  key: url.domain
+  name: domain
+  scope: url
+  tag: 1
+  type: string
+url.extension:
+  deprecated: false
+  key: url.extension
+  name: extension
+  scope: url
+  tag: 2
+  type: string
+url.fragment:
+  deprecated: false
+  key: url.fragment
+  name: fragment
+  scope: url
+  tag: 3
+  type: string
+url.full:
+  deprecated: false
+  key: url.full
+  name: full
+  scope: url
+  tag: 4
+  type: string
+url.original:
+  deprecated: false
+  key: url.original
+  name: original
+  scope: url
+  tag: 5
+  type: string
+url.password:
+  deprecated: false
+  key: url.password
+  name: password
+  scope: url
+  tag: 6
+  type: string
+url.path:
+  deprecated: false
+  key: url.path
+  name: path
+  scope: url
+  tag: 7
+  type: string
+url.port:
+  deprecated: false
+  key: url.port
+  name: port
+  scope: url
+  tag: 8
+  type: int64
+url.query:
+  deprecated: false
+  key: url.query
+  name: query
+  scope: url
+  tag: 9
+  type: string
+url.registered_domain:
+  deprecated: false
+  key: url.registered_domain
+  name: registered_domain
+  scope: url
+  tag: 10
+  type: string
+url.scheme:
+  deprecated: false
+  key: url.scheme
+  name: scheme
+  scope: url
+  tag: 11
+  type: string
+url.top_level_domain:
+  deprecated: false
+  key: url.top_level_domain
+  name: top_level_domain
+  scope: url
+  tag: 12
+  type: string
+url.username:
+  deprecated: false
+  key: url.username
+  name: username
+  scope: url
+  tag: 13
+  type: string
+user:
+  deprecated: false
+  key: user
+  name: user
+  scope: ''
+  tag: 43
+  type: User
+user.domain:
+  deprecated: false
+  key: user.domain
+  name: domain
+  scope: user
+  tag: 1
+  type: string
+user.email:
+  deprecated: false
+  key: user.email
+  name: email
+  scope: user
+  tag: 2
+  type: string
+user.full_name:
+  deprecated: false
+  key: user.full_name
+  name: full_name
+  scope: user
+  tag: 3
+  type: string
+user.group:
+  deprecated: false
+  key: user.group
+  name: group
+  scope: user
+  tag: 4
+  type: Group
+user.group.domain:
+  deprecated: false
+  key: user.group.domain
+  name: domain
+  scope: user.group
+  tag: 1
+  type: string
+user.group.id:
+  deprecated: false
+  key: user.group.id
+  name: id
+  scope: user.group
+  tag: 2
+  type: string
+user.group.name:
+  deprecated: false
+  key: user.group.name
+  name: name
+  scope: user.group
+  tag: 3
+  type: string
+user.hash:
+  deprecated: false
+  key: user.hash
+  name: hash
+  scope: user
+  tag: 5
+  type: string
+user.id:
+  deprecated: false
+  key: user.id
+  name: id
+  scope: user
+  tag: 6
+  type: string
+user.name:
+  deprecated: false
+  key: user.name
+  name: name
+  scope: user
+  tag: 7
+  type: string
+user_agent:
+  deprecated: false
+  key: user_agent
+  name: user_agent
+  scope: ''
+  tag: 44
+  type: UserAgent
+user_agent.device:
+  deprecated: false
+  key: user_agent.device
+  name: device
+  scope: user_agent
+  tag: 1
+  type: Device
+user_agent.device.name:
+  deprecated: false
+  key: user_agent.device.name
+  name: name
+  scope: user_agent.device
+  tag: 1
+  type: string
+user_agent.name:
+  deprecated: false
+  key: user_agent.name
+  name: name
+  scope: user_agent
+  tag: 2
+  type: string
+user_agent.original:
+  deprecated: false
+  key: user_agent.original
+  name: original
+  scope: user_agent
+  tag: 3
+  type: string
+user_agent.os:
+  deprecated: false
+  key: user_agent.os
+  name: os
+  scope: user_agent
+  tag: 4
+  type: Os
+user_agent.os.family:
+  deprecated: false
+  key: user_agent.os.family
+  name: family
+  scope: user_agent.os
+  tag: 1
+  type: string
+user_agent.os.full:
+  deprecated: false
+  key: user_agent.os.full
+  name: full
+  scope: user_agent.os
+  tag: 2
+  type: string
+user_agent.os.kernel:
+  deprecated: false
+  key: user_agent.os.kernel
+  name: kernel
+  scope: user_agent.os
+  tag: 3
+  type: string
+user_agent.os.name:
+  deprecated: false
+  key: user_agent.os.name
+  name: name
+  scope: user_agent.os
+  tag: 4
+  type: string
+user_agent.os.platform:
+  deprecated: false
+  key: user_agent.os.platform
+  name: platform
+  scope: user_agent.os
+  tag: 5
+  type: string
+user_agent.os.version:
+  deprecated: false
+  key: user_agent.os.version
+  name: version
+  scope: user_agent.os
+  tag: 6
+  type: string
+user_agent.version:
+  deprecated: false
+  key: user_agent.version
+  name: version
+  scope: user_agent
+  tag: 5
+  type: string
+vlan:
+  deprecated: false
+  key: vlan
+  name: vlan
+  scope: ''
+  tag: 45
+  type: Vlan
+vlan.id:
+  deprecated: false
+  key: vlan.id
+  name: id
+  scope: vlan
+  tag: 1
+  type: string
+vlan.name:
+  deprecated: false
+  key: vlan.name
+  name: name
+  scope: vlan
+  tag: 2
+  type: string
+vulnerability:
+  deprecated: false
+  key: vulnerability
+  name: vulnerability
+  scope: ''
+  tag: 46
+  type: Vulnerability
+vulnerability.category:
+  deprecated: false
+  key: vulnerability.category
+  name: category
+  scope: vulnerability
+  tag: 1
+  type: string
+vulnerability.classification:
+  deprecated: false
+  key: vulnerability.classification
+  name: classification
+  scope: vulnerability
+  tag: 2
+  type: string
+vulnerability.description:
+  deprecated: false
+  key: vulnerability.description
+  name: description
+  scope: vulnerability
+  tag: 3
+  type: string
+vulnerability.enumeration:
+  deprecated: false
+  key: vulnerability.enumeration
+  name: enumeration
+  scope: vulnerability
+  tag: 4
+  type: string
+vulnerability.id:
+  deprecated: false
+  key: vulnerability.id
+  name: id
+  scope: vulnerability
+  tag: 5
+  type: string
+vulnerability.reference:
+  deprecated: false
+  key: vulnerability.reference
+  name: reference
+  scope: vulnerability
+  tag: 6
+  type: string
+vulnerability.report_id:
+  deprecated: false
+  key: vulnerability.report_id
+  name: report_id
+  scope: vulnerability
+  tag: 7
+  type: string
+vulnerability.scanner:
+  deprecated: false
+  key: vulnerability.scanner
+  name: scanner
+  scope: vulnerability
+  tag: 8
+  type: Scanner
+vulnerability.scanner.vendor:
+  deprecated: false
+  key: vulnerability.scanner.vendor
+  name: vendor
+  scope: vulnerability.scanner
+  tag: 1
+  type: string
+vulnerability.score:
+  deprecated: false
+  key: vulnerability.score
+  name: score
+  scope: vulnerability
+  tag: 9
+  type: Score
+vulnerability.score.base:
+  deprecated: false
+  key: vulnerability.score.base
+  name: base
+  scope: vulnerability.score
+  tag: 1
+  type: float
+vulnerability.score.environmental:
+  deprecated: false
+  key: vulnerability.score.environmental
+  name: environmental
+  scope: vulnerability.score
+  tag: 2
+  type: float
+vulnerability.score.temporal:
+  deprecated: false
+  key: vulnerability.score.temporal
+  name: temporal
+  scope: vulnerability.score
+  tag: 3
+  type: float
+vulnerability.score.version:
+  deprecated: false
+  key: vulnerability.score.version
+  name: version
+  scope: vulnerability.score
+  tag: 4
+  type: string
+vulnerability.severity:
+  deprecated: false
+  key: vulnerability.severity
+  name: severity
+  scope: vulnerability
+  tag: 10
+  type: string

--- a/generated/protobuf/ecs.proto
+++ b/generated/protobuf/ecs.proto
@@ -216,7 +216,7 @@ message Document {
       string type = 6;
     }
 
-    map <string, string> answers = 1;
+    Answers answers = 1;
     string header_flags = 2;
     string id = 3;
     string op_code = 4;
@@ -439,7 +439,7 @@ message Document {
     string logger = 3;
     Origin origin = 4;
     string original = 5;
-    map <string, string> syslog = 6;
+    Syslog syslog = 6;
   }
 
   message Network {
@@ -463,7 +463,7 @@ message Document {
     string direction = 4;
     string forwarded_ip = 5;
     string iana_number = 6;
-    map <string, string> inner = 7;
+    Inner inner = 7;
     string name = 8;
     int64 packets = 9;
     string protocol = 10;
@@ -527,10 +527,10 @@ message Document {
       string version = 6;
     }
 
-    map <string, string> egress = 1;
+    Egress egress = 1;
     Geo geo = 2;
     string hostname = 3;
-    map <string, string> ingress = 4;
+    Ingress ingress = 4;
     string ip = 5;
     string mac = 6;
     string name = 7;

--- a/generated/protobuf/ecs.proto
+++ b/generated/protobuf/ecs.proto
@@ -98,7 +98,7 @@ message Document {
   message Container {
     message Image {
       string name = 1;
-      string tag = 2;
+      repeated string tag = 2;
     }
 
     string id = 1;
@@ -217,11 +217,11 @@ message Document {
     }
 
     Answers answers = 1;
-    string header_flags = 2;
+    repeated string header_flags = 2;
     string id = 3;
     string op_code = 4;
     Question question = 5;
-    string resolved_ip = 6;
+    repeated string resolved_ip = 6;
     string response_code = 7;
     string type = 8;
   }
@@ -240,7 +240,7 @@ message Document {
 
   message Event {
     string action = 1;
-    string category = 2;
+    repeated string category = 2;
     string code = 3;
     string created = 4;
     string dataset = 5;
@@ -261,7 +261,7 @@ message Document {
     int64 severity = 20;
     string start = 21;
     string timezone = 22;
-    string type = 23;
+    repeated string type = 23;
     string url = 24;
   }
 
@@ -292,7 +292,7 @@ message Document {
     }
 
     string accessed = 1;
-    string attributes = 2;
+    repeated string attributes = 2;
     CodeSignature code_signature = 3;
     string created = 4;
     string ctime = 5;
@@ -365,8 +365,8 @@ message Document {
     Geo geo = 3;
     string hostname = 4;
     string id = 5;
-    string ip = 6;
-    string mac = 7;
+    repeated string ip = 6;
+    repeated string mac = 7;
     string name = 8;
     Os os = 9;
     string type = 10;
@@ -531,8 +531,8 @@ message Document {
     Geo geo = 2;
     string hostname = 3;
     Ingress ingress = 4;
-    string ip = 5;
-    string mac = 6;
+    repeated string ip = 5;
+    repeated string mac = 6;
     string name = 7;
     Os os = 8;
     string product = 9;
@@ -600,7 +600,7 @@ message Document {
         string name = 2;
       }
 
-      string args = 1;
+      repeated string args = 1;
       int64 args_count = 2;
       CodeSignature code_signature = 3;
       string command_line = 4;
@@ -634,7 +634,7 @@ message Document {
       string name = 2;
     }
 
-    string args = 1;
+    repeated string args = 1;
     int64 args_count = 2;
     CodeSignature code_signature = 3;
     string command_line = 4;
@@ -658,7 +658,7 @@ message Document {
   message Registry {
     message Data {
       string bytes = 1;
-      string strings = 2;
+      repeated string strings = 2;
       string type = 3;
     }
 
@@ -670,13 +670,13 @@ message Document {
   }
 
   message Related {
-    string hash = 1;
-    string ip = 2;
-    string user = 3;
+    repeated string hash = 1;
+    repeated string ip = 2;
+    repeated string user = 3;
   }
 
   message Rule {
-    string author = 1;
+    repeated string author = 1;
     string category = 2;
     string description = 3;
     string id = 4;
@@ -818,15 +818,15 @@ message Document {
 
   message Threat {
     message Tactic {
-      string id = 1;
-      string name = 2;
-      string reference = 3;
+      repeated string id = 1;
+      repeated string name = 2;
+      repeated string reference = 3;
     }
 
     message Technique {
-      string id = 1;
-      string name = 2;
-      string reference = 3;
+      repeated string id = 1;
+      repeated string name = 2;
+      repeated string reference = 3;
     }
 
     string framework = 1;
@@ -843,7 +843,7 @@ message Document {
       }
 
       string certificate = 1;
-      string certificate_chain = 2;
+      repeated string certificate_chain = 2;
       Hash hash = 3;
       string issuer = 4;
       string ja3 = 5;
@@ -851,7 +851,7 @@ message Document {
       string not_before = 7;
       string server_name = 8;
       string subject = 9;
-      string supported_ciphers = 10;
+      repeated string supported_ciphers = 10;
     }
 
     message Server {
@@ -862,7 +862,7 @@ message Document {
       }
 
       string certificate = 1;
-      string certificate_chain = 2;
+      repeated string certificate_chain = 2;
       Hash hash = 3;
       string issuer = 4;
       string ja3s = 5;
@@ -955,7 +955,7 @@ message Document {
       string version = 4;
     }
 
-    string category = 1;
+    repeated string category = 1;
     string classification = 2;
     string description = 3;
     string enumeration = 4;
@@ -995,7 +995,7 @@ message Document {
   Server server = 26;
   Service service = 27;
   Source source = 28;
-  string tags = 29;
+  repeated string tags = 29;
   Threat threat = 30;
   string timestamp = 31;
   Tls tls = 32;

--- a/generated/protobuf/ecs.proto
+++ b/generated/protobuf/ecs.proto
@@ -16,15 +16,6 @@ message Document {
     string version = 6;
   }
 
-  message As {
-    message Organization {
-      string name = 1;
-    }
-
-    int64 number = 1;
-    Organization organization = 2;
-  }
-
   message Client {
     message As {
       message Organization {
@@ -102,14 +93,6 @@ message Document {
     Machine machine = 4;
     string provider = 5;
     string region = 6;
-  }
-
-  message CodeSignature {
-    bool exists = 1;
-    string status = 2;
-    string subject_name = 3;
-    bool trusted = 4;
-    bool valid = 5;
   }
 
   message Container {
@@ -334,28 +317,10 @@ message Document {
     string uid = 24;
   }
 
-  message Geo {
-    string city_name = 1;
-    string continent_name = 2;
-    string country_iso_code = 3;
-    string country_name = 4;
-    string location = 5;
-    string name = 6;
-    string region_iso_code = 7;
-    string region_name = 8;
-  }
-
   message Group {
     string domain = 1;
     string id = 2;
     string name = 3;
-  }
-
-  message Hash {
-    string md5 = 1;
-    string sha1 = 2;
-    string sha256 = 3;
-    string sha512 = 4;
   }
 
   message Host {
@@ -436,12 +401,6 @@ message Document {
     Request request = 1;
     Response response = 2;
     string version = 3;
-  }
-
-  message Interface {
-    string alias = 1;
-    string id = 2;
-    string name = 3;
   }
 
   message Log {
@@ -588,15 +547,6 @@ message Document {
     string name = 2;
   }
 
-  message Os {
-    string family = 1;
-    string full = 2;
-    string kernel = 3;
-    string name = 4;
-    string platform = 5;
-    string version = 6;
-  }
-
   message Package {
     string architecture = 1;
     string build_version = 2;
@@ -611,16 +561,6 @@ message Document {
     int64 size = 11;
     string type = 12;
     string version = 13;
-  }
-
-  message Pe {
-    string architecture = 1;
-    string company = 2;
-    string description = 3;
-    string file_version = 4;
-    string imphash = 5;
-    string original_file_name = 6;
-    string product = 7;
   }
 
   message Process {
@@ -1003,11 +943,6 @@ message Document {
     string version = 5;
   }
 
-  message Vlan {
-    string id = 1;
-    string name = 2;
-  }
-
   message Vulnerability {
     message Scanner {
       string vendor = 1;
@@ -1033,50 +968,42 @@ message Document {
   }
 
   Agent agent = 1;
-  As as = 2;
-  Client client = 3;
-  Cloud cloud = 4;
-  CodeSignature code_signature = 5;
-  Container container = 6;
-  Destination destination = 7;
-  Dll dll = 8;
-  Dns dns = 9;
-  Ecs ecs = 10;
-  Error error = 11;
-  Event event = 12;
-  File file = 13;
-  Geo geo = 14;
-  Group group = 15;
-  Hash hash = 16;
-  Host host = 17;
-  Http http = 18;
-  Interface interface = 19;
-  map <string, string> labels = 20;
-  Log log = 21;
-  string message = 22;
-  Network network = 23;
-  Observer observer = 24;
-  Organization organization = 25;
-  Os os = 26;
-  Package package = 27;
-  Pe pe = 28;
-  Process process = 29;
-  Registry registry = 30;
-  Related related = 31;
-  Rule rule = 32;
-  Server server = 33;
-  Service service = 34;
-  Source source = 35;
-  string tags = 36;
-  Threat threat = 37;
-  string timestamp = 38;
-  Tls tls = 39;
-  Trace trace = 40;
-  Transaction transaction = 41;
-  Url url = 42;
-  User user = 43;
-  UserAgent user_agent = 44;
-  Vlan vlan = 45;
-  Vulnerability vulnerability = 46;
+  Client client = 2;
+  Cloud cloud = 3;
+  Container container = 4;
+  Destination destination = 5;
+  Dll dll = 6;
+  Dns dns = 7;
+  Ecs ecs = 8;
+  Error error = 9;
+  Event event = 10;
+  File file = 11;
+  Group group = 12;
+  Host host = 13;
+  Http http = 14;
+  map <string, string> labels = 15;
+  Log log = 16;
+  string message = 17;
+  Network network = 18;
+  Observer observer = 19;
+  Organization organization = 20;
+  Package package = 21;
+  Process process = 22;
+  Registry registry = 23;
+  Related related = 24;
+  Rule rule = 25;
+  Server server = 26;
+  Service service = 27;
+  Source source = 28;
+  string tags = 29;
+  Threat threat = 30;
+  string timestamp = 31;
+  Tls tls = 32;
+  Trace trace = 33;
+  Transaction transaction = 34;
+  Url url = 35;
+  User user = 36;
+  UserAgent user_agent = 37;
+  Vulnerability vulnerability = 38;
 }
 

--- a/generated/protobuf/ecs.proto
+++ b/generated/protobuf/ecs.proto
@@ -1,0 +1,1082 @@
+syntax = "proto3";
+
+package ecs;
+
+message Document {
+  message Agent {
+    message Build {
+      string original = 1;
+    }
+
+    Build build = 1;
+    string ephemeral_id = 2;
+    string id = 3;
+    string name = 4;
+    string type = 5;
+    string version = 6;
+  }
+
+  message As {
+    message Organization {
+      string name = 1;
+    }
+
+    int64 number = 1;
+    Organization organization = 2;
+  }
+
+  message Client {
+    message As {
+      message Organization {
+        string name = 1;
+      }
+
+      int64 number = 1;
+      Organization organization = 2;
+    }
+
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Nat {
+      string ip = 1;
+      int64 port = 2;
+    }
+
+    message User {
+      message Group {
+        string domain = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      string domain = 1;
+      string email = 2;
+      string full_name = 3;
+      Group group = 4;
+      string hash = 5;
+      string id = 6;
+      string name = 7;
+    }
+
+    string address = 1;
+    As as = 2;
+    int64 bytes = 3;
+    string domain = 4;
+    Geo geo = 5;
+    string ip = 6;
+    string mac = 7;
+    Nat nat = 8;
+    int64 packets = 9;
+    int64 port = 10;
+    string registered_domain = 11;
+    string top_level_domain = 12;
+    User user = 13;
+  }
+
+  message Cloud {
+    message Account {
+      string id = 1;
+    }
+
+    message Instance {
+      string id = 1;
+      string name = 2;
+    }
+
+    message Machine {
+      string type = 1;
+    }
+
+    Account account = 1;
+    string availability_zone = 2;
+    Instance instance = 3;
+    Machine machine = 4;
+    string provider = 5;
+    string region = 6;
+  }
+
+  message CodeSignature {
+    bool exists = 1;
+    string status = 2;
+    string subject_name = 3;
+    bool trusted = 4;
+    bool valid = 5;
+  }
+
+  message Container {
+    message Image {
+      string name = 1;
+      string tag = 2;
+    }
+
+    string id = 1;
+    Image image = 2;
+    map <string, string> labels = 3;
+    string name = 4;
+    string runtime = 5;
+  }
+
+  message Destination {
+    message As {
+      message Organization {
+        string name = 1;
+      }
+
+      int64 number = 1;
+      Organization organization = 2;
+    }
+
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Nat {
+      string ip = 1;
+      int64 port = 2;
+    }
+
+    message User {
+      message Group {
+        string domain = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      string domain = 1;
+      string email = 2;
+      string full_name = 3;
+      Group group = 4;
+      string hash = 5;
+      string id = 6;
+      string name = 7;
+    }
+
+    string address = 1;
+    As as = 2;
+    int64 bytes = 3;
+    string domain = 4;
+    Geo geo = 5;
+    string ip = 6;
+    string mac = 7;
+    Nat nat = 8;
+    int64 packets = 9;
+    int64 port = 10;
+    string registered_domain = 11;
+    string top_level_domain = 12;
+    User user = 13;
+  }
+
+  message Dll {
+    message CodeSignature {
+      bool exists = 1;
+      string status = 2;
+      string subject_name = 3;
+      bool trusted = 4;
+      bool valid = 5;
+    }
+
+    message Hash {
+      string md5 = 1;
+      string sha1 = 2;
+      string sha256 = 3;
+      string sha512 = 4;
+    }
+
+    message Pe {
+      string architecture = 1;
+      string company = 2;
+      string description = 3;
+      string file_version = 4;
+      string imphash = 5;
+      string original_file_name = 6;
+      string product = 7;
+    }
+
+    CodeSignature code_signature = 1;
+    Hash hash = 2;
+    string name = 3;
+    string path = 4;
+    Pe pe = 5;
+  }
+
+  message Dns {
+    message Answers {
+      string class = 1;
+      string data = 2;
+      string name = 3;
+      int64 ttl = 4;
+      string type = 5;
+    }
+
+    message Question {
+      string class = 1;
+      string name = 2;
+      string registered_domain = 3;
+      string subdomain = 4;
+      string top_level_domain = 5;
+      string type = 6;
+    }
+
+    map <string, string> answers = 1;
+    string header_flags = 2;
+    string id = 3;
+    string op_code = 4;
+    Question question = 5;
+    string resolved_ip = 6;
+    string response_code = 7;
+    string type = 8;
+  }
+
+  message Ecs {
+    string version = 1;
+  }
+
+  message Error {
+    string code = 1;
+    string id = 2;
+    string message = 3;
+    string stack_trace = 4;
+    string type = 5;
+  }
+
+  message Event {
+    string action = 1;
+    string category = 2;
+    string code = 3;
+    string created = 4;
+    string dataset = 5;
+    int64 duration = 6;
+    string end = 7;
+    string hash = 8;
+    string id = 9;
+    string ingested = 10;
+    string kind = 11;
+    string module = 12;
+    string original = 13;
+    string outcome = 14;
+    string provider = 15;
+    string reference = 16;
+    float risk_score = 17;
+    float risk_score_norm = 18;
+    int64 sequence = 19;
+    int64 severity = 20;
+    string start = 21;
+    string timezone = 22;
+    string type = 23;
+    string url = 24;
+  }
+
+  message File {
+    message CodeSignature {
+      bool exists = 1;
+      string status = 2;
+      string subject_name = 3;
+      bool trusted = 4;
+      bool valid = 5;
+    }
+
+    message Hash {
+      string md5 = 1;
+      string sha1 = 2;
+      string sha256 = 3;
+      string sha512 = 4;
+    }
+
+    message Pe {
+      string architecture = 1;
+      string company = 2;
+      string description = 3;
+      string file_version = 4;
+      string imphash = 5;
+      string original_file_name = 6;
+      string product = 7;
+    }
+
+    string accessed = 1;
+    string attributes = 2;
+    CodeSignature code_signature = 3;
+    string created = 4;
+    string ctime = 5;
+    string device = 6;
+    string directory = 7;
+    string drive_letter = 8;
+    string extension = 9;
+    string gid = 10;
+    string group = 11;
+    Hash hash = 12;
+    string inode = 13;
+    string mime_type = 14;
+    string mode = 15;
+    string mtime = 16;
+    string name = 17;
+    string owner = 18;
+    string path = 19;
+    Pe pe = 20;
+    int64 size = 21;
+    string target_path = 22;
+    string type = 23;
+    string uid = 24;
+  }
+
+  message Geo {
+    string city_name = 1;
+    string continent_name = 2;
+    string country_iso_code = 3;
+    string country_name = 4;
+    string location = 5;
+    string name = 6;
+    string region_iso_code = 7;
+    string region_name = 8;
+  }
+
+  message Group {
+    string domain = 1;
+    string id = 2;
+    string name = 3;
+  }
+
+  message Hash {
+    string md5 = 1;
+    string sha1 = 2;
+    string sha256 = 3;
+    string sha512 = 4;
+  }
+
+  message Host {
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Os {
+      string family = 1;
+      string full = 2;
+      string kernel = 3;
+      string name = 4;
+      string platform = 5;
+      string version = 6;
+    }
+
+    message User {
+      message Group {
+        string domain = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      string domain = 1;
+      string email = 2;
+      string full_name = 3;
+      Group group = 4;
+      string hash = 5;
+      string id = 6;
+      string name = 7;
+    }
+
+    string architecture = 1;
+    string domain = 2;
+    Geo geo = 3;
+    string hostname = 4;
+    string id = 5;
+    string ip = 6;
+    string mac = 7;
+    string name = 8;
+    Os os = 9;
+    string type = 10;
+    int64 uptime = 11;
+    User user = 12;
+  }
+
+  message Http {
+    message Request {
+      message Body {
+        int64 bytes = 1;
+        string content = 2;
+      }
+
+      Body body = 1;
+      int64 bytes = 2;
+      string method = 3;
+      string referrer = 4;
+    }
+
+    message Response {
+      message Body {
+        int64 bytes = 1;
+        string content = 2;
+      }
+
+      Body body = 1;
+      int64 bytes = 2;
+      int64 status_code = 3;
+    }
+
+    Request request = 1;
+    Response response = 2;
+    string version = 3;
+  }
+
+  message Interface {
+    string alias = 1;
+    string id = 2;
+    string name = 3;
+  }
+
+  message Log {
+    message File {
+      string path = 1;
+    }
+
+    message Origin {
+      message File {
+        int32 line = 1;
+        string name = 2;
+      }
+
+      File file = 1;
+      string function = 2;
+    }
+
+    message Syslog {
+      message Facility {
+        int64 code = 1;
+        string name = 2;
+      }
+
+      message Severity {
+        int64 code = 1;
+        string name = 2;
+      }
+
+      Facility facility = 1;
+      int64 priority = 2;
+      Severity severity = 3;
+    }
+
+    File file = 1;
+    string level = 2;
+    string logger = 3;
+    Origin origin = 4;
+    string original = 5;
+    map <string, string> syslog = 6;
+  }
+
+  message Network {
+    message Inner {
+      message Vlan {
+        string id = 1;
+        string name = 2;
+      }
+
+      Vlan vlan = 1;
+    }
+
+    message Vlan {
+      string id = 1;
+      string name = 2;
+    }
+
+    string application = 1;
+    int64 bytes = 2;
+    string community_id = 3;
+    string direction = 4;
+    string forwarded_ip = 5;
+    string iana_number = 6;
+    map <string, string> inner = 7;
+    string name = 8;
+    int64 packets = 9;
+    string protocol = 10;
+    string transport = 11;
+    string type = 12;
+    Vlan vlan = 13;
+  }
+
+  message Observer {
+    message Egress {
+      message Interface {
+        string alias = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      message Vlan {
+        string id = 1;
+        string name = 2;
+      }
+
+      Interface interface = 1;
+      Vlan vlan = 2;
+      string zone = 3;
+    }
+
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Ingress {
+      message Interface {
+        string alias = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      message Vlan {
+        string id = 1;
+        string name = 2;
+      }
+
+      Interface interface = 1;
+      Vlan vlan = 2;
+      string zone = 3;
+    }
+
+    message Os {
+      string family = 1;
+      string full = 2;
+      string kernel = 3;
+      string name = 4;
+      string platform = 5;
+      string version = 6;
+    }
+
+    map <string, string> egress = 1;
+    Geo geo = 2;
+    string hostname = 3;
+    map <string, string> ingress = 4;
+    string ip = 5;
+    string mac = 6;
+    string name = 7;
+    Os os = 8;
+    string product = 9;
+    string serial_number = 10;
+    string type = 11;
+    string vendor = 12;
+    string version = 13;
+  }
+
+  message Organization {
+    string id = 1;
+    string name = 2;
+  }
+
+  message Os {
+    string family = 1;
+    string full = 2;
+    string kernel = 3;
+    string name = 4;
+    string platform = 5;
+    string version = 6;
+  }
+
+  message Package {
+    string architecture = 1;
+    string build_version = 2;
+    string checksum = 3;
+    string description = 4;
+    string install_scope = 5;
+    string installed = 6;
+    string license = 7;
+    string name = 8;
+    string path = 9;
+    string reference = 10;
+    int64 size = 11;
+    string type = 12;
+    string version = 13;
+  }
+
+  message Pe {
+    string architecture = 1;
+    string company = 2;
+    string description = 3;
+    string file_version = 4;
+    string imphash = 5;
+    string original_file_name = 6;
+    string product = 7;
+  }
+
+  message Process {
+    message CodeSignature {
+      bool exists = 1;
+      string status = 2;
+      string subject_name = 3;
+      bool trusted = 4;
+      bool valid = 5;
+    }
+
+    message Hash {
+      string md5 = 1;
+      string sha1 = 2;
+      string sha256 = 3;
+      string sha512 = 4;
+    }
+
+    message Parent {
+      message CodeSignature {
+        bool exists = 1;
+        string status = 2;
+        string subject_name = 3;
+        bool trusted = 4;
+        bool valid = 5;
+      }
+
+      message Hash {
+        string md5 = 1;
+        string sha1 = 2;
+        string sha256 = 3;
+        string sha512 = 4;
+      }
+
+      message Thread {
+        int64 id = 1;
+        string name = 2;
+      }
+
+      string args = 1;
+      int64 args_count = 2;
+      CodeSignature code_signature = 3;
+      string command_line = 4;
+      string entity_id = 5;
+      string executable = 6;
+      int64 exit_code = 7;
+      Hash hash = 8;
+      string name = 9;
+      int64 pgid = 10;
+      int64 pid = 11;
+      int64 ppid = 12;
+      string start = 13;
+      Thread thread = 14;
+      string title = 15;
+      int64 uptime = 16;
+      string working_directory = 17;
+    }
+
+    message Pe {
+      string architecture = 1;
+      string company = 2;
+      string description = 3;
+      string file_version = 4;
+      string imphash = 5;
+      string original_file_name = 6;
+      string product = 7;
+    }
+
+    message Thread {
+      int64 id = 1;
+      string name = 2;
+    }
+
+    string args = 1;
+    int64 args_count = 2;
+    CodeSignature code_signature = 3;
+    string command_line = 4;
+    string entity_id = 5;
+    string executable = 6;
+    int64 exit_code = 7;
+    Hash hash = 8;
+    string name = 9;
+    Parent parent = 10;
+    Pe pe = 11;
+    int64 pgid = 12;
+    int64 pid = 13;
+    int64 ppid = 14;
+    string start = 15;
+    Thread thread = 16;
+    string title = 17;
+    int64 uptime = 18;
+    string working_directory = 19;
+  }
+
+  message Registry {
+    message Data {
+      string bytes = 1;
+      string strings = 2;
+      string type = 3;
+    }
+
+    Data data = 1;
+    string hive = 2;
+    string key = 3;
+    string path = 4;
+    string value = 5;
+  }
+
+  message Related {
+    string hash = 1;
+    string ip = 2;
+    string user = 3;
+  }
+
+  message Rule {
+    string author = 1;
+    string category = 2;
+    string description = 3;
+    string id = 4;
+    string license = 5;
+    string name = 6;
+    string reference = 7;
+    string ruleset = 8;
+    string uuid = 9;
+    string version = 10;
+  }
+
+  message Server {
+    message As {
+      message Organization {
+        string name = 1;
+      }
+
+      int64 number = 1;
+      Organization organization = 2;
+    }
+
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Nat {
+      string ip = 1;
+      int64 port = 2;
+    }
+
+    message User {
+      message Group {
+        string domain = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      string domain = 1;
+      string email = 2;
+      string full_name = 3;
+      Group group = 4;
+      string hash = 5;
+      string id = 6;
+      string name = 7;
+    }
+
+    string address = 1;
+    As as = 2;
+    int64 bytes = 3;
+    string domain = 4;
+    Geo geo = 5;
+    string ip = 6;
+    string mac = 7;
+    Nat nat = 8;
+    int64 packets = 9;
+    int64 port = 10;
+    string registered_domain = 11;
+    string top_level_domain = 12;
+    User user = 13;
+  }
+
+  message Service {
+    message Node {
+      string name = 1;
+    }
+
+    string ephemeral_id = 1;
+    string id = 2;
+    string name = 3;
+    Node node = 4;
+    string state = 5;
+    string type = 6;
+    string version = 7;
+  }
+
+  message Source {
+    message As {
+      message Organization {
+        string name = 1;
+      }
+
+      int64 number = 1;
+      Organization organization = 2;
+    }
+
+    message Geo {
+      string city_name = 1;
+      string continent_name = 2;
+      string country_iso_code = 3;
+      string country_name = 4;
+      string location = 5;
+      string name = 6;
+      string region_iso_code = 7;
+      string region_name = 8;
+    }
+
+    message Nat {
+      string ip = 1;
+      int64 port = 2;
+    }
+
+    message User {
+      message Group {
+        string domain = 1;
+        string id = 2;
+        string name = 3;
+      }
+
+      string domain = 1;
+      string email = 2;
+      string full_name = 3;
+      Group group = 4;
+      string hash = 5;
+      string id = 6;
+      string name = 7;
+    }
+
+    string address = 1;
+    As as = 2;
+    int64 bytes = 3;
+    string domain = 4;
+    Geo geo = 5;
+    string ip = 6;
+    string mac = 7;
+    Nat nat = 8;
+    int64 packets = 9;
+    int64 port = 10;
+    string registered_domain = 11;
+    string top_level_domain = 12;
+    User user = 13;
+  }
+
+  message Threat {
+    message Tactic {
+      string id = 1;
+      string name = 2;
+      string reference = 3;
+    }
+
+    message Technique {
+      string id = 1;
+      string name = 2;
+      string reference = 3;
+    }
+
+    string framework = 1;
+    Tactic tactic = 2;
+    Technique technique = 3;
+  }
+
+  message Tls {
+    message Client {
+      message Hash {
+        string md5 = 1;
+        string sha1 = 2;
+        string sha256 = 3;
+      }
+
+      string certificate = 1;
+      string certificate_chain = 2;
+      Hash hash = 3;
+      string issuer = 4;
+      string ja3 = 5;
+      string not_after = 6;
+      string not_before = 7;
+      string server_name = 8;
+      string subject = 9;
+      string supported_ciphers = 10;
+    }
+
+    message Server {
+      message Hash {
+        string md5 = 1;
+        string sha1 = 2;
+        string sha256 = 3;
+      }
+
+      string certificate = 1;
+      string certificate_chain = 2;
+      Hash hash = 3;
+      string issuer = 4;
+      string ja3s = 5;
+      string not_after = 6;
+      string not_before = 7;
+      string subject = 8;
+    }
+
+    string cipher = 1;
+    Client client = 2;
+    string curve = 3;
+    bool established = 4;
+    string next_protocol = 5;
+    bool resumed = 6;
+    Server server = 7;
+    string version = 8;
+    string version_protocol = 9;
+  }
+
+  message Trace {
+    string id = 1;
+  }
+
+  message Transaction {
+    string id = 1;
+  }
+
+  message Url {
+    string domain = 1;
+    string extension = 2;
+    string fragment = 3;
+    string full = 4;
+    string original = 5;
+    string password = 6;
+    string path = 7;
+    int64 port = 8;
+    string query = 9;
+    string registered_domain = 10;
+    string scheme = 11;
+    string top_level_domain = 12;
+    string username = 13;
+  }
+
+  message User {
+    message Group {
+      string domain = 1;
+      string id = 2;
+      string name = 3;
+    }
+
+    string domain = 1;
+    string email = 2;
+    string full_name = 3;
+    Group group = 4;
+    string hash = 5;
+    string id = 6;
+    string name = 7;
+  }
+
+  message UserAgent {
+    message Device {
+      string name = 1;
+    }
+
+    message Os {
+      string family = 1;
+      string full = 2;
+      string kernel = 3;
+      string name = 4;
+      string platform = 5;
+      string version = 6;
+    }
+
+    Device device = 1;
+    string name = 2;
+    string original = 3;
+    Os os = 4;
+    string version = 5;
+  }
+
+  message Vlan {
+    string id = 1;
+    string name = 2;
+  }
+
+  message Vulnerability {
+    message Scanner {
+      string vendor = 1;
+    }
+
+    message Score {
+      float base = 1;
+      float environmental = 2;
+      float temporal = 3;
+      string version = 4;
+    }
+
+    string category = 1;
+    string classification = 2;
+    string description = 3;
+    string enumeration = 4;
+    string id = 5;
+    string reference = 6;
+    string report_id = 7;
+    Scanner scanner = 8;
+    Score score = 9;
+    string severity = 10;
+  }
+
+  Agent agent = 1;
+  As as = 2;
+  Client client = 3;
+  Cloud cloud = 4;
+  CodeSignature code_signature = 5;
+  Container container = 6;
+  Destination destination = 7;
+  Dll dll = 8;
+  Dns dns = 9;
+  Ecs ecs = 10;
+  Error error = 11;
+  Event event = 12;
+  File file = 13;
+  Geo geo = 14;
+  Group group = 15;
+  Hash hash = 16;
+  Host host = 17;
+  Http http = 18;
+  Interface interface = 19;
+  map <string, string> labels = 20;
+  Log log = 21;
+  string message = 22;
+  Network network = 23;
+  Observer observer = 24;
+  Organization organization = 25;
+  Os os = 26;
+  Package package = 27;
+  Pe pe = 28;
+  Process process = 29;
+  Registry registry = 30;
+  Related related = 31;
+  Rule rule = 32;
+  Server server = 33;
+  Service service = 34;
+  Source source = 35;
+  string tags = 36;
+  Threat threat = 37;
+  string timestamp = 38;
+  Tls tls = 39;
+  Trace trace = 40;
+  Transaction transaction = 41;
+  Url url = 42;
+  User user = 43;
+  UserAgent user_agent = 44;
+  Vlan vlan = 45;
+  Vulnerability vulnerability = 46;
+}
+

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -9,6 +9,7 @@ from generators import es_template
 from generators import beats
 from generators import asciidoc_fields
 from generators import ecs_helpers
+from generators import protobuf
 
 
 def main():
@@ -61,6 +62,7 @@ def main():
 
     csv_generator.generate(flat, ecs_version, out_dir)
     es_template.generate(flat, ecs_version, out_dir)
+    protobuf.generate(flat, ecs_version, out_dir)
     if args.include or args.subset:
         exit()
     beats.generate(nested, ecs_version, out_dir)

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -61,23 +61,26 @@ def parse_flat_fields(flat_fields):
         name = segments.pop()
         scope = '.'.join(segments)
 
-        if len(segments) > 0:
+        while len(segments) > 0:
+            parent_key = '.'.join(segments)
             parent_name = segments.pop()
-            fields.setdefault(scope, {
-                'key': scope,
+            parent_scope = '.'.join(segments)
+
+            fields[parent_key] = {
+                'key': parent_key,
                 'name': parent_name,
-                'scope': '.'.join(segments),
+                'scope': parent_scope,
                 'type': camelize(parent_name),
                 'deprecated': False,
-            })
+            }
 
-        fields[key] = {
+        fields.setdefault(key, {
             'key': key,
             'name': name,
             'scope': scope,
             'type': field_type_to_protobuf_type[flat_field['type']],
             'deprecated': False,
-        }
+        })
 
     return fields
 

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -41,8 +41,8 @@ protobuf_legal_type_changes_for = {
 
 
 valid_normalize_settings = [
- [],
- ['array'],
+    [],
+    ['array'],
 ]
 
 

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -1,6 +1,3 @@
-import csv
-import json
-import re
 import sys
 import yaml
 

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -9,7 +9,7 @@ field_type_to_protobuf_type = {
     'binary': 'string',
     'boolean': 'bool',
     'byte': 'int32',
-    'data_nanos': 'long',
+    'date_nanos': 'long',
     'date': 'string',
     'double': 'double',
     'float': 'float',

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -1,0 +1,171 @@
+import csv
+import json
+import re
+import sys
+import yaml
+
+from os.path import join, exists
+from generators import ecs_helpers
+
+field_type_to_protobuf_type = {
+    'boolean':    'bool',
+    'date':       'string',
+    'float':      'float',
+    'geo_point':  'string',
+    'integer':    'int32',
+    'ip':         'string',
+    'keyword':    'string',
+    'long':       'int64',
+    'object':     'map <string, string>',
+    'text':       'string',
+}
+
+
+def generate(ecs_flat, ecs_version, out_dir):
+    current_fields = parse_flat_fields(ecs_flat)
+    cached_file    = join(out_dir, 'protobuf', 'cached-fields.yaml')
+    proto_file     = join(out_dir, 'protobuf', 'ecs.proto')
+    cached_fields  = load_cached_fields(cached_file)
+
+    sync_current_fields_with_cached_fields(current_fields, cached_fields)
+    write_cached_fields(cached_file, current_fields)
+    write_proto(proto_file, current_fields)
+
+
+def parse_flat_fields(flat_fields):
+    fields = {}
+
+    for flat_name in sorted(flat_fields):
+        flat_field  = flat_fields[flat_name]
+        key         = 'timestamp' if flat_name == '@timestamp' else flat_name
+        segments    = key.split('.')
+        name        = segments.pop()
+        scope       = '.'.join(segments)
+
+        if len(segments) > 0:
+            parent_name = segments.pop()
+            fields.setdefault(scope, {
+                'key': scope,
+                'name': parent_name,
+                'scope': '.'.join(segments),
+                'type': camelize(parent_name),
+                'deprecated': False,
+            })
+
+        fields[key] = {
+            'key':         key,
+            'name':        name,
+            'scope':       scope,
+            'type':        field_type_to_protobuf_type[flat_field['type']],
+            'deprecated':  False,
+        }
+
+    return fields
+
+
+def load_cached_fields(cached_file):
+    if not exists(cached_file):
+        return {}
+
+    with open(cached_file) as f:
+        return yaml.safe_load(f.read())
+
+
+def sync_current_fields_with_cached_fields(current_fields, cached_fields):
+    current_by_scope = {}
+    cached_by_scope  = {}
+
+    for field in current_fields.values():
+        scope = field['scope']
+        current_by_scope.setdefault(scope, {})
+        current_by_scope[scope][field['key']] = field
+
+    for field in cached_fields.values():
+        scope = field['scope']
+        cached_by_scope.setdefault(scope, {})
+        cached_by_scope[scope][field['key']] = field
+
+    scopes = set(list(current_by_scope.keys()) + list(cached_by_scope.keys()))
+
+    for scope in sorted(scopes):
+        scoped_current_fields = current_by_scope.get(scope, {})
+        scoped_cached_fields  = cached_by_scope.get(scope, {})
+        next_tag              = len(scoped_cached_fields) + 1
+
+        for key in sorted(scoped_current_fields):
+            current_field = scoped_current_fields[key]
+            cached_field  = scoped_cached_fields.get(key)
+
+            if cached_field == None:
+                tag = next_tag
+                next_tag = next_tag + 1
+            else:
+                tag = cached_field['tag']
+
+            current_field['tag'] = tag
+
+        for key in sorted(scoped_cached_fields):
+            current_field = scoped_current_fields.get(key)
+            cached_field  = scoped_cached_fields[key]
+
+            if current_field == None:
+                if not cached_field['deprecated']:
+                    print('marking protobuf field as deprecated: ' + key)
+                    cached_field.update({'deprecated': True})
+                current_fields[key] = cached_field
+            elif current_field['type'] != cached_field['type']:
+                print('ERROR: cannot change ' + key + ' from ' + cached_field['type'] + ' to ' + current_field['type'])
+                sys.exit(1)
+
+
+def write_cached_fields(cached_file, fields):
+    with open(cached_file, 'w') as f:
+        yaml.dump(fields, f, default_flow_style=False)
+
+
+def camelize(string):
+    return ''.join([item.capitalize() for item in string.split('_')])
+
+
+def write_proto_message(f, message_name, message, indent=0):
+    spaces = ' ' * indent * 2
+
+    f.write(spaces + 'message ' + message_name + ' {\n')
+
+    for nested_key in sorted(message):
+        if nested_key == '__fields__':
+            continue
+        nested_name = camelize(nested_key)
+        write_proto_message(f, nested_name, message[nested_key], indent + 1)
+
+    for field in message.get('__fields__', []):
+        f_name       = field['name']
+        f_type       = field['type']
+        f_tag        = str(field['tag'])
+        f_deprecated = ' [deprecated=true]' if field['deprecated'] else ''
+
+        f.write(spaces + '  ' + f_type + ' ' + f_name + ' = ' + f_tag + f_deprecated + ';\n')
+
+    f.write(spaces + '}\n\n')
+
+
+def write_proto(proto_file, fields):
+    root_message = {}
+
+    for key in sorted(fields):
+        field   = fields[key]
+        scope   = field['scope']
+        message = root_message
+
+        if scope != '':
+            for name in scope.split('.'):
+                message.setdefault(name, {})
+                message = message[name]
+
+        message.setdefault('__fields__', [])
+        message['__fields__'].append(field)
+
+    with open(proto_file, 'w') as f:
+        f.write('syntax = "proto3";\n\n')
+        f.write('package ecs;\n\n')
+        write_proto_message(f, 'Document', root_message)

--- a/scripts/generators/protobuf.py
+++ b/scripts/generators/protobuf.py
@@ -6,45 +6,45 @@ from generators import ecs_helpers
 
 
 field_type_to_protobuf_type = {
-    'binary':        'string',
-    'boolean':       'bool',
-    'byte':          'int32',
-    'data_nanos':    'long',
-    'date':          'string',
-    'double':        'double',
-    'float':         'float',
-    'geo_point':     'string',
-    'half_float':    'float',
-    'integer':       'int32',
-    'ip':            'string',
-    'keyword':       'string',
-    'long':          'int64',
-    'object':        'map <string, string>',
-    'scaled_float':  'double',
-    'short':         'int32',
-    'text':          'string',
+    'binary': 'string',
+    'boolean': 'bool',
+    'byte': 'int32',
+    'data_nanos': 'long',
+    'date': 'string',
+    'double': 'double',
+    'float': 'float',
+    'geo_point': 'string',
+    'half_float': 'float',
+    'integer': 'int32',
+    'ip': 'string',
+    'keyword': 'string',
+    'long': 'int64',
+    'object': 'map <string, string>',
+    'scaled_float': 'double',
+    'short': 'int32',
+    'text': 'string',
 }
 
 
 protobuf_legal_type_changes_for = {
-    'int32':   ['int32', 'uint32', 'int64', 'uint64', 'bool'],
-    'uint32':  ['int32', 'uint32', 'int64', 'uint64', 'bool'],
-    'int64':   ['int32', 'uint32', 'int64', 'uint64', 'bool'],
-    'uint64':  ['int32', 'uint32', 'int64', 'uint64', 'bool'],
-    'bool':    ['int32', 'uint32', 'int64', 'uint64', 'bool'],
-    'sint32':  ['sint32', 'sint64'],
-    'sint64':  ['sint32', 'sint64'],
+    'int32': ['int32', 'uint32', 'int64', 'uint64', 'bool'],
+    'uint32': ['int32', 'uint32', 'int64', 'uint64', 'bool'],
+    'int64': ['int32', 'uint32', 'int64', 'uint64', 'bool'],
+    'uint64': ['int32', 'uint32', 'int64', 'uint64', 'bool'],
+    'bool': ['int32', 'uint32', 'int64', 'uint64', 'bool'],
+    'sint32': ['sint32', 'sint64'],
+    'sint64': ['sint32', 'sint64'],
     'fixed32': ['fixed32', 'sfixed32'],
     'fixed64': ['fixed64', 'sfixed64'],
-    'enum':    ['enum', 'int32', 'uint32', 'int64', 'uint64'],
+    'enum': ['enum', 'int32', 'uint32', 'int64', 'uint64'],
 }
 
 
 def generate(ecs_flat, ecs_version, out_dir):
     current_fields = parse_flat_fields(ecs_flat)
-    cached_file    = join(out_dir, 'protobuf', 'cached-fields.yaml')
-    proto_file     = join(out_dir, 'protobuf', 'ecs.proto')
-    cached_fields  = load_cached_fields(cached_file)
+    cached_file = join(out_dir, 'protobuf', 'cached-fields.yaml')
+    proto_file = join(out_dir, 'protobuf', 'ecs.proto')
+    cached_fields = load_cached_fields(cached_file)
 
     sync_current_fields_with_cached_fields(current_fields, cached_fields)
     write_cached_fields(cached_file, current_fields)
@@ -55,11 +55,11 @@ def parse_flat_fields(flat_fields):
     fields = {}
 
     for flat_name in sorted(flat_fields):
-        flat_field  = flat_fields[flat_name]
-        key         = 'timestamp' if flat_name == '@timestamp' else flat_name
-        segments    = key.split('.')
-        name        = segments.pop()
-        scope       = '.'.join(segments)
+        flat_field = flat_fields[flat_name]
+        key = 'timestamp' if flat_name == '@timestamp' else flat_name
+        segments = key.split('.')
+        name = segments.pop()
+        scope = '.'.join(segments)
 
         if len(segments) > 0:
             parent_name = segments.pop()
@@ -72,11 +72,11 @@ def parse_flat_fields(flat_fields):
             })
 
         fields[key] = {
-            'key':         key,
-            'name':        name,
-            'scope':       scope,
-            'type':        field_type_to_protobuf_type[flat_field['type']],
-            'deprecated':  False,
+            'key': key,
+            'name': name,
+            'scope': scope,
+            'type': field_type_to_protobuf_type[flat_field['type']],
+            'deprecated': False,
         }
 
     return fields
@@ -92,7 +92,7 @@ def load_cached_fields(cached_file):
 
 def sync_current_fields_with_cached_fields(current_fields, cached_fields):
     current_by_scope = {}
-    cached_by_scope  = {}
+    cached_by_scope = {}
 
     for field in current_fields.values():
         scope = field['scope']
@@ -108,19 +108,19 @@ def sync_current_fields_with_cached_fields(current_fields, cached_fields):
 
     for scope in sorted(scopes):
         scoped_current_fields = current_by_scope.get(scope, {})
-        scoped_cached_fields  = cached_by_scope.get(scope, {})
-        next_tag              = len(scoped_cached_fields) + 1
+        scoped_cached_fields = cached_by_scope.get(scope, {})
+        next_tag = len(scoped_cached_fields) + 1
 
         for key in sorted(scoped_current_fields):
             current_field = scoped_current_fields[key]
-            cached_field  = scoped_cached_fields.get(key)
+            cached_field = scoped_cached_fields.get(key)
 
             if cached_field == None:
                 tag = next_tag
                 next_tag = next_tag + 1
             else:
                 current_type = current_field['type']
-                cached_type  = cached_field['type']
+                cached_type = cached_field['type']
 
                 if current_type != cached_type and current_type not in protobuf_legal_type_changes_for.get(cached_type, []):
                     old_key = cached_field["key"]
@@ -130,7 +130,8 @@ def sync_current_fields_with_cached_fields(current_fields, cached_fields):
                     current_fields[new_key] = cached_field
                     tag = next_tag
                     next_tag = next_tag + 1
-                    print('Cannot change {} from {} to {}. The {} version will be renamed to {}'.format(old_key, cached_type, current_type, cached_type, new_key))
+                    print('Cannot change {} from {} to {}. The {} version will be renamed to {}'.format(
+                        old_key, cached_type, current_type, cached_type, new_key))
                 else:
                     tag = cached_field['tag']
 
@@ -138,7 +139,7 @@ def sync_current_fields_with_cached_fields(current_fields, cached_fields):
 
         for key in sorted(scoped_cached_fields):
             current_field = scoped_current_fields.get(key)
-            cached_field  = scoped_cached_fields[key]
+            cached_field = scoped_cached_fields[key]
 
             if current_field == None:
                 if not cached_field['deprecated']:
@@ -168,9 +169,9 @@ def write_proto_message(f, message_name, message, indent=0):
         write_proto_message(f, nested_name, message[nested_key], indent + 1)
 
     for field in message.get('__fields__', []):
-        f_name       = field['name']
-        f_type       = field['type']
-        f_tag        = str(field['tag'])
+        f_name = field['name']
+        f_type = field['type']
+        f_tag = str(field['tag'])
         f_deprecated = ' [deprecated=true]' if field['deprecated'] else ''
 
         f.write(spaces + '  ' + f_type + ' ' + f_name + ' = ' + f_tag + f_deprecated + ';\n')
@@ -182,8 +183,8 @@ def write_proto(proto_file, fields):
     root_message = {}
 
     for key in sorted(fields, key=lambda k: (fields[k]["scope"], fields[k]["tag"])):
-        field   = fields[key]
-        scope   = field['scope']
+        field = fields[key]
+        scope = field['scope']
         message = root_message
 
         if scope != '':


### PR DESCRIPTION
Not sure if this is useful for the general ECS audience, but I thought I'd try contributing it back just in case. This adds a protobuf generator to elastic common schema. The two major challenges I'm aware of, and how I tried to solve them, are detailed below:

 1. Protobuf does not allow fields to be removed.

    To deal with this, I cache all the generated protobuf fields to a yaml file. Upon next run, if a field is in the cache, but no longer in the schema, it is marked as deprecated in the protobuf definition. If I deleted the `agent.id` field, for example, here's how the protobuf definition changes:

    ```diff
    diff --git a/generated/protobuf/ecs.proto b/generated/protobuf/ecs.proto
    index 3b75872..2136522 100644
    --- a/generated/protobuf/ecs.proto
    +++ b/generated/protobuf/ecs.proto
    @@ -10,7 +10,7 @@ message Document {

         Build build = 1;
         string ephemeral_id = 2;
    -    string id = 3;
    +    string id = 3 [deprecated=true];
         string name = 4;
         string type = 5;
         string version = 6;
    ```

 2. Protobuf does not allow fields to change types.

    There are some exceptions (`int32` to `uint32`), and I've accounted for those, but other type changes are invalid in protobuf. For example, changing the `agent.id` field from `string` to `int32` is invalid in protobuf. Here's how I deal with that:

    The original `string` version of `agent.id` is renamed to `agent.deprecated_id` in the protobuf object and keeps its original protobuf tag. A new protobuf tag is allocated for the `int32` version of `agent.id`.

    ```diff
    diff --git a/generated/protobuf/ecs.proto b/generated/protobuf/ecs.proto
    index 3b75872..a9b731c 100644
    --- a/generated/protobuf/ecs.proto
    +++ b/generated/protobuf/ecs.proto
    @@ -10,10 +10,11 @@ message Document {
 
         Build build = 1;
         string ephemeral_id = 2;
    -    string id = 3;
    +    string deprecated_id = 3 [deprecated=true];
         string name = 4;
         string type = 5;
         string version = 6;
    +    int32 id = 7;
       }
 
       message Client {
    ```

Since protobuf also exports extensions, it might be useful to allocate a block of tags in each message for that purpose, but I haven't added logic for that yet.

For active development, the generated protobuf object will likely get rather messy as fields are added, removed, and updated, but sprawl could be kept to a minimum by regenerating at release time with the cached fields from the previous release.