### PR TITLE
[DOCS] Fixes SIEM links

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -5,8 +5,8 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 
 * {beats-ref}/beats-reference.html[{beats}]
 * {apm-get-started-ref}/overview.html[APM]
-* {siem-guide}/siem-overview.html[Elastic SIEM app]
-** {siem-guide}/siem-field-reference.html[SIEM Field Reference Guide] - a list of ECS fields used in the SIEM app
+* {security-guide}/siem-overview.html[Elastic SIEM app]
+** {security-guide}/siem-field-reference.html[SIEM Field Reference Guide] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
 * {logs-guide}/logs-app-overview.html[Logs app]

--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -5,7 +5,7 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 
 * {beats-ref}/beats-reference.html[{beats}]
 * {apm-get-started-ref}/overview.html[APM]
-* {security-guide}/siem-overview.html[Elastic SIEM app]
+* {security-guide}/es-overview.html[Elastic Security app]
 ** {security-guide}/siem-field-reference.html[SIEM Field Reference Guide] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]

--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -5,11 +5,11 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 
 * {beats-ref}/beats-reference.html[{beats}]
 * {apm-get-started-ref}/overview.html[APM]
-* {security-guide}/es-overview.html[Elastic Security app]
-** {security-guide}/siem-field-reference.html[SIEM Field Reference Guide] - a list of ECS fields used in the SIEM app
+* {security-guide}/es-overview.html[Elastic Security]
+** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
-* {logs-guide}/logs-app-overview.html[Logs app]
+* {logs-guide}/logs-app-overview.html[Logs UI]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 

--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -9,7 +9,7 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
-* {logs-guide}/logs-app-overview.html[Logs UI]
+* {logs-guide}/logs-app-overview.html[Logs Monitoring]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 

--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,5 +285,5 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-* {logs-guide}/logs-fields-reference.html[Logs UI fields reference]
-* {security-guide}/siem-field-reference.html[Elastic Security fields reference]
+* {logs-guide}/logs-fields-reference.html[Logs Monitoring Field Reference]
+* {security-guide}/siem-field-reference.html[Elastic Security Field Reference]

--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,5 +285,5 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-* https://www.elastic.co/guide/en/logs/guide/current/logs-fields-reference.html[Logs UI fields reference]
-* https://www.elastic.co/guide/en/security/master/siem-field-reference.html[Elastic Security fields reference]
+* {logs-guide}/logs-fields-reference.html[Logs UI fields reference]
+* {security-guide}/siem-field-reference.html[Elastic Security fields reference]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1932

This PR addresses the following links that will be broken when "current" shifts to the 7.9 documentation branch:

````
13:54:52 INFO:build_docs:Bad cross-document links:
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.3/ecs-products-solutions.html:
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-overview.html
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.4/ecs-products-solutions.html:
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-overview.html
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.5/ecs-products-solutions.html:
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-overview.html
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/current/ecs-products-solutions.html:
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-overview.html
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/master/ecs-products-solutions.html:
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-field-reference.html
13:54:52 INFO:build_docs:   - en/siem/guide/7.9/siem-overview.html
````

This needs to be applied to the following branches on release day:

- [ ] master #908
- [ ] 1.x #936
- [ ] 1.6 #926
- [ ] 1.5 #911 
- [ ] 1.4 #912
- [ ] 1.3 #927

