### PR TITLE
[DOCS] Removes incorrect `nested` datatype definition

### DIFF
--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -62,8 +62,6 @@ In Elasticsearch, `user` is represented as an {ref}/object.html[object
 datatype]. In the case of the underline notation, both are just
 {ref}/mapping-types.html[string datatypes].
 
-NOTE: ECS does not use {ref}/nested.html[nested datatypes].
-
 [float]
 [[dot-adv]]
 ===== Advantages of dot notation

--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -62,8 +62,7 @@ In Elasticsearch, `user` is represented as an {ref}/object.html[object
 datatype]. In the case of the underline notation, both are just
 {ref}/mapping-types.html[string datatypes].
 
-NOTE: ECS does not use {ref}/nested.html[nested
-datatypes], which are arrays of objects.
+NOTE: ECS does not use {ref}/nested.html[nested datatypes].
 
 [float]
 [[dot-adv]]


### PR DESCRIPTION
Removes an incorrect definition of the [`nested` field datatype][0].

An [`object` datatype][1], which is used by the Elastic Common Schema,
can also contain an array of objects as a value.

The primary difference between the `object` and `nested` datatypes is
that objects in a `nested `datatype can be queried independently.

However, that distinction isn't needed or relevant here.

Closes #826

[0]: https://www.elastic.co/guide/en/elasticsearch/reference/master/nested.html
[1]: https://www.elastic.co/guide/en/elasticsearch/reference/master/object.html