### PR TITLE
ip address locality

### DIFF
--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -40,6 +40,15 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: locality
+      level: extended
+      type: keyword
+      short: Client locality.
+      description: >
+        Identify if the IP address is internal or external to the management
+        system. Could also identify rfc1918 IPv4 addresses. Suggested attributes
+        can be: "public" or "private" (or "rfc1918"), "external" or "internal".
+
     - name: port
       format: string
       level: core

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -31,6 +31,15 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: locality
+      level: extended
+      type: keyword
+      short: Destination locality.
+      description: >
+        Identify if the IP address is internal or external to the management
+        system. Could also identify rfc1918 IPv4 addresses. Suggested attributes
+        can be: "public" or "private" (or "rfc1918"), "external" or "internal".
+
     - name: port
       format: string
       level: core

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -40,6 +40,15 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: locality
+      level: extended
+      type: keyword
+      short: Server locality.
+      description: >
+        Identify if the IP address is internal or external to the management
+        system. Could also identify rfc1918 IPv4 addresses. Suggested attributes
+        can be: "public" or "private" (or "rfc1918"), "external" or "internal".
+
     - name: port
       format: string
       level: core

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -31,6 +31,15 @@
 
         Can be one or multiple IPv4 or IPv6 addresses.
 
+    - name: locality
+      level: extended
+      type: keyword
+      short: Source locality.
+      description: >
+        Identify if the IP address is internal or external to the management
+        system. Could also identify rfc1918 IPv4 addresses. Suggested attributes
+        can be: "public" or "private" (or "rfc1918"), "external" or "internal".
+
     - name: port
       format: string
       level: core


### PR DESCRIPTION
We found useful having an attribute defining if the IP is local or not. We can use it as a self-describing field:
- internal to the organization
- external
Or it can also be used with:
- public
- private (or rfc1918)
The latter case is useless for IPv6.
Third option could be a bool:
- internal: False|True

Depending on the case, it can be useful having that info as both tag and attribute.

Any thoughts?