### PR TITLE
Update templates to reference RFC process

### DIFF
--- a/.github/ISSUE_TEMPLATE/schema-changes-additions.md
+++ b/.github/ISSUE_TEMPLATE/schema-changes-additions.md
@@ -1,11 +1,13 @@
 ---
-name: "Schema Changes and Additions"
-about: "Changes or additions to ECS."
+name: "Minor Schema Changes and Additions"
+about: "Minor changes or additions to ECS."
 labels: "enhancement"
 
 ---
 <!--
 Please first search existing issues for the changes you are requesting; it may already exist as an open issue.
+
+Substantial schema changes or additions should follow the RFC process: https://github.com/elastic/ecs/blob/master/rfcs/README.md
 
 Please fill in the following sections describing your proposed changes: -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ our submission, but they are here to help bring them to your attention.
 
 - Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
 - Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md)?
+- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/master/rfcs/README.md)?
 - If submitting code/script changes, have you verified all tests pass locally using `make test`?
 - If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
 - Is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.


### PR DESCRIPTION
Two GitHub template updates:

1. Add a link in the PR template to the RFC README.
2. Indicate the `schema-changes-additions` issue type is intended for smaller, less substantial schema changes.
