### PR TITLE
Fix some ATT&CK verbiage and trademark

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,7 @@ Thanks, you're awesome :-) -->
 * Remove misleading pluralization in the description of `user.id`, it should
   contain one ID, not many. #801
 * Clarified misleading wording about multiple IPs in src/dst or cli/srv. #804
+ Verbiage about the MITRE ATT&CK® framework. #866
 
 #### Deprecated
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,7 +30,7 @@ Thanks, you're awesome :-) -->
 * Remove misleading pluralization in the description of `user.id`, it should
   contain one ID, not many. #801
 * Clarified misleading wording about multiple IPs in src/dst or cli/srv. #804
- Verbiage about the MITRE ATT&CK® framework. #866
+* Improved verbiage about the MITRE ATT&CK® framework. #866
 
 #### Deprecated
 

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -35,32 +35,29 @@ type Threat struct {
 	Framework string `ecs:"framework"`
 
 	// Name of the type of tactic used by this threat. You can use a MITRE
-	// ATT&CK® Matrix tactic, for example. (ex.
+	// ATT&CK® tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/)
 	TacticName string `ecs:"tactic.name"`
 
-	// The id of tactic used by this threat. You can use a MITRE ATT&CK
-	// Matrix® tactic, for example. (ex.
-	// https://attack.mitre.org/tactics/TA0040/ )
+	// The id of tactic used by this threat. You can use a MITRE ATT&CK®
+	// tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
 	TacticID string `ecs:"tactic.id"`
 
 	// The reference url of tactic used by this threat. You can use a MITRE
-	// ATT&CK® Matrix tactic, for example. (ex.
+	// ATT&CK® tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/ )
 	TacticReference string `ecs:"tactic.reference"`
 
 	// The name of technique used by this threat. You can use a MITRE ATT&CK®
-	// Matrix technique, for example. (ex.
-	// https://attack.mitre.org/techniques/T1499/)
+	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 	TechniqueName string `ecs:"technique.name"`
 
 	// The id of technique used by this threat. You can use a MITRE ATT&CK®
-	// Matrix technique, for example. (ex.
-	// https://attack.mitre.org/techniques/T1499/)
+	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 	TechniqueID string `ecs:"technique.id"`
 
 	// The reference url of technique used by this threat. You can use a MITRE
-	// ATT&CK® Matrix technique, for example. (ex.
+	// ATT&CK® technique, for example. (ex.
 	// https://attack.mitre.org/techniques/T1499/ )
 	TechniqueReference string `ecs:"technique.reference"`
 }

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -34,8 +34,8 @@ type Threat struct {
 	// retrospectively tagged to events.
 	Framework string `ecs:"framework"`
 
-	// Name of the type of tactic used by this threat. You can use the MITRE
-	// ATT&CK® Matrix tactic categorization, for example. (ex.
+	// Name of the type of tactic used by this threat. You can use a MITRE
+	// ATT&CK® Matrix tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/)
 	TacticName string `ecs:"tactic.name"`
 

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -20,7 +20,7 @@
 package ecs
 
 // Fields to classify events and alerts according to a threat taxonomy such as
-// the Mitre ATT&CK framework.
+// the MITRE ATT&CK® framework.
 // These fields are for users to classify alerts from all of their sources
 // (e.g. IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are
 // meant to capture the high level category of the threat (e.g. "impact"). The
@@ -34,33 +34,33 @@ type Threat struct {
 	// retrospectively tagged to events.
 	Framework string `ecs:"framework"`
 
-	// Name of the type of tactic used by this threat. You can use the Mitre
-	// ATT&CK Matrix Tactic categorization, for example. (ex.
-	// https://attack.mitre.org/tactics/TA0040/ )
+	// Name of the type of tactic used by this threat. You can use the MITRE
+	// ATT&CK® Matrix tactic categorization, for example. (ex.
+	// https://attack.mitre.org/tactics/TA0040/)
 	TacticName string `ecs:"tactic.name"`
 
-	// The id of tactic used by this threat. You can use the Mitre ATT&CK
-	// Matrix Tactic categorization, for example. (ex.
+	// The id of tactic used by this threat. You can use a MITRE ATT&CK
+	// Matrix® tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/ )
 	TacticID string `ecs:"tactic.id"`
 
-	// The reference url of tactic used by this threat. You can use the Mitre
-	// ATT&CK Matrix Tactic categorization, for example. (ex.
+	// The reference url of tactic used by this threat. You can use a MITRE
+	// ATT&CK® Matrix tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/ )
 	TacticReference string `ecs:"tactic.reference"`
 
-	// The name of technique used by this tactic. You can use the Mitre ATT&CK
-	// Matrix Tactic categorization, for example. (ex.
-	// https://attack.mitre.org/techniques/T1499/ )
+	// The name of technique used by this threat. You can use a MITRE ATT&CK®
+	// Matrix technique, for example. (ex.
+	// https://attack.mitre.org/techniques/T1499/)
 	TechniqueName string `ecs:"technique.name"`
 
-	// The id of technique used by this tactic. You can use the Mitre ATT&CK
-	// Matrix Tactic categorization, for example. (ex.
-	// https://attack.mitre.org/techniques/T1499/ )
+	// The id of technique used by this threat. You can use a MITRE ATT&CK®
+	// Matrix technique, for example. (ex.
+	// https://attack.mitre.org/techniques/T1499/)
 	TechniqueID string `ecs:"technique.id"`
 
-	// The reference url of technique used by this tactic. You can use the
-	// Mitre ATT&CK Matrix Tactic categorization, for example. (ex.
+	// The reference url of technique used by this threat. You can use a MITRE
+	// ATT&CK® Matrix technique, for example. (ex.
 	// https://attack.mitre.org/techniques/T1499/ )
 	TechniqueReference string `ecs:"technique.reference"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5621,7 +5621,7 @@ example: `co.uk`
 [[ecs-threat]]
 === Threat Fields
 
-Fields to classify events and alerts according to a threat taxonomy such as the Mitre ATT&CK framework.
+Fields to classify events and alerts according to a threat taxonomy such as the MITRE ATT&CK® framework.
 
 These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat (e.g. "impact"). The threat.technique.* fields are meant to capture which kind of approach is used by this detected threat, to accomplish the goal (e.g. "endpoint denial of service").
 
@@ -5647,7 +5647,7 @@ example: `MITRE ATT&CK`
 // ===============================================================
 
 | threat.tactic.id
-| The id of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
 
 type: keyword
 
@@ -5663,7 +5663,7 @@ example: `TA0040`
 // ===============================================================
 
 | threat.tactic.name
-| Name of the type of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| Name of the type of tactic used by this threat. You can use the MITRE ATT&CK® Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
 
 type: keyword
 
@@ -5679,7 +5679,7 @@ example: `impact`
 // ===============================================================
 
 | threat.tactic.reference
-| The reference url of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The reference url of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
 
 type: keyword
 
@@ -5695,7 +5695,7 @@ example: `https://attack.mitre.org/tactics/TA0040/`
 // ===============================================================
 
 | threat.technique.id
-| The id of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
+| The id of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 
 type: keyword
 
@@ -5711,7 +5711,7 @@ example: `T1499`
 // ===============================================================
 
 | threat.technique.name
-| The name of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
+| The name of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 
 type: keyword
 
@@ -5726,14 +5726,14 @@ Note: this field should contain an array of values.
 
 
 
-example: `endpoint denial of service`
+example: `Endpoint Denial of Service`
 
 | extended
 
 // ===============================================================
 
 | threat.technique.reference
-| The reference url of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
+| The reference url of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5663,7 +5663,7 @@ example: `TA0040`
 // ===============================================================
 
 | threat.tactic.name
-| Name of the type of tactic used by this threat. You can use the MITRE ATT&CK® Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
+| Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5647,7 +5647,7 @@ example: `MITRE ATT&CK`
 // ===============================================================
 
 | threat.tactic.id
-| The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
 
 type: keyword
 
@@ -5663,7 +5663,7 @@ example: `TA0040`
 // ===============================================================
 
 | threat.tactic.name
-| Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
+| Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
 
 type: keyword
 
@@ -5679,7 +5679,7 @@ example: `impact`
 // ===============================================================
 
 | threat.tactic.reference
-| The reference url of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
 
 type: keyword
 
@@ -5695,7 +5695,7 @@ example: `https://attack.mitre.org/tactics/TA0040/`
 // ===============================================================
 
 | threat.technique.id
-| The id of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
+| The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 
 type: keyword
 
@@ -5711,7 +5711,7 @@ example: `T1499`
 // ===============================================================
 
 | threat.technique.name
-| The name of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
+| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
 
 type: keyword
 
@@ -5733,7 +5733,7 @@ example: `Endpoint Denial of Service`
 // ===============================================================
 
 | threat.technique.reference
-| The reference url of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
+| The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4413,8 +4413,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Name of the type of tactic used by this threat. You can use the\
-        \ MITRE ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+      description: "Name of the type of tactic used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
     - name: tactic.reference
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4383,14 +4383,13 @@
   - name: threat
     title: Threat
     group: 2
-    description: 'Fields to classify events and alerts according to a threat taxonomy
-      such as the Mitre ATT&CK framework.
-
-      These fields are for users to classify alerts from all of their sources (e.g.
-      IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to
-      capture the high level category of the threat (e.g. "impact"). The threat.technique.*
-      fields are meant to capture which kind of approach is used by this detected
-      threat, to accomplish the goal (e.g. "endpoint denial of service").'
+    description: "Fields to classify events and alerts according to a threat taxonomy\
+      \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
+      \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
+      \ The threat.tactic.* are meant to capture the high level category of the threat\
+      \ (e.g. \"impact\"). The threat.technique.* fields are meant to capture which\
+      \ kind of approach is used by this detected threat, to accomplish the goal (e.g.\
+      \ \"endpoint denial of service\")."
     type: group
     fields:
     - name: framework
@@ -4406,33 +4405,31 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-        Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\
+        \ Matrix\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ )"
       example: TA0040
     - name: tactic.name
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Name of the type of tactic used by this threat. You can use the
-        Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "Name of the type of tactic used by this threat. You can use the\
+        \ MITRE ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
     - name: tactic.reference
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The reference url of tactic used by this threat. You can use the
-        Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "The reference url of tactic used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ )"
       example: https://attack.mitre.org/tactics/TA0040/
     - name: technique.id
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The id of technique used by this tactic. You can use the Mitre
-        ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: T1499
     - name: technique.name
       level: extended
@@ -4443,17 +4440,16 @@
         type: text
         norms: false
         default_field: false
-      description: The name of technique used by this tactic. You can use the Mitre
-        ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
-      example: endpoint denial of service
+      description: "The name of technique used by this threat. You can use a MITRE\
+        \ ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+      example: Endpoint Denial of Service
     - name: technique.reference
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The reference url of technique used by this tactic. You can use
-        the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
+      description: "The reference url of technique used by this threat. You can use\
+        \ a MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+        \ )"
       example: https://attack.mitre.org/techniques/T1499/
   - name: tls
     title: TLS

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4405,23 +4405,22 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\
-        \ Matrix\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
-        \ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
       example: TA0040
     - name: tactic.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
     - name: tactic.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0040/
     - name: technique.id
@@ -4429,7 +4428,7 @@
       type: keyword
       ignore_above: 1024
       description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: T1499
     - name: technique.name
       level: extended
@@ -4441,14 +4440,14 @@
         norms: false
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: Endpoint Denial of Service
     - name: technique.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
         \ )"
       example: https://attack.mitre.org/techniques/T1499/
   - name: tls

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -519,11 +519,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 1.6.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
 1.6.0-dev,true,threat,threat.tactic.name,keyword,extended,array,impact,Threat tactic.
-1.6.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0040/,Threat tactic url reference.
+1.6.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0040/,Threat tactic URL reference.
 1.6.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1499,Threat technique id.
-1.6.0-dev,true,threat,threat.technique.name,keyword,extended,array,endpoint denial of service,Threat technique name.
-1.6.0-dev,true,threat,threat.technique.name.text,text,extended,,endpoint denial of service,Threat technique name.
-1.6.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1499/,Threat technique reference.
+1.6.0-dev,true,threat,threat.technique.name,keyword,extended,array,Endpoint Denial of Service,Threat technique name.
+1.6.0-dev,true,threat,threat.technique.name.text,text,extended,,Endpoint Denial of Service,Threat technique name.
+1.6.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1499/,Threat technique URL reference.
 1.6.0-dev,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 1.6.0-dev,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client. This is usually mutually-exclusive of `client.certificate_chain` since this value also exists in that list.
 1.6.0-dev,true,tls,tls.client.certificate_chain,keyword,extended,array,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the client. This is usually mutually-exclusive of `client.certificate` since that value should be the first certificate in the chain.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6697,9 +6697,8 @@ threat.framework:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix\xAE\
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
   example: TA0040
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -6711,9 +6710,8 @@ threat.tactic.id:
   type: keyword
 threat.tactic.name:
   dashed_name: threat-tactic-name
-  description: Name of the type of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "Name of the type of tactic used by this threat. You can use the MITRE\
+    \ ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -6725,9 +6723,9 @@ threat.tactic.name:
   type: keyword
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
-  description: The reference url of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The reference url of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ )"
   example: https://attack.mitre.org/tactics/TA0040/
   flat_name: threat.tactic.reference
   ignore_above: 1024
@@ -6735,13 +6733,12 @@ threat.tactic.reference:
   name: tactic.reference
   normalize:
   - array
-  short: Threat tactic url reference.
+  short: Threat tactic URL reference.
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: The id of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: T1499
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -6753,10 +6750,9 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: The name of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
-  example: endpoint denial of service
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+  example: Endpoint Denial of Service
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
@@ -6772,9 +6768,9 @@ threat.technique.name:
   type: keyword
 threat.technique.reference:
   dashed_name: threat-technique-reference
-  description: The reference url of technique used by this tactic. You can use the
-    Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The reference url of technique used by this threat. You can use a\
+    \ MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+    \ )"
   example: https://attack.mitre.org/techniques/T1499/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -6782,7 +6778,7 @@ threat.technique.reference:
   name: technique.reference
   normalize:
   - array
-  short: Threat technique reference.
+  short: Threat technique URL reference.
   type: keyword
 tls.cipher:
   dashed_name: tls-cipher

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6697,7 +6697,7 @@ threat.framework:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix\xAE\
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
     \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
   example: TA0040
   flat_name: threat.tactic.id
@@ -6711,7 +6711,7 @@ threat.tactic.id:
 threat.tactic.name:
   dashed_name: threat-tactic-name
   description: "Name of the type of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -6724,7 +6724,7 @@ threat.tactic.name:
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
   description: "The reference url of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
     \ )"
   example: https://attack.mitre.org/tactics/TA0040/
   flat_name: threat.tactic.reference
@@ -6738,7 +6738,7 @@ threat.tactic.reference:
 threat.technique.id:
   dashed_name: threat-technique-id
   description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: T1499
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -6751,7 +6751,7 @@ threat.technique.id:
 threat.technique.name:
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: Endpoint Denial of Service
   flat_name: threat.technique.name
   ignore_above: 1024
@@ -6769,7 +6769,7 @@ threat.technique.name:
 threat.technique.reference:
   dashed_name: threat-technique-reference
   description: "The reference url of technique used by this threat. You can use a\
-    \ MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
     \ )"
   example: https://attack.mitre.org/techniques/T1499/
   flat_name: threat.technique.reference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6710,8 +6710,8 @@ threat.tactic.id:
   type: keyword
 threat.tactic.name:
   dashed_name: threat-tactic-name
-  description: "Name of the type of tactic used by this threat. You can use the MITRE\
-    \ ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+  description: "Name of the type of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7699,14 +7699,13 @@ source:
   title: Source
   type: group
 threat:
-  description: 'Fields to classify events and alerts according to a threat taxonomy
-    such as the Mitre ATT&CK framework.
-
-    These fields are for users to classify alerts from all of their sources (e.g.
-    IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture
-    the high level category of the threat (e.g. "impact"). The threat.technique.*
-    fields are meant to capture which kind of approach is used by this detected threat,
-    to accomplish the goal (e.g. "endpoint denial of service").'
+  description: "Fields to classify events and alerts according to a threat taxonomy\
+    \ such as the MITRE ATT&CK\xAE framework.\nThese fields are for users to classify\
+    \ alerts from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy.\
+    \ The threat.tactic.* are meant to capture the high level category of the threat\
+    \ (e.g. \"impact\"). The threat.technique.* fields are meant to capture which\
+    \ kind of approach is used by this detected threat, to accomplish the goal (e.g.\
+    \ \"endpoint denial of service\")."
   fields:
     framework:
       dashed_name: threat-framework
@@ -7724,9 +7723,9 @@ threat:
       type: keyword
     tactic.id:
       dashed_name: threat-tactic-id
-      description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-        Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\
+        \ Matrix\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ )"
       example: TA0040
       flat_name: threat.tactic.id
       ignore_above: 1024
@@ -7738,9 +7737,8 @@ threat:
       type: keyword
     tactic.name:
       dashed_name: threat-tactic-name
-      description: Name of the type of tactic used by this threat. You can use the
-        Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "Name of the type of tactic used by this threat. You can use the\
+        \ MITRE ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
       flat_name: threat.tactic.name
       ignore_above: 1024
@@ -7752,9 +7750,9 @@ threat:
       type: keyword
     tactic.reference:
       dashed_name: threat-tactic-reference
-      description: The reference url of tactic used by this threat. You can use the
-        Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-        )
+      description: "The reference url of tactic used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ )"
       example: https://attack.mitre.org/tactics/TA0040/
       flat_name: threat.tactic.reference
       ignore_above: 1024
@@ -7762,13 +7760,12 @@ threat:
       name: tactic.reference
       normalize:
       - array
-      short: Threat tactic url reference.
+      short: Threat tactic URL reference.
       type: keyword
     technique.id:
       dashed_name: threat-technique-id
-      description: The id of technique used by this tactic. You can use the Mitre
-        ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
+      description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: T1499
       flat_name: threat.technique.id
       ignore_above: 1024
@@ -7780,10 +7777,9 @@ threat:
       type: keyword
     technique.name:
       dashed_name: threat-technique-name
-      description: The name of technique used by this tactic. You can use the Mitre
-        ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
-      example: endpoint denial of service
+      description: "The name of technique used by this threat. You can use a MITRE\
+        \ ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+      example: Endpoint Denial of Service
       flat_name: threat.technique.name
       ignore_above: 1024
       level: extended
@@ -7799,9 +7795,9 @@ threat:
       type: keyword
     technique.reference:
       dashed_name: threat-technique-reference
-      description: The reference url of technique used by this tactic. You can use
-        the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-        )
+      description: "The reference url of technique used by this threat. You can use\
+        \ a MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+        \ )"
       example: https://attack.mitre.org/techniques/T1499/
       flat_name: threat.technique.reference
       ignore_above: 1024
@@ -7809,7 +7805,7 @@ threat:
       name: technique.reference
       normalize:
       - array
-      short: Threat technique reference.
+      short: Threat technique URL reference.
       type: keyword
   group: 2
   name: threat

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7723,9 +7723,8 @@ threat:
       type: keyword
     tactic.id:
       dashed_name: threat-tactic-id
-      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\
-        \ Matrix\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
-        \ )"
+      description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
       example: TA0040
       flat_name: threat.tactic.id
       ignore_above: 1024
@@ -7738,7 +7737,7 @@ threat:
     tactic.name:
       dashed_name: threat-tactic-name
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
       flat_name: threat.tactic.name
       ignore_above: 1024
@@ -7751,7 +7750,7 @@ threat:
     tactic.reference:
       dashed_name: threat-tactic-reference
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
         \ )"
       example: https://attack.mitre.org/tactics/TA0040/
       flat_name: threat.tactic.reference
@@ -7765,7 +7764,7 @@ threat:
     technique.id:
       dashed_name: threat-technique-id
       description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: T1499
       flat_name: threat.technique.id
       ignore_above: 1024
@@ -7778,7 +7777,7 @@ threat:
     technique.name:
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
       example: Endpoint Denial of Service
       flat_name: threat.technique.name
       ignore_above: 1024
@@ -7796,7 +7795,7 @@ threat:
     technique.reference:
       dashed_name: threat-technique-reference
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE Matrix technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
         \ )"
       example: https://attack.mitre.org/techniques/T1499/
       flat_name: threat.technique.reference

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7737,8 +7737,8 @@ threat:
       type: keyword
     tactic.name:
       dashed_name: threat-tactic-name
-      description: "Name of the type of tactic used by this threat. You can use the\
-        \ MITRE ATT&CK\xAE Matrix tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
+      description: "Name of the type of tactic used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE Matrix tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
       example: impact
       flat_name: threat.tactic.name
       ignore_above: 1024

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -4,7 +4,7 @@
   group: 2
   short: Fields to classify events and alerts according to a threat taxonomy.
   description: >
-   Fields to classify events and alerts according to a threat taxonomy such as the Mitre ATT&CK framework.
+   Fields to classify events and alerts according to a threat taxonomy such as the MITRE ATT&CK® framework.
 
    These fields are for users to classify alerts from all of their sources (e.g. IDS, NGFW, etc.) within a
    common taxonomy. The threat.tactic.* are meant to capture the high level category of the threat
@@ -29,8 +29,8 @@
       type: keyword
       short: Threat tactic.
       description: >
-          Name of the type of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
-          (ex. https://attack.mitre.org/tactics/TA0040/ )
+          Name of the type of tactic used by this threat. You can use the MITRE ATT&CK® Matrix tactic categorization, for example.
+          (ex. https://attack.mitre.org/tactics/TA0040/)
 
       example: impact
       normalize:
@@ -41,7 +41,7 @@
       type: keyword
       short: Threat tactic id.
       description: >
-          The id of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
+          The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix® tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: TA0040
@@ -51,9 +51,9 @@
     - name: tactic.reference
       level: extended
       type: keyword
-      short: Threat tactic url reference.
+      short: Threat tactic URL reference.
       description: >
-          The reference url of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
+          The reference url of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: https://attack.mitre.org/tactics/TA0040/
@@ -68,10 +68,10 @@
         name: text
       short: Threat technique name.
       description: >
-          The name of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
-          (ex. https://attack.mitre.org/techniques/T1499/ )
+          The name of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
+          (ex. https://attack.mitre.org/techniques/T1499/)
 
-      example: endpoint denial of service
+      example: Endpoint Denial of Service
       normalize:
         - array
 
@@ -80,8 +80,8 @@
       type: keyword
       short: Threat technique id.
       description: >
-          The id of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
-          (ex. https://attack.mitre.org/techniques/T1499/ )
+          The id of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
+          (ex. https://attack.mitre.org/techniques/T1499/)
 
       example: T1499
       normalize:
@@ -90,9 +90,9 @@
     - name: technique.reference
       level: extended
       type: keyword
-      short: Threat technique reference.
+      short: Threat technique URL reference.
       description: >
-          The reference url of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example.
+          The reference url of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
           (ex. https://attack.mitre.org/techniques/T1499/ )
 
       example: https://attack.mitre.org/techniques/T1499/

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -29,7 +29,7 @@
       type: keyword
       short: Threat tactic.
       description: >
-          Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example.
+          Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/)
 
       example: impact
@@ -41,7 +41,7 @@
       type: keyword
       short: Threat tactic id.
       description: >
-          The id of tactic used by this threat. You can use a MITRE ATT&CK Matrix® tactic, for example.
+          The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: TA0040
@@ -53,7 +53,7 @@
       type: keyword
       short: Threat tactic URL reference.
       description: >
-          The reference url of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example.
+          The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/ )
 
       example: https://attack.mitre.org/tactics/TA0040/
@@ -68,7 +68,7 @@
         name: text
       short: Threat technique name.
       description: >
-          The name of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
+          The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
           (ex. https://attack.mitre.org/techniques/T1499/)
 
       example: Endpoint Denial of Service
@@ -80,7 +80,7 @@
       type: keyword
       short: Threat technique id.
       description: >
-          The id of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
+          The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
           (ex. https://attack.mitre.org/techniques/T1499/)
 
       example: T1499
@@ -92,7 +92,7 @@
       type: keyword
       short: Threat technique URL reference.
       description: >
-          The reference url of technique used by this threat. You can use a MITRE ATT&CK® Matrix technique, for example.
+          The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
           (ex. https://attack.mitre.org/techniques/T1499/ )
 
       example: https://attack.mitre.org/techniques/T1499/

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -29,7 +29,7 @@
       type: keyword
       short: Threat tactic.
       description: >
-          Name of the type of tactic used by this threat. You can use the MITRE ATT&CK® Matrix tactic categorization, for example.
+          Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® Matrix tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0040/)
 
       example: impact


### PR DESCRIPTION
I saw some verbiage for `threat.*` that mentioned the MITRE ATT&CK® framework but needed to be adjusted.

Some of the changes
- Added ®. We were supposed to have ™ before, but early in 2020 they were granted ®.
- Correctly spelled MITRE with all capital letters
- Removed some confusing verbiage like "You can use the Mitre ATT&CK Matrix Tactic categorization." The words "Tactic categorization" are a little confusing and not part of the framework. Instead I went with "You can use a MITRE ATT&CK Matrix® tactic, for example." Also, it's possible to mention tactics without concrete techniques and vice versa, so I removed any language that coupled them together.