### PR TITLE
Add event.reason field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -26,6 +26,7 @@ Thanks, you're awesome :-) -->
 * Added more account and project cloud metadata. (#816)
 * Added missing field reuse of `pe` at `process.parent.pe` #868
 * Added `span.id` to the tracing fieldset, for additional log correlation (#882)
+* Added `event.reason` for the reason why an event's outcome or action was taken. #907
 
 #### Improvements
 

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -207,4 +207,12 @@ type Event struct {
 	// specific occurence of this event can take place. Alert events, indicated
 	// by `event.kind:alert`, are a common use case for this field.
 	Url string `ecs:"url"`
+
+	// The reason captured by the event.
+	// This describes the why of a particular action or outcome captured in the
+	// event. Where `event.action` captures the action from the event,
+	// `event.reason` describes why that action was taken. For example, a web
+	// proxy with an `event.action` which denied the request may also populate
+	// `event.reason` with the reason why (e.g. `blocked site`).
+	Reason string `ecs:"reason"`
 }

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -208,7 +208,7 @@ type Event struct {
 	// by `event.kind:alert`, are a common use case for this field.
 	Url string `ecs:"url"`
 
-	// The reason captured by the event.
+	// Reason why this event happened, according to the source.
 	// This describes the why of a particular action or outcome captured in the
 	// event. Where `event.action` captures the action from the event,
 	// `event.reason` describes why that action was taken. For example, a web

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1777,17 +1777,11 @@ example: `kernel`
 // ===============================================================
 
 | event.reason
-| The reason captured by the event.
+| Reason why this event happened, according to the source.
 
 This describes the why of a particular action or outcome captured in the event. Where `event.action` captures the action from the event, `event.reason` describes why that action was taken. For example, a web proxy with an `event.action` which denied the request may also populate `event.reason` with the reason why (e.g. `blocked site`).
 
 type: keyword
-
-Multi-fields:
-
-* event.reason.text (type: text)
-
-
 
 
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1776,6 +1776,27 @@ example: `kernel`
 
 // ===============================================================
 
+| event.reason
+| The reason captured by the event.
+
+This describes the why of a particular action or outcome captured in the event. Where `event.action` captures the action from the event, `event.reason` describes why that action was taken. For example, a web proxy with an `event.action` which denied the request may also populate `event.reason` with the reason why (e.g. `blocked site`).
+
+type: keyword
+
+Multi-fields:
+
+* event.reason.text (type: text)
+
+
+
+
+
+example: `Terminated an unexpected process`
+
+| extended
+
+// ===============================================================
+
 | event.reference
 | Reference URL linking to additional information about this event.
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1354,11 +1354,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      multi_fields:
-      - name: text
-        type: text
-        norms: false
-      description: 'The reason captured by the event.
+      description: 'Reason why this event happened, according to the source.
 
         This describes the why of a particular action or outcome captured in the event.
         Where `event.action` captures the action from the event, `event.reason` describes

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1350,6 +1350,23 @@
         the event (e.g. Sysmon, httpd), or of a subsystem of the operating system
         (kernel, Microsoft-Windows-Security-Auditing).'
       example: kernel
+    - name: reason
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'The reason captured by the event.
+
+        This describes the why of a particular action or outcome captured in the event.
+        Where `event.action` captures the action from the event, `event.reason` describes
+        why that action was taken. For example, a web proxy with an `event.action`
+        which denied the request may also populate `event.reason` with the reason
+        why (e.g. `blocked site`).'
+      example: Terminated an unexpected process
+      default_field: false
     - name: reference
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -149,6 +149,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 1.6.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 1.6.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
+1.6.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,The reason captured by the event
+1.6.0-dev,true,event,event.reason.text,text,extended,,Terminated an unexpected process,The reason captured by the event
 1.6.0-dev,true,event,event.reference,keyword,extended,,https://system.vendor.com/event/#0001234,Event reference URL
 1.6.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.6.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -149,8 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 1.6.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 1.6.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
-1.6.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,The reason captured by the event
-1.6.0-dev,true,event,event.reason.text,text,extended,,Terminated an unexpected process,The reason captured by the event
+1.6.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"
 1.6.0-dev,true,event,event.reference,keyword,extended,,https://system.vendor.com/event/#0001234,Event reference URL
 1.6.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.6.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2053,6 +2053,28 @@ event.provider:
   normalize: []
   short: Source of the event.
   type: keyword
+event.reason:
+  dashed_name: event-reason
+  description: 'The reason captured by the event.
+
+    This describes the why of a particular action or outcome captured in the event.
+    Where `event.action` captures the action from the event, `event.reason` describes
+    why that action was taken. For example, a web proxy with an `event.action` which
+    denied the request may also populate `event.reason` with the reason why (e.g.
+    `blocked site`).'
+  example: Terminated an unexpected process
+  flat_name: event.reason
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: event.reason.text
+    name: text
+    norms: false
+    type: text
+  name: reason
+  normalize: []
+  short: The reason captured by the event
+  type: keyword
 event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2055,7 +2055,7 @@ event.provider:
   type: keyword
 event.reason:
   dashed_name: event-reason
-  description: 'The reason captured by the event.
+  description: 'Reason why this event happened, according to the source.
 
     This describes the why of a particular action or outcome captured in the event.
     Where `event.action` captures the action from the event, `event.reason` describes
@@ -2066,14 +2066,9 @@ event.reason:
   flat_name: event.reason
   ignore_above: 1024
   level: extended
-  multi_fields:
-  - flat_name: event.reason.text
-    name: text
-    norms: false
-    type: text
   name: reason
   normalize: []
-  short: The reason captured by the event
+  short: Reason why this event happened, according to the source
   type: keyword
 event.reference:
   dashed_name: event-reference

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2452,7 +2452,7 @@ event:
       type: keyword
     event.reason:
       dashed_name: event-reason
-      description: 'The reason captured by the event.
+      description: 'Reason why this event happened, according to the source.
 
         This describes the why of a particular action or outcome captured in the event.
         Where `event.action` captures the action from the event, `event.reason` describes
@@ -2463,14 +2463,9 @@ event:
       flat_name: event.reason
       ignore_above: 1024
       level: extended
-      multi_fields:
-      - flat_name: event.reason.text
-        name: text
-        norms: false
-        type: text
       name: reason
       normalize: []
-      short: The reason captured by the event
+      short: Reason why this event happened, according to the source
       type: keyword
     event.reference:
       dashed_name: event-reference

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2450,6 +2450,28 @@ event:
       normalize: []
       short: Source of the event.
       type: keyword
+    event.reason:
+      dashed_name: event-reason
+      description: 'The reason captured by the event.
+
+        This describes the why of a particular action or outcome captured in the event.
+        Where `event.action` captures the action from the event, `event.reason` describes
+        why that action was taken. For example, a web proxy with an `event.action`
+        which denied the request may also populate `event.reason` with the reason
+        why (e.g. `blocked site`).'
+      example: Terminated an unexpected process
+      flat_name: event.reason
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: event.reason.text
+        name: text
+        norms: false
+        type: text
+      name: reason
+      normalize: []
+      short: The reason captured by the event
+      type: keyword
     event.reference:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -726,6 +726,16 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "reason": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "reference": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -727,12 +727,6 @@
               "type": "keyword"
             },
             "reason": {
-              "fields": {
-                "text": {
-                  "norms": false,
-                  "type": "text"
-                }
-              },
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -726,12 +726,6 @@
             "type": "keyword"
           },
           "reason": {
-            "fields": {
-              "text": {
-                "norms": false,
-                "type": "text"
-              }
-            },
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -725,6 +725,16 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "reason": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "reference": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -704,3 +704,19 @@
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
       example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+
+    - name: reason
+      level: extended
+      type: keyword
+      short: The reason captured by the event
+      description: >
+        The reason captured by the event.
+
+        This describes the why of a particular action or outcome captured in the event. Where
+        `event.action` captures the action from the event, `event.reason` describes why that action
+        was taken. For example, a web proxy with an `event.action` which denied the request may also
+        populate `event.reason` with the reason why (e.g. `blocked site`).
+      example: "Terminated an unexpected process"
+      multi_fields:
+      - type: text
+        name: text

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -708,9 +708,9 @@
     - name: reason
       level: extended
       type: keyword
-      short: The reason captured by the event
+      short: Reason why this event happened, according to the source
       description: >
-        The reason captured by the event.
+        Reason why this event happened, according to the source.
 
         This describes the why of a particular action or outcome captured in the event. Where
         `event.action` captures the action from the event, `event.reason` describes why that action

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -717,6 +717,3 @@
         was taken. For example, a web proxy with an `event.action` which denied the request may also
         populate `event.reason` with the reason why (e.g. `blocked site`).
       example: "Terminated an unexpected process"
-      multi_fields:
-      - type: text
-        name: text


### PR DESCRIPTION
**Summary**

Adds a new field under `event.*`, `event.reason`, which provides a location to capture the reason _why_ an event occurred.

**Example usage**

* A web proxy event shows a denied connection request. `event.action:"request-denied"` describes the action captured and why the action took place is captured in `event.reason:"Blocked site: example.com"`
* An endpoint agent terminates a process on a host system. `event.action:"process-terminated" with reason describing why as `event.reason:"Terminated an unexpected process"` 

**Discussion Points**

Two items I wanted to call to attention: 

1. `event.reason` is currently defined as `type: extended`. This felt most appropriate starting off.
2. A `text` multi-field is included. `event.reason` could possibly hold a longer string (e.g. `File Sharing site URL blocked`).

Closes #613 