### PR TITLE
Add x509 to code_signature

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -22,7 +22,7 @@ Thanks, you're awesome :-) -->
 
 * Add architecture and imphash for PE field set. (#763)
 * Added `agent.build.*` for extended agent version information. (#764)
-* Added `x509.*` field set. (#762)
+* Added `x509.*` field set. (#762, #852)
 * Added more account and project cloud metadata. (#816)
 
 #### Improvements

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -709,6 +709,24 @@ Note also that the `code_signature` fields are not expected to be used directly 
 
 
 
+[[ecs-code_signature-nestings]]
+===== Field sets that can be nested under Code Signature
+
+[options="header"]
+|=====
+| Nested fields | Description
+
+// ===============================================================
+
+
+| <<ecs-x509,code_signature.x509.*>>
+| This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).
+
+// ===============================================================
+
+
+|=====
+
 [[ecs-container]]
 === Container Fields
 
@@ -1090,6 +1108,12 @@ example: `C:\Windows\System32\kernel32.dll`
 
 | <<ecs-code_signature,dll.code_signature.*>>
 | These fields contain information about binary code signatures.
+
+// ===============================================================
+
+
+| <<ecs-x509,dll.code_signature.x509.*>>
+| This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).
 
 // ===============================================================
 
@@ -2269,6 +2293,12 @@ example: `1001`
 
 | <<ecs-code_signature,file.code_signature.*>>
 | These fields contain information about binary code signatures.
+
+// ===============================================================
+
+
+| <<ecs-x509,file.code_signature.x509.*>>
+| This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).
 
 // ===============================================================
 
@@ -4704,6 +4734,12 @@ example: `/home/alice`
 // ===============================================================
 
 
+| <<ecs-x509,process.code_signature.x509.*>>
+| This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).
+
+// ===============================================================
+
+
 | <<ecs-hash,process.hash.*>>
 | Hashes, usually file hashes.
 
@@ -4712,6 +4748,12 @@ example: `/home/alice`
 
 | <<ecs-code_signature,process.parent.code_signature.*>>
 | These fields contain information about binary code signatures.
+
+// ===============================================================
+
+
+| <<ecs-x509,process.parent.code_signature.x509.*>>
+| This implements the common core fields for x509 certificates. This information is likely logged with TLS sessions, digital signatures found in executable binaries, S/MIME information in email bodies, or analysis of files on disk. When only a single certificate is logged in an event, it should be nested under `file`. When hashes of the DER-encoded certificate are available, the `hash` data set should be populated as well (e.g. `file.hash.sha256`). For events that contain certificate information for both sides of the connection, the x509 object could be nested under the respective side of the connection information (e.g. `tls.server.x509`).
 
 // ===============================================================
 
@@ -7306,7 +7348,7 @@ example: `3`
 
 ==== Field Reuse
 
-The `x509` fields are expected to be nested at: `file.x509`, `tls.client.x509`, `tls.server.x509`.
+The `x509` fields are expected to be nested at: `code_signature.x509`, `file.x509`, `tls.client.x509`, `tls.server.x509`.
 
 Note also that the `x509` fields are not expected to be used directly at the top level.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -512,6 +512,176 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: x509.alternative_names
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      default_field: false
+    - name: x509.issuer.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      default_field: false
+    - name: x509.issuer.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) codes
+      example: US
+      default_field: false
+    - name: x509.issuer.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      default_field: false
+    - name: x509.issuer.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: Mountain View
+      default_field: false
+    - name: x509.issuer.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      default_field: false
+    - name: x509.issuer.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      default_field: false
+    - name: x509.issuer.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: x509.not_after
+      level: extended
+      type: date
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      default_field: false
+    - name: x509.not_before
+      level: extended
+      type: date
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      default_field: false
+    - name: x509.public_key_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Algorithm used to generate the public key.
+      example: RSA
+      default_field: false
+    - name: x509.public_key_curve
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      default_field: false
+    - name: x509.public_key_exponent
+      level: extended
+      type: long
+      description: Exponent used to derive the public key. This is algorithm specific.
+      example: 65537
+      default_field: false
+    - name: x509.public_key_size
+      level: extended
+      type: long
+      description: The size of the public key space in bits.
+      example: 2048
+      default_field: false
+    - name: x509.serial_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      default_field: false
+    - name: x509.signature_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      default_field: false
+    - name: x509.subject.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      default_field: false
+    - name: x509.subject.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) code
+      example: US
+      default_field: false
+    - name: x509.subject.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      default_field: false
+    - name: x509.subject.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: San Francisco
+      default_field: false
+    - name: x509.subject.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      default_field: false
+    - name: x509.subject.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of subject.
+      default_field: false
+    - name: x509.subject.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: x509.version_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of x509 format.
+      example: 3
+      default_field: false
   - name: container
     title: Container
     group: 2
@@ -831,6 +1001,176 @@
 
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
+      default_field: false
+    - name: code_signature.x509.alternative_names
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      default_field: false
+    - name: code_signature.x509.issuer.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) codes
+      example: US
+      default_field: false
+    - name: code_signature.x509.issuer.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: Mountain View
+      default_field: false
+    - name: code_signature.x509.issuer.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      default_field: false
+    - name: code_signature.x509.issuer.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      default_field: false
+    - name: code_signature.x509.issuer.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.not_after
+      level: extended
+      type: date
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      default_field: false
+    - name: code_signature.x509.not_before
+      level: extended
+      type: date
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      default_field: false
+    - name: code_signature.x509.public_key_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Algorithm used to generate the public key.
+      example: RSA
+      default_field: false
+    - name: code_signature.x509.public_key_curve
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      default_field: false
+    - name: code_signature.x509.public_key_exponent
+      level: extended
+      type: long
+      description: Exponent used to derive the public key. This is algorithm specific.
+      example: 65537
+      default_field: false
+    - name: code_signature.x509.public_key_size
+      level: extended
+      type: long
+      description: The size of the public key space in bits.
+      example: 2048
+      default_field: false
+    - name: code_signature.x509.serial_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      default_field: false
+    - name: code_signature.x509.signature_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      default_field: false
+    - name: code_signature.x509.subject.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) code
+      example: US
+      default_field: false
+    - name: code_signature.x509.subject.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: San Francisco
+      default_field: false
+    - name: code_signature.x509.subject.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      default_field: false
+    - name: code_signature.x509.subject.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of subject.
+      default_field: false
+    - name: code_signature.x509.subject.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.version_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of x509 format.
+      example: 3
       default_field: false
     - name: hash.md5
       level: extended
@@ -1505,6 +1845,176 @@
 
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
+      default_field: false
+    - name: code_signature.x509.alternative_names
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      default_field: false
+    - name: code_signature.x509.issuer.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) codes
+      example: US
+      default_field: false
+    - name: code_signature.x509.issuer.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: Mountain View
+      default_field: false
+    - name: code_signature.x509.issuer.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      default_field: false
+    - name: code_signature.x509.issuer.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      default_field: false
+    - name: code_signature.x509.issuer.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.not_after
+      level: extended
+      type: date
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      default_field: false
+    - name: code_signature.x509.not_before
+      level: extended
+      type: date
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      default_field: false
+    - name: code_signature.x509.public_key_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Algorithm used to generate the public key.
+      example: RSA
+      default_field: false
+    - name: code_signature.x509.public_key_curve
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      default_field: false
+    - name: code_signature.x509.public_key_exponent
+      level: extended
+      type: long
+      description: Exponent used to derive the public key. This is algorithm specific.
+      example: 65537
+      default_field: false
+    - name: code_signature.x509.public_key_size
+      level: extended
+      type: long
+      description: The size of the public key space in bits.
+      example: 2048
+      default_field: false
+    - name: code_signature.x509.serial_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      default_field: false
+    - name: code_signature.x509.signature_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      default_field: false
+    - name: code_signature.x509.subject.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) code
+      example: US
+      default_field: false
+    - name: code_signature.x509.subject.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: San Francisco
+      default_field: false
+    - name: code_signature.x509.subject.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      default_field: false
+    - name: code_signature.x509.subject.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of subject.
+      default_field: false
+    - name: code_signature.x509.subject.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.version_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of x509 format.
+      example: 3
       default_field: false
     - name: created
       level: extended
@@ -3223,6 +3733,176 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: code_signature.x509.alternative_names
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      default_field: false
+    - name: code_signature.x509.issuer.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) codes
+      example: US
+      default_field: false
+    - name: code_signature.x509.issuer.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      default_field: false
+    - name: code_signature.x509.issuer.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: Mountain View
+      default_field: false
+    - name: code_signature.x509.issuer.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      default_field: false
+    - name: code_signature.x509.issuer.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      default_field: false
+    - name: code_signature.x509.issuer.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.not_after
+      level: extended
+      type: date
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      default_field: false
+    - name: code_signature.x509.not_before
+      level: extended
+      type: date
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      default_field: false
+    - name: code_signature.x509.public_key_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Algorithm used to generate the public key.
+      example: RSA
+      default_field: false
+    - name: code_signature.x509.public_key_curve
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      default_field: false
+    - name: code_signature.x509.public_key_exponent
+      level: extended
+      type: long
+      description: Exponent used to derive the public key. This is algorithm specific.
+      example: 65537
+      default_field: false
+    - name: code_signature.x509.public_key_size
+      level: extended
+      type: long
+      description: The size of the public key space in bits.
+      example: 2048
+      default_field: false
+    - name: code_signature.x509.serial_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      default_field: false
+    - name: code_signature.x509.signature_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      default_field: false
+    - name: code_signature.x509.subject.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) code
+      example: US
+      default_field: false
+    - name: code_signature.x509.subject.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      default_field: false
+    - name: code_signature.x509.subject.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: San Francisco
+      default_field: false
+    - name: code_signature.x509.subject.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      default_field: false
+    - name: code_signature.x509.subject.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of subject.
+      default_field: false
+    - name: code_signature.x509.subject.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: code_signature.x509.version_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of x509 format.
+      example: 3
+      default_field: false
     - name: command_line
       level: extended
       type: keyword
@@ -3369,6 +4049,176 @@
 
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
+      default_field: false
+    - name: parent.code_signature.x509.alternative_names
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      default_field: false
+    - name: parent.code_signature.x509.issuer.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      default_field: false
+    - name: parent.code_signature.x509.issuer.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) codes
+      example: US
+      default_field: false
+    - name: parent.code_signature.x509.issuer.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      default_field: false
+    - name: parent.code_signature.x509.issuer.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: Mountain View
+      default_field: false
+    - name: parent.code_signature.x509.issuer.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      default_field: false
+    - name: parent.code_signature.x509.issuer.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      default_field: false
+    - name: parent.code_signature.x509.issuer.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: parent.code_signature.x509.not_after
+      level: extended
+      type: date
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      default_field: false
+    - name: parent.code_signature.x509.not_before
+      level: extended
+      type: date
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      default_field: false
+    - name: parent.code_signature.x509.public_key_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Algorithm used to generate the public key.
+      example: RSA
+      default_field: false
+    - name: parent.code_signature.x509.public_key_curve
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      default_field: false
+    - name: parent.code_signature.x509.public_key_exponent
+      level: extended
+      type: long
+      description: Exponent used to derive the public key. This is algorithm specific.
+      example: 65537
+      default_field: false
+    - name: parent.code_signature.x509.public_key_size
+      level: extended
+      type: long
+      description: The size of the public key space in bits.
+      example: 2048
+      default_field: false
+    - name: parent.code_signature.x509.serial_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      default_field: false
+    - name: parent.code_signature.x509.signature_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      default_field: false
+    - name: parent.code_signature.x509.subject.common_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      default_field: false
+    - name: parent.code_signature.x509.subject.country
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of country (C) code
+      example: US
+      default_field: false
+    - name: parent.code_signature.x509.subject.distinguished_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      default_field: false
+    - name: parent.code_signature.x509.subject.locality
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of locality names (L)
+      example: San Francisco
+      default_field: false
+    - name: parent.code_signature.x509.subject.organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      default_field: false
+    - name: parent.code_signature.x509.subject.organizational_unit
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of organizational units (OU) of subject.
+      default_field: false
+    - name: parent.code_signature.x509.subject.state_or_province
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of state or province names (ST, S, or P)
+      example: California
+      default_field: false
+    - name: parent.code_signature.x509.version_number
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of x509 format.
+      example: 3
       default_field: false
     - name: parent.command_line
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -96,6 +96,30 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.6.0-dev,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.6.0-dev,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+1.6.0-dev,true,dll,dll.code_signature.x509.alternative_names,keyword,extended,array,*.elastic.co,"List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses."
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,dll,dll.code_signature.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,dll,dll.code_signature.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.6.0-dev,true,dll,dll.code_signature.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.6.0-dev,true,dll,dll.code_signature.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.6.0-dev,true,dll,dll.code_signature.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.6.0-dev,false,dll,dll.code_signature.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.6.0-dev,true,dll,dll.code_signature.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.6.0-dev,true,dll,dll.code_signature.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,"Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters."
+1.6.0-dev,true,dll,dll.code_signature.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm. Recommend using names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.6.0-dev,true,dll,dll.code_signature.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,dll,dll.code_signature.x509.version_number,keyword,extended,,3,Version of x509 format.
 1.6.0-dev,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
 1.6.0-dev,true,dll,dll.hash.sha1,keyword,extended,,,SHA1 hash.
 1.6.0-dev,true,dll,dll.hash.sha256,keyword,extended,,,SHA256 hash.
@@ -165,6 +189,30 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.6.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.6.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+1.6.0-dev,true,file,file.code_signature.x509.alternative_names,keyword,extended,array,*.elastic.co,"List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses."
+1.6.0-dev,true,file,file.code_signature.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,file,file.code_signature.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.6.0-dev,true,file,file.code_signature.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,file,file.code_signature.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.6.0-dev,true,file,file.code_signature.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,file,file.code_signature.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,file,file.code_signature.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,file,file.code_signature.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.6.0-dev,true,file,file.code_signature.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.6.0-dev,true,file,file.code_signature.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.6.0-dev,true,file,file.code_signature.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.6.0-dev,false,file,file.code_signature.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.6.0-dev,true,file,file.code_signature.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.6.0-dev,true,file,file.code_signature.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,"Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters."
+1.6.0-dev,true,file,file.code_signature.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm. Recommend using names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+1.6.0-dev,true,file,file.code_signature.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,file,file.code_signature.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.6.0-dev,true,file,file.code_signature.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,file,file.code_signature.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.6.0-dev,true,file,file.code_signature.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,file,file.code_signature.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.6.0-dev,true,file,file.code_signature.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,file,file.code_signature.x509.version_number,keyword,extended,,3,Version of x509 format.
 1.6.0-dev,true,file,file.created,date,extended,,,File creation time.
 1.6.0-dev,true,file,file.ctime,date,extended,,,Last time the file attributes or metadata changed.
 1.6.0-dev,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
@@ -363,6 +411,30 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.6.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.6.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+1.6.0-dev,true,process,process.code_signature.x509.alternative_names,keyword,extended,array,*.elastic.co,"List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses."
+1.6.0-dev,true,process,process.code_signature.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,process,process.code_signature.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.6.0-dev,true,process,process.code_signature.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,process,process.code_signature.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.6.0-dev,true,process,process.code_signature.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,process,process.code_signature.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,process,process.code_signature.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,process,process.code_signature.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.6.0-dev,true,process,process.code_signature.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.6.0-dev,true,process,process.code_signature.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.6.0-dev,true,process,process.code_signature.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.6.0-dev,false,process,process.code_signature.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.6.0-dev,true,process,process.code_signature.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.6.0-dev,true,process,process.code_signature.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,"Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters."
+1.6.0-dev,true,process,process.code_signature.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm. Recommend using names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+1.6.0-dev,true,process,process.code_signature.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,process,process.code_signature.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.6.0-dev,true,process,process.code_signature.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,process,process.code_signature.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.6.0-dev,true,process,process.code_signature.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,process,process.code_signature.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.6.0-dev,true,process,process.code_signature.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,process,process.code_signature.x509.version_number,keyword,extended,,3,Version of x509 format.
 1.6.0-dev,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.6.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.6.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
@@ -382,6 +454,30 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.6.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.6.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+1.6.0-dev,true,process,process.parent.code_signature.x509.alternative_names,keyword,extended,array,*.elastic.co,"List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses."
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,process,process.parent.code_signature.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,process,process.parent.code_signature.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.6.0-dev,true,process,process.parent.code_signature.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.6.0-dev,true,process,process.parent.code_signature.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.6.0-dev,true,process,process.parent.code_signature.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.6.0-dev,false,process,process.parent.code_signature.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.6.0-dev,true,process,process.parent.code_signature.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.6.0-dev,true,process,process.parent.code_signature.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,"Unique serial number issued by the certificate authority. For consistency, if this value is alphanumeric, it should be formatted without colons and uppercase characters."
+1.6.0-dev,true,process,process.parent.code_signature.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm. Recommend using names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.6.0-dev,true,process,process.parent.code_signature.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.6.0-dev,true,process,process.parent.code_signature.x509.version_number,keyword,extended,,3,Version of x509 format.
 1.6.0-dev,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.6.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.6.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1118,6 +1118,319 @@ dll.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.code_signature.x509.alternative_names:
+  dashed_name: dll-code-signature-x509-alternative-names
+  description: List of subject alternative names (SAN). Name types vary by certificate
+    authority and certificate type but commonly contain IP addresses, DNS names (and
+    wildcards), and email addresses.
+  example: '*.elastic.co'
+  flat_name: dll.code_signature.x509.alternative_names
+  ignore_above: 1024
+  level: extended
+  name: alternative_names
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of subject alternative names (SAN). Name types vary by certificate authority
+    and certificate type but commonly contain IP addresses, DNS names (and wildcards),
+    and email addresses.
+  short_description: List of subject alternative names (SAN)
+  type: keyword
+dll.code_signature.x509.issuer.common_name:
+  dashed_name: dll-code-signature-x509-issuer-common-name
+  description: List of common name (CN) of issuing certificate authority.
+  example: DigiCert SHA2 High Assurance Server CA
+  flat_name: dll.code_signature.x509.issuer.common_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common name (CN) of issuing certificate authority.
+  type: keyword
+dll.code_signature.x509.issuer.country:
+  dashed_name: dll-code-signature-x509-issuer-country
+  description: List of country (C) codes
+  example: US
+  flat_name: dll.code_signature.x509.issuer.country
+  ignore_above: 1024
+  level: extended
+  name: issuer.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) codes
+  type: keyword
+dll.code_signature.x509.issuer.distinguished_name:
+  dashed_name: dll-code-signature-x509-issuer-distinguished-name
+  description: Distinguished name (DN) of issuing certificate authority.
+  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+    Server CA
+  flat_name: dll.code_signature.x509.issuer.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of issuing certificate authority.
+  type: keyword
+dll.code_signature.x509.issuer.locality:
+  dashed_name: dll-code-signature-x509-issuer-locality
+  description: List of locality names (L)
+  example: Mountain View
+  flat_name: dll.code_signature.x509.issuer.locality
+  ignore_above: 1024
+  level: extended
+  name: issuer.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+dll.code_signature.x509.issuer.organization:
+  dashed_name: dll-code-signature-x509-issuer-organization
+  description: List of organizations (O) of issuing certificate authority.
+  example: DigiCert Inc
+  flat_name: dll.code_signature.x509.issuer.organization
+  ignore_above: 1024
+  level: extended
+  name: issuer.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of issuing certificate authority.
+  type: keyword
+dll.code_signature.x509.issuer.organizational_unit:
+  dashed_name: dll-code-signature-x509-issuer-organizational-unit
+  description: List of organizational units (OU) of issuing certificate authority.
+  example: www.digicert.com
+  flat_name: dll.code_signature.x509.issuer.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: issuer.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of issuing certificate authority.
+  type: keyword
+dll.code_signature.x509.issuer.state_or_province:
+  dashed_name: dll-code-signature-x509-issuer-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: dll.code_signature.x509.issuer.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: issuer.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+dll.code_signature.x509.not_after:
+  dashed_name: dll-code-signature-x509-not-after
+  description: Time at which the certificate is no longer considered valid.
+  example: 2020-07-16 03:15:39+00:00
+  flat_name: dll.code_signature.x509.not_after
+  level: extended
+  name: not_after
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is no longer considered valid.
+  type: date
+dll.code_signature.x509.not_before:
+  dashed_name: dll-code-signature-x509-not-before
+  description: Time at which the certificate is first considered valid.
+  example: 2019-08-16 01:40:25+00:00
+  flat_name: dll.code_signature.x509.not_before
+  level: extended
+  name: not_before
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is first considered valid.
+  type: date
+dll.code_signature.x509.public_key_algorithm:
+  dashed_name: dll-code-signature-x509-public-key-algorithm
+  description: Algorithm used to generate the public key.
+  example: RSA
+  flat_name: dll.code_signature.x509.public_key_algorithm
+  ignore_above: 1024
+  level: extended
+  name: public_key_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Algorithm used to generate the public key.
+  type: keyword
+dll.code_signature.x509.public_key_curve:
+  dashed_name: dll-code-signature-x509-public-key-curve
+  description: The curve used by the elliptic curve public key algorithm. This is
+    algorithm specific.
+  example: nistp521
+  flat_name: dll.code_signature.x509.public_key_curve
+  ignore_above: 1024
+  level: extended
+  name: public_key_curve
+  normalize: []
+  original_fieldset: x509
+  short: The curve used by the elliptic curve public key algorithm. This is algorithm
+    specific.
+  type: keyword
+dll.code_signature.x509.public_key_exponent:
+  dashed_name: dll-code-signature-x509-public-key-exponent
+  description: Exponent used to derive the public key. This is algorithm specific.
+  doc_values: false
+  example: 65537
+  flat_name: dll.code_signature.x509.public_key_exponent
+  index: false
+  level: extended
+  name: public_key_exponent
+  normalize: []
+  original_fieldset: x509
+  short: Exponent used to derive the public key. This is algorithm specific.
+  type: long
+dll.code_signature.x509.public_key_size:
+  dashed_name: dll-code-signature-x509-public-key-size
+  description: The size of the public key space in bits.
+  example: 2048
+  flat_name: dll.code_signature.x509.public_key_size
+  level: extended
+  name: public_key_size
+  normalize: []
+  original_fieldset: x509
+  short: The size of the public key space in bits.
+  type: long
+dll.code_signature.x509.serial_number:
+  dashed_name: dll-code-signature-x509-serial-number
+  description: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  example: 55FBB9C7DEBF09809D12CCAA
+  flat_name: dll.code_signature.x509.serial_number
+  ignore_above: 1024
+  level: extended
+  name: serial_number
+  normalize: []
+  original_fieldset: x509
+  short: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  short_description: Unique serial number issued by the certificate authority.
+  type: keyword
+dll.code_signature.x509.signature_algorithm:
+  dashed_name: dll-code-signature-x509-signature-algorithm
+  description: Identifier for certificate signature algorithm. Recommend using names
+    found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  example: SHA256-RSA
+  flat_name: dll.code_signature.x509.signature_algorithm
+  ignore_above: 1024
+  level: extended
+  name: signature_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Identifier for certificate signature algorithm. Recommend using names found
+    in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  type: keyword
+dll.code_signature.x509.subject.common_name:
+  dashed_name: dll-code-signature-x509-subject-common-name
+  description: List of common names (CN) of subject.
+  example: r2.shared.global.fastly.net
+  flat_name: dll.code_signature.x509.subject.common_name
+  ignore_above: 1024
+  level: extended
+  name: subject.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common names (CN) of subject.
+  type: keyword
+dll.code_signature.x509.subject.country:
+  dashed_name: dll-code-signature-x509-subject-country
+  description: List of country (C) code
+  example: US
+  flat_name: dll.code_signature.x509.subject.country
+  ignore_above: 1024
+  level: extended
+  name: subject.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) code
+  type: keyword
+dll.code_signature.x509.subject.distinguished_name:
+  dashed_name: dll-code-signature-x509-subject-distinguished-name
+  description: Distinguished name (DN) of the certificate subject entity.
+  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  flat_name: dll.code_signature.x509.subject.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: subject.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of the certificate subject entity.
+  type: keyword
+dll.code_signature.x509.subject.locality:
+  dashed_name: dll-code-signature-x509-subject-locality
+  description: List of locality names (L)
+  example: San Francisco
+  flat_name: dll.code_signature.x509.subject.locality
+  ignore_above: 1024
+  level: extended
+  name: subject.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+dll.code_signature.x509.subject.organization:
+  dashed_name: dll-code-signature-x509-subject-organization
+  description: List of organizations (O) of subject.
+  example: Fastly, Inc.
+  flat_name: dll.code_signature.x509.subject.organization
+  ignore_above: 1024
+  level: extended
+  name: subject.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of subject.
+  type: keyword
+dll.code_signature.x509.subject.organizational_unit:
+  dashed_name: dll-code-signature-x509-subject-organizational-unit
+  description: List of organizational units (OU) of subject.
+  flat_name: dll.code_signature.x509.subject.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: subject.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of subject.
+  type: keyword
+dll.code_signature.x509.subject.state_or_province:
+  dashed_name: dll-code-signature-x509-subject-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: dll.code_signature.x509.subject.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: subject.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+dll.code_signature.x509.version_number:
+  dashed_name: dll-code-signature-x509-version-number
+  description: Version of x509 format.
+  example: 3
+  flat_name: dll.code_signature.x509.version_number
+  ignore_above: 1024
+  level: extended
+  name: version_number
+  normalize: []
+  original_fieldset: x509
+  short: Version of x509 format.
+  type: keyword
 dll.hash.md5:
   dashed_name: dll-hash-md5
   description: MD5 hash.
@@ -2478,6 +2791,319 @@ file.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+file.code_signature.x509.alternative_names:
+  dashed_name: file-code-signature-x509-alternative-names
+  description: List of subject alternative names (SAN). Name types vary by certificate
+    authority and certificate type but commonly contain IP addresses, DNS names (and
+    wildcards), and email addresses.
+  example: '*.elastic.co'
+  flat_name: file.code_signature.x509.alternative_names
+  ignore_above: 1024
+  level: extended
+  name: alternative_names
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of subject alternative names (SAN). Name types vary by certificate authority
+    and certificate type but commonly contain IP addresses, DNS names (and wildcards),
+    and email addresses.
+  short_description: List of subject alternative names (SAN)
+  type: keyword
+file.code_signature.x509.issuer.common_name:
+  dashed_name: file-code-signature-x509-issuer-common-name
+  description: List of common name (CN) of issuing certificate authority.
+  example: DigiCert SHA2 High Assurance Server CA
+  flat_name: file.code_signature.x509.issuer.common_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common name (CN) of issuing certificate authority.
+  type: keyword
+file.code_signature.x509.issuer.country:
+  dashed_name: file-code-signature-x509-issuer-country
+  description: List of country (C) codes
+  example: US
+  flat_name: file.code_signature.x509.issuer.country
+  ignore_above: 1024
+  level: extended
+  name: issuer.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) codes
+  type: keyword
+file.code_signature.x509.issuer.distinguished_name:
+  dashed_name: file-code-signature-x509-issuer-distinguished-name
+  description: Distinguished name (DN) of issuing certificate authority.
+  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+    Server CA
+  flat_name: file.code_signature.x509.issuer.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of issuing certificate authority.
+  type: keyword
+file.code_signature.x509.issuer.locality:
+  dashed_name: file-code-signature-x509-issuer-locality
+  description: List of locality names (L)
+  example: Mountain View
+  flat_name: file.code_signature.x509.issuer.locality
+  ignore_above: 1024
+  level: extended
+  name: issuer.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+file.code_signature.x509.issuer.organization:
+  dashed_name: file-code-signature-x509-issuer-organization
+  description: List of organizations (O) of issuing certificate authority.
+  example: DigiCert Inc
+  flat_name: file.code_signature.x509.issuer.organization
+  ignore_above: 1024
+  level: extended
+  name: issuer.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of issuing certificate authority.
+  type: keyword
+file.code_signature.x509.issuer.organizational_unit:
+  dashed_name: file-code-signature-x509-issuer-organizational-unit
+  description: List of organizational units (OU) of issuing certificate authority.
+  example: www.digicert.com
+  flat_name: file.code_signature.x509.issuer.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: issuer.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of issuing certificate authority.
+  type: keyword
+file.code_signature.x509.issuer.state_or_province:
+  dashed_name: file-code-signature-x509-issuer-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: file.code_signature.x509.issuer.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: issuer.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+file.code_signature.x509.not_after:
+  dashed_name: file-code-signature-x509-not-after
+  description: Time at which the certificate is no longer considered valid.
+  example: 2020-07-16 03:15:39+00:00
+  flat_name: file.code_signature.x509.not_after
+  level: extended
+  name: not_after
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is no longer considered valid.
+  type: date
+file.code_signature.x509.not_before:
+  dashed_name: file-code-signature-x509-not-before
+  description: Time at which the certificate is first considered valid.
+  example: 2019-08-16 01:40:25+00:00
+  flat_name: file.code_signature.x509.not_before
+  level: extended
+  name: not_before
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is first considered valid.
+  type: date
+file.code_signature.x509.public_key_algorithm:
+  dashed_name: file-code-signature-x509-public-key-algorithm
+  description: Algorithm used to generate the public key.
+  example: RSA
+  flat_name: file.code_signature.x509.public_key_algorithm
+  ignore_above: 1024
+  level: extended
+  name: public_key_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Algorithm used to generate the public key.
+  type: keyword
+file.code_signature.x509.public_key_curve:
+  dashed_name: file-code-signature-x509-public-key-curve
+  description: The curve used by the elliptic curve public key algorithm. This is
+    algorithm specific.
+  example: nistp521
+  flat_name: file.code_signature.x509.public_key_curve
+  ignore_above: 1024
+  level: extended
+  name: public_key_curve
+  normalize: []
+  original_fieldset: x509
+  short: The curve used by the elliptic curve public key algorithm. This is algorithm
+    specific.
+  type: keyword
+file.code_signature.x509.public_key_exponent:
+  dashed_name: file-code-signature-x509-public-key-exponent
+  description: Exponent used to derive the public key. This is algorithm specific.
+  doc_values: false
+  example: 65537
+  flat_name: file.code_signature.x509.public_key_exponent
+  index: false
+  level: extended
+  name: public_key_exponent
+  normalize: []
+  original_fieldset: x509
+  short: Exponent used to derive the public key. This is algorithm specific.
+  type: long
+file.code_signature.x509.public_key_size:
+  dashed_name: file-code-signature-x509-public-key-size
+  description: The size of the public key space in bits.
+  example: 2048
+  flat_name: file.code_signature.x509.public_key_size
+  level: extended
+  name: public_key_size
+  normalize: []
+  original_fieldset: x509
+  short: The size of the public key space in bits.
+  type: long
+file.code_signature.x509.serial_number:
+  dashed_name: file-code-signature-x509-serial-number
+  description: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  example: 55FBB9C7DEBF09809D12CCAA
+  flat_name: file.code_signature.x509.serial_number
+  ignore_above: 1024
+  level: extended
+  name: serial_number
+  normalize: []
+  original_fieldset: x509
+  short: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  short_description: Unique serial number issued by the certificate authority.
+  type: keyword
+file.code_signature.x509.signature_algorithm:
+  dashed_name: file-code-signature-x509-signature-algorithm
+  description: Identifier for certificate signature algorithm. Recommend using names
+    found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  example: SHA256-RSA
+  flat_name: file.code_signature.x509.signature_algorithm
+  ignore_above: 1024
+  level: extended
+  name: signature_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Identifier for certificate signature algorithm. Recommend using names found
+    in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  type: keyword
+file.code_signature.x509.subject.common_name:
+  dashed_name: file-code-signature-x509-subject-common-name
+  description: List of common names (CN) of subject.
+  example: r2.shared.global.fastly.net
+  flat_name: file.code_signature.x509.subject.common_name
+  ignore_above: 1024
+  level: extended
+  name: subject.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common names (CN) of subject.
+  type: keyword
+file.code_signature.x509.subject.country:
+  dashed_name: file-code-signature-x509-subject-country
+  description: List of country (C) code
+  example: US
+  flat_name: file.code_signature.x509.subject.country
+  ignore_above: 1024
+  level: extended
+  name: subject.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) code
+  type: keyword
+file.code_signature.x509.subject.distinguished_name:
+  dashed_name: file-code-signature-x509-subject-distinguished-name
+  description: Distinguished name (DN) of the certificate subject entity.
+  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  flat_name: file.code_signature.x509.subject.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: subject.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of the certificate subject entity.
+  type: keyword
+file.code_signature.x509.subject.locality:
+  dashed_name: file-code-signature-x509-subject-locality
+  description: List of locality names (L)
+  example: San Francisco
+  flat_name: file.code_signature.x509.subject.locality
+  ignore_above: 1024
+  level: extended
+  name: subject.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+file.code_signature.x509.subject.organization:
+  dashed_name: file-code-signature-x509-subject-organization
+  description: List of organizations (O) of subject.
+  example: Fastly, Inc.
+  flat_name: file.code_signature.x509.subject.organization
+  ignore_above: 1024
+  level: extended
+  name: subject.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of subject.
+  type: keyword
+file.code_signature.x509.subject.organizational_unit:
+  dashed_name: file-code-signature-x509-subject-organizational-unit
+  description: List of organizational units (OU) of subject.
+  flat_name: file.code_signature.x509.subject.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: subject.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of subject.
+  type: keyword
+file.code_signature.x509.subject.state_or_province:
+  dashed_name: file-code-signature-x509-subject-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: file.code_signature.x509.subject.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: subject.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+file.code_signature.x509.version_number:
+  dashed_name: file-code-signature-x509-version-number
+  description: Version of x509 format.
+  example: 3
+  flat_name: file.code_signature.x509.version_number
+  ignore_above: 1024
+  level: extended
+  name: version_number
+  normalize: []
+  original_fieldset: x509
+  short: Version of x509 format.
+  type: keyword
 file.created:
   dashed_name: file-created
   description: 'File creation time.
@@ -4881,6 +5507,319 @@ process.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.code_signature.x509.alternative_names:
+  dashed_name: process-code-signature-x509-alternative-names
+  description: List of subject alternative names (SAN). Name types vary by certificate
+    authority and certificate type but commonly contain IP addresses, DNS names (and
+    wildcards), and email addresses.
+  example: '*.elastic.co'
+  flat_name: process.code_signature.x509.alternative_names
+  ignore_above: 1024
+  level: extended
+  name: alternative_names
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of subject alternative names (SAN). Name types vary by certificate authority
+    and certificate type but commonly contain IP addresses, DNS names (and wildcards),
+    and email addresses.
+  short_description: List of subject alternative names (SAN)
+  type: keyword
+process.code_signature.x509.issuer.common_name:
+  dashed_name: process-code-signature-x509-issuer-common-name
+  description: List of common name (CN) of issuing certificate authority.
+  example: DigiCert SHA2 High Assurance Server CA
+  flat_name: process.code_signature.x509.issuer.common_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common name (CN) of issuing certificate authority.
+  type: keyword
+process.code_signature.x509.issuer.country:
+  dashed_name: process-code-signature-x509-issuer-country
+  description: List of country (C) codes
+  example: US
+  flat_name: process.code_signature.x509.issuer.country
+  ignore_above: 1024
+  level: extended
+  name: issuer.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) codes
+  type: keyword
+process.code_signature.x509.issuer.distinguished_name:
+  dashed_name: process-code-signature-x509-issuer-distinguished-name
+  description: Distinguished name (DN) of issuing certificate authority.
+  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+    Server CA
+  flat_name: process.code_signature.x509.issuer.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of issuing certificate authority.
+  type: keyword
+process.code_signature.x509.issuer.locality:
+  dashed_name: process-code-signature-x509-issuer-locality
+  description: List of locality names (L)
+  example: Mountain View
+  flat_name: process.code_signature.x509.issuer.locality
+  ignore_above: 1024
+  level: extended
+  name: issuer.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+process.code_signature.x509.issuer.organization:
+  dashed_name: process-code-signature-x509-issuer-organization
+  description: List of organizations (O) of issuing certificate authority.
+  example: DigiCert Inc
+  flat_name: process.code_signature.x509.issuer.organization
+  ignore_above: 1024
+  level: extended
+  name: issuer.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of issuing certificate authority.
+  type: keyword
+process.code_signature.x509.issuer.organizational_unit:
+  dashed_name: process-code-signature-x509-issuer-organizational-unit
+  description: List of organizational units (OU) of issuing certificate authority.
+  example: www.digicert.com
+  flat_name: process.code_signature.x509.issuer.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: issuer.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of issuing certificate authority.
+  type: keyword
+process.code_signature.x509.issuer.state_or_province:
+  dashed_name: process-code-signature-x509-issuer-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: process.code_signature.x509.issuer.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: issuer.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+process.code_signature.x509.not_after:
+  dashed_name: process-code-signature-x509-not-after
+  description: Time at which the certificate is no longer considered valid.
+  example: 2020-07-16 03:15:39+00:00
+  flat_name: process.code_signature.x509.not_after
+  level: extended
+  name: not_after
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is no longer considered valid.
+  type: date
+process.code_signature.x509.not_before:
+  dashed_name: process-code-signature-x509-not-before
+  description: Time at which the certificate is first considered valid.
+  example: 2019-08-16 01:40:25+00:00
+  flat_name: process.code_signature.x509.not_before
+  level: extended
+  name: not_before
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is first considered valid.
+  type: date
+process.code_signature.x509.public_key_algorithm:
+  dashed_name: process-code-signature-x509-public-key-algorithm
+  description: Algorithm used to generate the public key.
+  example: RSA
+  flat_name: process.code_signature.x509.public_key_algorithm
+  ignore_above: 1024
+  level: extended
+  name: public_key_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Algorithm used to generate the public key.
+  type: keyword
+process.code_signature.x509.public_key_curve:
+  dashed_name: process-code-signature-x509-public-key-curve
+  description: The curve used by the elliptic curve public key algorithm. This is
+    algorithm specific.
+  example: nistp521
+  flat_name: process.code_signature.x509.public_key_curve
+  ignore_above: 1024
+  level: extended
+  name: public_key_curve
+  normalize: []
+  original_fieldset: x509
+  short: The curve used by the elliptic curve public key algorithm. This is algorithm
+    specific.
+  type: keyword
+process.code_signature.x509.public_key_exponent:
+  dashed_name: process-code-signature-x509-public-key-exponent
+  description: Exponent used to derive the public key. This is algorithm specific.
+  doc_values: false
+  example: 65537
+  flat_name: process.code_signature.x509.public_key_exponent
+  index: false
+  level: extended
+  name: public_key_exponent
+  normalize: []
+  original_fieldset: x509
+  short: Exponent used to derive the public key. This is algorithm specific.
+  type: long
+process.code_signature.x509.public_key_size:
+  dashed_name: process-code-signature-x509-public-key-size
+  description: The size of the public key space in bits.
+  example: 2048
+  flat_name: process.code_signature.x509.public_key_size
+  level: extended
+  name: public_key_size
+  normalize: []
+  original_fieldset: x509
+  short: The size of the public key space in bits.
+  type: long
+process.code_signature.x509.serial_number:
+  dashed_name: process-code-signature-x509-serial-number
+  description: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  example: 55FBB9C7DEBF09809D12CCAA
+  flat_name: process.code_signature.x509.serial_number
+  ignore_above: 1024
+  level: extended
+  name: serial_number
+  normalize: []
+  original_fieldset: x509
+  short: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  short_description: Unique serial number issued by the certificate authority.
+  type: keyword
+process.code_signature.x509.signature_algorithm:
+  dashed_name: process-code-signature-x509-signature-algorithm
+  description: Identifier for certificate signature algorithm. Recommend using names
+    found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  example: SHA256-RSA
+  flat_name: process.code_signature.x509.signature_algorithm
+  ignore_above: 1024
+  level: extended
+  name: signature_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Identifier for certificate signature algorithm. Recommend using names found
+    in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  type: keyword
+process.code_signature.x509.subject.common_name:
+  dashed_name: process-code-signature-x509-subject-common-name
+  description: List of common names (CN) of subject.
+  example: r2.shared.global.fastly.net
+  flat_name: process.code_signature.x509.subject.common_name
+  ignore_above: 1024
+  level: extended
+  name: subject.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common names (CN) of subject.
+  type: keyword
+process.code_signature.x509.subject.country:
+  dashed_name: process-code-signature-x509-subject-country
+  description: List of country (C) code
+  example: US
+  flat_name: process.code_signature.x509.subject.country
+  ignore_above: 1024
+  level: extended
+  name: subject.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) code
+  type: keyword
+process.code_signature.x509.subject.distinguished_name:
+  dashed_name: process-code-signature-x509-subject-distinguished-name
+  description: Distinguished name (DN) of the certificate subject entity.
+  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  flat_name: process.code_signature.x509.subject.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: subject.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of the certificate subject entity.
+  type: keyword
+process.code_signature.x509.subject.locality:
+  dashed_name: process-code-signature-x509-subject-locality
+  description: List of locality names (L)
+  example: San Francisco
+  flat_name: process.code_signature.x509.subject.locality
+  ignore_above: 1024
+  level: extended
+  name: subject.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+process.code_signature.x509.subject.organization:
+  dashed_name: process-code-signature-x509-subject-organization
+  description: List of organizations (O) of subject.
+  example: Fastly, Inc.
+  flat_name: process.code_signature.x509.subject.organization
+  ignore_above: 1024
+  level: extended
+  name: subject.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of subject.
+  type: keyword
+process.code_signature.x509.subject.organizational_unit:
+  dashed_name: process-code-signature-x509-subject-organizational-unit
+  description: List of organizational units (OU) of subject.
+  flat_name: process.code_signature.x509.subject.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: subject.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of subject.
+  type: keyword
+process.code_signature.x509.subject.state_or_province:
+  dashed_name: process-code-signature-x509-subject-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: process.code_signature.x509.subject.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: subject.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+process.code_signature.x509.version_number:
+  dashed_name: process-code-signature-x509-version-number
+  description: Version of x509 format.
+  example: 3
+  flat_name: process.code_signature.x509.version_number
+  ignore_above: 1024
+  level: extended
+  name: version_number
+  normalize: []
+  original_fieldset: x509
+  short: Version of x509 format.
+  type: keyword
 process.command_line:
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
@@ -5110,6 +6049,319 @@ process.parent.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.code_signature.x509.alternative_names:
+  dashed_name: process-parent-code-signature-x509-alternative-names
+  description: List of subject alternative names (SAN). Name types vary by certificate
+    authority and certificate type but commonly contain IP addresses, DNS names (and
+    wildcards), and email addresses.
+  example: '*.elastic.co'
+  flat_name: process.parent.code_signature.x509.alternative_names
+  ignore_above: 1024
+  level: extended
+  name: alternative_names
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of subject alternative names (SAN). Name types vary by certificate authority
+    and certificate type but commonly contain IP addresses, DNS names (and wildcards),
+    and email addresses.
+  short_description: List of subject alternative names (SAN)
+  type: keyword
+process.parent.code_signature.x509.issuer.common_name:
+  dashed_name: process-parent-code-signature-x509-issuer-common-name
+  description: List of common name (CN) of issuing certificate authority.
+  example: DigiCert SHA2 High Assurance Server CA
+  flat_name: process.parent.code_signature.x509.issuer.common_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common name (CN) of issuing certificate authority.
+  type: keyword
+process.parent.code_signature.x509.issuer.country:
+  dashed_name: process-parent-code-signature-x509-issuer-country
+  description: List of country (C) codes
+  example: US
+  flat_name: process.parent.code_signature.x509.issuer.country
+  ignore_above: 1024
+  level: extended
+  name: issuer.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) codes
+  type: keyword
+process.parent.code_signature.x509.issuer.distinguished_name:
+  dashed_name: process-parent-code-signature-x509-issuer-distinguished-name
+  description: Distinguished name (DN) of issuing certificate authority.
+  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+    Server CA
+  flat_name: process.parent.code_signature.x509.issuer.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: issuer.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of issuing certificate authority.
+  type: keyword
+process.parent.code_signature.x509.issuer.locality:
+  dashed_name: process-parent-code-signature-x509-issuer-locality
+  description: List of locality names (L)
+  example: Mountain View
+  flat_name: process.parent.code_signature.x509.issuer.locality
+  ignore_above: 1024
+  level: extended
+  name: issuer.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+process.parent.code_signature.x509.issuer.organization:
+  dashed_name: process-parent-code-signature-x509-issuer-organization
+  description: List of organizations (O) of issuing certificate authority.
+  example: DigiCert Inc
+  flat_name: process.parent.code_signature.x509.issuer.organization
+  ignore_above: 1024
+  level: extended
+  name: issuer.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of issuing certificate authority.
+  type: keyword
+process.parent.code_signature.x509.issuer.organizational_unit:
+  dashed_name: process-parent-code-signature-x509-issuer-organizational-unit
+  description: List of organizational units (OU) of issuing certificate authority.
+  example: www.digicert.com
+  flat_name: process.parent.code_signature.x509.issuer.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: issuer.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of issuing certificate authority.
+  type: keyword
+process.parent.code_signature.x509.issuer.state_or_province:
+  dashed_name: process-parent-code-signature-x509-issuer-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: process.parent.code_signature.x509.issuer.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: issuer.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+process.parent.code_signature.x509.not_after:
+  dashed_name: process-parent-code-signature-x509-not-after
+  description: Time at which the certificate is no longer considered valid.
+  example: 2020-07-16 03:15:39+00:00
+  flat_name: process.parent.code_signature.x509.not_after
+  level: extended
+  name: not_after
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is no longer considered valid.
+  type: date
+process.parent.code_signature.x509.not_before:
+  dashed_name: process-parent-code-signature-x509-not-before
+  description: Time at which the certificate is first considered valid.
+  example: 2019-08-16 01:40:25+00:00
+  flat_name: process.parent.code_signature.x509.not_before
+  level: extended
+  name: not_before
+  normalize: []
+  original_fieldset: x509
+  short: Time at which the certificate is first considered valid.
+  type: date
+process.parent.code_signature.x509.public_key_algorithm:
+  dashed_name: process-parent-code-signature-x509-public-key-algorithm
+  description: Algorithm used to generate the public key.
+  example: RSA
+  flat_name: process.parent.code_signature.x509.public_key_algorithm
+  ignore_above: 1024
+  level: extended
+  name: public_key_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Algorithm used to generate the public key.
+  type: keyword
+process.parent.code_signature.x509.public_key_curve:
+  dashed_name: process-parent-code-signature-x509-public-key-curve
+  description: The curve used by the elliptic curve public key algorithm. This is
+    algorithm specific.
+  example: nistp521
+  flat_name: process.parent.code_signature.x509.public_key_curve
+  ignore_above: 1024
+  level: extended
+  name: public_key_curve
+  normalize: []
+  original_fieldset: x509
+  short: The curve used by the elliptic curve public key algorithm. This is algorithm
+    specific.
+  type: keyword
+process.parent.code_signature.x509.public_key_exponent:
+  dashed_name: process-parent-code-signature-x509-public-key-exponent
+  description: Exponent used to derive the public key. This is algorithm specific.
+  doc_values: false
+  example: 65537
+  flat_name: process.parent.code_signature.x509.public_key_exponent
+  index: false
+  level: extended
+  name: public_key_exponent
+  normalize: []
+  original_fieldset: x509
+  short: Exponent used to derive the public key. This is algorithm specific.
+  type: long
+process.parent.code_signature.x509.public_key_size:
+  dashed_name: process-parent-code-signature-x509-public-key-size
+  description: The size of the public key space in bits.
+  example: 2048
+  flat_name: process.parent.code_signature.x509.public_key_size
+  level: extended
+  name: public_key_size
+  normalize: []
+  original_fieldset: x509
+  short: The size of the public key space in bits.
+  type: long
+process.parent.code_signature.x509.serial_number:
+  dashed_name: process-parent-code-signature-x509-serial-number
+  description: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  example: 55FBB9C7DEBF09809D12CCAA
+  flat_name: process.parent.code_signature.x509.serial_number
+  ignore_above: 1024
+  level: extended
+  name: serial_number
+  normalize: []
+  original_fieldset: x509
+  short: Unique serial number issued by the certificate authority. For consistency,
+    if this value is alphanumeric, it should be formatted without colons and uppercase
+    characters.
+  short_description: Unique serial number issued by the certificate authority.
+  type: keyword
+process.parent.code_signature.x509.signature_algorithm:
+  dashed_name: process-parent-code-signature-x509-signature-algorithm
+  description: Identifier for certificate signature algorithm. Recommend using names
+    found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  example: SHA256-RSA
+  flat_name: process.parent.code_signature.x509.signature_algorithm
+  ignore_above: 1024
+  level: extended
+  name: signature_algorithm
+  normalize: []
+  original_fieldset: x509
+  short: Identifier for certificate signature algorithm. Recommend using names found
+    in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+  type: keyword
+process.parent.code_signature.x509.subject.common_name:
+  dashed_name: process-parent-code-signature-x509-subject-common-name
+  description: List of common names (CN) of subject.
+  example: r2.shared.global.fastly.net
+  flat_name: process.parent.code_signature.x509.subject.common_name
+  ignore_above: 1024
+  level: extended
+  name: subject.common_name
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of common names (CN) of subject.
+  type: keyword
+process.parent.code_signature.x509.subject.country:
+  dashed_name: process-parent-code-signature-x509-subject-country
+  description: List of country (C) code
+  example: US
+  flat_name: process.parent.code_signature.x509.subject.country
+  ignore_above: 1024
+  level: extended
+  name: subject.country
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of country (C) code
+  type: keyword
+process.parent.code_signature.x509.subject.distinguished_name:
+  dashed_name: process-parent-code-signature-x509-subject-distinguished-name
+  description: Distinguished name (DN) of the certificate subject entity.
+  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  flat_name: process.parent.code_signature.x509.subject.distinguished_name
+  ignore_above: 1024
+  level: extended
+  name: subject.distinguished_name
+  normalize: []
+  original_fieldset: x509
+  short: Distinguished name (DN) of the certificate subject entity.
+  type: keyword
+process.parent.code_signature.x509.subject.locality:
+  dashed_name: process-parent-code-signature-x509-subject-locality
+  description: List of locality names (L)
+  example: San Francisco
+  flat_name: process.parent.code_signature.x509.subject.locality
+  ignore_above: 1024
+  level: extended
+  name: subject.locality
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of locality names (L)
+  type: keyword
+process.parent.code_signature.x509.subject.organization:
+  dashed_name: process-parent-code-signature-x509-subject-organization
+  description: List of organizations (O) of subject.
+  example: Fastly, Inc.
+  flat_name: process.parent.code_signature.x509.subject.organization
+  ignore_above: 1024
+  level: extended
+  name: subject.organization
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizations (O) of subject.
+  type: keyword
+process.parent.code_signature.x509.subject.organizational_unit:
+  dashed_name: process-parent-code-signature-x509-subject-organizational-unit
+  description: List of organizational units (OU) of subject.
+  flat_name: process.parent.code_signature.x509.subject.organizational_unit
+  ignore_above: 1024
+  level: extended
+  name: subject.organizational_unit
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of organizational units (OU) of subject.
+  type: keyword
+process.parent.code_signature.x509.subject.state_or_province:
+  dashed_name: process-parent-code-signature-x509-subject-state-or-province
+  description: List of state or province names (ST, S, or P)
+  example: California
+  flat_name: process.parent.code_signature.x509.subject.state_or_province
+  ignore_above: 1024
+  level: extended
+  name: subject.state_or_province
+  normalize:
+  - array
+  original_fieldset: x509
+  short: List of state or province names (ST, S, or P)
+  type: keyword
+process.parent.code_signature.x509.version_number:
+  dashed_name: process-parent-code-signature-x509-version-number
+  description: Version of x509 format.
+  example: 3
+  flat_name: process.parent.code_signature.x509.version_number
+  ignore_above: 1024
+  level: extended
+  name: version_number
+  normalize: []
+  original_fieldset: x509
+  short: Version of x509 format.
+  type: keyword
 process.parent.command_line:
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -836,8 +836,323 @@ code_signature:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    x509.alternative_names:
+      dashed_name: code-signature-x509-alternative-names
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      flat_name: code_signature.x509.alternative_names
+      ignore_above: 1024
+      level: extended
+      name: alternative_names
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      short_description: List of subject alternative names (SAN)
+      type: keyword
+    x509.issuer.common_name:
+      dashed_name: code-signature-x509-issuer-common-name
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      flat_name: code_signature.x509.issuer.common_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common name (CN) of issuing certificate authority.
+      type: keyword
+    x509.issuer.country:
+      dashed_name: code-signature-x509-issuer-country
+      description: List of country (C) codes
+      example: US
+      flat_name: code_signature.x509.issuer.country
+      ignore_above: 1024
+      level: extended
+      name: issuer.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) codes
+      type: keyword
+    x509.issuer.distinguished_name:
+      dashed_name: code-signature-x509-issuer-distinguished-name
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      flat_name: code_signature.x509.issuer.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of issuing certificate authority.
+      type: keyword
+    x509.issuer.locality:
+      dashed_name: code-signature-x509-issuer-locality
+      description: List of locality names (L)
+      example: Mountain View
+      flat_name: code_signature.x509.issuer.locality
+      ignore_above: 1024
+      level: extended
+      name: issuer.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    x509.issuer.organization:
+      dashed_name: code-signature-x509-issuer-organization
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      flat_name: code_signature.x509.issuer.organization
+      ignore_above: 1024
+      level: extended
+      name: issuer.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of issuing certificate authority.
+      type: keyword
+    x509.issuer.organizational_unit:
+      dashed_name: code-signature-x509-issuer-organizational-unit
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      flat_name: code_signature.x509.issuer.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: issuer.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of issuing certificate authority.
+      type: keyword
+    x509.issuer.state_or_province:
+      dashed_name: code-signature-x509-issuer-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: code_signature.x509.issuer.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: issuer.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    x509.not_after:
+      dashed_name: code-signature-x509-not-after
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      flat_name: code_signature.x509.not_after
+      level: extended
+      name: not_after
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is no longer considered valid.
+      type: date
+    x509.not_before:
+      dashed_name: code-signature-x509-not-before
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      flat_name: code_signature.x509.not_before
+      level: extended
+      name: not_before
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is first considered valid.
+      type: date
+    x509.public_key_algorithm:
+      dashed_name: code-signature-x509-public-key-algorithm
+      description: Algorithm used to generate the public key.
+      example: RSA
+      flat_name: code_signature.x509.public_key_algorithm
+      ignore_above: 1024
+      level: extended
+      name: public_key_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Algorithm used to generate the public key.
+      type: keyword
+    x509.public_key_curve:
+      dashed_name: code-signature-x509-public-key-curve
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      flat_name: code_signature.x509.public_key_curve
+      ignore_above: 1024
+      level: extended
+      name: public_key_curve
+      normalize: []
+      original_fieldset: x509
+      short: The curve used by the elliptic curve public key algorithm. This is algorithm
+        specific.
+      type: keyword
+    x509.public_key_exponent:
+      dashed_name: code-signature-x509-public-key-exponent
+      description: Exponent used to derive the public key. This is algorithm specific.
+      doc_values: false
+      example: 65537
+      flat_name: code_signature.x509.public_key_exponent
+      index: false
+      level: extended
+      name: public_key_exponent
+      normalize: []
+      original_fieldset: x509
+      short: Exponent used to derive the public key. This is algorithm specific.
+      type: long
+    x509.public_key_size:
+      dashed_name: code-signature-x509-public-key-size
+      description: The size of the public key space in bits.
+      example: 2048
+      flat_name: code_signature.x509.public_key_size
+      level: extended
+      name: public_key_size
+      normalize: []
+      original_fieldset: x509
+      short: The size of the public key space in bits.
+      type: long
+    x509.serial_number:
+      dashed_name: code-signature-x509-serial-number
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      flat_name: code_signature.x509.serial_number
+      ignore_above: 1024
+      level: extended
+      name: serial_number
+      normalize: []
+      original_fieldset: x509
+      short: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      short_description: Unique serial number issued by the certificate authority.
+      type: keyword
+    x509.signature_algorithm:
+      dashed_name: code-signature-x509-signature-algorithm
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      flat_name: code_signature.x509.signature_algorithm
+      ignore_above: 1024
+      level: extended
+      name: signature_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Identifier for certificate signature algorithm. Recommend using names
+        found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      type: keyword
+    x509.subject.common_name:
+      dashed_name: code-signature-x509-subject-common-name
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      flat_name: code_signature.x509.subject.common_name
+      ignore_above: 1024
+      level: extended
+      name: subject.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common names (CN) of subject.
+      type: keyword
+    x509.subject.country:
+      dashed_name: code-signature-x509-subject-country
+      description: List of country (C) code
+      example: US
+      flat_name: code_signature.x509.subject.country
+      ignore_above: 1024
+      level: extended
+      name: subject.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) code
+      type: keyword
+    x509.subject.distinguished_name:
+      dashed_name: code-signature-x509-subject-distinguished-name
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      flat_name: code_signature.x509.subject.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: subject.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of the certificate subject entity.
+      type: keyword
+    x509.subject.locality:
+      dashed_name: code-signature-x509-subject-locality
+      description: List of locality names (L)
+      example: San Francisco
+      flat_name: code_signature.x509.subject.locality
+      ignore_above: 1024
+      level: extended
+      name: subject.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    x509.subject.organization:
+      dashed_name: code-signature-x509-subject-organization
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      flat_name: code_signature.x509.subject.organization
+      ignore_above: 1024
+      level: extended
+      name: subject.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of subject.
+      type: keyword
+    x509.subject.organizational_unit:
+      dashed_name: code-signature-x509-subject-organizational-unit
+      description: List of organizational units (OU) of subject.
+      flat_name: code_signature.x509.subject.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: subject.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of subject.
+      type: keyword
+    x509.subject.state_or_province:
+      dashed_name: code-signature-x509-subject-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: code_signature.x509.subject.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: subject.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    x509.version_number:
+      dashed_name: code-signature-x509-version-number
+      description: Version of x509 format.
+      example: 3
+      flat_name: code_signature.x509.version_number
+      ignore_above: 1024
+      level: extended
+      name: version_number
+      normalize: []
+      original_fieldset: x509
+      short: Version of x509 format.
+      type: keyword
   group: 2
   name: code_signature
+  nestings:
+  - code_signature.x509
   prefix: code_signature.
   reusable:
     expected:
@@ -1404,6 +1719,319 @@ dll:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    code_signature.x509.alternative_names:
+      dashed_name: dll-code-signature-x509-alternative-names
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      flat_name: dll.code_signature.x509.alternative_names
+      ignore_above: 1024
+      level: extended
+      name: alternative_names
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      short_description: List of subject alternative names (SAN)
+      type: keyword
+    code_signature.x509.issuer.common_name:
+      dashed_name: dll-code-signature-x509-issuer-common-name
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      flat_name: dll.code_signature.x509.issuer.common_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common name (CN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.country:
+      dashed_name: dll-code-signature-x509-issuer-country
+      description: List of country (C) codes
+      example: US
+      flat_name: dll.code_signature.x509.issuer.country
+      ignore_above: 1024
+      level: extended
+      name: issuer.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) codes
+      type: keyword
+    code_signature.x509.issuer.distinguished_name:
+      dashed_name: dll-code-signature-x509-issuer-distinguished-name
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      flat_name: dll.code_signature.x509.issuer.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.locality:
+      dashed_name: dll-code-signature-x509-issuer-locality
+      description: List of locality names (L)
+      example: Mountain View
+      flat_name: dll.code_signature.x509.issuer.locality
+      ignore_above: 1024
+      level: extended
+      name: issuer.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.issuer.organization:
+      dashed_name: dll-code-signature-x509-issuer-organization
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      flat_name: dll.code_signature.x509.issuer.organization
+      ignore_above: 1024
+      level: extended
+      name: issuer.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.organizational_unit:
+      dashed_name: dll-code-signature-x509-issuer-organizational-unit
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      flat_name: dll.code_signature.x509.issuer.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: issuer.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.state_or_province:
+      dashed_name: dll-code-signature-x509-issuer-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: dll.code_signature.x509.issuer.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: issuer.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.not_after:
+      dashed_name: dll-code-signature-x509-not-after
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      flat_name: dll.code_signature.x509.not_after
+      level: extended
+      name: not_after
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is no longer considered valid.
+      type: date
+    code_signature.x509.not_before:
+      dashed_name: dll-code-signature-x509-not-before
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      flat_name: dll.code_signature.x509.not_before
+      level: extended
+      name: not_before
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is first considered valid.
+      type: date
+    code_signature.x509.public_key_algorithm:
+      dashed_name: dll-code-signature-x509-public-key-algorithm
+      description: Algorithm used to generate the public key.
+      example: RSA
+      flat_name: dll.code_signature.x509.public_key_algorithm
+      ignore_above: 1024
+      level: extended
+      name: public_key_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Algorithm used to generate the public key.
+      type: keyword
+    code_signature.x509.public_key_curve:
+      dashed_name: dll-code-signature-x509-public-key-curve
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      flat_name: dll.code_signature.x509.public_key_curve
+      ignore_above: 1024
+      level: extended
+      name: public_key_curve
+      normalize: []
+      original_fieldset: x509
+      short: The curve used by the elliptic curve public key algorithm. This is algorithm
+        specific.
+      type: keyword
+    code_signature.x509.public_key_exponent:
+      dashed_name: dll-code-signature-x509-public-key-exponent
+      description: Exponent used to derive the public key. This is algorithm specific.
+      doc_values: false
+      example: 65537
+      flat_name: dll.code_signature.x509.public_key_exponent
+      index: false
+      level: extended
+      name: public_key_exponent
+      normalize: []
+      original_fieldset: x509
+      short: Exponent used to derive the public key. This is algorithm specific.
+      type: long
+    code_signature.x509.public_key_size:
+      dashed_name: dll-code-signature-x509-public-key-size
+      description: The size of the public key space in bits.
+      example: 2048
+      flat_name: dll.code_signature.x509.public_key_size
+      level: extended
+      name: public_key_size
+      normalize: []
+      original_fieldset: x509
+      short: The size of the public key space in bits.
+      type: long
+    code_signature.x509.serial_number:
+      dashed_name: dll-code-signature-x509-serial-number
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      flat_name: dll.code_signature.x509.serial_number
+      ignore_above: 1024
+      level: extended
+      name: serial_number
+      normalize: []
+      original_fieldset: x509
+      short: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      short_description: Unique serial number issued by the certificate authority.
+      type: keyword
+    code_signature.x509.signature_algorithm:
+      dashed_name: dll-code-signature-x509-signature-algorithm
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      flat_name: dll.code_signature.x509.signature_algorithm
+      ignore_above: 1024
+      level: extended
+      name: signature_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Identifier for certificate signature algorithm. Recommend using names
+        found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      type: keyword
+    code_signature.x509.subject.common_name:
+      dashed_name: dll-code-signature-x509-subject-common-name
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      flat_name: dll.code_signature.x509.subject.common_name
+      ignore_above: 1024
+      level: extended
+      name: subject.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common names (CN) of subject.
+      type: keyword
+    code_signature.x509.subject.country:
+      dashed_name: dll-code-signature-x509-subject-country
+      description: List of country (C) code
+      example: US
+      flat_name: dll.code_signature.x509.subject.country
+      ignore_above: 1024
+      level: extended
+      name: subject.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) code
+      type: keyword
+    code_signature.x509.subject.distinguished_name:
+      dashed_name: dll-code-signature-x509-subject-distinguished-name
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      flat_name: dll.code_signature.x509.subject.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: subject.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of the certificate subject entity.
+      type: keyword
+    code_signature.x509.subject.locality:
+      dashed_name: dll-code-signature-x509-subject-locality
+      description: List of locality names (L)
+      example: San Francisco
+      flat_name: dll.code_signature.x509.subject.locality
+      ignore_above: 1024
+      level: extended
+      name: subject.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.subject.organization:
+      dashed_name: dll-code-signature-x509-subject-organization
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      flat_name: dll.code_signature.x509.subject.organization
+      ignore_above: 1024
+      level: extended
+      name: subject.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of subject.
+      type: keyword
+    code_signature.x509.subject.organizational_unit:
+      dashed_name: dll-code-signature-x509-subject-organizational-unit
+      description: List of organizational units (OU) of subject.
+      flat_name: dll.code_signature.x509.subject.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: subject.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of subject.
+      type: keyword
+    code_signature.x509.subject.state_or_province:
+      dashed_name: dll-code-signature-x509-subject-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: dll.code_signature.x509.subject.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: subject.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.version_number:
+      dashed_name: dll-code-signature-x509-version-number
+      description: Version of x509 format.
+      example: 3
+      flat_name: dll.code_signature.x509.version_number
+      ignore_above: 1024
+      level: extended
+      name: version_number
+      normalize: []
+      original_fieldset: x509
+      short: Version of x509 format.
+      type: keyword
     hash.md5:
       dashed_name: dll-hash-md5
       description: MD5 hash.
@@ -1564,6 +2192,7 @@ dll:
   name: dll
   nestings:
   - dll.code_signature
+  - dll.code_signature.x509
   - dll.hash
   - dll.pe
   prefix: dll.
@@ -2857,6 +3486,319 @@ file:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    code_signature.x509.alternative_names:
+      dashed_name: file-code-signature-x509-alternative-names
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      flat_name: file.code_signature.x509.alternative_names
+      ignore_above: 1024
+      level: extended
+      name: alternative_names
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      short_description: List of subject alternative names (SAN)
+      type: keyword
+    code_signature.x509.issuer.common_name:
+      dashed_name: file-code-signature-x509-issuer-common-name
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      flat_name: file.code_signature.x509.issuer.common_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common name (CN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.country:
+      dashed_name: file-code-signature-x509-issuer-country
+      description: List of country (C) codes
+      example: US
+      flat_name: file.code_signature.x509.issuer.country
+      ignore_above: 1024
+      level: extended
+      name: issuer.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) codes
+      type: keyword
+    code_signature.x509.issuer.distinguished_name:
+      dashed_name: file-code-signature-x509-issuer-distinguished-name
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      flat_name: file.code_signature.x509.issuer.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.locality:
+      dashed_name: file-code-signature-x509-issuer-locality
+      description: List of locality names (L)
+      example: Mountain View
+      flat_name: file.code_signature.x509.issuer.locality
+      ignore_above: 1024
+      level: extended
+      name: issuer.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.issuer.organization:
+      dashed_name: file-code-signature-x509-issuer-organization
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      flat_name: file.code_signature.x509.issuer.organization
+      ignore_above: 1024
+      level: extended
+      name: issuer.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.organizational_unit:
+      dashed_name: file-code-signature-x509-issuer-organizational-unit
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      flat_name: file.code_signature.x509.issuer.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: issuer.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.state_or_province:
+      dashed_name: file-code-signature-x509-issuer-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: file.code_signature.x509.issuer.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: issuer.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.not_after:
+      dashed_name: file-code-signature-x509-not-after
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      flat_name: file.code_signature.x509.not_after
+      level: extended
+      name: not_after
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is no longer considered valid.
+      type: date
+    code_signature.x509.not_before:
+      dashed_name: file-code-signature-x509-not-before
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      flat_name: file.code_signature.x509.not_before
+      level: extended
+      name: not_before
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is first considered valid.
+      type: date
+    code_signature.x509.public_key_algorithm:
+      dashed_name: file-code-signature-x509-public-key-algorithm
+      description: Algorithm used to generate the public key.
+      example: RSA
+      flat_name: file.code_signature.x509.public_key_algorithm
+      ignore_above: 1024
+      level: extended
+      name: public_key_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Algorithm used to generate the public key.
+      type: keyword
+    code_signature.x509.public_key_curve:
+      dashed_name: file-code-signature-x509-public-key-curve
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      flat_name: file.code_signature.x509.public_key_curve
+      ignore_above: 1024
+      level: extended
+      name: public_key_curve
+      normalize: []
+      original_fieldset: x509
+      short: The curve used by the elliptic curve public key algorithm. This is algorithm
+        specific.
+      type: keyword
+    code_signature.x509.public_key_exponent:
+      dashed_name: file-code-signature-x509-public-key-exponent
+      description: Exponent used to derive the public key. This is algorithm specific.
+      doc_values: false
+      example: 65537
+      flat_name: file.code_signature.x509.public_key_exponent
+      index: false
+      level: extended
+      name: public_key_exponent
+      normalize: []
+      original_fieldset: x509
+      short: Exponent used to derive the public key. This is algorithm specific.
+      type: long
+    code_signature.x509.public_key_size:
+      dashed_name: file-code-signature-x509-public-key-size
+      description: The size of the public key space in bits.
+      example: 2048
+      flat_name: file.code_signature.x509.public_key_size
+      level: extended
+      name: public_key_size
+      normalize: []
+      original_fieldset: x509
+      short: The size of the public key space in bits.
+      type: long
+    code_signature.x509.serial_number:
+      dashed_name: file-code-signature-x509-serial-number
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      flat_name: file.code_signature.x509.serial_number
+      ignore_above: 1024
+      level: extended
+      name: serial_number
+      normalize: []
+      original_fieldset: x509
+      short: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      short_description: Unique serial number issued by the certificate authority.
+      type: keyword
+    code_signature.x509.signature_algorithm:
+      dashed_name: file-code-signature-x509-signature-algorithm
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      flat_name: file.code_signature.x509.signature_algorithm
+      ignore_above: 1024
+      level: extended
+      name: signature_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Identifier for certificate signature algorithm. Recommend using names
+        found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      type: keyword
+    code_signature.x509.subject.common_name:
+      dashed_name: file-code-signature-x509-subject-common-name
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      flat_name: file.code_signature.x509.subject.common_name
+      ignore_above: 1024
+      level: extended
+      name: subject.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common names (CN) of subject.
+      type: keyword
+    code_signature.x509.subject.country:
+      dashed_name: file-code-signature-x509-subject-country
+      description: List of country (C) code
+      example: US
+      flat_name: file.code_signature.x509.subject.country
+      ignore_above: 1024
+      level: extended
+      name: subject.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) code
+      type: keyword
+    code_signature.x509.subject.distinguished_name:
+      dashed_name: file-code-signature-x509-subject-distinguished-name
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      flat_name: file.code_signature.x509.subject.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: subject.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of the certificate subject entity.
+      type: keyword
+    code_signature.x509.subject.locality:
+      dashed_name: file-code-signature-x509-subject-locality
+      description: List of locality names (L)
+      example: San Francisco
+      flat_name: file.code_signature.x509.subject.locality
+      ignore_above: 1024
+      level: extended
+      name: subject.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.subject.organization:
+      dashed_name: file-code-signature-x509-subject-organization
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      flat_name: file.code_signature.x509.subject.organization
+      ignore_above: 1024
+      level: extended
+      name: subject.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of subject.
+      type: keyword
+    code_signature.x509.subject.organizational_unit:
+      dashed_name: file-code-signature-x509-subject-organizational-unit
+      description: List of organizational units (OU) of subject.
+      flat_name: file.code_signature.x509.subject.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: subject.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of subject.
+      type: keyword
+    code_signature.x509.subject.state_or_province:
+      dashed_name: file-code-signature-x509-subject-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: file.code_signature.x509.subject.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: subject.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.version_number:
+      dashed_name: file-code-signature-x509-version-number
+      description: Version of x509 format.
+      example: 3
+      flat_name: file.code_signature.x509.version_number
+      ignore_above: 1024
+      level: extended
+      name: version_number
+      normalize: []
+      original_fieldset: x509
+      short: Version of x509 format.
+      type: keyword
     created:
       dashed_name: file-created
       description: 'File creation time.
@@ -3531,6 +4473,7 @@ file:
   name: file
   nestings:
   - file.code_signature
+  - file.code_signature.x509
   - file.hash
   - file.pe
   - file.x509
@@ -5798,6 +6741,319 @@ process:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    code_signature.x509.alternative_names:
+      dashed_name: process-code-signature-x509-alternative-names
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      flat_name: process.code_signature.x509.alternative_names
+      ignore_above: 1024
+      level: extended
+      name: alternative_names
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      short_description: List of subject alternative names (SAN)
+      type: keyword
+    code_signature.x509.issuer.common_name:
+      dashed_name: process-code-signature-x509-issuer-common-name
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      flat_name: process.code_signature.x509.issuer.common_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common name (CN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.country:
+      dashed_name: process-code-signature-x509-issuer-country
+      description: List of country (C) codes
+      example: US
+      flat_name: process.code_signature.x509.issuer.country
+      ignore_above: 1024
+      level: extended
+      name: issuer.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) codes
+      type: keyword
+    code_signature.x509.issuer.distinguished_name:
+      dashed_name: process-code-signature-x509-issuer-distinguished-name
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      flat_name: process.code_signature.x509.issuer.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.locality:
+      dashed_name: process-code-signature-x509-issuer-locality
+      description: List of locality names (L)
+      example: Mountain View
+      flat_name: process.code_signature.x509.issuer.locality
+      ignore_above: 1024
+      level: extended
+      name: issuer.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.issuer.organization:
+      dashed_name: process-code-signature-x509-issuer-organization
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      flat_name: process.code_signature.x509.issuer.organization
+      ignore_above: 1024
+      level: extended
+      name: issuer.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.organizational_unit:
+      dashed_name: process-code-signature-x509-issuer-organizational-unit
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      flat_name: process.code_signature.x509.issuer.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: issuer.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of issuing certificate authority.
+      type: keyword
+    code_signature.x509.issuer.state_or_province:
+      dashed_name: process-code-signature-x509-issuer-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: process.code_signature.x509.issuer.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: issuer.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.not_after:
+      dashed_name: process-code-signature-x509-not-after
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      flat_name: process.code_signature.x509.not_after
+      level: extended
+      name: not_after
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is no longer considered valid.
+      type: date
+    code_signature.x509.not_before:
+      dashed_name: process-code-signature-x509-not-before
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      flat_name: process.code_signature.x509.not_before
+      level: extended
+      name: not_before
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is first considered valid.
+      type: date
+    code_signature.x509.public_key_algorithm:
+      dashed_name: process-code-signature-x509-public-key-algorithm
+      description: Algorithm used to generate the public key.
+      example: RSA
+      flat_name: process.code_signature.x509.public_key_algorithm
+      ignore_above: 1024
+      level: extended
+      name: public_key_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Algorithm used to generate the public key.
+      type: keyword
+    code_signature.x509.public_key_curve:
+      dashed_name: process-code-signature-x509-public-key-curve
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      flat_name: process.code_signature.x509.public_key_curve
+      ignore_above: 1024
+      level: extended
+      name: public_key_curve
+      normalize: []
+      original_fieldset: x509
+      short: The curve used by the elliptic curve public key algorithm. This is algorithm
+        specific.
+      type: keyword
+    code_signature.x509.public_key_exponent:
+      dashed_name: process-code-signature-x509-public-key-exponent
+      description: Exponent used to derive the public key. This is algorithm specific.
+      doc_values: false
+      example: 65537
+      flat_name: process.code_signature.x509.public_key_exponent
+      index: false
+      level: extended
+      name: public_key_exponent
+      normalize: []
+      original_fieldset: x509
+      short: Exponent used to derive the public key. This is algorithm specific.
+      type: long
+    code_signature.x509.public_key_size:
+      dashed_name: process-code-signature-x509-public-key-size
+      description: The size of the public key space in bits.
+      example: 2048
+      flat_name: process.code_signature.x509.public_key_size
+      level: extended
+      name: public_key_size
+      normalize: []
+      original_fieldset: x509
+      short: The size of the public key space in bits.
+      type: long
+    code_signature.x509.serial_number:
+      dashed_name: process-code-signature-x509-serial-number
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      flat_name: process.code_signature.x509.serial_number
+      ignore_above: 1024
+      level: extended
+      name: serial_number
+      normalize: []
+      original_fieldset: x509
+      short: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      short_description: Unique serial number issued by the certificate authority.
+      type: keyword
+    code_signature.x509.signature_algorithm:
+      dashed_name: process-code-signature-x509-signature-algorithm
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      flat_name: process.code_signature.x509.signature_algorithm
+      ignore_above: 1024
+      level: extended
+      name: signature_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Identifier for certificate signature algorithm. Recommend using names
+        found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      type: keyword
+    code_signature.x509.subject.common_name:
+      dashed_name: process-code-signature-x509-subject-common-name
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      flat_name: process.code_signature.x509.subject.common_name
+      ignore_above: 1024
+      level: extended
+      name: subject.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common names (CN) of subject.
+      type: keyword
+    code_signature.x509.subject.country:
+      dashed_name: process-code-signature-x509-subject-country
+      description: List of country (C) code
+      example: US
+      flat_name: process.code_signature.x509.subject.country
+      ignore_above: 1024
+      level: extended
+      name: subject.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) code
+      type: keyword
+    code_signature.x509.subject.distinguished_name:
+      dashed_name: process-code-signature-x509-subject-distinguished-name
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      flat_name: process.code_signature.x509.subject.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: subject.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of the certificate subject entity.
+      type: keyword
+    code_signature.x509.subject.locality:
+      dashed_name: process-code-signature-x509-subject-locality
+      description: List of locality names (L)
+      example: San Francisco
+      flat_name: process.code_signature.x509.subject.locality
+      ignore_above: 1024
+      level: extended
+      name: subject.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    code_signature.x509.subject.organization:
+      dashed_name: process-code-signature-x509-subject-organization
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      flat_name: process.code_signature.x509.subject.organization
+      ignore_above: 1024
+      level: extended
+      name: subject.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of subject.
+      type: keyword
+    code_signature.x509.subject.organizational_unit:
+      dashed_name: process-code-signature-x509-subject-organizational-unit
+      description: List of organizational units (OU) of subject.
+      flat_name: process.code_signature.x509.subject.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: subject.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of subject.
+      type: keyword
+    code_signature.x509.subject.state_or_province:
+      dashed_name: process-code-signature-x509-subject-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: process.code_signature.x509.subject.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: subject.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    code_signature.x509.version_number:
+      dashed_name: process-code-signature-x509-version-number
+      description: Version of x509 format.
+      example: 3
+      flat_name: process.code_signature.x509.version_number
+      ignore_above: 1024
+      level: extended
+      name: version_number
+      normalize: []
+      original_fieldset: x509
+      short: Version of x509 format.
+      type: keyword
     command_line:
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
@@ -6027,6 +7283,319 @@ process:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    parent.code_signature.x509.alternative_names:
+      dashed_name: process-parent-code-signature-x509-alternative-names
+      description: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      example: '*.elastic.co'
+      flat_name: process.parent.code_signature.x509.alternative_names
+      ignore_above: 1024
+      level: extended
+      name: alternative_names
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of subject alternative names (SAN). Name types vary by certificate
+        authority and certificate type but commonly contain IP addresses, DNS names
+        (and wildcards), and email addresses.
+      short_description: List of subject alternative names (SAN)
+      type: keyword
+    parent.code_signature.x509.issuer.common_name:
+      dashed_name: process-parent-code-signature-x509-issuer-common-name
+      description: List of common name (CN) of issuing certificate authority.
+      example: DigiCert SHA2 High Assurance Server CA
+      flat_name: process.parent.code_signature.x509.issuer.common_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common name (CN) of issuing certificate authority.
+      type: keyword
+    parent.code_signature.x509.issuer.country:
+      dashed_name: process-parent-code-signature-x509-issuer-country
+      description: List of country (C) codes
+      example: US
+      flat_name: process.parent.code_signature.x509.issuer.country
+      ignore_above: 1024
+      level: extended
+      name: issuer.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) codes
+      type: keyword
+    parent.code_signature.x509.issuer.distinguished_name:
+      dashed_name: process-parent-code-signature-x509-issuer-distinguished-name
+      description: Distinguished name (DN) of issuing certificate authority.
+      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+        Server CA
+      flat_name: process.parent.code_signature.x509.issuer.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: issuer.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of issuing certificate authority.
+      type: keyword
+    parent.code_signature.x509.issuer.locality:
+      dashed_name: process-parent-code-signature-x509-issuer-locality
+      description: List of locality names (L)
+      example: Mountain View
+      flat_name: process.parent.code_signature.x509.issuer.locality
+      ignore_above: 1024
+      level: extended
+      name: issuer.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    parent.code_signature.x509.issuer.organization:
+      dashed_name: process-parent-code-signature-x509-issuer-organization
+      description: List of organizations (O) of issuing certificate authority.
+      example: DigiCert Inc
+      flat_name: process.parent.code_signature.x509.issuer.organization
+      ignore_above: 1024
+      level: extended
+      name: issuer.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of issuing certificate authority.
+      type: keyword
+    parent.code_signature.x509.issuer.organizational_unit:
+      dashed_name: process-parent-code-signature-x509-issuer-organizational-unit
+      description: List of organizational units (OU) of issuing certificate authority.
+      example: www.digicert.com
+      flat_name: process.parent.code_signature.x509.issuer.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: issuer.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of issuing certificate authority.
+      type: keyword
+    parent.code_signature.x509.issuer.state_or_province:
+      dashed_name: process-parent-code-signature-x509-issuer-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: process.parent.code_signature.x509.issuer.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: issuer.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    parent.code_signature.x509.not_after:
+      dashed_name: process-parent-code-signature-x509-not-after
+      description: Time at which the certificate is no longer considered valid.
+      example: 2020-07-16 03:15:39+00:00
+      flat_name: process.parent.code_signature.x509.not_after
+      level: extended
+      name: not_after
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is no longer considered valid.
+      type: date
+    parent.code_signature.x509.not_before:
+      dashed_name: process-parent-code-signature-x509-not-before
+      description: Time at which the certificate is first considered valid.
+      example: 2019-08-16 01:40:25+00:00
+      flat_name: process.parent.code_signature.x509.not_before
+      level: extended
+      name: not_before
+      normalize: []
+      original_fieldset: x509
+      short: Time at which the certificate is first considered valid.
+      type: date
+    parent.code_signature.x509.public_key_algorithm:
+      dashed_name: process-parent-code-signature-x509-public-key-algorithm
+      description: Algorithm used to generate the public key.
+      example: RSA
+      flat_name: process.parent.code_signature.x509.public_key_algorithm
+      ignore_above: 1024
+      level: extended
+      name: public_key_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Algorithm used to generate the public key.
+      type: keyword
+    parent.code_signature.x509.public_key_curve:
+      dashed_name: process-parent-code-signature-x509-public-key-curve
+      description: The curve used by the elliptic curve public key algorithm. This
+        is algorithm specific.
+      example: nistp521
+      flat_name: process.parent.code_signature.x509.public_key_curve
+      ignore_above: 1024
+      level: extended
+      name: public_key_curve
+      normalize: []
+      original_fieldset: x509
+      short: The curve used by the elliptic curve public key algorithm. This is algorithm
+        specific.
+      type: keyword
+    parent.code_signature.x509.public_key_exponent:
+      dashed_name: process-parent-code-signature-x509-public-key-exponent
+      description: Exponent used to derive the public key. This is algorithm specific.
+      doc_values: false
+      example: 65537
+      flat_name: process.parent.code_signature.x509.public_key_exponent
+      index: false
+      level: extended
+      name: public_key_exponent
+      normalize: []
+      original_fieldset: x509
+      short: Exponent used to derive the public key. This is algorithm specific.
+      type: long
+    parent.code_signature.x509.public_key_size:
+      dashed_name: process-parent-code-signature-x509-public-key-size
+      description: The size of the public key space in bits.
+      example: 2048
+      flat_name: process.parent.code_signature.x509.public_key_size
+      level: extended
+      name: public_key_size
+      normalize: []
+      original_fieldset: x509
+      short: The size of the public key space in bits.
+      type: long
+    parent.code_signature.x509.serial_number:
+      dashed_name: process-parent-code-signature-x509-serial-number
+      description: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      example: 55FBB9C7DEBF09809D12CCAA
+      flat_name: process.parent.code_signature.x509.serial_number
+      ignore_above: 1024
+      level: extended
+      name: serial_number
+      normalize: []
+      original_fieldset: x509
+      short: Unique serial number issued by the certificate authority. For consistency,
+        if this value is alphanumeric, it should be formatted without colons and uppercase
+        characters.
+      short_description: Unique serial number issued by the certificate authority.
+      type: keyword
+    parent.code_signature.x509.signature_algorithm:
+      dashed_name: process-parent-code-signature-x509-signature-algorithm
+      description: Identifier for certificate signature algorithm. Recommend using
+        names found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      example: SHA256-RSA
+      flat_name: process.parent.code_signature.x509.signature_algorithm
+      ignore_above: 1024
+      level: extended
+      name: signature_algorithm
+      normalize: []
+      original_fieldset: x509
+      short: Identifier for certificate signature algorithm. Recommend using names
+        found in Go Lang Crypto library (See https://github.com/golang/go/blob/go1.14/src/crypto/x509/x509.go#L337-L353).
+      type: keyword
+    parent.code_signature.x509.subject.common_name:
+      dashed_name: process-parent-code-signature-x509-subject-common-name
+      description: List of common names (CN) of subject.
+      example: r2.shared.global.fastly.net
+      flat_name: process.parent.code_signature.x509.subject.common_name
+      ignore_above: 1024
+      level: extended
+      name: subject.common_name
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of common names (CN) of subject.
+      type: keyword
+    parent.code_signature.x509.subject.country:
+      dashed_name: process-parent-code-signature-x509-subject-country
+      description: List of country (C) code
+      example: US
+      flat_name: process.parent.code_signature.x509.subject.country
+      ignore_above: 1024
+      level: extended
+      name: subject.country
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of country (C) code
+      type: keyword
+    parent.code_signature.x509.subject.distinguished_name:
+      dashed_name: process-parent-code-signature-x509-subject-distinguished-name
+      description: Distinguished name (DN) of the certificate subject entity.
+      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      flat_name: process.parent.code_signature.x509.subject.distinguished_name
+      ignore_above: 1024
+      level: extended
+      name: subject.distinguished_name
+      normalize: []
+      original_fieldset: x509
+      short: Distinguished name (DN) of the certificate subject entity.
+      type: keyword
+    parent.code_signature.x509.subject.locality:
+      dashed_name: process-parent-code-signature-x509-subject-locality
+      description: List of locality names (L)
+      example: San Francisco
+      flat_name: process.parent.code_signature.x509.subject.locality
+      ignore_above: 1024
+      level: extended
+      name: subject.locality
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of locality names (L)
+      type: keyword
+    parent.code_signature.x509.subject.organization:
+      dashed_name: process-parent-code-signature-x509-subject-organization
+      description: List of organizations (O) of subject.
+      example: Fastly, Inc.
+      flat_name: process.parent.code_signature.x509.subject.organization
+      ignore_above: 1024
+      level: extended
+      name: subject.organization
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizations (O) of subject.
+      type: keyword
+    parent.code_signature.x509.subject.organizational_unit:
+      dashed_name: process-parent-code-signature-x509-subject-organizational-unit
+      description: List of organizational units (OU) of subject.
+      flat_name: process.parent.code_signature.x509.subject.organizational_unit
+      ignore_above: 1024
+      level: extended
+      name: subject.organizational_unit
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of organizational units (OU) of subject.
+      type: keyword
+    parent.code_signature.x509.subject.state_or_province:
+      dashed_name: process-parent-code-signature-x509-subject-state-or-province
+      description: List of state or province names (ST, S, or P)
+      example: California
+      flat_name: process.parent.code_signature.x509.subject.state_or_province
+      ignore_above: 1024
+      level: extended
+      name: subject.state_or_province
+      normalize:
+      - array
+      original_fieldset: x509
+      short: List of state or province names (ST, S, or P)
+      type: keyword
+    parent.code_signature.x509.version_number:
+      dashed_name: process-parent-code-signature-x509-version-number
+      description: Version of x509 format.
+      example: 3
+      flat_name: process.parent.code_signature.x509.version_number
+      ignore_above: 1024
+      level: extended
+      name: version_number
+      normalize: []
+      original_fieldset: x509
+      short: Version of x509 format.
+      type: keyword
     parent.command_line:
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
@@ -6464,8 +8033,10 @@ process:
   name: process
   nestings:
   - process.code_signature
+  - process.code_signature.x509
   - process.hash
   - process.parent.code_signature
+  - process.parent.code_signature.x509
   - process.parent.hash
   - process.pe
   prefix: process.
@@ -9904,6 +11475,7 @@ x509:
   prefix: x509.
   reusable:
     expected:
+    - code_signature
     - file
     - tls.client
     - tls.server

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -482,6 +482,112 @@
                 },
                 "valid": {
                   "type": "boolean"
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
@@ -786,6 +892,112 @@
                 },
                 "valid": {
                   "type": "boolean"
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
@@ -1728,6 +1940,112 @@
                 },
                 "valid": {
                   "type": "boolean"
+                },
+                "x509": {
+                  "properties": {
+                    "alternative_names": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "issuer": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "not_after": {
+                      "type": "date"
+                    },
+                    "not_before": {
+                      "type": "date"
+                    },
+                    "public_key_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_curve": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "public_key_exponent": {
+                      "doc_values": false,
+                      "index": false,
+                      "type": "long"
+                    },
+                    "public_key_size": {
+                      "type": "long"
+                    },
+                    "serial_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "signature_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject": {
+                      "properties": {
+                        "common_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "country": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "distinguished_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "locality": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organization": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "organizational_unit": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "state_or_province": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "version_number": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             },
@@ -1815,6 +2133,112 @@
                     },
                     "valid": {
                       "type": "boolean"
+                    },
+                    "x509": {
+                      "properties": {
+                        "alternative_names": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "issuer": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "not_after": {
+                          "type": "date"
+                        },
+                        "not_before": {
+                          "type": "date"
+                        },
+                        "public_key_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_curve": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "public_key_exponent": {
+                          "doc_values": false,
+                          "index": false,
+                          "type": "long"
+                        },
+                        "public_key_size": {
+                          "type": "long"
+                        },
+                        "serial_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "signature_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject": {
+                          "properties": {
+                            "common_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "country": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "distinguished_name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "locality": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organization": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "organizational_unit": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "state_or_province": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "version_number": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     }
                   }
                 },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -481,6 +481,112 @@
               },
               "valid": {
                 "type": "boolean"
+              },
+              "x509": {
+                "properties": {
+                  "alternative_names": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "issuer": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "not_after": {
+                    "type": "date"
+                  },
+                  "not_before": {
+                    "type": "date"
+                  },
+                  "public_key_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_curve": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_exponent": {
+                    "doc_values": false,
+                    "index": false,
+                    "type": "long"
+                  },
+                  "public_key_size": {
+                    "type": "long"
+                  },
+                  "serial_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "signature_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "version_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           },
@@ -785,6 +891,112 @@
               },
               "valid": {
                 "type": "boolean"
+              },
+              "x509": {
+                "properties": {
+                  "alternative_names": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "issuer": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "not_after": {
+                    "type": "date"
+                  },
+                  "not_before": {
+                    "type": "date"
+                  },
+                  "public_key_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_curve": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_exponent": {
+                    "doc_values": false,
+                    "index": false,
+                    "type": "long"
+                  },
+                  "public_key_size": {
+                    "type": "long"
+                  },
+                  "serial_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "signature_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "version_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           },
@@ -1727,6 +1939,112 @@
               },
               "valid": {
                 "type": "boolean"
+              },
+              "x509": {
+                "properties": {
+                  "alternative_names": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "issuer": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "not_after": {
+                    "type": "date"
+                  },
+                  "not_before": {
+                    "type": "date"
+                  },
+                  "public_key_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_curve": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "public_key_exponent": {
+                    "doc_values": false,
+                    "index": false,
+                    "type": "long"
+                  },
+                  "public_key_size": {
+                    "type": "long"
+                  },
+                  "serial_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "signature_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject": {
+                    "properties": {
+                      "common_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "country": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "distinguished_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "locality": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organization": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "organizational_unit": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "state_or_province": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "version_number": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           },
@@ -1814,6 +2132,112 @@
                   },
                   "valid": {
                     "type": "boolean"
+                  },
+                  "x509": {
+                    "properties": {
+                      "alternative_names": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "issuer": {
+                        "properties": {
+                          "common_name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "country": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "distinguished_name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "locality": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "organization": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "organizational_unit": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "state_or_province": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
+                      "not_after": {
+                        "type": "date"
+                      },
+                      "not_before": {
+                        "type": "date"
+                      },
+                      "public_key_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "public_key_curve": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "public_key_exponent": {
+                        "doc_values": false,
+                        "index": false,
+                        "type": "long"
+                      },
+                      "public_key_size": {
+                        "type": "long"
+                      },
+                      "serial_number": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "signature_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "subject": {
+                        "properties": {
+                          "common_name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "country": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "distinguished_name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "locality": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "organization": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "organizational_unit": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "state_or_province": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
+                      "version_number": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
                   }
                 }
               },

--- a/schemas/x509.yml
+++ b/schemas/x509.yml
@@ -14,6 +14,7 @@
   reusable:
     top_level: false
     expected:
+      - code_signature
       - file
       - tls.client
       - tls.server
@@ -190,4 +191,4 @@
         - array
       short_description: List of subject alternative names (SAN)
       description: List of subject alternative names (SAN). Name types vary by certificate authority and certificate type but commonly contain IP addresses, DNS names (and wildcards), and email addresses.
-      example: "*.elastic.co"
+      example: '*.elastic.co'


### PR DESCRIPTION
I'm not entirely sure about other paradigms, but both Mac mach-o binary signatures and Windows pe signatures are in pkcs7 format with embedded x509 cert information. For example, on my machine (with a jank parser I quickly wrote up):

For a mach-o file:

```
➜ ./gocodesign -in /Applications/Microsoft\ Excel.app/Contents/MacOS/Microsoft\ Excel
Subject: CN=Developer ID Application: Microsoft Corporation (UBF8T346G9),OU=UBF8T346G9,O=Microsoft Corporation,C=US
Issuer: CN=Apple Root CA,OU=Apple Certification Authority,O=Apple Inc.,C=US
Issuer: CN=Apple Root CA,OU=Apple Certification Authority,O=Apple Inc.,C=US
Issuer: CN=Developer ID Certification Authority,OU=Apple Certification Authority,O=Apple Inc.,C=US
```
And for a pe I dumped from a windows VM:
```
➜ ./gocodesign -in svchost.exe
Subject: CN=Microsoft Windows Publisher,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
Issuer: CN=Microsoft Windows Production PCA 2011,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
Issuer: CN=Microsoft Root Certificate Authority 2010,O=Microsoft Corporation,L=Redmond,ST=Washington,C=US
```

So it seems to me that we should allow for the `x509` fields to be nested under `code_signature` since pkcs7 is a widely used code signing format.