### PR TITLE
Add build-version option for building specific versions of ECS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 - 1.13.x
 
 install:
+- git fetch --tags --all
 - make setup
 
 addons:

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -61,6 +61,7 @@ Thanks, you're awesome :-) -->
 * Add support for reusing offical fieldsets in custom schemas. #751
 * Add full path names to reused fieldsets in `nestings` array in `ecs_nested.yml`. #803
 * Allow shorthand notation for including all subfields in subsets. #805
+* Add `ref` option to generator allowing schemas to be built for a specific ECS version. #851
 
 #### Deprecated
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ FORCE_GO_MODULES := GO111MODULE=on
 OPEN_DOCS        ?= "--open"
 PYTHON           := build/ve/bin/python
 VERSION          := $(shell cat version)
+BUILD_VERSION      := "master"
 
 #
 # Targets (sorted alphabetically)
@@ -61,7 +62,7 @@ generate: legacy_use_cases codegen generator
 # Run the new generator
 .PHONY: generator
 generator:
-	$(PYTHON) scripts/generator.py --include "${INCLUDE}"
+	$(PYTHON) scripts/generator.py --include "${INCLUDE}" --build-version ${BUILD_VERSION}
 
 # Generate Go code from the schema.
 .PHONY: gocodegen

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ FORCE_GO_MODULES := GO111MODULE=on
 OPEN_DOCS        ?= "--open"
 PYTHON           := build/ve/bin/python
 VERSION          := $(shell cat version)
-BUILD_VERSION      := "master"
 
 #
 # Targets (sorted alphabetically)
@@ -62,7 +61,7 @@ generate: legacy_use_cases codegen generator
 # Run the new generator
 .PHONY: generator
 generator:
-	$(PYTHON) scripts/generator.py --include "${INCLUDE}" --build-version ${BUILD_VERSION}
+	$(PYTHON) scripts/generator.py --include "${INCLUDE}"
 
 # Generate Go code from the schema.
 .PHONY: gocodegen

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -18,7 +18,6 @@ def main():
     if args.include and [''] == args.include:
         args.include.clear()
 
-    
     if args.ref:
         # Load ECS schemas from a specific git ref
         print('Loading schemas from git ref ' + args.ref)
@@ -30,7 +29,7 @@ def main():
         print('Loading default schemas')
         ecs_version = read_version()
         ecs_schemas = schema_reader.load_schemas_from_files()
-    
+
     print('Running generator. ECS version ' + ecs_version)
     intermediate_fields = schema_reader.create_schema_dicts(ecs_schemas)
 

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import yaml
+import git
 
 from collections import OrderedDict
 from copy import deepcopy
@@ -113,6 +114,12 @@ def get_glob_files(paths, file_types):
         for t in file_types:
             all_files.extend(glob.glob(os.path.join(path, t)))
     return sorted(all_files)
+
+
+def get_git_tree(version):
+    repo = git.Repo(os.getcwd())
+    commit = repo.commit(version)
+    return commit.tree
 
 
 def ecs_files():

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -116,9 +116,9 @@ def get_glob_files(paths, file_types):
     return sorted(all_files)
 
 
-def get_git_tree(version):
+def get_tree_by_ref(ref):
     repo = git.Repo(os.getcwd())
-    commit = repo.commit(version)
+    commit = repo.commit(ref)
     return commit.tree
 
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ pip
 PyYAML==5.3b1
 autopep8==1.4.4
 yamllint==1.19.0
+gitpython==3.1.2

--- a/scripts/schema_reader.py
+++ b/scripts/schema_reader.py
@@ -33,7 +33,7 @@ def create_fields_dict(raw):
     return fields
 
 
-def load_schemas_from_files(files):
+def load_schemas_from_files(files=ecs_helpers.ecs_files()):
     schemas = []
     for file in files:
         with open(file) as f:

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -234,6 +234,11 @@ class TestECSHelpers(unittest.TestCase):
         actual = ecs_helpers.get_nested_field(nested_field_name, fields)
         self.assertEqual(actual, expected)
 
+    def test_get_tree_by_ref(self):
+        ref = 'v1.5.0'
+        tree = ecs_helpers.get_tree_by_ref(ref)
+        self.assertEqual(tree.hexsha, '4449df245f6930d59bcd537a5958891261a9476b')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -5,97 +5,106 @@ import unittest
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from scripts import schema_reader
-
-schemas = schema_reader.load_schemas()
-schema_reader.assemble_reusables(schemas)
-(nested, flat) = schema_reader.generate_nested_flat(schemas)
+from generators import ecs_helpers
 
 
 class TestEcsSpec(unittest.TestCase):
     """Sanity check for things that should be true in the ECS spec."""
 
     def setUp(self):
-        global nested
-        global flat
-        self.ecs_nested = nested
-        self.ecs_fields = flat
+        versions = ['master', 'v1.5.0']
+        self.ecs_nested_schemas = []
+        self.ecs_flat_schemas = []
+        for version in versions:
+            tree = ecs_helpers.get_git_tree(version)
+            schemas = schema_reader.load_schemas_from_git(tree)
+            intermediate_schemas = schema_reader.create_schema_dicts(schemas)
+            schema_reader.assemble_reusables(intermediate_schemas)
+            (nested, flat) = schema_reader.generate_nested_flat(intermediate_schemas)
+            self.ecs_nested_schemas.append(nested)
+            self.ecs_flat_schemas.append(flat)
 
     def test_base_flat_name(self):
-        self.assertIsInstance(self.ecs_fields['@timestamp'], dict)
-        self.assertEqual(
-            self.ecs_nested['base']['fields']['@timestamp']['flat_name'],
-            '@timestamp')
+        for flat_schema in self.ecs_flat_schemas:
+            self.assertIsInstance(flat_schema['@timestamp'], dict)
+        for nested_schema in self.ecs_nested_schemas:
+            self.assertEqual(
+                nested_schema['base']['fields']['@timestamp']['flat_name'],
+                '@timestamp')
 
     def test_flat_includes_reusable_fields(self):
-        all_keys = sorted(self.ecs_fields.keys())
+        for flat_schema in self.ecs_flat_schemas:
+            all_keys = sorted(flat_schema.keys())
 
-        # geo
-        self.assertIn('client.geo.name', all_keys)
-        self.assertIn('destination.geo.name', all_keys)
-        self.assertIn('host.geo.name', all_keys)
-        self.assertIn('observer.geo.name', all_keys)
-        self.assertIn('server.geo.name', all_keys)
-        self.assertIn('source.geo.name', all_keys)
+            # geo
+            self.assertIn('client.geo.name', all_keys)
+            self.assertIn('destination.geo.name', all_keys)
+            self.assertIn('host.geo.name', all_keys)
+            self.assertIn('observer.geo.name', all_keys)
+            self.assertIn('server.geo.name', all_keys)
+            self.assertIn('source.geo.name', all_keys)
 
-        # group
-        self.assertIn('user.group.name', all_keys)
-        self.assertIn('client.user.group.id', all_keys)
-        self.assertIn('destination.user.group.id', all_keys)
-        self.assertIn('server.user.group.id', all_keys)
-        self.assertIn('source.user.group.id', all_keys)
+            # group
+            self.assertIn('user.group.name', all_keys)
+            self.assertIn('client.user.group.id', all_keys)
+            self.assertIn('destination.user.group.id', all_keys)
+            self.assertIn('server.user.group.id', all_keys)
+            self.assertIn('source.user.group.id', all_keys)
 
-        # user
-        self.assertIn('client.user.id', all_keys)
-        self.assertIn('destination.user.id', all_keys)
-        self.assertIn('server.user.id', all_keys)
-        self.assertIn('source.user.id', all_keys)
+            # user
+            self.assertIn('client.user.id', all_keys)
+            self.assertIn('destination.user.id', all_keys)
+            self.assertIn('server.user.id', all_keys)
+            self.assertIn('source.user.id', all_keys)
 
-        # os
-        self.assertIn('host.os.name', all_keys)
-        self.assertIn('observer.os.name', all_keys)
-        self.assertIn('user_agent.os.name', all_keys)
+            # os
+            self.assertIn('host.os.name', all_keys)
+            self.assertIn('observer.os.name', all_keys)
+            self.assertIn('user_agent.os.name', all_keys)
 
     def test_nested_includes_reusable_fields(self):
-        client_keys = sorted(self.ecs_nested['client']['fields'].keys())
-        destination_keys = sorted(self.ecs_nested['destination']['fields'].keys())
-        host_keys = sorted(self.ecs_nested['host']['fields'].keys())
-        observer_keys = sorted(self.ecs_nested['observer']['fields'].keys())
-        server_keys = sorted(self.ecs_nested['server']['fields'].keys())
-        source_keys = sorted(self.ecs_nested['source']['fields'].keys())
-        user_agent_keys = sorted(self.ecs_nested['user_agent']['fields'].keys())
-        user_keys = sorted(self.ecs_nested['user']['fields'].keys())
+        for nested_schema in self.ecs_nested_schemas:
+            client_keys = sorted(nested_schema['client']['fields'].keys())
+            destination_keys = sorted(nested_schema['destination']['fields'].keys())
+            host_keys = sorted(nested_schema['host']['fields'].keys())
+            observer_keys = sorted(nested_schema['observer']['fields'].keys())
+            server_keys = sorted(nested_schema['server']['fields'].keys())
+            source_keys = sorted(nested_schema['source']['fields'].keys())
+            user_agent_keys = sorted(nested_schema['user_agent']['fields'].keys())
+            user_keys = sorted(nested_schema['user']['fields'].keys())
 
-        # geo
-        self.assertIn('geo.name', client_keys)
-        self.assertIn('geo.name', destination_keys)
-        self.assertIn('geo.name', host_keys)
-        self.assertIn('geo.name', observer_keys)
-        self.assertIn('geo.name', server_keys)
-        self.assertIn('geo.name', source_keys)
+            # geo
+            self.assertIn('geo.name', client_keys)
+            self.assertIn('geo.name', destination_keys)
+            self.assertIn('geo.name', host_keys)
+            self.assertIn('geo.name', observer_keys)
+            self.assertIn('geo.name', server_keys)
+            self.assertIn('geo.name', source_keys)
 
-        # group
-        self.assertIn('group.name', user_keys)
-        self.assertIn('user.group.id', client_keys)
-        self.assertIn('user.group.id', destination_keys)
-        self.assertIn('user.group.id', server_keys)
-        self.assertIn('user.group.id', source_keys)
+            # group
+            self.assertIn('group.name', user_keys)
+            self.assertIn('user.group.id', client_keys)
+            self.assertIn('user.group.id', destination_keys)
+            self.assertIn('user.group.id', server_keys)
+            self.assertIn('user.group.id', source_keys)
 
-        # user
-        self.assertIn('user.id', client_keys)
-        self.assertIn('user.id', destination_keys)
-        self.assertIn('user.id', server_keys)
-        self.assertIn('user.id', source_keys)
+            # user
+            self.assertIn('user.id', client_keys)
+            self.assertIn('user.id', destination_keys)
+            self.assertIn('user.id', server_keys)
+            self.assertIn('user.id', source_keys)
 
-        # os
-        self.assertIn('os.name', host_keys)
-        self.assertIn('os.name', observer_keys)
-        self.assertIn('os.name', user_agent_keys)
+            # os
+            self.assertIn('os.name', host_keys)
+            self.assertIn('os.name', observer_keys)
+            self.assertIn('os.name', user_agent_keys)
 
     def test_related_fields_always_arrays(self):
-        for (field_name, field) in self.ecs_nested['related']['fields'].items():
-            self.assertIn('normalize', field.keys())
-            self.assertIn('array', field['normalize'],
-                          "All fields under `related.*` should be arrays")
+        for nested_schema in self.ecs_nested_schemas:
+            for (field_name, field) in nested_schema['related']['fields'].items():
+                self.assertIn('normalize', field.keys())
+                self.assertIn('array', field['normalize'],
+                              "All fields under `related.*` should be arrays")
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -92,7 +92,7 @@ class TestEcsSpec(unittest.TestCase):
         for (field_name, field) in self.ecs_nested['related']['fields'].items():
             self.assertIn('normalize', field.keys())
             self.assertIn('array', field['normalize'],
-                            "All fields under `related.*` should be arrays")
+                          "All fields under `related.*` should be arrays")
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -12,99 +12,87 @@ class TestEcsSpec(unittest.TestCase):
     """Sanity check for things that should be true in the ECS spec."""
 
     def setUp(self):
-        versions = ['master', 'v1.5.0']
-        self.ecs_nested_schemas = []
-        self.ecs_flat_schemas = []
-        for version in versions:
-            tree = ecs_helpers.get_git_tree(version)
-            schemas = schema_reader.load_schemas_from_git(tree)
-            intermediate_schemas = schema_reader.create_schema_dicts(schemas)
-            schema_reader.assemble_reusables(intermediate_schemas)
-            (nested, flat) = schema_reader.generate_nested_flat(intermediate_schemas)
-            self.ecs_nested_schemas.append(nested)
-            self.ecs_flat_schemas.append(flat)
+        schemas = schema_reader.load_schemas_from_files()
+        intermediate_schemas = schema_reader.create_schema_dicts(schemas)
+        schema_reader.assemble_reusables(intermediate_schemas)
+        (self.ecs_nested, self.ecs_fields) = schema_reader.generate_nested_flat(intermediate_schemas)
 
     def test_base_flat_name(self):
-        for flat_schema in self.ecs_flat_schemas:
-            self.assertIsInstance(flat_schema['@timestamp'], dict)
-        for nested_schema in self.ecs_nested_schemas:
-            self.assertEqual(
-                nested_schema['base']['fields']['@timestamp']['flat_name'],
-                '@timestamp')
+        self.assertIsInstance(self.ecs_fields['@timestamp'], dict)
+        self.assertEqual(
+            self.ecs_nested['base']['fields']['@timestamp']['flat_name'],
+            '@timestamp')
 
     def test_flat_includes_reusable_fields(self):
-        for flat_schema in self.ecs_flat_schemas:
-            all_keys = sorted(flat_schema.keys())
+        all_keys = sorted(self.ecs_fields.keys())
 
-            # geo
-            self.assertIn('client.geo.name', all_keys)
-            self.assertIn('destination.geo.name', all_keys)
-            self.assertIn('host.geo.name', all_keys)
-            self.assertIn('observer.geo.name', all_keys)
-            self.assertIn('server.geo.name', all_keys)
-            self.assertIn('source.geo.name', all_keys)
+        # geo
+        self.assertIn('client.geo.name', all_keys)
+        self.assertIn('destination.geo.name', all_keys)
+        self.assertIn('host.geo.name', all_keys)
+        self.assertIn('observer.geo.name', all_keys)
+        self.assertIn('server.geo.name', all_keys)
+        self.assertIn('source.geo.name', all_keys)
 
-            # group
-            self.assertIn('user.group.name', all_keys)
-            self.assertIn('client.user.group.id', all_keys)
-            self.assertIn('destination.user.group.id', all_keys)
-            self.assertIn('server.user.group.id', all_keys)
-            self.assertIn('source.user.group.id', all_keys)
+        # group
+        self.assertIn('user.group.name', all_keys)
+        self.assertIn('client.user.group.id', all_keys)
+        self.assertIn('destination.user.group.id', all_keys)
+        self.assertIn('server.user.group.id', all_keys)
+        self.assertIn('source.user.group.id', all_keys)
 
-            # user
-            self.assertIn('client.user.id', all_keys)
-            self.assertIn('destination.user.id', all_keys)
-            self.assertIn('server.user.id', all_keys)
-            self.assertIn('source.user.id', all_keys)
+        # user
+        self.assertIn('client.user.id', all_keys)
+        self.assertIn('destination.user.id', all_keys)
+        self.assertIn('server.user.id', all_keys)
+        self.assertIn('source.user.id', all_keys)
 
-            # os
-            self.assertIn('host.os.name', all_keys)
-            self.assertIn('observer.os.name', all_keys)
-            self.assertIn('user_agent.os.name', all_keys)
+        # os
+        self.assertIn('host.os.name', all_keys)
+        self.assertIn('observer.os.name', all_keys)
+        self.assertIn('user_agent.os.name', all_keys)
 
     def test_nested_includes_reusable_fields(self):
-        for nested_schema in self.ecs_nested_schemas:
-            client_keys = sorted(nested_schema['client']['fields'].keys())
-            destination_keys = sorted(nested_schema['destination']['fields'].keys())
-            host_keys = sorted(nested_schema['host']['fields'].keys())
-            observer_keys = sorted(nested_schema['observer']['fields'].keys())
-            server_keys = sorted(nested_schema['server']['fields'].keys())
-            source_keys = sorted(nested_schema['source']['fields'].keys())
-            user_agent_keys = sorted(nested_schema['user_agent']['fields'].keys())
-            user_keys = sorted(nested_schema['user']['fields'].keys())
+        client_keys = sorted(self.ecs_nested['client']['fields'].keys())
+        destination_keys = sorted(self.ecs_nested['destination']['fields'].keys())
+        host_keys = sorted(self.ecs_nested['host']['fields'].keys())
+        observer_keys = sorted(self.ecs_nested['observer']['fields'].keys())
+        server_keys = sorted(self.ecs_nested['server']['fields'].keys())
+        source_keys = sorted(self.ecs_nested['source']['fields'].keys())
+        user_agent_keys = sorted(self.ecs_nested['user_agent']['fields'].keys())
+        user_keys = sorted(self.ecs_nested['user']['fields'].keys())
 
-            # geo
-            self.assertIn('geo.name', client_keys)
-            self.assertIn('geo.name', destination_keys)
-            self.assertIn('geo.name', host_keys)
-            self.assertIn('geo.name', observer_keys)
-            self.assertIn('geo.name', server_keys)
-            self.assertIn('geo.name', source_keys)
+        # geo
+        self.assertIn('geo.name', client_keys)
+        self.assertIn('geo.name', destination_keys)
+        self.assertIn('geo.name', host_keys)
+        self.assertIn('geo.name', observer_keys)
+        self.assertIn('geo.name', server_keys)
+        self.assertIn('geo.name', source_keys)
 
-            # group
-            self.assertIn('group.name', user_keys)
-            self.assertIn('user.group.id', client_keys)
-            self.assertIn('user.group.id', destination_keys)
-            self.assertIn('user.group.id', server_keys)
-            self.assertIn('user.group.id', source_keys)
+        # group
+        self.assertIn('group.name', user_keys)
+        self.assertIn('user.group.id', client_keys)
+        self.assertIn('user.group.id', destination_keys)
+        self.assertIn('user.group.id', server_keys)
+        self.assertIn('user.group.id', source_keys)
 
-            # user
-            self.assertIn('user.id', client_keys)
-            self.assertIn('user.id', destination_keys)
-            self.assertIn('user.id', server_keys)
-            self.assertIn('user.id', source_keys)
+        # user
+        self.assertIn('user.id', client_keys)
+        self.assertIn('user.id', destination_keys)
+        self.assertIn('user.id', server_keys)
+        self.assertIn('user.id', source_keys)
 
-            # os
-            self.assertIn('os.name', host_keys)
-            self.assertIn('os.name', observer_keys)
-            self.assertIn('os.name', user_agent_keys)
+        # os
+        self.assertIn('os.name', host_keys)
+        self.assertIn('os.name', observer_keys)
+        self.assertIn('os.name', user_agent_keys)
 
     def test_related_fields_always_arrays(self):
-        for nested_schema in self.ecs_nested_schemas:
-            for (field_name, field) in nested_schema['related']['fields'].items():
-                self.assertIn('normalize', field.keys())
-                self.assertIn('array', field['normalize'],
-                              "All fields under `related.*` should be arrays")
+        for (field_name, field) in self.ecs_nested['related']['fields'].items():
+            self.assertIn('normalize', field.keys())
+            self.assertIn('array', field['normalize'],
+                            "All fields under `related.*` should be arrays")
 
 
 if __name__ == '__main__':

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -68,8 +68,8 @@ class TestSchemaReader(unittest.TestCase):
         self.assertEqual(field, expected)
 
     def test_load_schemas_with_empty_list_loads_nothing(self):
-        result = schema_reader.load_schemas([])
-        self.assertEqual(result, ({}))
+        result = schema_reader.load_schemas_from_files([])
+        self.assertEqual(result, ([]))
 
     def test_flatten_fields(self):
         fields = {

--- a/scripts/tests/test_schema_reader.py
+++ b/scripts/tests/test_schema_reader.py
@@ -5,6 +5,7 @@ import unittest
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from scripts import schema_reader
+from generators import ecs_helpers
 
 
 class TestSchemaReader(unittest.TestCase):
@@ -70,6 +71,12 @@ class TestSchemaReader(unittest.TestCase):
     def test_load_schemas_with_empty_list_loads_nothing(self):
         result = schema_reader.load_schemas_from_files([])
         self.assertEqual(result, ([]))
+
+    def test_load_schemas_by_git_ref(self):
+        ref = 'v1.5.0'
+        tree = ecs_helpers.get_tree_by_ref(ref)
+        schemas = schema_reader.load_schemas_from_git(tree)
+        self.assertEqual(len(schemas), 42)
 
     def test_flatten_fields(self):
         fields = {


### PR DESCRIPTION
Closes https://github.com/elastic/ecs/issues/837
This provides an easy way to use the upgraded tooling in master to build any version of the ECS schemas.  The new `build-version` command line option accepts both tags, such as `v1.5.0`, and commit hashes, such as `1454f8b`. This makes it easy to use new tooling features related to custom schemas with a stable released version of the official schema.