### PR TITLE
Deprecate event.module

### DIFF
--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2005,6 +2005,7 @@ event.kind:
   type: keyword
 event.module:
   dashed_name: event-module
+  deprecated: true
   description: 'Name of the module this data is coming from.
 
     If your monitoring agent supports the concept of modules or plugins to process

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2359,6 +2359,7 @@ event:
       type: keyword
     module:
       dashed_name: event-module
+      deprecated: true
       description: 'Name of the module this data is coming from.
 
         If your monitoring agent supports the concept of modules or plugins to process

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -499,6 +499,7 @@
         process events of a given source (e.g. Apache logs),
         `event.module` should contain the name of this module.
       example: apache
+      deprecated: true
 
     - name: dataset
       level: core


### PR DESCRIPTION
event.module was introduced together with event.dataset. With https://github.com/elastic/ecs/pull/845 the new stream fields are introduced and module is not used anymore.

When we introduce event.module the assumption was that this is the field used for quering but it turned out in most casese event.dataset is needed and required. I expect event.module to be removed from ECS in the next major version but this does not mean, it cant still be used by Beats for example.