### PR TITLE
[1.5] [DOCS] Removes incorrect `nested` datatype definition (#827)

### DIFF
--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -62,9 +62,6 @@ In Elasticsearch, `user` is represented as an {ref}/object.html[object
 datatype]. In the case of the underline notation, both are just
 {ref}/mapping-types.html[string datatypes].
 
-NOTE: ECS does not use {ref}/nested.html[nested
-datatypes], which are arrays of objects.
-
 [float]
 [[dot-adv]]
 ===== Advantages of dot notation


### PR DESCRIPTION
1.5 backport of #827