### PR TITLE
Add option for custom template and mapping settings

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -62,6 +62,7 @@ Thanks, you're awesome :-) -->
 * Add full path names to reused fieldsets in `nestings` array in `ecs_nested.yml`. #803
 * Allow shorthand notation for including all subfields in subsets. #805
 * Add `ref` option to generator allowing schemas to be built for a specific ECS version. #851
+* Add `template-settings` and `mapping-settings` options to allow override of defaults in generated ES templates. #856
 
 #### Deprecated
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -3,6 +3,7 @@ import glob
 import os
 import schema_reader
 import yaml
+import json
 
 from generators import intermediate_files
 from generators import csv_generator
@@ -73,7 +74,13 @@ def main():
         exit()
 
     csv_generator.generate(flat, ecs_version, out_dir)
-    es_template.generate(flat, ecs_version, out_dir)
+    custom_template_settings = None
+    if args.template_settings:
+        custom_template_settings = json.load(open(args.template_settings))
+    custom_mapping_settings = None
+    if args.mapping_settings:
+        custom_mapping_settings = json.load(open(args.mapping_settings))
+    es_template.generate(flat, ecs_version, out_dir, custom_template_settings, custom_mapping_settings)
     beats.generate(nested, ecs_version, out_dir)
     if args.include or args.subset:
         exit()
@@ -90,6 +97,10 @@ def argument_parser():
                         help='render a subset of the schema')
     parser.add_argument('--out', action='store', help='directory to store the generated files')
     parser.add_argument('--ref', action='store', help='git reference to use when building schemas')
+    parser.add_argument('--template-settings', action='store',
+                        help='index template settings to use when generating elasticsearch template')
+    parser.add_argument('--mapping-settings', action='store',
+                        help='mapping settings to use when generating elasticsearch template')
     return parser.parse_args()
 
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -3,7 +3,6 @@ import glob
 import os
 import schema_reader
 import yaml
-import json
 
 from generators import intermediate_files
 from generators import csv_generator

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -74,13 +74,7 @@ def main():
         exit()
 
     csv_generator.generate(flat, ecs_version, out_dir)
-    custom_template_settings = None
-    if args.template_settings:
-        custom_template_settings = json.load(open(args.template_settings))
-    custom_mapping_settings = None
-    if args.mapping_settings:
-        custom_mapping_settings = json.load(open(args.mapping_settings))
-    es_template.generate(flat, ecs_version, out_dir, custom_template_settings, custom_mapping_settings)
+    es_template.generate(flat, ecs_version, out_dir, args.template_settings, args.mapping_settings)
     beats.generate(nested, ecs_version, out_dir)
     if args.include or args.subset:
         exit()

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -1,22 +1,25 @@
 import json
 import sys
+import copy
 
 from os.path import join
 from generators import ecs_helpers
 
 
-def generate(ecs_flat, ecs_version, out_dir):
+def generate(ecs_flat, ecs_version, out_dir, custom_template_settings, custom_mapping_settings):
     field_mappings = {}
     for flat_name in sorted(ecs_flat):
         field = ecs_flat[flat_name]
         nestings = flat_name.split('.')
         dict_add_nested(field_mappings, nestings, entry_for(field))
 
-    mappings_section = mapping_settings(ecs_version)
+    mappings_section = default_mapping_settings(
+        ecs_version) if custom_mapping_settings is None else custom_mapping_settings
+
     mappings_section['properties'] = field_mappings
 
-    generate_template_version(6, mappings_section, out_dir)
-    generate_template_version(7, mappings_section, out_dir)
+    generate_template_version(6, mappings_section, out_dir, custom_template_settings)
+    generate_template_version(7, mappings_section, out_dir, custom_template_settings)
 
 # Field mappings
 
@@ -66,9 +69,9 @@ def entry_for(field):
 # Generated files
 
 
-def generate_template_version(elasticsearch_version, mappings_section, out_dir):
+def generate_template_version(elasticsearch_version, mappings_section, out_dir, custom_template_settings):
     ecs_helpers.make_dirs(join(out_dir, 'elasticsearch', str(elasticsearch_version)))
-    template = template_settings()
+    template = default_template_settings() if custom_template_settings is None else copy.deepcopy(custom_template_settings)
     if elasticsearch_version == 6:
         template['mappings'] = {'_doc': mappings_section}
     else:
@@ -86,7 +89,7 @@ def save_json(file, data):
         jsonfile.write(json.dumps(data, indent=2, sort_keys=True))
 
 
-def template_settings():
+def default_template_settings():
     return {
         "index_patterns": ["ecs-*"],
         "order": 1,
@@ -104,7 +107,7 @@ def template_settings():
     }
 
 
-def mapping_settings(ecs_version):
+def default_mapping_settings(ecs_version):
     return {
         "_meta": {"version": ecs_version},
         "date_detection": False,


### PR DESCRIPTION
Little quality of life improvement that lets users override the default template and mapping settings for the generated ES templates. This PR adds 2 new options, `template-settings` and `mapping-settings` that take in filenames and use those json files to populate the template and mapping settings of the generated ES template.

Example usage, run in the ECS directory:
`python scripts/generator.py --mapping-settings custom_mapping.json --template-settings custom_template.json`
This replaces the mapping and template settings with whatever is in custom_mapping.json and custom_template.json, respectively.