### PR TITLE
Fix up generated go code for arrays

### DIFF
--- a/code/go/ecs/base.go
+++ b/code/go/ecs/base.go
@@ -35,7 +35,7 @@ type Base struct {
 	Timestamp time.Time `ecs:"@timestamp"`
 
 	// List of keywords used to tag each event.
-	Tags string `ecs:"tags"`
+	Tags []string `ecs:"tags"`
 
 	// Custom key/value pairs.
 	// Can be used to add meta information to events. Should not contain nested

--- a/code/go/ecs/container.go
+++ b/code/go/ecs/container.go
@@ -33,7 +33,7 @@ type Container struct {
 	ImageName string `ecs:"image.name"`
 
 	// Container image tags.
-	ImageTag string `ecs:"image.tag"`
+	ImageTag []string `ecs:"image.tag"`
 
 	// Container name.
 	Name string `ecs:"name"`

--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -45,7 +45,7 @@ type Dns struct {
 
 	// Array of 2 letter DNS header flags.
 	// Expected values are: AA, TC, RD, RA, AD, CD, DO.
-	HeaderFlags string `ecs:"header_flags"`
+	HeaderFlags []string `ecs:"header_flags"`
 
 	// The DNS response code.
 	ResponseCode string `ecs:"response_code"`
@@ -96,7 +96,7 @@ type Dns struct {
 	// answer objects must contain the `data` key. If more information is
 	// available, map as much of it to ECS as possible, and add any additional
 	// fields to the answer objects as custom fields.
-	Answers map[string]interface{} `ecs:"answers"`
+	Answers []map[string]interface{} `ecs:"answers"`
 
 	// The domain name to which this resource record pertains.
 	// If a chain of CNAME is being resolved, each answer's `name` should be
@@ -125,5 +125,5 @@ type Dns struct {
 	// data formats it can contain. Extracting all IP addresses seen in there
 	// to `dns.resolved_ip` makes it possible to index them as IP addresses,
 	// and makes them easier to visualize and query for.
-	ResolvedIP string `ecs:"resolved_ip"`
+	ResolvedIP []string `ecs:"resolved_ip"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -64,7 +64,7 @@ type Event struct {
 	// `event.type`, which is used as a subcategory.
 	// This field is an array. This will allow proper categorization of some
 	// events that fall in multiple categories.
-	Category string `ecs:"category"`
+	Category []string `ecs:"category"`
 
 	// The action captured by the event.
 	// This describes the information in the event. It is more specific than
@@ -96,7 +96,7 @@ type Event struct {
 	// down to a level appropriate for single visualization.
 	// This field is an array. This will allow proper categorization of some
 	// events that fall in multiple event types.
-	Type string `ecs:"type"`
+	Type []string `ecs:"type"`
 
 	// Name of the module this data is coming from.
 	// If your monitoring agent supports the concept of modules or plugins to

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -37,7 +37,7 @@ type File struct {
 	// Attributes names will vary by platform. Here's a non-exhaustive list of
 	// values that are expected in this field: archive, compressed, directory,
 	// encrypted, execute, hidden, read, readonly, system, write.
-	Attributes string `ecs:"attributes"`
+	Attributes []string `ecs:"attributes"`
 
 	// Directory where the file is located. It should include the drive letter,
 	// when appropriate.

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -42,10 +42,10 @@ type Host struct {
 	ID string `ecs:"id"`
 
 	// Host ip addresses.
-	IP string `ecs:"ip"`
+	IP []string `ecs:"ip"`
 
 	// Host mac addresses.
-	MAC string `ecs:"mac"`
+	MAC []string `ecs:"mac"`
 
 	// Type of host.
 	// For Cloud providers this can be the machine type like `t2.medium`. If

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -33,10 +33,10 @@ package ecs
 // observers in ECS.
 type Observer struct {
 	// MAC addresses of the observer
-	MAC string `ecs:"mac"`
+	MAC []string `ecs:"mac"`
 
 	// IP addresses of the observer.
-	IP string `ecs:"ip"`
+	IP []string `ecs:"ip"`
 
 	// Hostname of the observer.
 	Hostname string `ecs:"hostname"`

--- a/code/go/ecs/registry.go
+++ b/code/go/ecs/registry.go
@@ -43,7 +43,7 @@ type Registry struct {
 	// array will be variable length. For numeric data, such as REG_DWORD and
 	// REG_QWORD, this should be populated with the decimal representation (e.g
 	// `"1"`).
-	DataStrings string `ecs:"data.strings"`
+	DataStrings []string `ecs:"data.strings"`
 
 	// Original bytes written with base64 encoding.
 	// For Windows registry operations, such as SetValueEx and RegQueryValueEx,

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -29,13 +29,13 @@ package ecs
 // matter where it appeared, by querying `related.ip:192.0.2.15`.
 type Related struct {
 	// All of the IPs seen on your event.
-	IP string `ecs:"ip"`
+	IP []string `ecs:"ip"`
 
 	// All the user names seen on your event.
-	User string `ecs:"user"`
+	User []string `ecs:"user"`
 
 	// All the hashes seen on your event. Populating this field, then using it
 	// to search for hashes can help in situations where you're unsure what the
 	// hash algorithm is (and therefore which key name to search).
-	Hash string `ecs:"hash"`
+	Hash []string `ecs:"hash"`
 }

--- a/code/go/ecs/rule.go
+++ b/code/go/ecs/rule.go
@@ -60,7 +60,7 @@ type Rule struct {
 
 	// Name, organization, or pseudonym of the author or authors who created
 	// the rule used to generate this event.
-	Author string `ecs:"author"`
+	Author []string `ecs:"author"`
 
 	// Name of the license under which the rule used to generate this event is
 	// made available.

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -37,27 +37,27 @@ type Threat struct {
 	// Name of the type of tactic used by this threat. You can use a MITRE
 	// ATT&CK® tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/)
-	TacticName string `ecs:"tactic.name"`
+	TacticName []string `ecs:"tactic.name"`
 
 	// The id of tactic used by this threat. You can use a MITRE ATT&CK®
 	// tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
-	TacticID string `ecs:"tactic.id"`
+	TacticID []string `ecs:"tactic.id"`
 
 	// The reference url of tactic used by this threat. You can use a MITRE
 	// ATT&CK® tactic, for example. (ex.
 	// https://attack.mitre.org/tactics/TA0040/ )
-	TacticReference string `ecs:"tactic.reference"`
+	TacticReference []string `ecs:"tactic.reference"`
 
 	// The name of technique used by this threat. You can use a MITRE ATT&CK®
 	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
-	TechniqueName string `ecs:"technique.name"`
+	TechniqueName []string `ecs:"technique.name"`
 
 	// The id of technique used by this threat. You can use a MITRE ATT&CK®
 	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
-	TechniqueID string `ecs:"technique.id"`
+	TechniqueID []string `ecs:"technique.id"`
 
 	// The reference url of technique used by this threat. You can use a MITRE
 	// ATT&CK® technique, for example. (ex.
 	// https://attack.mitre.org/techniques/T1499/ )
-	TechniqueReference string `ecs:"technique.reference"`
+	TechniqueReference []string `ecs:"technique.reference"`
 }

--- a/code/go/ecs/tls.go
+++ b/code/go/ecs/tls.go
@@ -63,7 +63,7 @@ type Tls struct {
 	ClientServerName string `ecs:"client.server_name"`
 
 	// Array of ciphers offered by the client during the client hello.
-	ClientSupportedCiphers string `ecs:"client.supported_ciphers"`
+	ClientSupportedCiphers []string `ecs:"client.supported_ciphers"`
 
 	// Distinguished name of subject of the x.509 certificate presented by the
 	// client.
@@ -84,7 +84,7 @@ type Tls struct {
 	// offered by the client. This is usually mutually-exclusive of
 	// `client.certificate` since that value should be the first certificate in
 	// the chain.
-	ClientCertificateChain string `ecs:"client.certificate_chain"`
+	ClientCertificateChain []string `ecs:"client.certificate_chain"`
 
 	// PEM-encoded stand-alone certificate offered by the client. This is
 	// usually mutually-exclusive of `client.certificate_chain` since this
@@ -127,7 +127,7 @@ type Tls struct {
 	// offered by the server. This is usually mutually-exclusive of
 	// `server.certificate` since that value should be the first certificate in
 	// the chain.
-	ServerCertificateChain string `ecs:"server.certificate_chain"`
+	ServerCertificateChain []string `ecs:"server.certificate_chain"`
 
 	// PEM-encoded stand-alone certificate offered by the server. This is
 	// usually mutually-exclusive of `server.certificate_chain` since this

--- a/code/go/ecs/vulnerability.go
+++ b/code/go/ecs/vulnerability.go
@@ -69,7 +69,7 @@ type Vulnerability struct {
 	// (https://qualysguard.qualys.com/qwebhelp/fo_portal/knowledgebase/vulnerability_categories.htm[Qualys
 	// vulnerability categories])
 	// This field must be an array.
-	Category string `ecs:"category"`
+	Category []string `ecs:"category"`
 
 	// The description of the vulnerability that provides additional context of
 	// the vulnerability. For example

--- a/code/go/ecs/x509.go
+++ b/code/go/ecs/x509.go
@@ -45,22 +45,22 @@ type X509 struct {
 	IssuerDistinguishedName string `ecs:"issuer.distinguished_name"`
 
 	// List of common name (CN) of issuing certificate authority.
-	IssuerCommonName string `ecs:"issuer.common_name"`
+	IssuerCommonName []string `ecs:"issuer.common_name"`
 
 	// List of organizational units (OU) of issuing certificate authority.
-	IssuerOrganizationalUnit string `ecs:"issuer.organizational_unit"`
+	IssuerOrganizationalUnit []string `ecs:"issuer.organizational_unit"`
 
 	// List of organizations (O) of issuing certificate authority.
-	IssuerOrganization string `ecs:"issuer.organization"`
+	IssuerOrganization []string `ecs:"issuer.organization"`
 
 	// List of locality names (L)
-	IssuerLocality string `ecs:"issuer.locality"`
+	IssuerLocality []string `ecs:"issuer.locality"`
 
 	// List of state or province names (ST, S, or P)
-	IssuerStateOrProvince string `ecs:"issuer.state_or_province"`
+	IssuerStateOrProvince []string `ecs:"issuer.state_or_province"`
 
 	// List of country (C) codes
-	IssuerCountry string `ecs:"issuer.country"`
+	IssuerCountry []string `ecs:"issuer.country"`
 
 	// Identifier for certificate signature algorithm. Recommend using names
 	// found in Go Lang Crypto library (See
@@ -77,22 +77,22 @@ type X509 struct {
 	SubjectDistinguishedName string `ecs:"subject.distinguished_name"`
 
 	// List of common names (CN) of subject.
-	SubjectCommonName string `ecs:"subject.common_name"`
+	SubjectCommonName []string `ecs:"subject.common_name"`
 
 	// List of organizational units (OU) of subject.
-	SubjectOrganizationalUnit string `ecs:"subject.organizational_unit"`
+	SubjectOrganizationalUnit []string `ecs:"subject.organizational_unit"`
 
 	// List of organizations (O) of subject.
-	SubjectOrganization string `ecs:"subject.organization"`
+	SubjectOrganization []string `ecs:"subject.organization"`
 
 	// List of locality names (L)
-	SubjectLocality string `ecs:"subject.locality"`
+	SubjectLocality []string `ecs:"subject.locality"`
 
 	// List of state or province names (ST, S, or P)
-	SubjectStateOrProvince string `ecs:"subject.state_or_province"`
+	SubjectStateOrProvince []string `ecs:"subject.state_or_province"`
 
 	// List of country (C) code
-	SubjectCountry string `ecs:"subject.country"`
+	SubjectCountry []string `ecs:"subject.country"`
 
 	// Algorithm used to generate the public key.
 	PublicKeyAlgorithm string `ecs:"public_key_algorithm"`
@@ -110,5 +110,5 @@ type X509 struct {
 	// List of subject alternative names (SAN). Name types vary by certificate
 	// authority and certificate type but commonly contain IP addresses, DNS
 	// names (and wildcards), and email addresses.
-	AlternativeNames string `ecs:"alternative_names"`
+	AlternativeNames []string `ecs:"alternative_names"`
 }


### PR DESCRIPTION
I noticed recently when fixing up some packetbeat code that the generated structures for go don't respect array normalization--makes it so we have to do some gross stuff like this as a workaround right now:

```go
type ecsEvent struct {
	ecs.Event `ecs:",inline"`
	// overridden because this needs to be an array
	Category []string `ecs:"category"`
	// overridden because this needs to be an array
	Type []string `ecs:"type"`
}
```

I'll see about adding in some json/`common.MapStr` serializers at some point in a follow-up.