### PR TITLE
Document ECS RFC process

### DIFF
--- a/PROPOSING_CHANGES.md
+++ b/PROPOSING_CHANGES.md
@@ -1,0 +1,50 @@
+# Proposing material changes to ECS
+
+Changes to ECS are proposed as Requests for Comments (RFC) and iterated on through a series of <a href="https://elastic.github.io/ecs/stages.html">stages</a>. To advance to a specific stage, an RFC must meet the documented requirements for that stage. After being accepted into a given stage, there are stage-specific expectations and goals to be met. The overall goal of this process is to thoroughly evaluate and verify the assumptions being made about a change before formally committing it to the schema.
+
+Each RFC is represented as a markdown document following a prescribed template that gets committed to the repo. Each stage of the RFC is represented as a pull request against that document.
+
+Generally speaking, the ECS team will help steward the process, but the work of researching and iterating on aspects of an RFC will be owned by that RFC's contributor. If an RFC is being contributed by a community member, then someone at Elastic will need to act as a sponsor of the change to act as a long term owner after completion of the process.
+
+## Key questions we seek to answer through RFC process
+
+* Is this change appropriate for ECS?
+* Does this change provide enough utility for its intended use cases?
+* Does this change strike sufficient balance between introducing new fields and reusing existing common fields?
+* Is ownership for the ongoing maintenance of this change clearly defined and accepted?
+* Is the scope of impact of this change to ingestion, existing applications, and the ECS project itself understood?
+* Are the technical details of the change defined clearly enough to implement in the schema?
+* Are we confident these changes can be stable upon release without requiring revisions or breaking changes?
+* Have our assumptions about the shape and utility of these changes been verified by real-world, production-ready usage?
+
+## Goals with this contributing process
+
+* Allow contributors to quickly iterate and receive feedback on their fields in a transparent way without the high bar set for general availability in the schema
+* Clarify the level of stability to expect from a change in ECS while still allowing early adopters to try it out and provide feedback
+* Offer assurance that once an RFC reaches stage 4, we're able to guarantee backwards compatibility
+
+## Responsibilities in this process
+
+Member(s) of the **ECS committee**:
+* evaluates whether the changes are appropriate in terms of the goals of the ECS project
+* provides recommendations on the which common fields would be best suited for reuse versus adding new fields
+* determines whether each RFC is accepted into the next target stage by merging the RFC PR
+
+The **ECS team**:
+* provides procedural guidance for moving an RFC through stages
+* curates the overall RFC process, including closing stalled or abandoned RFCs
+* reports on the status of open RFCs
+* acts on behalf of the committee for some but not all PRs
+
+The **contributor**:
+* takes responsibility for doing all necessary legwork to move their RFC forward including but not limited to responding to feedback, identifying and bringing in subject matter experts, and researching scope of impact
+* demonstrates how the fields in the RFC are expected to be used: from the data source, all the way to its consumption
+* commits to iterating on the RFCs through to stage 4 if necessary
+* creates and iterate on RFC PRs
+* implements all necessary changes to their RFC PRs
+
+The **sponsor** at Elastic:
+* can be the same person as the contributor if they're an appropriate engineer at Elastic
+* is involved at least from stage 1 onward if a different person than the contributor
+* signs off on each stage if a different person than the contributor
+* takes or coordinates ownership of the addition in terms of support and maintenance after the RFC process is completed

--- a/stages.html
+++ b/stages.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<style>
+  html {
+    font-family: sans-serif;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  th, td {
+    vertical-align: top;
+    border: 1px solid black;
+    padding: 0.3em;
+  }
+
+  ul {
+    padding: 0 0 0 1.2em;
+    margin: 0;
+  }
+</style>
+
+<title>ECS Proposal Stages</title>
+
+<h1>ECS Proposal Stages</h1>
+
+<p>These are the stages that an individual RFC advances through before being released for general availability in the Elastic Common Schema (ECS). See the <a href="https://github.com/elastic/ecs/blob/master/PROPOSING_CHANGES.md">Contributing Guide</a> for broader details about contributing changes to ECS through the RFC process.
+
+<table>
+  <thead>
+    <tr>
+      <th>
+      <th>Stage
+      <th>Goals during this stage
+      <th>Criteria for consideration for this stage
+      <th>Acceptance into this stage signifies
+      <th>Acceptable changes to schema in this stage
+      <th>Breaking changes expected after acceptance into this stage
+      <th>Recommended types of usage implementation
+    </tr>
+  </thead>
+  <tr>
+    <td>0
+    <td>Strawperson
+    <td>
+      <ul>
+        <li>Discuss with domain or subject matter experts the utility of these changes
+        <li>Discuss with ECS team whether these changes seem appropriate for ECS
+      </ul>
+    </td>
+    <td>Opened RFC pull request for this strawperson at <a href="https://github.com/elastic/ecs">elastic/ecs
+    <td>The premise of these changes is not obviously useless or inappropriate for ECS
+    <td>None
+    <td>Major
+    <td>N/A
+  </tr>
+  <tr>
+    <td>1
+    <td>Proposal
+    <td>
+      <ul>
+        <li>Make the case for these changes
+        <li>Describe the field definitions at a high level
+        <li>Identify potential challenges and areas that need more clarity
+      </ul>
+    </td>
+    <td>
+      <ul>
+        <li>Opened pull request for this proposal revising the existing strawperson
+        <li>Identified "sponsor" at Elastic who will participate in RFC process and take ownership of the change after the process completes
+        <li>Types of fields or changes outlined
+        <li>High-level description of examples of usage
+        <li>High-level description of example sources of data
+        <li>Identified potential concerns and implementation challenges/complexity
+        <li>Subject matter experts identified and weighed in on the high level utility of these changes in the pull request
+        <li>ECS team weighed in on appropriateness of these changes in the pull request
+      </ul>
+    </td>
+    <td>ECS team accepts the premise of the addition and commits to considering this proposal as it advances.
+    <td>None
+    <td>Major
+    <td>Proof of concepts, demos
+  </tr>
+  <tr>
+    <td>2
+    <td>Draft
+    <td>Identify a comprehensive set of field definitions that could be appropriate for real-world usage
+    <td>
+      <ul>
+        <li>Opened pull request for this draft revising the existing proposal
+        <li>Outlined initial field definitions
+        <li>Included a real world example source document
+        <li>Identifies scope of impact of changes to ingestion mechanisms (e.g. beats/logstash), usage mechanisms (e.g. Kibana applications, detections), and the ECS project (e.g. docs, tooling)
+        <li>Subject matter experts weighed in on technical utility of field definitions in the pull request
+      </ul>
+    </td>
+    <td>The initial field definitions are a comprehensive, though not necessarily complete, model of the addition to the schema. Fundamental questions and concerns are resolved, though some less significant questions remain open.
+    <td>Draft field definitions can be committed to the ECS schema as "experimental" fields
+    <td>Iterative
+    <td>Experimental and beta features
+  </tr>
+  <tr>
+    <td>3
+    <td>Candidate
+    <td>Indicate that direct experience from implementations and users is necessary to validate the additions
+    <td>
+      <ul>
+        <li>Opened pull request for this candidate revising the existing draft
+        <li>Completed field definitions
+        <li>Included multiple real world example source documents
+        <li>Existing or newly raised questions and concerns are addressed
+      </ul>
+    </td>
+    <td>There are no further open questions or unaddressed concerns, and the field definitions are complete based on the information and usage experience we have.
+    <td>Candidate field definitions can be committed to the ECS schema as "beta" fields
+    <td>Minimal: only those determined to be critical based on usage experience
+    <td>GA features
+  </tr>
+  <tr>
+    <td>4
+    <td>Finished
+    <td>Indicate that the addition is ready for GA release in ECS
+    <td>
+      <ul>
+        <li>Opened pull request for this candidate revising the existing candidate
+        <li>At least one real-world, production-ready usage implementation exists for the field definitions
+        <li>Existing or newly raised questions and concerns are addressed
+        <li>No objections from sponsor, ECS team, or subject matter experts
+      </ul>
+    </td>
+    <td>The field definitions are in use as defined in real-world, production-ready software without raising additional questions or concerns that need to be resolved. The changes are ready to be released as GA in ECS.
+    <td>Field definitions can be committed to the ECS schema as "GA" fields
+    <td>None outside major versions
+    <td>Any
+  </tr>
+</table>


### PR DESCRIPTION
I still need to reconcile the existing readme and contributing guide with these changes, but I wanted to put this content into a draft PR for visibility.

The rendered stages doc can be seen here: https://epixa.github.io/ecs/stages.html