### PR TITLE
Use safe_merge to handle multiple definitions of a single field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -58,6 +58,7 @@ Thanks, you're awesome :-) -->
 * Add support for reusing offical fieldsets in custom schemas. #751
 * Add full path names to reused fieldsets in `nestings` array in `ecs_nested.yml`. #803
 * Allow shorthand notation for including all subfields in subsets. #805
+* Prevent custom schema from defining a type more than once. #821
 
 #### Deprecated
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ pip
 PyYAML==5.3b1
 autopep8==1.4.4
 yamllint==1.19.0
+mock

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -28,7 +28,7 @@ def load_schema_files(files):
     fields_nested = {}
     for f in files:
         new_fields = read_schema_file(f)
-        fields_nested.update(new_fields)
+        fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
     return fields_nested
 
 


### PR DESCRIPTION
This PR addresses a potential issue where a user defining their own schema files accidentally defines a custom extension for the same field twice. For example in endpoint we extend the `file` schema:

```
---
- name: file
  title: File
  short: Fields describing files.
  description: ...
  type: group
  fields:
    - name: entry_modified
      level: custom
      type: double
      description: >
        Time of last status change.  See `st_ctim` member of `struct stat`.
```

If we had another file that redefines fields for `file`, the actual type used would depend on which schema file was read last by the ecs generator.

This probably won't happen in practice, but I figured it was worth pointing out just in case.

With this change, it will throw an error indicating that `file` was found more than once:
```
python scripts/generator.py --out ../gen --include ../endpoint-app-team/custom_schemas --subset ../endpoint-app-team/custom_subsets/elastic_endpoint/events/*
Running generator. ECS version 1.6.0-dev
Loading default schemas
Loading user defined schemas: ['../endpoint-app-team/custom_schemas/custom_call_stack.yml', '../endpoint-app-team/custom_schemas/custom_dll.yml', '../endpoint-app-team/custom_schemas/custom_elastic.yml', '../endpoint-app-team/custom_schemas/custom_endpoint.yml', '../endpoint-app-team/custom_schemas/custom_file.yml', '../endpoint-app-team/custom_schemas/custom_hash.yml', '../endpoint-app-team/custom_schemas/custom_http.yml', '../endpoint-app-team/custom_schemas/custom_macro.yml', '../endpoint-app-team/custom_schemas/custom_malware_classification.yml', '../endpoint-app-team/custom_schemas/custom_os.yml', '../endpoint-app-team/custom_schemas/custom_process.yml', '../endpoint-app-team/custom_schemas/custom_target.yml', '../endpoint-app-team/custom_schemas/custom_test.yml', '../endpoint-app-team/custom_schemas/custom_token.yml']
Traceback (most recent call last):
  File "scripts/generator.py", line 91, in <module>
    main()
  File "scripts/generator.py", line 33, in main
    intermediate_custom = schema_reader.load_schemas(include_glob)
  File "/Users/jbuttner/proj/es/ecs/scripts/schema_reader.py", line 22, in load_schemas
    fields_intermediate = load_schema_files(files)
  File "/Users/jbuttner/proj/es/ecs/scripts/schema_reader.py", line 31, in load_schema_files
    fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
  File "/Users/jbuttner/proj/es/ecs/scripts/generators/ecs_helpers.py", line 50, in safe_merge_dicts
    raise ValueError('Duplicate key found when merging dictionaries: {0}'.format(key))
ValueError: Duplicate key found when merging dictionaries: file
```

