### PR TITLE
Add a list of links to subpages

### DIFF
--- a/docs/additional.asciidoc
+++ b/docs/additional.asciidoc
@@ -1,6 +1,10 @@
 [[ecs-additional-information]]
 == Additional Information
 
+* <<ecs-faq>>
+* <<ecs-glossary>>
+* <<ecs-contributing>>
+
 // include::use-cases.asciidoc[]
 include::faq.asciidoc[]
 include::glossary.asciidoc[]


### PR DESCRIPTION
Improve `additional.asciidoc` appearance by adding a list of links to its subpages.