### PR TITLE
Add flexibility to the field set reuse mechanism

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,6 +40,8 @@ Thanks, you're awesome :-) -->
   had `reusable.top_level:false`. This PR affects `ecs_flat.yml`, the csv file
   and the sample Elasticsearch templates. #495, #813
 * Removed the `order` attribute from the `ecs_nested.yml` and `ecs_flat.yml` files. #811
+* In `ecs_nested.yml`, the array of strings that used to be in `reusable.expected`
+  has been replaced by an array of objects with 3 keys: 'as', 'at' and 'full'. #820
 
 #### Bugfixes
 
@@ -58,6 +60,8 @@ Thanks, you're awesome :-) -->
 * Add support for reusing offical fieldsets in custom schemas. #751
 * Add full path names to reused fieldsets in `nestings` array in `ecs_nested.yml`. #803
 * Allow shorthand notation for including all subfields in subsets. #805
+* Add ability to nest field sets as another name. #820
+* Add ability to nest field sets within themselves (e.g. `process.parent.*`). #820
 
 #### Deprecated
 

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -31,9 +31,6 @@ type Process struct {
 	// Process id.
 	PID int64 `ecs:"pid"`
 
-	// Process id.
-	ParentPID int64 `ecs:"parent.pid"`
-
 	// Unique identifier for the process.
 	// The implementation of this is specified by the data source, but some
 	// examples of what could be used here are a process-generated UUID, Sysmon
@@ -44,54 +41,25 @@ type Process struct {
 	// across multiple monitored hosts.
 	EntityID string `ecs:"entity_id"`
 
-	// Unique identifier for the process.
-	// The implementation of this is specified by the data source, but some
-	// examples of what could be used here are a process-generated UUID, Sysmon
-	// Process GUIDs, or a hash of some uniquely identifying components of a
-	// process.
-	// Constructing a globally unique identifier is a common practice to
-	// mitigate PID reuse as well as to identify a specific process over time,
-	// across multiple monitored hosts.
-	ParentEntityID string `ecs:"parent.entity_id"`
-
 	// Process name.
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
-	// Process name.
-	// Sometimes called program name or similar.
-	ParentName string `ecs:"parent.name"`
-
 	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 
-	// Parent process' pid.
-	ParentPPID int64 `ecs:"parent.ppid"`
-
 	// Identifier of the group of processes the process belongs to.
 	PGID int64 `ecs:"pgid"`
-
-	// Identifier of the group of processes the process belongs to.
-	ParentPGID int64 `ecs:"parent.pgid"`
 
 	// Full command line that started the process, including the absolute path
 	// to the executable, and all arguments.
 	// Some arguments may be filtered to protect sensitive information.
 	CommandLine string `ecs:"command_line"`
 
-	// Full command line that started the process, including the absolute path
-	// to the executable, and all arguments.
-	// Some arguments may be filtered to protect sensitive information.
-	ParentCommandLine string `ecs:"parent.command_line"`
-
 	// Array of process arguments, starting with the absolute path to the
 	// executable.
 	// May be filtered to protect sensitive information.
 	Args []string `ecs:"args"`
-
-	// Array of process arguments.
-	// May be filtered to protect sensitive information.
-	ParentArgs string `ecs:"parent.args"`
 
 	// Length of the process.args array.
 	// This field can be useful for querying or performing bucket analysis on
@@ -99,17 +67,8 @@ type Process struct {
 	// be an indication of suspicious activity.
 	ArgsCount int64 `ecs:"args_count"`
 
-	// Length of the process.args array.
-	// This field can be useful for querying or performing bucket analysis on
-	// how many arguments were provided to start a process. More arguments may
-	// be an indication of suspicious activity.
-	ParentArgsCount int64 `ecs:"parent.args_count"`
-
 	// Absolute path to the process executable.
 	Executable string `ecs:"executable"`
-
-	// Absolute path to the process executable.
-	ParentExecutable string `ecs:"parent.executable"`
 
 	// Process title.
 	// The proctitle, some times the same as process name. Can also be
@@ -117,49 +76,23 @@ type Process struct {
 	// currently opened.
 	Title string `ecs:"title"`
 
-	// Process title.
-	// The proctitle, some times the same as process name. Can also be
-	// different: for example a browser setting its title to the web page
-	// currently opened.
-	ParentTitle string `ecs:"parent.title"`
-
 	// Thread ID.
 	ThreadID int64 `ecs:"thread.id"`
-
-	// Thread ID.
-	ParentThreadID int64 `ecs:"parent.thread.id"`
 
 	// Thread name.
 	ThreadName string `ecs:"thread.name"`
 
-	// Thread name.
-	ParentThreadName string `ecs:"parent.thread.name"`
-
 	// The time the process started.
 	Start time.Time `ecs:"start"`
-
-	// The time the process started.
-	ParentStart time.Time `ecs:"parent.start"`
 
 	// Seconds the process has been up.
 	Uptime int64 `ecs:"uptime"`
 
-	// Seconds the process has been up.
-	ParentUptime int64 `ecs:"parent.uptime"`
-
 	// The working directory of the process.
 	WorkingDirectory string `ecs:"working_directory"`
-
-	// The working directory of the process.
-	ParentWorkingDirectory string `ecs:"parent.working_directory"`
 
 	// The exit code of the process, if this is a termination event.
 	// The field should be absent if there is no exit code for the event (e.g.
 	// process start).
 	ExitCode int64 `ecs:"exit_code"`
-
-	// The exit code of the process, if this is a termination event.
-	// The field should be absent if there is no exit code for the event (e.g.
-	// process start).
-	ParentExitCode int64 `ecs:"parent.exit_code"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6644,7 +6644,7 @@ example: `outside`
 
 ==== Field Reuse
 
-The `vlan` fields are expected to be nested at: `network.vlan`, `network.inner.vlan`, `observer.egress.vlan`, `observer.ingress.vlan`.
+The `vlan` fields are expected to be nested at: `network.inner.vlan`, `network.vlan`, `observer.egress.vlan`, `observer.ingress.vlan`.
 
 Note also that the `vlan` fields are not expected to be used directly at the top level.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4402,7 +4402,7 @@ Note also that the `process` fields may be used directly at the top level.
 // ===============================================================
 
 
-| <<ecs-parent,process.parent.*>>
+| <<ecs-process,process.parent.*>>
 | These fields contain information about a process.
 
 // ===============================================================

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -657,7 +657,7 @@ example: `true`
 
 ==== Field Reuse
 
-The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`, `process.parent.code_signature`.
+The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`.
 
 Note also that the `code_signature` fields are not expected to be used directly at the top level.
 
@@ -2512,7 +2512,7 @@ type: keyword
 
 ==== Field Reuse
 
-The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`, `process.parent.hash`.
+The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`.
 
 Note also that the `hash` fields are not expected to be used directly at the top level.
 
@@ -4238,263 +4238,6 @@ example: `ssh`
 
 // ===============================================================
 
-| process.parent.args
-| Array of process arguments.
-
-May be filtered to protect sensitive information.
-
-type: keyword
-
-
-Note: this field should contain an array of values.
-
-
-
-example: `['ssh', '-l', 'user', '10.0.0.16']`
-
-| extended
-
-// ===============================================================
-
-| process.parent.args_count
-| Length of the process.args array.
-
-This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.
-
-type: long
-
-
-
-example: `4`
-
-| extended
-
-// ===============================================================
-
-| process.parent.command_line
-| Full command line that started the process, including the absolute path to the executable, and all arguments.
-
-Some arguments may be filtered to protect sensitive information.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.command_line.text (type: text)
-
-
-
-
-
-example: `/usr/bin/ssh -l user 10.0.0.16`
-
-| extended
-
-// ===============================================================
-
-| process.parent.entity_id
-| Unique identifier for the process.
-
-The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
-
-Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.
-
-type: keyword
-
-
-
-example: `c2c455d9f99375d`
-
-| extended
-
-// ===============================================================
-
-| process.parent.executable
-| Absolute path to the process executable.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.executable.text (type: text)
-
-
-
-
-
-example: `/usr/bin/ssh`
-
-| extended
-
-// ===============================================================
-
-| process.parent.exit_code
-| The exit code of the process, if this is a termination event.
-
-The field should be absent if there is no exit code for the event (e.g. process start).
-
-type: long
-
-
-
-example: `137`
-
-| extended
-
-// ===============================================================
-
-| process.parent.name
-| Process name.
-
-Sometimes called program name or similar.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.name.text (type: text)
-
-
-
-
-
-example: `ssh`
-
-| extended
-
-// ===============================================================
-
-| process.parent.pgid
-| Identifier of the group of processes the process belongs to.
-
-type: long
-
-
-
-
-
-| extended
-
-// ===============================================================
-
-| process.parent.pid
-| Process id.
-
-type: long
-
-
-
-example: `4242`
-
-| core
-
-// ===============================================================
-
-| process.parent.ppid
-| Parent process' pid.
-
-type: long
-
-
-
-example: `4241`
-
-| extended
-
-// ===============================================================
-
-| process.parent.start
-| The time the process started.
-
-type: date
-
-
-
-example: `2016-05-23T08:05:34.853Z`
-
-| extended
-
-// ===============================================================
-
-| process.parent.thread.id
-| Thread ID.
-
-type: long
-
-
-
-example: `4242`
-
-| extended
-
-// ===============================================================
-
-| process.parent.thread.name
-| Thread name.
-
-type: keyword
-
-
-
-example: `thread-0`
-
-| extended
-
-// ===============================================================
-
-| process.parent.title
-| Process title.
-
-The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.title.text (type: text)
-
-
-
-
-
-
-
-| extended
-
-// ===============================================================
-
-| process.parent.uptime
-| Seconds the process has been up.
-
-type: long
-
-
-
-example: `1325`
-
-| extended
-
-// ===============================================================
-
-| process.parent.working_directory
-| The working directory of the process.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.working_directory.text (type: text)
-
-
-
-
-
-example: `/home/alice`
-
-| extended
-
-// ===============================================================
-
 | process.pgid
 | Identifier of the group of processes the process belongs to.
 
@@ -4630,6 +4373,10 @@ example: `/home/alice`
 
 ==== Field Reuse
 
+The `process` fields are expected to be nested at: `process.parent`.
+
+Note also that the `process` fields may be used directly at the top level.
+
 
 
 
@@ -4655,6 +4402,12 @@ example: `/home/alice`
 // ===============================================================
 
 
+| <<ecs-parent,process.parent.*>>
+| These fields contain information about a process.
+
+// ===============================================================
+
+
 | <<ecs-code_signature,process.parent.code_signature.*>>
 | These fields contain information about binary code signatures.
 
@@ -4663,6 +4416,12 @@ example: `/home/alice`
 
 | <<ecs-hash,process.parent.hash.*>>
 | Hashes, usually file hashes.
+
+// ===============================================================
+
+
+| <<ecs-pe,process.parent.pe.*>>
+| These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -241,7 +241,7 @@ example: `Google LLC`
 
 The `as` fields are expected to be nested at: `client.as`, `destination.as`, `server.as`, `source.as`.
 
-Note also that the `as` fields are not expected to be used directly at the top level.
+Note also that the `as` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -659,7 +659,7 @@ example: `true`
 
 The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`.
 
-Note also that the `code_signature` fields are not expected to be used directly at the top level.
+Note also that the `code_signature` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -2371,7 +2371,7 @@ example: `Quebec`
 
 The `geo` fields are expected to be nested at: `client.geo`, `destination.geo`, `host.geo`, `observer.geo`, `server.geo`, `source.geo`.
 
-Note also that the `geo` fields are not expected to be used directly at the top level.
+Note also that the `geo` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -2436,7 +2436,7 @@ type: keyword
 
 The `group` fields are expected to be nested at: `user.group`.
 
-Note also that the `group` fields may be used directly at the top level.
+Note also that the `group` fields may be used directly at the root of the events.
 
 
 
@@ -2514,7 +2514,7 @@ type: keyword
 
 The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`.
 
-Note also that the `hash` fields are not expected to be used directly at the top level.
+Note also that the `hash` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -2929,7 +2929,7 @@ example: `eth0`
 
 The `interface` fields are expected to be nested at: `observer.egress.interface`, `observer.ingress.interface`.
 
-Note also that the `interface` fields are not expected to be used directly at the top level.
+Note also that the `interface` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -3785,7 +3785,7 @@ example: `10.14.1`
 
 The `os` fields are expected to be nested at: `host.os`, `observer.os`, `user_agent.os`.
 
-Note also that the `os` fields are not expected to be used directly at the top level.
+Note also that the `os` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -4092,7 +4092,7 @@ example: `Microsoft® Windows® Operating System`
 
 The `pe` fields are expected to be nested at: `dll.pe`, `file.pe`, `process.pe`.
 
-Note also that the `pe` fields are not expected to be used directly at the top level.
+Note also that the `pe` fields are not expected to be used directly at the root of the events.
 
 
 
@@ -4375,7 +4375,7 @@ example: `/home/alice`
 
 The `process` fields are expected to be nested at: `process.parent`.
 
-Note also that the `process` fields may be used directly at the top level.
+Note also that the `process` fields may be used directly at the root of the events.
 
 
 
@@ -6233,7 +6233,7 @@ example: `albert`
 
 The `user` fields are expected to be nested at: `client.user`, `destination.user`, `host.user`, `server.user`, `source.user`.
 
-Note also that the `user` fields may be used directly at the top level.
+Note also that the `user` fields may be used directly at the root of the events.
 
 
 
@@ -6405,7 +6405,7 @@ example: `outside`
 
 The `vlan` fields are expected to be nested at: `network.inner.vlan`, `network.vlan`, `observer.egress.vlan`, `observer.ingress.vlan`.
 
-Note also that the `vlan` fields are not expected to be used directly at the top level.
+Note also that the `vlan` fields are not expected to be used directly at the root of the events.
 
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3106,11 +3106,12 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of process arguments.
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
 
         May be filtered to protect sensitive information.'
       example:
-      - ssh
+      - /usr/bin/ssh
       - -l
       - user
       - 10.0.0.16
@@ -3252,6 +3253,59 @@
 
         Sometimes called program name or similar.'
       example: ssh
+      default_field: false
+    - name: parent.pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: parent.pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: parent.pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: parent.pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: parent.pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: parent.pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: parent.pgid
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -348,7 +348,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 1.6.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
 1.6.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
-1.6.0-dev,true,process,process.parent.args,keyword,extended,array,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.6.0-dev,true,process,process.parent.args,keyword,extended,array,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
 1.6.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.6.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.6.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
@@ -367,6 +367,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 1.6.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
 1.6.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+1.6.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.6.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.6.0-dev,true,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.6.0-dev,true,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 1.6.0-dev,true,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 1.6.0-dev,true,process,process.parent.pid,long,core,,4242,Process id.
 1.6.0-dev,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4655,20 +4655,22 @@ process.name:
   type: keyword
 process.parent.args:
   dashed_name: process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
+  original_fieldset: parent
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -4681,8 +4683,9 @@ process.parent.args_count:
   example: 4
   flat_name: process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
+  original_fieldset: parent
   short: Length of the process.args array.
   type: long
 process.parent.code_signature.exists:
@@ -4768,8 +4771,9 @@ process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
+  original_fieldset: parent
   short: Full command line that started the process.
   type: keyword
 process.parent.entity_id:
@@ -4787,8 +4791,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: parent
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -4803,8 +4808,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: parent
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -4816,8 +4822,9 @@ process.parent.exit_code:
   example: 137
   flat_name: process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
+  original_fieldset: parent
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -4878,9 +4885,98 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: parent
   short: Process name.
+  type: keyword
+process.parent.pe.architecture:
+  dashed_name: process-parent-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.parent.pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.parent.pe.company:
+  dashed_name: process-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.description:
+  dashed_name: process-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.file_version:
+  dashed_name: process-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.parent.pe.imphash:
+  dashed_name: process-parent-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.parent.pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.parent.pe.original_file_name:
+  dashed_name: process-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.product:
+  dashed_name: process-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
   type: keyword
 process.parent.pgid:
   dashed_name: process-parent-pgid
@@ -4888,8 +4984,9 @@ process.parent.pgid:
   flat_name: process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
+  original_fieldset: parent
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -4899,8 +4996,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: parent
   short: Process id.
   type: long
 process.parent.ppid:
@@ -4910,8 +5008,9 @@ process.parent.ppid:
   flat_name: process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
+  original_fieldset: parent
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -4920,8 +5019,9 @@ process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
+  original_fieldset: parent
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -4931,8 +5031,9 @@ process.parent.thread.id:
   flat_name: process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
+  original_fieldset: parent
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -4942,8 +5043,9 @@ process.parent.thread.name:
   flat_name: process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
+  original_fieldset: parent
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -4960,8 +5062,9 @@ process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
+  original_fieldset: parent
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -4970,8 +5073,9 @@ process.parent.uptime:
   example: 1325
   flat_name: process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
+  original_fieldset: parent
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -4986,8 +5090,9 @@ process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
+  original_fieldset: parent
   short: The working directory of the process.
   type: keyword
 process.pe.architecture:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -142,12 +142,16 @@ as:
     expected:
     - as: as
       at: client
+      full: client.as
     - as: as
       at: destination
+      full: destination.as
     - as: as
       at: server
+      full: server.as
     - as: as
       at: source
+      full: source.as
     top_level: false
   short: Fields describing an Autonomous System (Internet routing prefix).
   title: Autonomous System
@@ -807,12 +811,16 @@ code_signature:
     expected:
     - as: code_signature
       at: file
+      full: file.code_signature
     - as: code_signature
       at: process
+      full: process.code_signature
     - as: code_signature
       at: process.parent
+      full: process.parent.code_signature
     - as: code_signature
       at: dll
+      full: dll.code_signature
     top_level: false
   short: These fields contain information about binary code signatures.
   title: Code Signature
@@ -3299,16 +3307,22 @@ geo:
     expected:
     - as: geo
       at: client
+      full: client.geo
     - as: geo
       at: destination
+      full: destination.geo
     - as: geo
       at: observer
+      full: observer.geo
     - as: geo
       at: host
+      full: host.geo
     - as: geo
       at: server
+      full: server.geo
     - as: geo
       at: source
+      full: source.geo
     top_level: false
   short: Fields describing a location.
   title: Geo
@@ -3356,6 +3370,7 @@ group:
     expected:
     - as: group
       at: user
+      full: user.group
     top_level: true
   short: User's group relevant to the event.
   title: Group
@@ -3414,12 +3429,16 @@ hash:
     expected:
     - as: hash
       at: file
+      full: file.hash
     - as: hash
       at: process
+      full: process.hash
     - as: hash
       at: process.parent
+      full: process.parent.hash
     - as: hash
       at: dll
+      full: dll.hash
     top_level: false
   short: Hashes, usually file hashes.
   title: Hash
@@ -4037,8 +4056,10 @@ interface:
     expected:
     - as: interface
       at: observer.ingress
+      full: observer.ingress.interface
     - as: interface
       at: observer.egress
+      full: observer.egress.interface
     top_level: false
   short: Fields to describe observer interface information.
   title: Interface
@@ -5088,10 +5109,13 @@ os:
     expected:
     - as: os
       at: observer
+      full: observer.os
     - as: os
       at: host
+      full: host.os
     - as: os
       at: user_agent
+      full: user_agent.os
     top_level: false
   short: OS fields contain information about the operating system.
   title: Operating System
@@ -5350,10 +5374,13 @@ pe:
     expected:
     - as: pe
       at: file
+      full: file.pe
     - as: pe
       at: dll
+      full: dll.pe
     - as: pe
       at: process
+      full: process.pe
     top_level: false
   short: These fields contain Windows Portable Executable (PE) metadata.
   title: PE Header
@@ -8248,14 +8275,19 @@ user:
     expected:
     - as: user
       at: client
+      full: client.user
     - as: user
       at: destination
+      full: destination.user
     - as: user
       at: host
+      full: host.user
     - as: user
       at: server
+      full: server.user
     - as: user
       at: source
+      full: source.user
     top_level: true
   short: Fields to describe the user relevant to the event.
   title: User
@@ -8452,12 +8484,16 @@ vlan:
     expected:
     - as: vlan
       at: observer.ingress
+      full: observer.ingress.vlan
     - as: vlan
       at: observer.egress
+      full: observer.egress.vlan
     - as: vlan
       at: network
+      full: network.vlan
     - as: vlan
       at: network.inner
+      full: network.inner.vlan
     top_level: false
   short: Fields to describe observed VLAN information.
   title: VLAN

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -816,9 +816,6 @@ code_signature:
       at: process
       full: process.code_signature
     - as: code_signature
-      at: process.parent
-      full: process.parent.code_signature
-    - as: code_signature
       at: dll
       full: dll.code_signature
     top_level: false
@@ -3434,9 +3431,6 @@ hash:
       at: process
       full: process.hash
     - as: hash
-      at: process.parent
-      full: process.parent.hash
-    - as: hash
       at: dll
       full: dll.hash
     top_level: false
@@ -5624,20 +5618,22 @@ process:
       type: keyword
     parent.args:
       dashed_name: process-parent-args
-      description: 'Array of process arguments.
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
 
         May be filtered to protect sensitive information.'
       example:
-      - ssh
+      - /usr/bin/ssh
       - -l
       - user
       - 10.0.0.16
       flat_name: process.parent.args
       ignore_above: 1024
       level: extended
-      name: parent.args
+      name: args
       normalize:
       - array
+      original_fieldset: parent
       short: Array of process arguments.
       type: keyword
     parent.args_count:
@@ -5650,8 +5646,9 @@ process:
       example: 4
       flat_name: process.parent.args_count
       level: extended
-      name: parent.args_count
+      name: args_count
       normalize: []
+      original_fieldset: parent
       short: Length of the process.args array.
       type: long
     parent.code_signature.exists:
@@ -5737,8 +5734,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.command_line
+      name: command_line
       normalize: []
+      original_fieldset: parent
       short: Full command line that started the process.
       type: keyword
     parent.entity_id:
@@ -5756,8 +5754,9 @@ process:
       flat_name: process.parent.entity_id
       ignore_above: 1024
       level: extended
-      name: parent.entity_id
+      name: entity_id
       normalize: []
+      original_fieldset: parent
       short: Unique identifier for the process.
       type: keyword
     parent.executable:
@@ -5772,8 +5771,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.executable
+      name: executable
       normalize: []
+      original_fieldset: parent
       short: Absolute path to the process executable.
       type: keyword
     parent.exit_code:
@@ -5785,8 +5785,9 @@ process:
       example: 137
       flat_name: process.parent.exit_code
       level: extended
-      name: parent.exit_code
+      name: exit_code
       normalize: []
+      original_fieldset: parent
       short: The exit code of the process.
       type: long
     parent.hash.md5:
@@ -5847,9 +5848,98 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.name
+      name: name
       normalize: []
+      original_fieldset: parent
       short: Process name.
+      type: keyword
+    parent.pe.architecture:
+      dashed_name: process-parent-pe-architecture
+      description: CPU architecture target for the file.
+      example: x64
+      flat_name: process.parent.pe.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: pe
+      short: CPU architecture target for the file.
+      type: keyword
+    parent.pe.company:
+      dashed_name: process-parent-pe-company
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      flat_name: process.parent.pe.company
+      ignore_above: 1024
+      level: extended
+      name: company
+      normalize: []
+      original_fieldset: pe
+      short: Internal company name of the file, provided at compile-time.
+      type: keyword
+    parent.pe.description:
+      dashed_name: process-parent-pe-description
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      flat_name: process.parent.pe.description
+      ignore_above: 1024
+      level: extended
+      name: description
+      normalize: []
+      original_fieldset: pe
+      short: Internal description of the file, provided at compile-time.
+      type: keyword
+    parent.pe.file_version:
+      dashed_name: process-parent-pe-file-version
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      flat_name: process.parent.pe.file_version
+      ignore_above: 1024
+      level: extended
+      name: file_version
+      normalize: []
+      original_fieldset: pe
+      short: Process name.
+      type: keyword
+    parent.pe.imphash:
+      dashed_name: process-parent-pe-imphash
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      flat_name: process.parent.pe.imphash
+      ignore_above: 1024
+      level: extended
+      name: imphash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in a PE file.
+      type: keyword
+    parent.pe.original_file_name:
+      dashed_name: process-parent-pe-original-file-name
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      flat_name: process.parent.pe.original_file_name
+      ignore_above: 1024
+      level: extended
+      name: original_file_name
+      normalize: []
+      original_fieldset: pe
+      short: Internal name of the file, provided at compile-time.
+      type: keyword
+    parent.pe.product:
+      dashed_name: process-parent-pe-product
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      flat_name: process.parent.pe.product
+      ignore_above: 1024
+      level: extended
+      name: product
+      normalize: []
+      original_fieldset: pe
+      short: Internal product name of the file, provided at compile-time.
       type: keyword
     parent.pgid:
       dashed_name: process-parent-pgid
@@ -5857,8 +5947,9 @@ process:
       flat_name: process.parent.pgid
       format: string
       level: extended
-      name: parent.pgid
+      name: pgid
       normalize: []
+      original_fieldset: parent
       short: Identifier of the group of processes the process belongs to.
       type: long
     parent.pid:
@@ -5868,8 +5959,9 @@ process:
       flat_name: process.parent.pid
       format: string
       level: core
-      name: parent.pid
+      name: pid
       normalize: []
+      original_fieldset: parent
       short: Process id.
       type: long
     parent.ppid:
@@ -5879,8 +5971,9 @@ process:
       flat_name: process.parent.ppid
       format: string
       level: extended
-      name: parent.ppid
+      name: ppid
       normalize: []
+      original_fieldset: parent
       short: Parent process' pid.
       type: long
     parent.start:
@@ -5889,8 +5982,9 @@ process:
       example: '2016-05-23T08:05:34.853Z'
       flat_name: process.parent.start
       level: extended
-      name: parent.start
+      name: start
       normalize: []
+      original_fieldset: parent
       short: The time the process started.
       type: date
     parent.thread.id:
@@ -5900,8 +5994,9 @@ process:
       flat_name: process.parent.thread.id
       format: string
       level: extended
-      name: parent.thread.id
+      name: thread.id
       normalize: []
+      original_fieldset: parent
       short: Thread ID.
       type: long
     parent.thread.name:
@@ -5911,8 +6006,9 @@ process:
       flat_name: process.parent.thread.name
       ignore_above: 1024
       level: extended
-      name: parent.thread.name
+      name: thread.name
       normalize: []
+      original_fieldset: parent
       short: Thread name.
       type: keyword
     parent.title:
@@ -5929,8 +6025,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.title
+      name: title
       normalize: []
+      original_fieldset: parent
       short: Process title.
       type: keyword
     parent.uptime:
@@ -5939,8 +6036,9 @@ process:
       example: 1325
       flat_name: process.parent.uptime
       level: extended
-      name: parent.uptime
+      name: uptime
       normalize: []
+      original_fieldset: parent
       short: Seconds the process has been up.
       type: long
     parent.working_directory:
@@ -5955,8 +6053,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.working_directory
+      name: working_directory
       normalize: []
+      original_fieldset: parent
       short: The working directory of the process.
       type: keyword
     pe.architecture:
@@ -6160,10 +6259,18 @@ process:
   nestings:
   - process.code_signature
   - process.hash
+  - process.parent
   - process.parent.code_signature
   - process.parent.hash
+  - process.parent.pe
   - process.pe
   prefix: process.
+  reusable:
+    expected:
+    - as: parent
+      at: process
+      full: process.parent
+    top_level: true
   short: These fields contain information about a process.
   title: Process
   type: group

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -140,10 +140,14 @@ as:
   prefix: as.
   reusable:
     expected:
-    - client
-    - destination
-    - server
-    - source
+    - as: as
+      at: client
+    - as: as
+      at: destination
+    - as: as
+      at: server
+    - as: as
+      at: source
     top_level: false
   short: Fields describing an Autonomous System (Internet routing prefix).
   title: Autonomous System
@@ -801,10 +805,14 @@ code_signature:
   prefix: code_signature.
   reusable:
     expected:
-    - file
-    - process
-    - process.parent
-    - dll
+    - as: code_signature
+      at: file
+    - as: code_signature
+      at: process
+    - as: code_signature
+      at: process.parent
+    - as: code_signature
+      at: dll
     top_level: false
   short: These fields contain information about binary code signatures.
   title: Code Signature
@@ -3289,12 +3297,18 @@ geo:
   prefix: geo.
   reusable:
     expected:
-    - client
-    - destination
-    - observer
-    - host
-    - server
-    - source
+    - as: geo
+      at: client
+    - as: geo
+      at: destination
+    - as: geo
+      at: observer
+    - as: geo
+      at: host
+    - as: geo
+      at: server
+    - as: geo
+      at: source
     top_level: false
   short: Fields describing a location.
   title: Geo
@@ -3340,7 +3354,8 @@ group:
   prefix: group.
   reusable:
     expected:
-    - user
+    - as: group
+      at: user
     top_level: true
   short: User's group relevant to the event.
   title: Group
@@ -3397,10 +3412,14 @@ hash:
   prefix: hash.
   reusable:
     expected:
-    - file
-    - process
-    - process.parent
-    - dll
+    - as: hash
+      at: file
+    - as: hash
+      at: process
+    - as: hash
+      at: process.parent
+    - as: hash
+      at: dll
     top_level: false
   short: Hashes, usually file hashes.
   title: Hash
@@ -4016,8 +4035,10 @@ interface:
   prefix: interface.
   reusable:
     expected:
-    - observer.ingress
-    - observer.egress
+    - as: interface
+      at: observer.ingress
+    - as: interface
+      at: observer.egress
     top_level: false
   short: Fields to describe observer interface information.
   title: Interface
@@ -5065,9 +5086,12 @@ os:
   prefix: os.
   reusable:
     expected:
-    - observer
-    - host
-    - user_agent
+    - as: os
+      at: observer
+    - as: os
+      at: host
+    - as: os
+      at: user_agent
     top_level: false
   short: OS fields contain information about the operating system.
   title: Operating System
@@ -5324,9 +5348,12 @@ pe:
   prefix: pe.
   reusable:
     expected:
-    - file
-    - dll
-    - process
+    - as: pe
+      at: file
+    - as: pe
+      at: dll
+    - as: pe
+      at: process
     top_level: false
   short: These fields contain Windows Portable Executable (PE) metadata.
   title: PE Header
@@ -8219,11 +8246,16 @@ user:
   prefix: user.
   reusable:
     expected:
-    - client
-    - destination
-    - host
-    - server
-    - source
+    - as: user
+      at: client
+    - as: user
+      at: destination
+    - as: user
+      at: host
+    - as: user
+      at: server
+    - as: user
+      at: source
     top_level: true
   short: Fields to describe the user relevant to the event.
   title: User
@@ -8418,10 +8450,14 @@ vlan:
   prefix: vlan.
   reusable:
     expected:
-    - observer.ingress
-    - observer.egress
-    - network
-    - network.inner
+    - as: vlan
+      at: observer.ingress
+    - as: vlan
+      at: observer.egress
+    - as: vlan
+      at: network
+    - as: vlan
+      at: network.inner
     top_level: false
   short: Fields to describe observed VLAN information.
   title: VLAN

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1753,6 +1753,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "pe": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "company": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "file_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imphash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "original_file_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "product": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "pgid": {
                   "type": "long"
                 },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1752,6 +1752,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "pe": {
+                "properties": {
+                  "architecture": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "company": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "description": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "file_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imphash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "original_file_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "product": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "pgid": {
                 "type": "long"
               },

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -9,7 +9,6 @@
     expected:
       - file
       - process
-      - process.parent
       - dll
       # - driver
   fields:

--- a/schemas/hash.yml
+++ b/schemas/hash.yml
@@ -16,7 +16,6 @@
     expected:
       - file
       - process
-      - process.parent
       - dll
 
   fields:

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -24,6 +24,11 @@
     from a log message.  The `process.pid` often stays in the metric itself and is
     copied to the global field for correlation.
   type: group
+  reusable:
+    top_level: true
+    expected:
+      - at: process
+        as: parent
   fields:
 
     - name: pid
@@ -34,32 +39,7 @@
         Process id.
       example: 4242
 
-    - name: parent.pid
-      format: string
-      level: core
-      type: long
-      description: >
-        Process id.
-      example: 4242
-
     - name: entity_id
-      level: extended
-      type: keyword
-      short: Unique identifier for the process.
-      description: >
-        Unique identifier for the process.
-
-        The implementation of this is specified by the data source, but some
-        examples of what could be used here are a process-generated UUID,
-        Sysmon Process GUIDs, or a hash of some uniquely identifying components
-        of a process.
-
-        Constructing a globally unique identifier is a common practice to mitigate
-        PID reuse as well as to identify a specific process over time, across multiple
-        monitored hosts.
-      example: c2c455d9f99375d
-
-    - name: parent.entity_id
       level: extended
       type: keyword
       short: Unique identifier for the process.
@@ -89,20 +69,6 @@
       - type: text
         name: text
 
-    - name: parent.name
-      level: extended
-      type: keyword
-      short: Process name.
-      description: >
-        Process name.
-
-        Sometimes called program name or similar.
-      example: ssh
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: ppid
       format: string
       level: extended
@@ -111,29 +77,12 @@
         Parent process' pid.
       example: 4241
 
-    - name: parent.ppid
-      format: string
-      level: extended
-      type: long
-      description: >
-        Parent process' pid.
-      example: 4241
-
-
     - name: pgid
       format: string
       level: extended
       type: long
       description: >
         Identifier of the group of processes the process belongs to.
-
-    - name: parent.pgid
-      format: string
-      level: extended
-      type: long
-      description: >
-        Identifier of the group of processes the process belongs to.
-
 
     - name: command_line
       level: extended
@@ -149,21 +98,6 @@
       - type: text
         name: text
 
-    - name: parent.command_line
-      level: extended
-      type: keyword
-      short: Full command line that started the process.
-      description: >
-        Full command line that started the process, including the absolute path
-        to the executable, and all arguments.
-
-        Some arguments may be filtered to protect sensitive information.
-      example: "/usr/bin/ssh -l user 10.0.0.16"
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: args
       level: extended
       type: keyword
@@ -173,18 +107,6 @@
 
         May be filtered to protect sensitive information.
       example: ["/usr/bin/ssh", "-l", "user", "10.0.0.16"]
-      normalize:
-        - array
-
-    - name: parent.args
-      level: extended
-      type: keyword
-      short: Array of process arguments.
-      description: >
-        Array of process arguments.
-
-        May be filtered to protect sensitive information.
-      example: ["ssh", "-l", "user", "10.0.0.16"]
       normalize:
         - array
 
@@ -200,19 +122,6 @@
         More arguments may be an indication of suspicious activity.
       example: 4
 
-    - name: parent.args_count
-      level: extended
-      type: long
-      short: Length of the process.args array.
-      description: >
-        Length of the process.args array.
-
-        This field can be useful for querying or performing bucket analysis on
-        how many arguments were provided to start a process.
-        More arguments may be an indication of suspicious activity.
-      example: 4
-
-
     - name: executable
       level: extended
       type: keyword
@@ -222,17 +131,6 @@
       multi_fields:
       - type: text
         name: text
-
-    - name: parent.executable
-      level: extended
-      type: keyword
-      description: >
-        Absolute path to the process executable.
-      example: /usr/bin/ssh
-      multi_fields:
-      - type: text
-        name: text
-
 
     - name: title
       level: extended
@@ -247,20 +145,6 @@
       - type: text
         name: text
 
-    - name: parent.title
-      level: extended
-      type: keyword
-      short: Process title.
-      description: >
-        Process title.
-
-        The proctitle, some times the same as process name. Can also be different:
-        for example a browser setting its title to the web page currently opened.
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: thread.id
       format: string
       level: extended
@@ -269,29 +153,12 @@
       description: >
         Thread ID.
 
-    - name: parent.thread.id
-      format: string
-      level: extended
-      type: long
-      example: 4242
-      description: >
-        Thread ID.
-
-
     - name: thread.name
       level: extended
       type: keyword
       example: 'thread-0'
       description: >
         Thread name.
-
-    - name: parent.thread.name
-      level: extended
-      type: keyword
-      example: 'thread-0'
-      description: >
-        Thread name.
-
 
     - name: start
       level: extended
@@ -300,28 +167,12 @@
       description: >
         The time the process started.
 
-    - name: parent.start
-      level: extended
-      type: date
-      example: "2016-05-23T08:05:34.853Z"
-      description: >
-        The time the process started.
-
-
     - name: uptime
       level: extended
       type: long
       example: 1325
       description: >
         Seconds the process has been up.
-
-    - name: parent.uptime
-      level: extended
-      type: long
-      example: 1325
-      description: >
-        Seconds the process has been up.
-
 
     - name: working_directory
       level: extended
@@ -333,29 +184,7 @@
       - type: text
         name: text
 
-    - name: parent.working_directory
-      level: extended
-      type: keyword
-      example: /home/alice
-      description: >
-        The working directory of the process.
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: exit_code
-      level: extended
-      type: long
-      example: 137
-      short: The exit code of the process.
-      description: >
-        The exit code of the process, if this is a termination event.
-
-        The field should be absent if there is no exit code for the event (e.g.
-        process start).
-
-    - name: parent.exit_code
       level: extended
       type: long
       example: 137

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -132,11 +132,11 @@ def render_fieldset_reuse_section(fieldset, intermediate_nested):
         )
         rows = []
         for nested_fs_name in fieldset['nestings']:
-            ecs = ecs_helpers.get_nested_field(nested_fs_name, intermediate_nested)
+            nested_fs = ecs_helpers.get_nested_field(nested_fs_name, intermediate_nested)
             rows.append({
                 'flat_nesting': "{}.*".format(nested_fs_name),
-                'name': nested_fs_name.split('.')[-1],
-                'short': ecs['short']
+                'name': nested_fs['name'],
+                'short': nested_fs['short']
             })
         for row in sorted(rows, key=lambda x: x['flat_nesting']):
             text += render_nesting_row(row)

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -156,10 +156,10 @@ def render_fieldset_reuses_text(fieldset):
         section_name, ', '.join(rendered_fields))
 
     if 'top_level' in fieldset['reusable'] and fieldset['reusable']['top_level']:
-        template = "Note also that the `{}` fields may be used directly at the top level.\n\n"
+        template = "Note also that the `{}` fields may be used directly at the root of the events.\n\n"
     else:
         template = "Note also that the `{}` fields are not expected to " + \
-            "be used directly at the top level.\n\n"
+            "be used directly at the root of the events.\n\n"
     text += template.format(section_name)
     return text
 

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -150,8 +150,8 @@ def render_fieldset_reuses_text(fieldset):
         return ''
 
     section_name = fieldset['name']
-    sorted_fields = sorted(fieldset['reusable']['expected'])
-    rendered_fields = map(lambda f: "`{}.{}`".format(f, section_name), sorted_fields)
+    sorted_fields = sorted(fieldset['reusable']['expected'], key=lambda k: k['full'])
+    rendered_fields = map(lambda f: "`{}`".format(f['full']), sorted_fields)
     text = "The `{}` fields are expected to be nested at: {}.\n\n".format(
         section_name, ', '.join(rendered_fields))
 

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -151,14 +151,6 @@ def list_extract_keys(lst, key_name):
     return acc
 
 
-def list_split_by(lst, size):
-    '''Splits a list in smaller lists of a given size'''
-    acc = []
-    for i in range(0, len(lst), size):
-        acc.append(lst[i:i + size])
-    return acc
-
-
 def get_nested_field(fieldname, field_dict):
     """Takes a field name in dot notation and a dictionary of fields and finds the field in the dictionary"""
     fields = fieldname.split('.')

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -149,8 +149,11 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
     # Here it simplifies the nesting of 'group' under 'user',
     # which is in turn reusable in a few places.
     if 'reusable' in schema:
+        resolve_reusable_shorthands(schema)
         for new_nesting in schema['reusable']['expected']:
-            split_flat_name = new_nesting.split('.')
+            nest_at = new_nesting['at']
+            nest_as = new_nesting['as']
+            split_flat_name = nest_at.split('.')
             top_level = split_flat_name[0]
             # List field set names expected under another field set.
             # E.g. host.nestings = [ 'geo', 'os', 'user' ]
@@ -158,12 +161,12 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
             for level in split_flat_name[1:]:
                 nested_schema = nested_schema.get(level, None)
                 if not nested_schema:
-                    raise ValueError('Field {} in path {} not found in schema'.format(level, new_nesting))
+                    raise ValueError('Field {} in path {} not found in schema'.format(level, nest_at))
                 if nested_schema.get('reusable', None):
                     raise ValueError(
                         'Reusable fields cannot be put inside other reusable fields except when the destination reusable is at the top level')
                 nested_schema = nested_schema.setdefault('fields', {})
-            nested_schema[schema['name']] = schema
+            nested_schema[nest_as] = schema
 
 
 def resolve_reusable_shorthands(schema):

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -185,10 +185,14 @@ def resolve_reusable_shorthands(schema):
         reuse_entries = []
         for reuse_entry in schema['reusable']['expected']:
             if type(reuse_entry) is dict:
-                reuse_entries.append(reuse_entry)
+                if 'at' in reuse_entry and 'as' in reuse_entry:
+                    reuse_entries.append(reuse_entry)
+                else:
+                    raise ValueError("When specifying reusable expected locations " +
+                    "with the dictionary notation, keys 'as' and 'at' are required. "+
+                    "Got {}.".format(reuse_entry))
             else:
-                explicit_entry = {'at': reuse_entry, 'as': schema['name']}
-                reuse_entries.append(explicit_entry)
+                reuse_entries.append({'at': reuse_entry, 'as': schema['name']})
         schema['reusable']['expected'] = reuse_entries
 
 

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -203,8 +203,8 @@ def resolve_reusable_shorthands(schema):
                     explicit_entry = reuse_entry
                 else:
                     raise ValueError("When specifying reusable expected locations " +
-                    "with the dictionary notation, keys 'as' and 'at' are required. "+
-                    "Got {}.".format(reuse_entry))
+                                     "with the dictionary notation, keys 'as' and 'at' are required. " +
+                                     "Got {}.".format(reuse_entry))
             else:
                 explicit_entry = {'at': reuse_entry, 'as': schema['name']}
             explicit_entry['full'] = explicit_entry['at'] + '.' + explicit_entry['as']

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -175,9 +175,6 @@ def duplicate_reusable_fieldsets(schema, fields_nested):
                 nesting_destination[nest_as] = copy.deepcopy(schema)
         for self_nesting in self_nestings:
             fields_nested[self_nesting['at']]['fields'][self_nesting['as']] = copy.deepcopy(schema)
-            # schema[self_nesting['as']] = copy.deepcopy(schema)
-            # print(self_nesting)
-        # print('self nestings for', schema['name'], self_nestings)
 
 
 def resolve_reusable_shorthands(schema):

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -189,13 +189,15 @@ def resolve_reusable_shorthands(schema):
         for reuse_entry in schema['reusable']['expected']:
             if type(reuse_entry) is dict:
                 if 'at' in reuse_entry and 'as' in reuse_entry:
-                    reuse_entries.append(reuse_entry)
+                    explicit_entry = reuse_entry
                 else:
                     raise ValueError("When specifying reusable expected locations " +
                     "with the dictionary notation, keys 'as' and 'at' are required. "+
                     "Got {}.".format(reuse_entry))
             else:
-                reuse_entries.append({'at': reuse_entry, 'as': schema['name']})
+                explicit_entry = {'at': reuse_entry, 'as': schema['name']}
+            explicit_entry['full'] = explicit_entry['at'] + '.' + explicit_entry['as']
+            reuse_entries.append(explicit_entry)
         schema['reusable']['expected'] = reuse_entries
 
 

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -84,11 +84,6 @@ class TestECSHelpers(unittest.TestCase):
         ecs_helpers.dict_clean_string_values(dict)
         self.assertEqual(dict, {'dirty': 'space, the final frontier', 'clean': 'val', 'int': 1})
 
-    def test_list_slit_by(self):
-        lst = ['ecs', 'has', 'a', 'meme', 'now']
-        split_list = ecs_helpers.list_split_by(lst, 3)
-        self.assertEqual(split_list, [['ecs', 'has', 'a'], ['meme', 'now']])
-
     def test_recursive_subset_merge(self):
         subset_a = {
             'field1': {

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -46,7 +46,7 @@ class TestSchemaReader(unittest.TestCase):
         ]
         schema = {
             'name': 'user',
-            'reusable': { 'top_level': False, 'expected': reusable_with_shorthand }
+            'reusable': {'top_level': False, 'expected': reusable_with_shorthand}
         }
         schema_reader.resolve_reusable_shorthands(schema)
         expected_reusable = [
@@ -61,7 +61,7 @@ class TestSchemaReader(unittest.TestCase):
         ]
         schema = {
             'name': 'user',
-            'reusable': { 'top_level': False, 'expected': reusable_with_key_errors }
+            'reusable': {'top_level': False, 'expected': reusable_with_key_errors}
         }
         with self.assertRaises(ValueError):
             schema_reader.resolve_reusable_shorthands(schema)

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -386,7 +386,10 @@ class TestSchemaReader(unittest.TestCase):
                         'reusable': {
                             'top_level': False,
                             'expected': [
-                                'test_fieldset.sub_field'
+                                {
+                                    'at': 'test_fieldset.sub_field',
+                                    'as': 'reusable_fieldset1'
+                                }
                             ]
                         },
                         'fields': {

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -39,6 +39,22 @@ class TestSchemaReader(unittest.TestCase):
         schema_reader.schema_set_default_values(schema)
         self.assertEqual(schema, {'group': 1, 'type': 'group', 'description': '...', 'short': '...'})
 
+    def test_resolve_reusable_shorthands(self):
+        reusable_with_shorthand = [
+            'destination',
+            {'at': 'user', 'as': 'effective'}
+        ]
+        schema = {
+            'name': 'user',
+            'reusable': { 'top_level': False, 'expected': reusable_with_shorthand }
+        }
+        schema_reader.resolve_reusable_shorthands(schema)
+        expected_reusable = [
+            {'at': 'destination', 'as': 'user'},
+            {'at': 'user', 'as': 'effective'}
+        ]
+        self.assertEqual(expected_reusable, schema['reusable']['expected'])
+
     # field definitions
 
     def test_field_set_defaults_no_short(self):

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -55,6 +55,17 @@ class TestSchemaReader(unittest.TestCase):
         ]
         self.assertEqual(expected_reusable, schema['reusable']['expected'])
 
+    def test_resolve_reusable_shorthands_raises_when_missing_keys_as_at(self):
+        reusable_with_key_errors = [
+            {'hat': 'user', 'has': 'effective'}
+        ]
+        schema = {
+            'name': 'user',
+            'reusable': { 'top_level': False, 'expected': reusable_with_key_errors }
+        }
+        with self.assertRaises(ValueError):
+            schema_reader.resolve_reusable_shorthands(schema)
+
     # field definitions
 
     def test_field_set_defaults_no_short(self):

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -50,8 +50,8 @@ class TestSchemaReader(unittest.TestCase):
         }
         schema_reader.resolve_reusable_shorthands(schema)
         expected_reusable = [
-            {'at': 'destination', 'as': 'user'},
-            {'at': 'user', 'as': 'effective'}
+            {'at': 'destination', 'as': 'user', 'full': 'destination.user'},
+            {'at': 'user', 'as': 'effective', 'full': 'user.effective'}
         ]
         self.assertEqual(expected_reusable, schema['reusable']['expected'])
 
@@ -388,7 +388,8 @@ class TestSchemaReader(unittest.TestCase):
                             'expected': [
                                 {
                                     'at': 'test_fieldset.sub_field',
-                                    'as': 'reusable_fieldset1'
+                                    'as': 'reusable_fieldset1',
+                                    'full': 'test_fieldset.sub_field.reusable_fieldset1'
                                 }
                             ]
                         },


### PR DESCRIPTION
New possibilities:

* nest as: lets us nest a field set as another name.
* self-nesting: lets us nest a field set within itself.

Most of the time, self-nesting and "nest as" will be used together. Nothing currently prevents the nesting of a fieldset elsewhere as another name. But this should be used with caution, as it could lead to confusion.

Examples:

* Nesting `process` at `process.parent`
* Nesting `user` at `user.target` and the other locations discussed in #809.

It's important to highlight one detail about self-nesting. Field sets like `user` that are also reused within other field sets (e.g. `destination.user`) and that will soon also have self-nesting (e.g. `user.target`, `user.effective`) will **not** carry the self-nesting in all other places (there won't be a `destination.user.target`).

In addition to improving the reuse mechanism, this PR replaces all of the `process.parent.*` manually duplicated fields. The process of removing this manual duplication exposed a few problems with the prior manual duplication, which are fixed by this PR:

* Small differences had crept up between the `process.*` and `process.parent.*` fields.
* The `pe` field set was nested `process.pe` but not `process.parent.pe`.
* Not an issue per se, but since `process.parent.*` fields were all explicit before, they were all explicitly listed in the asciidoc field listing. They are now indicated only via the normal "field reuse" section at the bottom of the page.

This PR does not address #809. This will be done as a separate PR.