### PR TITLE
Define process.parent via the new field reuse mechanism

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,7 @@ Thanks, you're awesome :-) -->
 * Added `agent.build.*` for extended agent version information. (#764)
 * Added `x509.*` field set. (#762)
 * Added more account and project cloud metadata. (#816)
+* Added missing field reuse of `pe` at `process.parent.pe` #868
 
 #### Improvements
 

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -31,9 +31,6 @@ type Process struct {
 	// Process id.
 	PID int64 `ecs:"pid"`
 
-	// Process id.
-	ParentPID int64 `ecs:"parent.pid"`
-
 	// Unique identifier for the process.
 	// The implementation of this is specified by the data source, but some
 	// examples of what could be used here are a process-generated UUID, Sysmon
@@ -44,54 +41,25 @@ type Process struct {
 	// across multiple monitored hosts.
 	EntityID string `ecs:"entity_id"`
 
-	// Unique identifier for the process.
-	// The implementation of this is specified by the data source, but some
-	// examples of what could be used here are a process-generated UUID, Sysmon
-	// Process GUIDs, or a hash of some uniquely identifying components of a
-	// process.
-	// Constructing a globally unique identifier is a common practice to
-	// mitigate PID reuse as well as to identify a specific process over time,
-	// across multiple monitored hosts.
-	ParentEntityID string `ecs:"parent.entity_id"`
-
 	// Process name.
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
-	// Process name.
-	// Sometimes called program name or similar.
-	ParentName string `ecs:"parent.name"`
-
 	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 
-	// Parent process' pid.
-	ParentPPID int64 `ecs:"parent.ppid"`
-
 	// Identifier of the group of processes the process belongs to.
 	PGID int64 `ecs:"pgid"`
-
-	// Identifier of the group of processes the process belongs to.
-	ParentPGID int64 `ecs:"parent.pgid"`
 
 	// Full command line that started the process, including the absolute path
 	// to the executable, and all arguments.
 	// Some arguments may be filtered to protect sensitive information.
 	CommandLine string `ecs:"command_line"`
 
-	// Full command line that started the process, including the absolute path
-	// to the executable, and all arguments.
-	// Some arguments may be filtered to protect sensitive information.
-	ParentCommandLine string `ecs:"parent.command_line"`
-
 	// Array of process arguments, starting with the absolute path to the
 	// executable.
 	// May be filtered to protect sensitive information.
 	Args []string `ecs:"args"`
-
-	// Array of process arguments.
-	// May be filtered to protect sensitive information.
-	ParentArgs string `ecs:"parent.args"`
 
 	// Length of the process.args array.
 	// This field can be useful for querying or performing bucket analysis on
@@ -99,17 +67,8 @@ type Process struct {
 	// be an indication of suspicious activity.
 	ArgsCount int64 `ecs:"args_count"`
 
-	// Length of the process.args array.
-	// This field can be useful for querying or performing bucket analysis on
-	// how many arguments were provided to start a process. More arguments may
-	// be an indication of suspicious activity.
-	ParentArgsCount int64 `ecs:"parent.args_count"`
-
 	// Absolute path to the process executable.
 	Executable string `ecs:"executable"`
-
-	// Absolute path to the process executable.
-	ParentExecutable string `ecs:"parent.executable"`
 
 	// Process title.
 	// The proctitle, some times the same as process name. Can also be
@@ -117,49 +76,23 @@ type Process struct {
 	// currently opened.
 	Title string `ecs:"title"`
 
-	// Process title.
-	// The proctitle, some times the same as process name. Can also be
-	// different: for example a browser setting its title to the web page
-	// currently opened.
-	ParentTitle string `ecs:"parent.title"`
-
 	// Thread ID.
 	ThreadID int64 `ecs:"thread.id"`
-
-	// Thread ID.
-	ParentThreadID int64 `ecs:"parent.thread.id"`
 
 	// Thread name.
 	ThreadName string `ecs:"thread.name"`
 
-	// Thread name.
-	ParentThreadName string `ecs:"parent.thread.name"`
-
 	// The time the process started.
 	Start time.Time `ecs:"start"`
-
-	// The time the process started.
-	ParentStart time.Time `ecs:"parent.start"`
 
 	// Seconds the process has been up.
 	Uptime int64 `ecs:"uptime"`
 
-	// Seconds the process has been up.
-	ParentUptime int64 `ecs:"parent.uptime"`
-
 	// The working directory of the process.
 	WorkingDirectory string `ecs:"working_directory"`
-
-	// The working directory of the process.
-	ParentWorkingDirectory string `ecs:"parent.working_directory"`
 
 	// The exit code of the process, if this is a termination event.
 	// The field should be absent if there is no exit code for the event (e.g.
 	// process start).
 	ExitCode int64 `ecs:"exit_code"`
-
-	// The exit code of the process, if this is a termination event.
-	// The field should be absent if there is no exit code for the event (e.g.
-	// process start).
-	ParentExitCode int64 `ecs:"parent.exit_code"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -696,7 +696,7 @@ example: `true`
 
 ==== Field Reuse
 
-The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`, `process.parent.code_signature`.
+The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`.
 
 Note also that the `code_signature` fields are not expected to be used directly at the top level.
 
@@ -2551,7 +2551,7 @@ type: keyword
 
 ==== Field Reuse
 
-The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`, `process.parent.hash`.
+The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`.
 
 Note also that the `hash` fields are not expected to be used directly at the top level.
 
@@ -4275,263 +4275,6 @@ example: `ssh`
 
 // ===============================================================
 
-| process.parent.args
-| Array of process arguments.
-
-May be filtered to protect sensitive information.
-
-type: keyword
-
-
-Note: this field should contain an array of values.
-
-
-
-example: `['ssh', '-l', 'user', '10.0.0.16']`
-
-| extended
-
-// ===============================================================
-
-| process.parent.args_count
-| Length of the process.args array.
-
-This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.
-
-type: long
-
-
-
-example: `4`
-
-| extended
-
-// ===============================================================
-
-| process.parent.command_line
-| Full command line that started the process, including the absolute path to the executable, and all arguments.
-
-Some arguments may be filtered to protect sensitive information.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.command_line.text (type: text)
-
-
-
-
-
-example: `/usr/bin/ssh -l user 10.0.0.16`
-
-| extended
-
-// ===============================================================
-
-| process.parent.entity_id
-| Unique identifier for the process.
-
-The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process.
-
-Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.
-
-type: keyword
-
-
-
-example: `c2c455d9f99375d`
-
-| extended
-
-// ===============================================================
-
-| process.parent.executable
-| Absolute path to the process executable.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.executable.text (type: text)
-
-
-
-
-
-example: `/usr/bin/ssh`
-
-| extended
-
-// ===============================================================
-
-| process.parent.exit_code
-| The exit code of the process, if this is a termination event.
-
-The field should be absent if there is no exit code for the event (e.g. process start).
-
-type: long
-
-
-
-example: `137`
-
-| extended
-
-// ===============================================================
-
-| process.parent.name
-| Process name.
-
-Sometimes called program name or similar.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.name.text (type: text)
-
-
-
-
-
-example: `ssh`
-
-| extended
-
-// ===============================================================
-
-| process.parent.pgid
-| Identifier of the group of processes the process belongs to.
-
-type: long
-
-
-
-
-
-| extended
-
-// ===============================================================
-
-| process.parent.pid
-| Process id.
-
-type: long
-
-
-
-example: `4242`
-
-| core
-
-// ===============================================================
-
-| process.parent.ppid
-| Parent process' pid.
-
-type: long
-
-
-
-example: `4241`
-
-| extended
-
-// ===============================================================
-
-| process.parent.start
-| The time the process started.
-
-type: date
-
-
-
-example: `2016-05-23T08:05:34.853Z`
-
-| extended
-
-// ===============================================================
-
-| process.parent.thread.id
-| Thread ID.
-
-type: long
-
-
-
-example: `4242`
-
-| extended
-
-// ===============================================================
-
-| process.parent.thread.name
-| Thread name.
-
-type: keyword
-
-
-
-example: `thread-0`
-
-| extended
-
-// ===============================================================
-
-| process.parent.title
-| Process title.
-
-The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.title.text (type: text)
-
-
-
-
-
-
-
-| extended
-
-// ===============================================================
-
-| process.parent.uptime
-| Seconds the process has been up.
-
-type: long
-
-
-
-example: `1325`
-
-| extended
-
-// ===============================================================
-
-| process.parent.working_directory
-| The working directory of the process.
-
-type: keyword
-
-Multi-fields:
-
-* process.parent.working_directory.text (type: text)
-
-
-
-
-
-example: `/home/alice`
-
-| extended
-
-// ===============================================================
-
 | process.pgid
 | Identifier of the group of processes the process belongs to.
 
@@ -4667,6 +4410,10 @@ example: `/home/alice`
 
 ==== Field Reuse
 
+The `process` fields are expected to be nested at: `process.parent`.
+
+Note also that the `process` fields may be used directly at the top level.
+
 
 
 
@@ -4692,14 +4439,8 @@ example: `/home/alice`
 // ===============================================================
 
 
-| <<ecs-code_signature,process.parent.code_signature.*>>
-| These fields contain information about binary code signatures.
-
-// ===============================================================
-
-
-| <<ecs-hash,process.parent.hash.*>>
-| Hashes, usually file hashes.
+| <<ecs-process,process.parent.*>>
+| These fields contain information about a process.
 
 // ===============================================================
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3309,11 +3309,12 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of process arguments.
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
 
         May be filtered to protect sensitive information.'
       example:
-      - ssh
+      - /usr/bin/ssh
       - -l
       - user
       - 10.0.0.16
@@ -3455,6 +3456,59 @@
 
         Sometimes called program name or similar.'
       example: ssh
+      default_field: false
+    - name: parent.pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: parent.pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: parent.pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: parent.pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: parent.pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: parent.pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
       default_field: false
     - name: parent.pgid
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -375,7 +375,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 1.6.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
 1.6.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
-1.6.0-dev,true,process,process.parent.args,keyword,extended,array,"['ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
+1.6.0-dev,true,process,process.parent.args,keyword,extended,array,"['/usr/bin/ssh', '-l', 'user', '10.0.0.16']",Array of process arguments.
 1.6.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.6.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.6.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
@@ -394,6 +394,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 1.6.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
 1.6.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+1.6.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.6.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.6.0-dev,true,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.6.0-dev,true,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.6.0-dev,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 1.6.0-dev,true,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 1.6.0-dev,true,process,process.parent.pid,long,core,,4242,Process id.
 1.6.0-dev,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5012,20 +5012,22 @@ process.name:
   type: keyword
 process.parent.args:
   dashed_name: process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
+  original_fieldset: process
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -5038,8 +5040,9 @@ process.parent.args_count:
   example: 4
   flat_name: process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
+  original_fieldset: process
   short: Length of the process.args array.
   type: long
 process.parent.code_signature.exists:
@@ -5125,8 +5128,9 @@ process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
+  original_fieldset: process
   short: Full command line that started the process.
   type: keyword
 process.parent.entity_id:
@@ -5144,8 +5148,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -5160,8 +5165,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -5173,8 +5179,9 @@ process.parent.exit_code:
   example: 137
   flat_name: process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
+  original_fieldset: process
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -5235,9 +5242,98 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
+  type: keyword
+process.parent.pe.architecture:
+  dashed_name: process-parent-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.parent.pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.parent.pe.company:
+  dashed_name: process-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.description:
+  dashed_name: process-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.file_version:
+  dashed_name: process-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.parent.pe.imphash:
+  dashed_name: process-parent-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.parent.pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.parent.pe.original_file_name:
+  dashed_name: process-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.product:
+  dashed_name: process-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
   type: keyword
 process.parent.pgid:
   dashed_name: process-parent-pgid
@@ -5245,8 +5341,9 @@ process.parent.pgid:
   flat_name: process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
+  original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -5256,8 +5353,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.parent.ppid:
@@ -5267,8 +5365,9 @@ process.parent.ppid:
   flat_name: process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
+  original_fieldset: process
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -5277,8 +5376,9 @@ process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
+  original_fieldset: process
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -5288,8 +5388,9 @@ process.parent.thread.id:
   flat_name: process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
+  original_fieldset: process
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -5299,8 +5400,9 @@ process.parent.thread.name:
   flat_name: process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
+  original_fieldset: process
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -5317,8 +5419,9 @@ process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
+  original_fieldset: process
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -5327,8 +5430,9 @@ process.parent.uptime:
   example: 1325
   flat_name: process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
+  original_fieldset: process
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -5343,8 +5447,9 @@ process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
+  original_fieldset: process
   short: The working directory of the process.
   type: keyword
 process.pe.architecture:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -865,9 +865,6 @@ code_signature:
       at: process
       full: process.code_signature
     - as: code_signature
-      at: process.parent
-      full: process.parent.code_signature
-    - as: code_signature
       at: dll
       full: dll.code_signature
     top_level: false
@@ -3836,9 +3833,6 @@ hash:
       at: process
       full: process.hash
     - as: hash
-      at: process.parent
-      full: process.parent.hash
-    - as: hash
       at: dll
       full: dll.hash
     top_level: false
@@ -6066,20 +6060,22 @@ process:
       type: keyword
     process.parent.args:
       dashed_name: process-parent-args
-      description: 'Array of process arguments.
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
 
         May be filtered to protect sensitive information.'
       example:
-      - ssh
+      - /usr/bin/ssh
       - -l
       - user
       - 10.0.0.16
       flat_name: process.parent.args
       ignore_above: 1024
       level: extended
-      name: parent.args
+      name: args
       normalize:
       - array
+      original_fieldset: process
       short: Array of process arguments.
       type: keyword
     process.parent.args_count:
@@ -6092,8 +6088,9 @@ process:
       example: 4
       flat_name: process.parent.args_count
       level: extended
-      name: parent.args_count
+      name: args_count
       normalize: []
+      original_fieldset: process
       short: Length of the process.args array.
       type: long
     process.parent.code_signature.exists:
@@ -6179,8 +6176,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.command_line
+      name: command_line
       normalize: []
+      original_fieldset: process
       short: Full command line that started the process.
       type: keyword
     process.parent.entity_id:
@@ -6198,8 +6196,9 @@ process:
       flat_name: process.parent.entity_id
       ignore_above: 1024
       level: extended
-      name: parent.entity_id
+      name: entity_id
       normalize: []
+      original_fieldset: process
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
@@ -6214,8 +6213,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.executable
+      name: executable
       normalize: []
+      original_fieldset: process
       short: Absolute path to the process executable.
       type: keyword
     process.parent.exit_code:
@@ -6227,8 +6227,9 @@ process:
       example: 137
       flat_name: process.parent.exit_code
       level: extended
-      name: parent.exit_code
+      name: exit_code
       normalize: []
+      original_fieldset: process
       short: The exit code of the process.
       type: long
     process.parent.hash.md5:
@@ -6289,9 +6290,98 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.name
+      name: name
       normalize: []
+      original_fieldset: process
       short: Process name.
+      type: keyword
+    process.parent.pe.architecture:
+      dashed_name: process-parent-pe-architecture
+      description: CPU architecture target for the file.
+      example: x64
+      flat_name: process.parent.pe.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: pe
+      short: CPU architecture target for the file.
+      type: keyword
+    process.parent.pe.company:
+      dashed_name: process-parent-pe-company
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      flat_name: process.parent.pe.company
+      ignore_above: 1024
+      level: extended
+      name: company
+      normalize: []
+      original_fieldset: pe
+      short: Internal company name of the file, provided at compile-time.
+      type: keyword
+    process.parent.pe.description:
+      dashed_name: process-parent-pe-description
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      flat_name: process.parent.pe.description
+      ignore_above: 1024
+      level: extended
+      name: description
+      normalize: []
+      original_fieldset: pe
+      short: Internal description of the file, provided at compile-time.
+      type: keyword
+    process.parent.pe.file_version:
+      dashed_name: process-parent-pe-file-version
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      flat_name: process.parent.pe.file_version
+      ignore_above: 1024
+      level: extended
+      name: file_version
+      normalize: []
+      original_fieldset: pe
+      short: Process name.
+      type: keyword
+    process.parent.pe.imphash:
+      dashed_name: process-parent-pe-imphash
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      flat_name: process.parent.pe.imphash
+      ignore_above: 1024
+      level: extended
+      name: imphash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in a PE file.
+      type: keyword
+    process.parent.pe.original_file_name:
+      dashed_name: process-parent-pe-original-file-name
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      flat_name: process.parent.pe.original_file_name
+      ignore_above: 1024
+      level: extended
+      name: original_file_name
+      normalize: []
+      original_fieldset: pe
+      short: Internal name of the file, provided at compile-time.
+      type: keyword
+    process.parent.pe.product:
+      dashed_name: process-parent-pe-product
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      flat_name: process.parent.pe.product
+      ignore_above: 1024
+      level: extended
+      name: product
+      normalize: []
+      original_fieldset: pe
+      short: Internal product name of the file, provided at compile-time.
       type: keyword
     process.parent.pgid:
       dashed_name: process-parent-pgid
@@ -6299,8 +6389,9 @@ process:
       flat_name: process.parent.pgid
       format: string
       level: extended
-      name: parent.pgid
+      name: pgid
       normalize: []
+      original_fieldset: process
       short: Identifier of the group of processes the process belongs to.
       type: long
     process.parent.pid:
@@ -6310,8 +6401,9 @@ process:
       flat_name: process.parent.pid
       format: string
       level: core
-      name: parent.pid
+      name: pid
       normalize: []
+      original_fieldset: process
       short: Process id.
       type: long
     process.parent.ppid:
@@ -6321,8 +6413,9 @@ process:
       flat_name: process.parent.ppid
       format: string
       level: extended
-      name: parent.ppid
+      name: ppid
       normalize: []
+      original_fieldset: process
       short: Parent process' pid.
       type: long
     process.parent.start:
@@ -6331,8 +6424,9 @@ process:
       example: '2016-05-23T08:05:34.853Z'
       flat_name: process.parent.start
       level: extended
-      name: parent.start
+      name: start
       normalize: []
+      original_fieldset: process
       short: The time the process started.
       type: date
     process.parent.thread.id:
@@ -6342,8 +6436,9 @@ process:
       flat_name: process.parent.thread.id
       format: string
       level: extended
-      name: parent.thread.id
+      name: thread.id
       normalize: []
+      original_fieldset: process
       short: Thread ID.
       type: long
     process.parent.thread.name:
@@ -6353,8 +6448,9 @@ process:
       flat_name: process.parent.thread.name
       ignore_above: 1024
       level: extended
-      name: parent.thread.name
+      name: thread.name
       normalize: []
+      original_fieldset: process
       short: Thread name.
       type: keyword
     process.parent.title:
@@ -6371,8 +6467,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.title
+      name: title
       normalize: []
+      original_fieldset: process
       short: Process title.
       type: keyword
     process.parent.uptime:
@@ -6381,8 +6478,9 @@ process:
       example: 1325
       flat_name: process.parent.uptime
       level: extended
-      name: parent.uptime
+      name: uptime
       normalize: []
+      original_fieldset: process
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
@@ -6397,8 +6495,9 @@ process:
         name: text
         norms: false
         type: text
-      name: parent.working_directory
+      name: working_directory
       normalize: []
+      original_fieldset: process
       short: The working directory of the process.
       type: keyword
     process.pe.architecture:
@@ -6602,26 +6701,28 @@ process:
   nestings:
   - process.code_signature
   - process.hash
-  - process.parent.code_signature
-  - process.parent.hash
+  - process.parent
   - process.pe
   prefix: process.
+  reusable:
+    expected:
+    - as: parent
+      at: process
+      full: process.parent
+    top_level: true
   reused_here:
   - full: process.code_signature
-    schema_name: code_signature
-    short: These fields contain information about binary code signatures.
-  - full: process.parent.code_signature
     schema_name: code_signature
     short: These fields contain information about binary code signatures.
   - full: process.hash
     schema_name: hash
     short: Hashes, usually file hashes.
-  - full: process.parent.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   - full: process.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
+  - full: process.parent
+    schema_name: process
+    short: These fields contain information about a process.
   short: These fields contain information about a process.
   title: Process
   type: group

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1875,6 +1875,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "pe": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "company": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "file_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imphash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "original_file_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "product": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "pgid": {
                   "type": "long"
                 },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1874,6 +1874,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "pe": {
+                "properties": {
+                  "architecture": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "company": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "description": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "file_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imphash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "original_file_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "product": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "pgid": {
                 "type": "long"
               },

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -9,7 +9,6 @@
     expected:
       - file
       - process
-      - process.parent
       - dll
       # - driver
   fields:

--- a/schemas/hash.yml
+++ b/schemas/hash.yml
@@ -16,7 +16,6 @@
     expected:
       - file
       - process
-      - process.parent
       - dll
 
   fields:

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -1,18 +1,3 @@
-# HEADS UP
-# This field set supports capturing the parent process (one level).
-#
-# Doing so via normal reuse/nesting is tricky mainly because it's reused as a
-# different name: the "process" field set is nested as "parent".
-# This is the only occurrence of this in ECS, so it's not supported.
-#
-# The workaround is to simply duplicate each field to generate the "parent.*"
-# equivalent of each "process.*" field. Please maintain each duplicate exactly as
-# the main field (e.g. same wording & example), as if it was normal nesting.
-#
-# Each such duplicated field for the parent process is directly below the original
-# field, which will hopefully help maintain this until a better solution is in place.
-
----
 - name: process
   title: Process
   group: 2
@@ -24,14 +9,11 @@
     from a log message.  The `process.pid` often stays in the metric itself and is
     copied to the global field for correlation.
   type: group
-
-  # TODO Temporarily commented out to simplify initial rewrite review
-
-  # reusable:
-  #   top_level: true
-  #   expected:
-  #     - at: process
-  #       as: parent
+  reusable:
+    top_level: true
+    expected:
+      - at: process
+        as: parent
 
   fields:
 
@@ -43,32 +25,7 @@
         Process id.
       example: 4242
 
-    - name: parent.pid
-      format: string
-      level: core
-      type: long
-      description: >
-        Process id.
-      example: 4242
-
     - name: entity_id
-      level: extended
-      type: keyword
-      short: Unique identifier for the process.
-      description: >
-        Unique identifier for the process.
-
-        The implementation of this is specified by the data source, but some
-        examples of what could be used here are a process-generated UUID,
-        Sysmon Process GUIDs, or a hash of some uniquely identifying components
-        of a process.
-
-        Constructing a globally unique identifier is a common practice to mitigate
-        PID reuse as well as to identify a specific process over time, across multiple
-        monitored hosts.
-      example: c2c455d9f99375d
-
-    - name: parent.entity_id
       level: extended
       type: keyword
       short: Unique identifier for the process.
@@ -98,20 +55,6 @@
       - type: text
         name: text
 
-    - name: parent.name
-      level: extended
-      type: keyword
-      short: Process name.
-      description: >
-        Process name.
-
-        Sometimes called program name or similar.
-      example: ssh
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: ppid
       format: string
       level: extended
@@ -120,29 +63,12 @@
         Parent process' pid.
       example: 4241
 
-    - name: parent.ppid
-      format: string
-      level: extended
-      type: long
-      description: >
-        Parent process' pid.
-      example: 4241
-
-
     - name: pgid
       format: string
       level: extended
       type: long
       description: >
         Identifier of the group of processes the process belongs to.
-
-    - name: parent.pgid
-      format: string
-      level: extended
-      type: long
-      description: >
-        Identifier of the group of processes the process belongs to.
-
 
     - name: command_line
       level: extended
@@ -158,21 +84,6 @@
       - type: text
         name: text
 
-    - name: parent.command_line
-      level: extended
-      type: keyword
-      short: Full command line that started the process.
-      description: >
-        Full command line that started the process, including the absolute path
-        to the executable, and all arguments.
-
-        Some arguments may be filtered to protect sensitive information.
-      example: "/usr/bin/ssh -l user 10.0.0.16"
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: args
       level: extended
       type: keyword
@@ -182,18 +93,6 @@
 
         May be filtered to protect sensitive information.
       example: ["/usr/bin/ssh", "-l", "user", "10.0.0.16"]
-      normalize:
-        - array
-
-    - name: parent.args
-      level: extended
-      type: keyword
-      short: Array of process arguments.
-      description: >
-        Array of process arguments.
-
-        May be filtered to protect sensitive information.
-      example: ["ssh", "-l", "user", "10.0.0.16"]
       normalize:
         - array
 
@@ -209,19 +108,6 @@
         More arguments may be an indication of suspicious activity.
       example: 4
 
-    - name: parent.args_count
-      level: extended
-      type: long
-      short: Length of the process.args array.
-      description: >
-        Length of the process.args array.
-
-        This field can be useful for querying or performing bucket analysis on
-        how many arguments were provided to start a process.
-        More arguments may be an indication of suspicious activity.
-      example: 4
-
-
     - name: executable
       level: extended
       type: keyword
@@ -231,17 +117,6 @@
       multi_fields:
       - type: text
         name: text
-
-    - name: parent.executable
-      level: extended
-      type: keyword
-      description: >
-        Absolute path to the process executable.
-      example: /usr/bin/ssh
-      multi_fields:
-      - type: text
-        name: text
-
 
     - name: title
       level: extended
@@ -256,20 +131,6 @@
       - type: text
         name: text
 
-    - name: parent.title
-      level: extended
-      type: keyword
-      short: Process title.
-      description: >
-        Process title.
-
-        The proctitle, some times the same as process name. Can also be different:
-        for example a browser setting its title to the web page currently opened.
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: thread.id
       format: string
       level: extended
@@ -278,29 +139,12 @@
       description: >
         Thread ID.
 
-    - name: parent.thread.id
-      format: string
-      level: extended
-      type: long
-      example: 4242
-      description: >
-        Thread ID.
-
-
     - name: thread.name
       level: extended
       type: keyword
       example: 'thread-0'
       description: >
         Thread name.
-
-    - name: parent.thread.name
-      level: extended
-      type: keyword
-      example: 'thread-0'
-      description: >
-        Thread name.
-
 
     - name: start
       level: extended
@@ -309,28 +153,12 @@
       description: >
         The time the process started.
 
-    - name: parent.start
-      level: extended
-      type: date
-      example: "2016-05-23T08:05:34.853Z"
-      description: >
-        The time the process started.
-
-
     - name: uptime
       level: extended
       type: long
       example: 1325
       description: >
         Seconds the process has been up.
-
-    - name: parent.uptime
-      level: extended
-      type: long
-      example: 1325
-      description: >
-        Seconds the process has been up.
-
 
     - name: working_directory
       level: extended
@@ -342,29 +170,7 @@
       - type: text
         name: text
 
-    - name: parent.working_directory
-      level: extended
-      type: keyword
-      example: /home/alice
-      description: >
-        The working directory of the process.
-      multi_fields:
-      - type: text
-        name: text
-
-
     - name: exit_code
-      level: extended
-      type: long
-      example: 137
-      short: The exit code of the process.
-      description: >
-        The exit code of the process, if this is a termination event.
-
-        The field should be absent if there is no exit code for the event (e.g.
-        process start).
-
-    - name: parent.exit_code
       level: extended
       type: long
       example: 137


### PR DESCRIPTION
The `process.parent` fields had initially been defined by duplicating each field explicitly, since the field reuse mechanism didn't support field reuse within the same field set at the time.

Introducing `process.parent.*` by duplicating fields has predictably led to a few small mistakes, despite us squinting very hard and trying to avoid this :-)

* At least one process field was modified without having the same modification applied to its `process.parent` twin.
* Also, the field set `pe` was only reused under `process`, but not `process.parent`. This was not intentional.

This PR removes the field duplication by using the improved reuse mechanism. This means both problems described above are also resolved by this PR.