### PR TITLE
schemas/tracing.yml: add span.id

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -25,6 +25,7 @@ Thanks, you're awesome :-) -->
 * Added `x509.*` field set. (#762)
 * Added more account and project cloud metadata. (#816)
 * Added missing field reuse of `pe` at `process.parent.pe` #868
+* Added `span.id` to the tracing fieldset, for additional log correlation (#882)
 
 #### Improvements
 

--- a/code/go/ecs/tracing.go
+++ b/code/go/ecs/tracing.go
@@ -34,4 +34,9 @@ type Tracing struct {
 	// A transaction is the highest level of work measured within a service,
 	// such as a request to a server.
 	TransactionID string `ecs:"transaction.id"`
+
+	// Unique identifier of the span.
+	// A span represents an operation within a transaction, such as a request
+	// to another service, or a database query.
+	SpanID string `ecs:"span.id"`
 }

--- a/code/go/ecs/tracing.go
+++ b/code/go/ecs/tracing.go
@@ -30,12 +30,12 @@ type Tracing struct {
 	// services.
 	TraceID string `ecs:"trace.id"`
 
-	// Unique identifier of the transaction.
+	// Unique identifier of the transaction within the scope of its trace.
 	// A transaction is the highest level of work measured within a service,
 	// such as a request to a server.
 	TransactionID string `ecs:"transaction.id"`
 
-	// Unique identifier of the span.
+	// Unique identifier of the span within the scope of its trace.
 	// A span represents an operation within a transaction, such as a request
 	// to another service, or a database query.
 	SpanID string `ecs:"span.id"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5905,7 +5905,7 @@ Distributed tracing makes it possible to analyze performance throughout a micros
 // ===============================================================
 
 | span.id
-| Unique identifier of the span.
+| Unique identifier of the span within the scope of its trace.
 
 A span represents an operation within a transaction, such as a request to another service, or a database query.
 
@@ -5935,7 +5935,7 @@ example: `4bf92f3577b34da6a3ce929d0e0e4736`
 // ===============================================================
 
 | transaction.id
-| Unique identifier of the transaction.
+| Unique identifier of the transaction within the scope of its trace.
 
 A transaction is the highest level of work measured within a service, such as a request to a server.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5904,6 +5904,21 @@ Distributed tracing makes it possible to analyze performance throughout a micros
 
 // ===============================================================
 
+| span.id
+| Unique identifier of the span.
+
+A span represents an operation within a transaction, such as a request to another service, or a database query.
+
+type: keyword
+
+
+
+example: `3ff9a8981b7ccd5a`
+
+| extended
+
+// ===============================================================
+
 | trace.id
 | Unique identifier of the trace.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5099,6 +5099,16 @@
       - to queries made through multiple back-end services.
     type: group
     fields:
+    - name: span.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of the span.
+
+        A span represents an operation within a transaction, such as a request to
+        another service, or a database query.'
+      example: 3ff9a8981b7ccd5a
+      default_field: false
     - name: trace.id
       level: extended
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5103,7 +5103,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Unique identifier of the span.
+      description: 'Unique identifier of the span within the scope of its trace.
 
         A span represents an operation within a transaction, such as a request to
         another service, or a database query.'
@@ -5122,7 +5122,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Unique identifier of the transaction.
+      description: 'Unique identifier of the transaction within the scope of its trace.
 
         A transaction is the highest level of work measured within a service, such
         as a request to a server.'

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -523,6 +523,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span.
 1.6.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 1.6.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
 1.6.0-dev,true,threat,threat.tactic.name,keyword,extended,array,impact,Threat tactic.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -523,7 +523,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
-1.6.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span.
+1.6.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 1.6.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 1.6.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
 1.6.0-dev,true,threat,threat.tactic.name,keyword,extended,array,impact,Threat tactic.
@@ -610,7 +610,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.version,keyword,extended,,1.2,Numeric part of the version parsed from the original string.
 1.6.0-dev,true,tls,tls.version_protocol,keyword,extended,,tls,Normalized lowercase protocol name parsed from original string.
 1.6.0-dev,true,trace,trace.id,keyword,extended,,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
-1.6.0-dev,true,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction.
+1.6.0-dev,true,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction within the scope of its trace.
 1.6.0-dev,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 1.6.0-dev,true,url,url.extension,keyword,extended,,png,File extension from the original request url.
 1.6.0-dev,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6683,6 +6683,20 @@ source.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+span.id:
+  dashed_name: span-id
+  description: 'Unique identifier of the span.
+
+    A span represents an operation within a transaction, such as a request to another
+    service, or a database query.'
+  example: 3ff9a8981b7ccd5a
+  flat_name: span.id
+  ignore_above: 1024
+  level: extended
+  name: span.id
+  normalize: []
+  short: Unique identifier of the span.
+  type: keyword
 tags:
   dashed_name: tags
   description: List of keywords used to tag each event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6685,7 +6685,7 @@ source.user.name:
   type: keyword
 span.id:
   dashed_name: span-id
-  description: 'Unique identifier of the span.
+  description: 'Unique identifier of the span within the scope of its trace.
 
     A span represents an operation within a transaction, such as a request to another
     service, or a database query.'
@@ -6695,7 +6695,7 @@ span.id:
   level: extended
   name: span.id
   normalize: []
-  short: Unique identifier of the span.
+  short: Unique identifier of the span within the scope of its trace.
   type: keyword
 tags:
   dashed_name: tags
@@ -7800,7 +7800,7 @@ trace.id:
   type: keyword
 transaction.id:
   dashed_name: transaction-id
-  description: 'Unique identifier of the transaction.
+  description: 'Unique identifier of the transaction within the scope of its trace.
 
     A transaction is the highest level of work measured within a service, such as
     a request to a server.'
@@ -7810,7 +7810,7 @@ transaction.id:
   level: extended
   name: transaction.id
   normalize: []
-  short: Unique identifier of the transaction.
+  short: Unique identifier of the transaction within the scope of its trace.
   type: keyword
 url.domain:
   dashed_name: url-domain

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8993,6 +8993,20 @@ tracing:
     of the requests - from the initial web request in the front-end service - to queries
     made through multiple back-end services.
   fields:
+    span.id:
+      dashed_name: span-id
+      description: 'Unique identifier of the span.
+
+        A span represents an operation within a transaction, such as a request to
+        another service, or a database query.'
+      example: 3ff9a8981b7ccd5a
+      flat_name: span.id
+      ignore_above: 1024
+      level: extended
+      name: span.id
+      normalize: []
+      short: Unique identifier of the span.
+      type: keyword
     trace.id:
       dashed_name: trace-id
       description: 'Unique identifier of the trace.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8995,7 +8995,7 @@ tracing:
   fields:
     span.id:
       dashed_name: span-id
-      description: 'Unique identifier of the span.
+      description: 'Unique identifier of the span within the scope of its trace.
 
         A span represents an operation within a transaction, such as a request to
         another service, or a database query.'
@@ -9005,7 +9005,7 @@ tracing:
       level: extended
       name: span.id
       normalize: []
-      short: Unique identifier of the span.
+      short: Unique identifier of the span within the scope of its trace.
       type: keyword
     trace.id:
       dashed_name: trace-id
@@ -9023,7 +9023,7 @@ tracing:
       type: keyword
     transaction.id:
       dashed_name: transaction-id
-      description: 'Unique identifier of the transaction.
+      description: 'Unique identifier of the transaction within the scope of its trace.
 
         A transaction is the highest level of work measured within a service, such
         as a request to a server.'
@@ -9033,7 +9033,7 @@ tracing:
       level: extended
       name: transaction.id
       normalize: []
-      short: Unique identifier of the transaction.
+      short: Unique identifier of the transaction within the scope of its trace.
       type: keyword
   group: 2
   name: tracing

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2482,6 +2482,14 @@
             }
           }
         },
+        "span": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
         "tags": {
           "ignore_above": 1024,
           "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2481,6 +2481,14 @@
           }
         }
       },
+      "span": {
+        "properties": {
+          "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
       "tags": {
         "ignore_above": 1024,
         "type": "keyword"

--- a/schemas/tracing.yml
+++ b/schemas/tracing.yml
@@ -29,3 +29,13 @@
         Unique identifier of the transaction.
 
         A transaction is the highest level of work measured within a service, such as a request to a server.
+
+    - name: span.id
+      level: extended
+      type: keyword
+      example: 3ff9a8981b7ccd5a
+      short: Unique identifier of the span.
+      description: >
+        Unique identifier of the span.
+
+        A span represents an operation within a transaction, such as a request to another service, or a database query.

--- a/schemas/tracing.yml
+++ b/schemas/tracing.yml
@@ -24,9 +24,9 @@
       level: extended
       type: keyword
       example: 00f067aa0ba902b7
-      short: Unique identifier of the transaction.
+      short: Unique identifier of the transaction within the scope of its trace.
       description: >
-        Unique identifier of the transaction.
+        Unique identifier of the transaction within the scope of its trace.
 
         A transaction is the highest level of work measured within a service, such as a request to a server.
 
@@ -34,8 +34,8 @@
       level: extended
       type: keyword
       example: 3ff9a8981b7ccd5a
-      short: Unique identifier of the span.
+      short: Unique identifier of the span within the scope of its trace.
       description: >
-        Unique identifier of the span.
+        Unique identifier of the span within the scope of its trace.
 
         A span represents an operation within a transaction, such as a request to another service, or a database query.


### PR DESCRIPTION
Add `span.id` to the tracing fields. This field may be useful for correlating logs with more specific operations, or where `transaction.id` is unavailable.

The `transaction.id` field is not always available for trace data received from other tracing systems, such as Jaeger and OpenTelemetry. We are guaranteed to have `trace.id` and `span.id`, but not necessarily `transaction.id`. Correlating logs with an entire trace (via `trace.id`) may result in too broad a set of results, compared to correlating with `span.id`.