### PR TITLE
Deprecate event.dataset

### DIFF
--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1837,6 +1837,7 @@ event.created:
   type: date
 event.dataset:
   dashed_name: event-dataset
+  deprecated: true
   description: 'Name of the dataset.
 
     If an event source publishes more than one type of log or events (e.g. access

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2188,6 +2188,7 @@ event:
       type: date
     dataset:
       dashed_name: event-dataset
+      deprecated: true
       description: 'Name of the dataset.
 
         If an event source publishes more than one type of log or events (e.g. access

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -514,6 +514,7 @@
         It's recommended but not required to start the dataset name with
         the module name, followed by a dot, then the dataset name.
       example: apache.access
+      deprecated: true
 
     - name: provider
       level: extended


### PR DESCRIPTION
With https://github.com/elastic/ecs/pull/845 stream.dataset is introduced. Even though event.dataset is still heavily used, users should start to switch over to using stream.dataset. I expect event.dataset to be remove from ECS in the next major version.

stream.dataset and event.dataset have the same content but are not of the same type. First one is constant_keyword, other one keyword. On the query side this should not make a difference but not sure if it is possible to use alias to reference one to an other.