### PR TITLE
Extend reusable list for custom schemas.

### DIFF
--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -60,7 +60,7 @@ def schema_cleanup_values(schema):
 def schema_set_default_values(schema):
     schema['type'] = 'group'
     schema.setdefault('group', 2)
-    schema.setdefault('short', schema['description'])
+    schema.setdefault('short', schema['description'] if 'description' in schema else '')
     if "\n" in schema['short']:
         raise ValueError("Short descriptions must be single line.\nFieldset: {}\n{}".format(schema['name'], schema))
 
@@ -116,6 +116,8 @@ def merge_schema_fields(a, b):
             if 'fields' in b[key]:
                 a[key].setdefault('fields', {})
                 merge_schema_fields(a[key]['fields'], b[key]['fields'])
+            if 'reusable' in b[key] and 'reusable' in a[key]:
+                a[key]['reusable']['expected'].extend(b[key]['reusable']['expected'])
 
 # Finalize the intermediate representation of all fields.
 


### PR DESCRIPTION
Hi,

This change allows us to reuse default ECS fields in user defined schema fields.

A little bit of background:
I am working on a generator that receives as an input the ecs_flat.yml file generated based on the default ECS plus user defined schemas I have. I want some user defined schema fields to reuse some core ECS fields.

As an example,  a new custom field I defined should have the core `geo` field nested under it.