### PR TITLE
add missing required hyphen

### DIFF
--- a/.github/ISSUE_TEMPLATE/schema-changes-additions.md
+++ b/.github/ISSUE_TEMPLATE/schema-changes-additions.md
@@ -3,7 +3,7 @@ name: "Schema Changes and Additions"
 about: "Changes or additions to ECS."
 labels: "enhancement"
 
---
+---
 <!--
 Please first search existing issues for the changes you are requesting; it may already exist as an open issue.
 


### PR DESCRIPTION
Missing hyphen is causing Github to omit this issue template as a selection. 
