### PR TITLE
Improvements for the RFC template, and adjustments to existing RFCs.

### DIFF
--- a/rfcs/0000-rfc-template.md
+++ b/rfcs/0000-rfc-template.md
@@ -93,3 +93,19 @@ e.g.:
 * @JaneDoe | grammar, spelling, prose
 * @Mariana
 -->
+
+
+## References
+
+<!-- Insert any links appropriate to this RFC in this section. -->
+
+### RFC Pull Requests
+
+<!-- An RFC should link to the PRs for each of it stage advancements. -->
+
+* Stage 0: https://github.com/elastic/ecs/pull/NNN
+
+<!--
+* Stage 1: https://github.com/elastic/ecs/pull/NNN
+...
+-->

--- a/rfcs/0000-rfc-template.md
+++ b/rfcs/0000-rfc-template.md
@@ -1,8 +1,8 @@
 # 0000: Name of RFC
-<!--^ The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC, taking care not to conflict with other RFCs.-->
+<!-- Leave this ID at 0000. The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC. -->
 
-- Stage: **0 (strawperson)** <!-- Update to reflect target stage -->
-- Date: **TBD** <!-- Update to reflect date of most recent stage advancement -->
+- Stage: **0 (strawperson)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
+- Date: **TBD** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
 
 <!--
 Stage 0: Provide a high level summary of the premise of these changes. Briefly describe the nature, purpose, and impact of the changes. ~2-5 sentences.

--- a/rfcs/text/0001-wildcard-data-type.md
+++ b/rfcs/text/0001-wildcard-data-type.md
@@ -152,3 +152,19 @@ The following are the people that consulted on the contents of this RFC.
 * [0] Wildcard queries on `text` fields are limited to matching individual tokens rather than the original value of the field.
 * [1] Keyword fields are not tokenized like `text` fields, so patterns can match multiple words. However they suffer from slow performance with wildcard searching (especially with leading wildcards).
 * [2] https://github.com/elastic/elasticsearch/pull/58483
+
+
+## References
+
+<!-- Insert any links appropriate to this RFC in this section. -->
+
+### RFC Pull Requests
+
+<!-- An RFC should link to the PRs for each of it stage advancements. -->
+
+* Stage 0: https://github.com/elastic/ecs/pull/890
+
+<!--
+* Stage 1: https://github.com/elastic/ecs/pull/NNN
+...
+-->

--- a/rfcs/text/0002-rfc-environment.md
+++ b/rfcs/text/0002-rfc-environment.md
@@ -113,7 +113,7 @@ Observability: data produced by the infrastruture and application layers. Data t
 Security: security data should also benefit of specifying the `environment` from which they are emitted to offer filtering (SIEM...) on Elastic cluster spreading across multiple environments (e.g. "production" and "staging").
 
 
-Logs are typically being collected by Filebeat, metrics are collected by Metricbeat, 
+Logs are typically being collected by Filebeat, metrics are collected by Metricbeat,
 <!--
 Stage 1: Provide a high-level description of example sources of data. This does not yet need to be a concrete example of a source document, but instead can simply describe a potential source (e.g. nginx access log). This will ultimately be fleshed out to include literal source examples in a future stage. The goal here is to identify practical sources for these fields in the real world. ~1-3 sentences or unordered list.
 -->
@@ -157,7 +157,7 @@ The goal here is to research and understand the impact of these changes on users
     * https://github.com/elastic/ecs/issues/268 Add new top level field "environment" #268
     * https://github.com/elastic/ecs/issues/704 New field: organization.environment #704
     * https://github.com/elastic/ecs/issues/143 agent.environment and service.environment #143
- 
+
 <!--
 Stage 1: Identify potential concerns, implementation challenges, or complexity. Spend some time on this. Play devil's advocate. Try to identify the sort of non-obvious challenges that tend to surface later. The goal here is to surface risks early, allow everyone the time to work through them, and ultimately document resolution for posterity's sake.
 -->
@@ -233,3 +233,19 @@ logging.level: info
 * ? | sponsor
 * @roncohen | subject matter expert
 * ? | grammar, spelling, prose
+
+
+## References
+
+<!-- Insert any links appropriate to this RFC in this section. -->
+
+### RFC Pull Requests
+
+<!-- An RFC should link to the PRs for each of it stage advancements. -->
+
+* Stage 0: https://github.com/elastic/ecs/pull/891
+
+<!--
+* Stage 1: https://github.com/elastic/ecs/pull/NNN
+...
+-->

--- a/rfcs/text/0003-object-field.md
+++ b/rfcs/text/0003-object-field.md
@@ -116,3 +116,19 @@ e.g.:
 * @JaneDoe | grammar, spelling, prose
 * @Mariana
 -->
+
+
+## References
+
+<!-- Insert any links appropriate to this RFC in this section. -->
+
+### RFC Pull Requests
+
+<!-- An RFC should link to the PRs for each of it stage advancements. -->
+
+* Stage 0: https://github.com/elastic/ecs/pull/883
+
+<!--
+* Stage 1: https://github.com/elastic/ecs/pull/NNN
+...
+-->


### PR DESCRIPTION
This PR:

* clarifies instructions around the ID and the date at the top of an RFC
* adds a "References" section at the very end of the RFC template. This section is meant to collect all links relevant to the RFC. It also contains a subsection for RFCs to link to each of their stage PRs.
* adjusts the 3 merged RFCs to link to their stage 0 PR.