### PR TITLE
Define fields to allow representing multiple users in an event.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,8 @@ Thanks, you're awesome :-) -->
 * Added `agent.build.*` for extended agent version information. (#764)
 * Added `x509.*` field set. (#762)
 * Added more account and project cloud metadata. (#816)
+* Added `user.effective`, `user.target`, and `user.changes` to capture more details
+  when multiple users are relevant to an event. #869
 
 #### Improvements
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6526,7 +6526,7 @@ example: `albert`
 
 ==== Field Reuse
 
-The `user` fields are expected to be nested at: `client.user`, `destination.user`, `host.user`, `server.user`, `source.user`.
+The `user` fields are expected to be nested at: `client.user`, `destination.user`, `host.user`, `server.user`, `source.user`, `user.changes`, `user.effective`, `user.target`.
 
 Note also that the `user` fields may be used directly at the top level.
 
@@ -6543,8 +6543,26 @@ Note also that the `user` fields may be used directly at the top level.
 // ===============================================================
 
 
+| <<ecs-user,user.changes.*>>
+| Fields to describe the user relevant to the event.
+
+// ===============================================================
+
+
+| <<ecs-user,user.effective.*>>
+| Fields to describe the user relevant to the event.
+
+// ===============================================================
+
+
 | <<ecs-group,user.group.*>>
 | User's group relevant to the event.
+
+// ===============================================================
+
+
+| <<ecs-user,user.target.*>>
+| Fields to describe the user relevant to the event.
 
 // ===============================================================
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5200,6 +5200,78 @@
       provide an array that includes all of them.'
     type: group
     fields:
+    - name: changes.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: changes.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+      default_field: false
+    - name: changes.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: User's full name, if available.
+      example: Albert Einstein
+      default_field: false
+    - name: changes.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: changes.group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: changes.group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: changes.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      default_field: false
+    - name: changes.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      default_field: false
+    - name: changes.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Short name or login of the user.
+      example: albert
+      default_field: false
     - name: domain
       level: extended
       type: keyword
@@ -5207,6 +5279,78 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: effective.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: effective.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+      default_field: false
+    - name: effective.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: User's full name, if available.
+      example: Albert Einstein
+      default_field: false
+    - name: effective.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: effective.group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: effective.group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: effective.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      default_field: false
+    - name: effective.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      default_field: false
+    - name: effective.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Short name or login of the user.
+      example: albert
+      default_field: false
     - name: email
       level: extended
       type: keyword
@@ -5265,6 +5409,78 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: target.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: target.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+      default_field: false
+    - name: target.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: User's full name, if available.
+      example: Albert Einstein
+      default_field: false
+    - name: target.group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: target.group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: target.group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: target.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      default_field: false
+    - name: target.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      default_field: false
+    - name: target.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Short name or login of the user.
+      example: albert
+      default_field: false
   - name: user_agent
     title: User agent
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -618,7 +618,29 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,url,url.scheme,keyword,extended,,https,Scheme of the url.
 1.6.0-dev,true,url,url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,url,url.username,keyword,extended,,,Username of the request.
+1.6.0-dev,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.6.0-dev,true,user,user.changes.email,keyword,extended,,,User email address.
+1.6.0-dev,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.6.0-dev,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.6.0-dev,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
+1.6.0-dev,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.6.0-dev,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
+1.6.0-dev,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
+1.6.0-dev,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.6.0-dev,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.6.0-dev,true,user,user.effective.email,keyword,extended,,,User email address.
+1.6.0-dev,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.6.0-dev,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.6.0-dev,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
+1.6.0-dev,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.6.0-dev,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
+1.6.0-dev,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
+1.6.0-dev,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user,user.email,keyword,extended,,,User email address.
 1.6.0-dev,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 1.6.0-dev,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
@@ -629,6 +651,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,user,user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.6.0-dev,true,user,user.target.email,keyword,extended,,,User email address.
+1.6.0-dev,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.6.0-dev,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.6.0-dev,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.6.0-dev,true,user,user.target.group.name,keyword,extended,,,Name of the group.
+1.6.0-dev,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.6.0-dev,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
+1.6.0-dev,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
+1.6.0-dev,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 1.6.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 1.6.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7998,6 +7998,125 @@ url.username:
   normalize: []
   short: Username of the request.
   type: keyword
+user.changes.domain:
+  dashed_name: user-changes-domain
+  description: 'Name of the directory the user is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.changes.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: user
+  short: Name of the directory the user is a member of.
+  type: keyword
+user.changes.email:
+  dashed_name: user-changes-email
+  description: User email address.
+  flat_name: user.changes.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  original_fieldset: user
+  short: User email address.
+  type: keyword
+user.changes.full_name:
+  dashed_name: user-changes-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.changes.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.changes.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  original_fieldset: user
+  short: User's full name, if available.
+  type: keyword
+user.changes.group.domain:
+  dashed_name: user-changes-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.changes.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.changes.group.id:
+  dashed_name: user-changes-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.changes.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.changes.group.name:
+  dashed_name: user-changes-group-name
+  description: Name of the group.
+  flat_name: user.changes.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.changes.hash:
+  dashed_name: user-changes-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.changes.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  original_fieldset: user
+  short: Unique user hash to correlate information for a user in anonymized form.
+  type: keyword
+user.changes.id:
+  dashed_name: user-changes-id
+  description: Unique identifier of the user.
+  flat_name: user.changes.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+user.changes.name:
+  dashed_name: user-changes-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: user.changes.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: user.changes.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 user.domain:
   dashed_name: user-domain
   description: 'Name of the directory the user is a member of.
@@ -8009,6 +8128,125 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.effective.domain:
+  dashed_name: user-effective-domain
+  description: 'Name of the directory the user is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.effective.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: user
+  short: Name of the directory the user is a member of.
+  type: keyword
+user.effective.email:
+  dashed_name: user-effective-email
+  description: User email address.
+  flat_name: user.effective.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  original_fieldset: user
+  short: User email address.
+  type: keyword
+user.effective.full_name:
+  dashed_name: user-effective-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.effective.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.effective.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  original_fieldset: user
+  short: User's full name, if available.
+  type: keyword
+user.effective.group.domain:
+  dashed_name: user-effective-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.effective.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.effective.group.id:
+  dashed_name: user-effective-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.effective.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.effective.group.name:
+  dashed_name: user-effective-group-name
+  description: Name of the group.
+  flat_name: user.effective.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.effective.hash:
+  dashed_name: user-effective-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.effective.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  original_fieldset: user
+  short: Unique user hash to correlate information for a user in anonymized form.
+  type: keyword
+user.effective.id:
+  dashed_name: user-effective-id
+  description: Unique identifier of the user.
+  flat_name: user.effective.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+user.effective.name:
+  dashed_name: user-effective-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: user.effective.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: user.effective.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
   type: keyword
 user.email:
   dashed_name: user-email
@@ -8109,6 +8347,125 @@ user.name:
     type: text
   name: name
   normalize: []
+  short: Short name or login of the user.
+  type: keyword
+user.target.domain:
+  dashed_name: user-target-domain
+  description: 'Name of the directory the user is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.target.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: user
+  short: Name of the directory the user is a member of.
+  type: keyword
+user.target.email:
+  dashed_name: user-target-email
+  description: User email address.
+  flat_name: user.target.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  original_fieldset: user
+  short: User email address.
+  type: keyword
+user.target.full_name:
+  dashed_name: user-target-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.target.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.target.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  original_fieldset: user
+  short: User's full name, if available.
+  type: keyword
+user.target.group.domain:
+  dashed_name: user-target-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.target.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.target.group.id:
+  dashed_name: user-target-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.target.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.target.group.name:
+  dashed_name: user-target-group-name
+  description: Name of the group.
+  flat_name: user.target.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.target.hash:
+  dashed_name: user-target-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.target.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  original_fieldset: user
+  short: Unique user hash to correlate information for a user in anonymized form.
+  type: keyword
+user.target.id:
+  dashed_name: user-target-id
+  description: Unique identifier of the user.
+  flat_name: user.target.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+user.target.name:
+  dashed_name: user-target-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: user.target.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: user.target.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
   short: Short name or login of the user.
   type: keyword
 user_agent.device.name:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9274,6 +9274,125 @@ user:
     Fields can have one entry or multiple entries. If a user has more than one id,
     provide an array that includes all of them.'
   fields:
+    user.changes.domain:
+      dashed_name: user-changes-domain
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.changes.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: user
+      short: Name of the directory the user is a member of.
+      type: keyword
+    user.changes.email:
+      dashed_name: user-changes-email
+      description: User email address.
+      flat_name: user.changes.email
+      ignore_above: 1024
+      level: extended
+      name: email
+      normalize: []
+      original_fieldset: user
+      short: User email address.
+      type: keyword
+    user.changes.full_name:
+      dashed_name: user-changes-full-name
+      description: User's full name, if available.
+      example: Albert Einstein
+      flat_name: user.changes.full_name
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: user.changes.full_name.text
+        name: text
+        norms: false
+        type: text
+      name: full_name
+      normalize: []
+      original_fieldset: user
+      short: User's full name, if available.
+      type: keyword
+    user.changes.group.domain:
+      dashed_name: user-changes-group-domain
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.changes.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: group
+      short: Name of the directory the group is a member of.
+      type: keyword
+    user.changes.group.id:
+      dashed_name: user-changes-group-id
+      description: Unique identifier for the group on the system/platform.
+      flat_name: user.changes.group.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      original_fieldset: group
+      short: Unique identifier for the group on the system/platform.
+      type: keyword
+    user.changes.group.name:
+      dashed_name: user-changes-group-name
+      description: Name of the group.
+      flat_name: user.changes.group.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
+    user.changes.hash:
+      dashed_name: user-changes-hash
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      flat_name: user.changes.hash
+      ignore_above: 1024
+      level: extended
+      name: hash
+      normalize: []
+      original_fieldset: user
+      short: Unique user hash to correlate information for a user in anonymized form.
+      type: keyword
+    user.changes.id:
+      dashed_name: user-changes-id
+      description: Unique identifier of the user.
+      flat_name: user.changes.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: user
+      short: Unique identifier of the user.
+      type: keyword
+    user.changes.name:
+      dashed_name: user-changes-name
+      description: Short name or login of the user.
+      example: albert
+      flat_name: user.changes.name
+      ignore_above: 1024
+      level: core
+      multi_fields:
+      - flat_name: user.changes.name.text
+        name: text
+        norms: false
+        type: text
+      name: name
+      normalize: []
+      original_fieldset: user
+      short: Short name or login of the user.
+      type: keyword
     user.domain:
       dashed_name: user-domain
       description: 'Name of the directory the user is a member of.
@@ -9285,6 +9404,125 @@ user:
       name: domain
       normalize: []
       short: Name of the directory the user is a member of.
+      type: keyword
+    user.effective.domain:
+      dashed_name: user-effective-domain
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.effective.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: user
+      short: Name of the directory the user is a member of.
+      type: keyword
+    user.effective.email:
+      dashed_name: user-effective-email
+      description: User email address.
+      flat_name: user.effective.email
+      ignore_above: 1024
+      level: extended
+      name: email
+      normalize: []
+      original_fieldset: user
+      short: User email address.
+      type: keyword
+    user.effective.full_name:
+      dashed_name: user-effective-full-name
+      description: User's full name, if available.
+      example: Albert Einstein
+      flat_name: user.effective.full_name
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: user.effective.full_name.text
+        name: text
+        norms: false
+        type: text
+      name: full_name
+      normalize: []
+      original_fieldset: user
+      short: User's full name, if available.
+      type: keyword
+    user.effective.group.domain:
+      dashed_name: user-effective-group-domain
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.effective.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: group
+      short: Name of the directory the group is a member of.
+      type: keyword
+    user.effective.group.id:
+      dashed_name: user-effective-group-id
+      description: Unique identifier for the group on the system/platform.
+      flat_name: user.effective.group.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      original_fieldset: group
+      short: Unique identifier for the group on the system/platform.
+      type: keyword
+    user.effective.group.name:
+      dashed_name: user-effective-group-name
+      description: Name of the group.
+      flat_name: user.effective.group.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
+    user.effective.hash:
+      dashed_name: user-effective-hash
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      flat_name: user.effective.hash
+      ignore_above: 1024
+      level: extended
+      name: hash
+      normalize: []
+      original_fieldset: user
+      short: Unique user hash to correlate information for a user in anonymized form.
+      type: keyword
+    user.effective.id:
+      dashed_name: user-effective-id
+      description: Unique identifier of the user.
+      flat_name: user.effective.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: user
+      short: Unique identifier of the user.
+      type: keyword
+    user.effective.name:
+      dashed_name: user-effective-name
+      description: Short name or login of the user.
+      example: albert
+      flat_name: user.effective.name
+      ignore_above: 1024
+      level: core
+      multi_fields:
+      - flat_name: user.effective.name.text
+        name: text
+        norms: false
+        type: text
+      name: name
+      normalize: []
+      original_fieldset: user
+      short: Short name or login of the user.
       type: keyword
     user.email:
       dashed_name: user-email
@@ -9387,10 +9625,132 @@ user:
       normalize: []
       short: Short name or login of the user.
       type: keyword
+    user.target.domain:
+      dashed_name: user-target-domain
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.target.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: user
+      short: Name of the directory the user is a member of.
+      type: keyword
+    user.target.email:
+      dashed_name: user-target-email
+      description: User email address.
+      flat_name: user.target.email
+      ignore_above: 1024
+      level: extended
+      name: email
+      normalize: []
+      original_fieldset: user
+      short: User email address.
+      type: keyword
+    user.target.full_name:
+      dashed_name: user-target-full-name
+      description: User's full name, if available.
+      example: Albert Einstein
+      flat_name: user.target.full_name
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: user.target.full_name.text
+        name: text
+        norms: false
+        type: text
+      name: full_name
+      normalize: []
+      original_fieldset: user
+      short: User's full name, if available.
+      type: keyword
+    user.target.group.domain:
+      dashed_name: user-target-group-domain
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      flat_name: user.target.group.domain
+      ignore_above: 1024
+      level: extended
+      name: domain
+      normalize: []
+      original_fieldset: group
+      short: Name of the directory the group is a member of.
+      type: keyword
+    user.target.group.id:
+      dashed_name: user-target-group-id
+      description: Unique identifier for the group on the system/platform.
+      flat_name: user.target.group.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      original_fieldset: group
+      short: Unique identifier for the group on the system/platform.
+      type: keyword
+    user.target.group.name:
+      dashed_name: user-target-group-name
+      description: Name of the group.
+      flat_name: user.target.group.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
+    user.target.hash:
+      dashed_name: user-target-hash
+      description: 'Unique user hash to correlate information for a user in anonymized
+        form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot
+        be used.'
+      flat_name: user.target.hash
+      ignore_above: 1024
+      level: extended
+      name: hash
+      normalize: []
+      original_fieldset: user
+      short: Unique user hash to correlate information for a user in anonymized form.
+      type: keyword
+    user.target.id:
+      dashed_name: user-target-id
+      description: Unique identifier of the user.
+      flat_name: user.target.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: user
+      short: Unique identifier of the user.
+      type: keyword
+    user.target.name:
+      dashed_name: user-target-name
+      description: Short name or login of the user.
+      example: albert
+      flat_name: user.target.name
+      ignore_above: 1024
+      level: core
+      multi_fields:
+      - flat_name: user.target.name.text
+        name: text
+        norms: false
+        type: text
+      name: name
+      normalize: []
+      original_fieldset: user
+      short: Short name or login of the user.
+      type: keyword
   group: 2
   name: user
   nestings:
+  - user.changes
+  - user.effective
   - user.group
+  - user.target
   prefix: user.
   reusable:
     expected:
@@ -9409,11 +9769,29 @@ user:
     - as: user
       at: source
       full: source.user
+    - as: target
+      at: user
+      full: user.target
+    - as: effective
+      at: user
+      full: user.effective
+    - as: changes
+      at: user
+      full: user.changes
     top_level: true
   reused_here:
   - full: user.group
     schema_name: group
     short: User's group relevant to the event.
+  - full: user.target
+    schema_name: user
+    short: Fields to describe the user relevant to the event.
+  - full: user.effective
+    schema_name: user
+    short: Fields to describe the user relevant to the event.
+  - full: user.changes
+    schema_name: user
+    short: Fields to describe the user relevant to the event.
   short: Fields to describe the user relevant to the event.
   title: User
   type: group

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2927,9 +2927,121 @@
         },
         "user": {
           "properties": {
+            "changes": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "domain": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "effective": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "email": {
               "ignore_above": 1024,
@@ -2978,6 +3090,62 @@
               },
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "email": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "full_name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "group": {
+                  "properties": {
+                    "domain": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2926,9 +2926,121 @@
       },
       "user": {
         "properties": {
+          "changes": {
+            "properties": {
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "email": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "group": {
+                "properties": {
+                  "domain": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "domain": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "effective": {
+            "properties": {
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "email": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "group": {
+                "properties": {
+                  "domain": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           },
           "email": {
             "ignore_above": 1024,
@@ -2977,6 +3089,62 @@
             },
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "target": {
+            "properties": {
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "email": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "full_name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "group": {
+                "properties": {
+                  "domain": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -18,15 +18,12 @@
       - host
       - server
       - source
-
-      # TODO Temporarily commented out to simplify initial rewrite review
-
-      # - at: user
-      #   as: target
-      # - at: user
-      #   as: effective
-      # - at: user
-      #   as: changes
+      - at: user
+        as: target
+      - at: user
+        as: effective
+      - at: user
+        as: changes
 
   type: group
   fields:


### PR DESCRIPTION
This PR implements the proposal discussed in #809. In short, we now reuse all `user` fields in 3 new places, in order to allow capturing more relevant users on a given event:

* `user.effective.*` is used to capture the effective user in cases of privilege escalation.
* `user.target.*` is used to capture a distinct user that is affected by an action, like IAM: Alice creates/suspends/deletes Bob.
* `user.changes.*` is used to capture the changes to an existing user. It's worth pointing out that only the attributes that change for the user are expected to be populated here.

For now this PR simply adds the fields. We don't yet have a good way to have either contextual definitions around field reuse, nor a place to document this via free form text, in the user page. This will come as a later addition.

I'm opening this PR in a straighforward manner, by directly introducing these fields. However I'm thinking this major addition is probably a good candidate to move through the RFC process.

What do you think @epixa @ebeahan @tsg?

Closes #809