### PR TITLE
Use appropriate reserved domain for example URLs

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,6 +40,7 @@ Thanks, you're awesome :-) -->
   `log.syslog`, `network.inner`, `observer.egress`, and `observer.ingress`. #871
 * Improved attribute `dashed_name` in `generated/ecs/*.yml` to also
   replace `@` with `-`. #871
+* Updated several URLs in the documentation with appropriate special-use domain. #910
 
 #### Deprecated
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,7 +40,7 @@ Thanks, you're awesome :-) -->
   `log.syslog`, `network.inner`, `observer.egress`, and `observer.ingress`. #871
 * Improved attribute `dashed_name` in `generated/ecs/*.yml` to also
   replace `@` with `-`. #871
-* Updated several URLs in the documentation with appropriate special-use domain. #910
+* Updated several URLs in the documentation with "example.com" domain. #910
 
 #### Deprecated
 

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -53,7 +53,8 @@ type Client struct {
 	Domain string `ecs:"domain"`
 
 	// The highest registered client domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -62,7 +63,7 @@ type Client struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -42,7 +42,8 @@ type Destination struct {
 	Domain string `ecs:"domain"`
 
 	// The highest registered destination domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -51,7 +52,7 @@ type Destination struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/code/go/ecs/dns.go
+++ b/code/go/ecs/dns.go
@@ -65,7 +65,8 @@ type Dns struct {
 	QuestionClass string `ecs:"question.class"`
 
 	// The highest registered domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -74,7 +75,7 @@ type Dns struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -204,8 +204,8 @@ type Event struct {
 	// URL linking to an external system to continue investigation of this
 	// event.
 	// This URL links to another system where in-depth investigation of the
-	// specific occurence of this event can take place. Alert events, indicated
-	// by `event.kind:alert`, are a common use case for this field.
+	// specific occurrence of this event can take place. Alert events,
+	// indicated by `event.kind:alert`, are a common use case for this field.
 	Url string `ecs:"url"`
 
 	// Reason why this event happened, according to the source.

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -53,7 +53,8 @@ type Server struct {
 	Domain string `ecs:"domain"`
 
 	// The highest registered server domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -62,7 +63,7 @@ type Server struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -42,7 +42,8 @@ type Source struct {
 	Domain string `ecs:"domain"`
 
 	// The highest registered source domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -51,7 +52,7 @@ type Source struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -45,7 +45,8 @@ type Url struct {
 	Domain string `ecs:"domain"`
 
 	// The highest registered url domain, stripped of the subdomain.
-	// For example, the registered domain for "foo.google.com" is "google.com".
+	// For example, the registered domain for "foo.example.com" is
+	// "example.com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last two labels will not work well for TLDs such as
@@ -54,7 +55,7 @@ type Url struct {
 
 	// The effective top level domain (eTLD), also known as the domain suffix,
 	// is the last part of the domain name. For example, the top level domain
-	// for google.com is "com".
+	// for example.com is "com".
 	// This value can be determined precisely with a list like the public
 	// suffix list (http://publicsuffix.org). Trying to approximate this by
 	// simply taking the last label will not work well for effective TLDs such

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -389,7 +389,7 @@ type: long
 | client.registered_domain
 | The highest registered client domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -397,14 +397,14 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
 // ===============================================================
 
 | client.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -942,7 +942,7 @@ type: long
 | destination.registered_domain
 | The highest registered destination domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -950,14 +950,14 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
 // ===============================================================
 
 | destination.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -1168,7 +1168,7 @@ type: keyword
 
 
 
-example: `www.google.com`
+example: `www.example.com`
 
 | extended
 
@@ -1266,7 +1266,7 @@ type: keyword
 
 
 
-example: `www.google.com`
+example: `www.example.com`
 
 | extended
 
@@ -1275,7 +1275,7 @@ example: `www.google.com`
 | dns.question.registered_domain
 | The highest registered domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -1283,7 +1283,7 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
@@ -1305,7 +1305,7 @@ example: `www`
 // ===============================================================
 
 | dns.question.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -4943,7 +4943,7 @@ type: long
 | server.registered_domain
 | The highest registered server domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -4951,14 +4951,14 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
 // ===============================================================
 
 | server.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -5278,7 +5278,7 @@ type: long
 | source.registered_domain
 | The highest registered source domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -5286,14 +5286,14 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
 // ===============================================================
 
 | source.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -6125,7 +6125,7 @@ type: keyword
 | url.registered_domain
 | The highest registered url domain, stripped of the subdomain.
 
-For example, the registered domain for "foo.google.com" is "google.com".
+For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
@@ -6133,7 +6133,7 @@ type: keyword
 
 
 
-example: `google.com`
+example: `example.com`
 
 | extended
 
@@ -6155,7 +6155,7 @@ example: `https`
 // ===============================================================
 
 | url.top_level_domain
-| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com".
+| The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk".
 
@@ -6718,7 +6718,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `DigiCert SHA2 High Assurance Server CA`
+example: `Example SHA2 High Assurance Server CA`
 
 | extended
 
@@ -6747,7 +6747,7 @@ type: keyword
 
 
 
-example: `C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA`
+example: `C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA`
 
 | extended
 
@@ -6779,7 +6779,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `DigiCert Inc`
+example: `Example Inc`
 
 | extended
 
@@ -6795,7 +6795,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `www.digicert.com`
+example: `www.example.com`
 
 | extended
 
@@ -6931,7 +6931,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `r2.shared.global.fastly.net`
+example: `shared.global.example.net`
 
 | extended
 
@@ -6960,7 +6960,7 @@ type: keyword
 
 
 
-example: `C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net`
+example: `C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net`
 
 | extended
 
@@ -6992,7 +6992,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `Fastly, Inc.`
+example: `Example, Inc.`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1800,7 +1800,7 @@ type: keyword
 
 
 
-example: `https://system.vendor.com/event/#0001234`
+example: `https://system.example.com/event/#0001234`
 
 | extended
 
@@ -1930,7 +1930,7 @@ type: keyword
 
 
 
-example: `https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
+example: `https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5577,7 +5577,7 @@ type: keyword
 
 
 
-example: `CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com`
+example: `CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com`
 
 | extended
 
@@ -5642,7 +5642,7 @@ type: keyword
 
 
 
-example: `CN=myclient, OU=Documentation Team, DC=mydomain, DC=com`
+example: `CN=myclient, OU=Documentation Team, DC=example, DC=com`
 
 | extended
 
@@ -5791,7 +5791,7 @@ type: keyword
 
 
 
-example: `CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com`
+example: `CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com`
 
 | extended
 
@@ -5843,7 +5843,7 @@ type: keyword
 
 
 
-example: `CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com`
+example: `CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1924,7 +1924,7 @@ To learn more about when to use which value, visit the page
 | event.url
 | URL linking to an external system to continue investigation of this event.
 
-This URL links to another system where in-depth investigation of the specific occurence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+This URL links to another system where in-depth investigation of the specific occurrence of this event can take place. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1371,7 +1371,7 @@
 
         This URL links to a static definition of the this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
-      example: https://system.vendor.com/event/#0001234
+      example: https://system.example.com/event/#0001234
       default_field: false
     - name: risk_score
       level: core
@@ -1447,7 +1447,7 @@
         This URL links to another system where in-depth investigation of the specific
         occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
-      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       default_field: false
   - name: file
     title: File

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -296,19 +296,19 @@
       ignore_above: 1024
       description: 'The highest registered client domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: top_level_domain
       level: extended
       type: keyword
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -690,19 +690,19 @@
       ignore_above: 1024
       description: 'The highest registered destination domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: top_level_domain
       level: extended
       type: keyword
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -972,7 +972,7 @@
         If a chain of CNAME is being resolved, each answer''s `name` should be the
         one that corresponds with the answer''s `data`. It should not simply be the
         original `question.name` repeated.'
-      example: www.google.com
+      example: www.example.com
     - name: answers.ttl
       level: extended
       type: long
@@ -1027,19 +1027,19 @@
         those characters should be represented as escaped base 10 integers (\DDD).
         Back slashes and quotes should be escaped. Tabs, carriage returns, and line
         feeds should be converted to \t, \r, and \n respectively.'
-      example: www.google.com
+      example: www.example.com
     - name: question.registered_domain
       level: extended
       type: keyword
       ignore_above: 1024
       description: 'The highest registered domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: question.subdomain
       level: extended
       type: keyword
@@ -1055,7 +1055,7 @@
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -1739,7 +1739,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       default_field: false
     - name: x509.issuer.country
       level: extended
@@ -1753,7 +1753,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       default_field: false
     - name: x509.issuer.locality
@@ -1768,14 +1768,14 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       default_field: false
     - name: x509.issuer.organizational_unit
       level: extended
       type: keyword
       ignore_above: 1024
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       default_field: false
     - name: x509.issuer.state_or_province
       level: extended
@@ -1846,7 +1846,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       default_field: false
     - name: x509.subject.country
       level: extended
@@ -1860,7 +1860,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
     - name: x509.subject.locality
       level: extended
@@ -1874,7 +1874,7 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       default_field: false
     - name: x509.subject.organizational_unit
       level: extended
@@ -4054,19 +4054,19 @@
       ignore_above: 1024
       description: 'The highest registered server domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: top_level_domain
       level: extended
       type: keyword
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -4363,19 +4363,19 @@
       ignore_above: 1024
       description: 'The highest registered source domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: top_level_domain
       level: extended
       type: keyword
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -4649,7 +4649,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       default_field: false
     - name: client.x509.issuer.country
       level: extended
@@ -4663,7 +4663,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       default_field: false
     - name: client.x509.issuer.locality
@@ -4678,14 +4678,14 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       default_field: false
     - name: client.x509.issuer.organizational_unit
       level: extended
       type: keyword
       ignore_above: 1024
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       default_field: false
     - name: client.x509.issuer.state_or_province
       level: extended
@@ -4756,7 +4756,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       default_field: false
     - name: client.x509.subject.country
       level: extended
@@ -4770,7 +4770,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
     - name: client.x509.subject.locality
       level: extended
@@ -4784,7 +4784,7 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       default_field: false
     - name: client.x509.subject.organizational_unit
       level: extended
@@ -4932,7 +4932,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       default_field: false
     - name: server.x509.issuer.country
       level: extended
@@ -4946,7 +4946,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       default_field: false
     - name: server.x509.issuer.locality
@@ -4961,14 +4961,14 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       default_field: false
     - name: server.x509.issuer.organizational_unit
       level: extended
       type: keyword
       ignore_above: 1024
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       default_field: false
     - name: server.x509.issuer.state_or_province
       level: extended
@@ -5039,7 +5039,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       default_field: false
     - name: server.x509.subject.country
       level: extended
@@ -5053,7 +5053,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
     - name: server.x509.subject.locality
       level: extended
@@ -5067,7 +5067,7 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       default_field: false
     - name: server.x509.subject.organizational_unit
       level: extended
@@ -5237,12 +5237,12 @@
       ignore_above: 1024
       description: 'The highest registered url domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
     - name: scheme
       level: extended
       type: keyword
@@ -5257,7 +5257,7 @@
       ignore_above: 1024
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -5618,7 +5618,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       default_field: false
     - name: issuer.country
       level: extended
@@ -5632,7 +5632,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       default_field: false
     - name: issuer.locality
@@ -5647,14 +5647,14 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       default_field: false
     - name: issuer.organizational_unit
       level: extended
       type: keyword
       ignore_above: 1024
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       default_field: false
     - name: issuer.state_or_province
       level: extended
@@ -5725,7 +5725,7 @@
       type: keyword
       ignore_above: 1024
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       default_field: false
     - name: subject.country
       level: extended
@@ -5739,7 +5739,7 @@
       type: keyword
       ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
     - name: subject.locality
       level: extended
@@ -5753,7 +5753,7 @@
       type: keyword
       ignore_above: 1024
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       default_field: false
     - name: subject.organizational_unit
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4584,7 +4584,7 @@
       ignore_above: 1024
       description: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
-      example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       default_field: false
     - name: client.ja3
       level: extended
@@ -4623,7 +4623,7 @@
       ignore_above: 1024
       description: Distinguished name of subject of the x.509 certificate presented
         by the client.
-      example: CN=myclient, OU=Documentation Team, DC=mydomain, DC=com
+      example: CN=myclient, OU=Documentation Team, DC=example, DC=com
       default_field: false
     - name: client.supported_ciphers
       level: extended
@@ -4887,7 +4887,7 @@
       ignore_above: 1024
       description: Subject of the issuer of the x.509 certificate presented by the
         server.
-      example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       default_field: false
     - name: server.ja3s
       level: extended
@@ -4916,7 +4916,7 @@
       type: keyword
       ignore_above: 1024
       description: Subject of the x.509 certificate presented by the server.
-      example: CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
       default_field: false
     - name: server.x509.alternative_names
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1445,7 +1445,7 @@
         this event.
 
         This URL links to another system where in-depth investigation of the specific
-        occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+        occurrence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       default_field: false

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -150,7 +150,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 1.6.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
 1.6.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"
-1.6.0-dev,true,event,event.reference,keyword,extended,,https://system.vendor.com/event/#0001234,Event reference URL
+1.6.0-dev,true,event,event.reference,keyword,extended,,https://system.example.com/event/#0001234,Event reference URL
 1.6.0-dev,true,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
 1.6.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 1.6.0-dev,true,event,event.sequence,long,extended,,,Sequence number of the event.
@@ -158,7 +158,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
 1.6.0-dev,true,event,event.timezone,keyword,extended,,,Event time zone.
 1.6.0-dev,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
-1.6.0-dev,true,event,event.url,keyword,extended,,https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
+1.6.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 1.6.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.6.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 1.6.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -539,12 +539,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.client.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client.
 1.6.0-dev,true,tls,tls.client.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client.
 1.6.0-dev,true,tls,tls.client.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client.
-1.6.0-dev,true,tls,tls.client.issuer,keyword,extended,,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+1.6.0-dev,true,tls,tls.client.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
 1.6.0-dev,true,tls,tls.client.ja3,keyword,extended,,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
 1.6.0-dev,true,tls,tls.client.not_after,date,extended,,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
 1.6.0-dev,true,tls,tls.client.not_before,date,extended,,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
 1.6.0-dev,true,tls,tls.client.server_name,keyword,extended,,www.elastic.co,Hostname the client is trying to connect to. Also called the SNI.
-1.6.0-dev,true,tls,tls.client.subject,keyword,extended,,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
+1.6.0-dev,true,tls,tls.client.subject,keyword,extended,,"CN=myclient, OU=Documentation Team, DC=example, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
 1.6.0-dev,true,tls,tls.client.supported_ciphers,keyword,extended,array,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the client during the client hello.
 1.6.0-dev,true,tls,tls.client.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
 1.6.0-dev,true,tls,tls.client.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
@@ -579,11 +579,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.server.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server.
 1.6.0-dev,true,tls,tls.server.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server.
 1.6.0-dev,true,tls,tls.server.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server.
-1.6.0-dev,true,tls,tls.server.issuer,keyword,extended,,"CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
+1.6.0-dev,true,tls,tls.server.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
 1.6.0-dev,true,tls,tls.server.ja3s,keyword,extended,,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
 1.6.0-dev,true,tls,tls.server.not_after,date,extended,,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
 1.6.0-dev,true,tls,tls.server.not_before,date,extended,,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
-1.6.0-dev,true,tls,tls.server.subject,keyword,extended,,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
+1.6.0-dev,true,tls,tls.server.subject,keyword,extended,,"CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com",Subject of the x.509 certificate presented by the server.
 1.6.0-dev,true,tls,tls.server.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
 1.6.0-dev,true,tls,tls.server.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.server.x509.issuer.country,keyword,extended,array,US,List of country (C) codes

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -29,7 +29,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,client,client.nat.port,long,extended,,,Client NAT port
 1.6.0-dev,true,client,client.packets,long,core,,12,Packets sent from the client to the server.
 1.6.0-dev,true,client,client.port,long,core,,,Port of the client.
-1.6.0-dev,true,client,client.registered_domain,keyword,extended,,google.com,"The highest registered client domain, stripped of the subdomain."
+1.6.0-dev,true,client,client.registered_domain,keyword,extended,,example.com,"The highest registered client domain, stripped of the subdomain."
 1.6.0-dev,true,client,client.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.6.0-dev,true,client,client.user.email,keyword,extended,,,User email address.
@@ -78,7 +78,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,destination,destination.nat.port,long,extended,,,Destination NAT Port
 1.6.0-dev,true,destination,destination.packets,long,core,,12,Packets sent from the destination to the source.
 1.6.0-dev,true,destination,destination.port,long,core,,,Port of the destination.
-1.6.0-dev,true,destination,destination.registered_domain,keyword,extended,,google.com,"The highest registered destination domain, stripped of the subdomain."
+1.6.0-dev,true,destination,destination.registered_domain,keyword,extended,,example.com,"The highest registered destination domain, stripped of the subdomain."
 1.6.0-dev,true,destination,destination.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.6.0-dev,true,destination,destination.user.email,keyword,extended,,,User email address.
@@ -112,15 +112,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,dns,dns.answers,object,extended,array,,Array of DNS answers.
 1.6.0-dev,true,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
 1.6.0-dev,true,dns,dns.answers.data,keyword,extended,,10.10.10.10,The data describing the resource.
-1.6.0-dev,true,dns,dns.answers.name,keyword,extended,,www.google.com,The domain name to which this resource record pertains.
+1.6.0-dev,true,dns,dns.answers.name,keyword,extended,,www.example.com,The domain name to which this resource record pertains.
 1.6.0-dev,true,dns,dns.answers.ttl,long,extended,,180,The time interval in seconds that this resource record may be cached before it should be discarded.
 1.6.0-dev,true,dns,dns.answers.type,keyword,extended,,CNAME,The type of data contained in this resource record.
 1.6.0-dev,true,dns,dns.header_flags,keyword,extended,array,"['RD', 'RA']",Array of DNS header flags.
 1.6.0-dev,true,dns,dns.id,keyword,extended,,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
 1.6.0-dev,true,dns,dns.op_code,keyword,extended,,QUERY,The DNS operation code that specifies the kind of query in the message.
 1.6.0-dev,true,dns,dns.question.class,keyword,extended,,IN,The class of records being queried.
-1.6.0-dev,true,dns,dns.question.name,keyword,extended,,www.google.com,The name being queried.
-1.6.0-dev,true,dns,dns.question.registered_domain,keyword,extended,,google.com,"The highest registered domain, stripped of the subdomain."
+1.6.0-dev,true,dns,dns.question.name,keyword,extended,,www.example.com,The name being queried.
+1.6.0-dev,true,dns,dns.question.registered_domain,keyword,extended,,example.com,"The highest registered domain, stripped of the subdomain."
 1.6.0-dev,true,dns,dns.question.subdomain,keyword,extended,,www,The subdomain of the domain.
 1.6.0-dev,true,dns,dns.question.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,dns,dns.question.type,keyword,extended,,AAAA,The type of record being queried.
@@ -199,12 +199,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.6.0-dev,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.6.0-dev,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
-1.6.0-dev,true,file,file.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,file,file.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 1.6.0-dev,true,file,file.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-1.6.0-dev,true,file,file.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,file,file.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 1.6.0-dev,true,file,file.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
-1.6.0-dev,true,file,file.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
-1.6.0-dev,true,file,file.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,file,file.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,file,file.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
 1.6.0-dev,true,file,file.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,file,file.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
 1.6.0-dev,true,file,file.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
@@ -214,11 +214,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,file,file.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
 1.6.0-dev,true,file,file.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
 1.6.0-dev,true,file,file.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
-1.6.0-dev,true,file,file.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,file,file.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 1.6.0-dev,true,file,file.x509.subject.country,keyword,extended,array,US,List of country (C) code
-1.6.0-dev,true,file,file.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,file,file.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 1.6.0-dev,true,file,file.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
-1.6.0-dev,true,file,file.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,file,file.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 1.6.0-dev,true,file,file.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 1.6.0-dev,true,file,file.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,file,file.x509.version_number,keyword,extended,,3,Version of x509 format.
@@ -471,7 +471,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,server,server.nat.port,long,extended,,,Server NAT port
 1.6.0-dev,true,server,server.packets,long,core,,12,Packets sent from the server to the client.
 1.6.0-dev,true,server,server.port,long,core,,,Port of the server.
-1.6.0-dev,true,server,server.registered_domain,keyword,extended,,google.com,"The highest registered server domain, stripped of the subdomain."
+1.6.0-dev,true,server,server.registered_domain,keyword,extended,,example.com,"The highest registered server domain, stripped of the subdomain."
 1.6.0-dev,true,server,server.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.6.0-dev,true,server,server.user.email,keyword,extended,,,User email address.
@@ -511,7 +511,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.nat.port,long,extended,,,Source NAT port
 1.6.0-dev,true,source,source.packets,long,core,,12,Packets sent from the source to the destination.
 1.6.0-dev,true,source,source.port,long,core,,,Port of the source.
-1.6.0-dev,true,source,source.registered_domain,keyword,extended,,google.com,"The highest registered source domain, stripped of the subdomain."
+1.6.0-dev,true,source,source.registered_domain,keyword,extended,,example.com,"The highest registered source domain, stripped of the subdomain."
 1.6.0-dev,true,source,source.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.6.0-dev,true,source,source.user.email,keyword,extended,,,User email address.
@@ -547,12 +547,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.client.subject,keyword,extended,,"CN=myclient, OU=Documentation Team, DC=mydomain, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
 1.6.0-dev,true,tls,tls.client.supported_ciphers,keyword,extended,array,"['TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384', 'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384', '...']",Array of ciphers offered by the client during the client hello.
 1.6.0-dev,true,tls,tls.client.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
-1.6.0-dev,true,tls,tls.client.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.client.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.client.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-1.6.0-dev,true,tls,tls.client.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.client.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.client.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
-1.6.0-dev,true,tls,tls.client.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
-1.6.0-dev,true,tls,tls.client.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.client.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.client.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.client.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,tls,tls.client.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
 1.6.0-dev,true,tls,tls.client.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
@@ -562,11 +562,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.client.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
 1.6.0-dev,true,tls,tls.client.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
 1.6.0-dev,true,tls,tls.client.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
-1.6.0-dev,true,tls,tls.client.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,tls,tls.client.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 1.6.0-dev,true,tls,tls.client.x509.subject.country,keyword,extended,array,US,List of country (C) code
-1.6.0-dev,true,tls,tls.client.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,tls,tls.client.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 1.6.0-dev,true,tls,tls.client.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
-1.6.0-dev,true,tls,tls.client.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,tls,tls.client.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 1.6.0-dev,true,tls,tls.client.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 1.6.0-dev,true,tls,tls.client.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,tls,tls.client.x509.version_number,keyword,extended,,3,Version of x509 format.
@@ -585,12 +585,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.server.not_before,date,extended,,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
 1.6.0-dev,true,tls,tls.server.subject,keyword,extended,,"CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com",Subject of the x.509 certificate presented by the server.
 1.6.0-dev,true,tls,tls.server.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
-1.6.0-dev,true,tls,tls.server.x509.issuer.common_name,keyword,extended,array,DigiCert SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.server.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.server.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-1.6.0-dev,true,tls,tls.server.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.server.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.server.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
-1.6.0-dev,true,tls,tls.server.x509.issuer.organization,keyword,extended,array,DigiCert Inc,List of organizations (O) of issuing certificate authority.
-1.6.0-dev,true,tls,tls.server.x509.issuer.organizational_unit,keyword,extended,array,www.digicert.com,List of organizational units (OU) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.server.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.6.0-dev,true,tls,tls.server.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
 1.6.0-dev,true,tls,tls.server.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,tls,tls.server.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
 1.6.0-dev,true,tls,tls.server.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
@@ -600,11 +600,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,tls,tls.server.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
 1.6.0-dev,true,tls,tls.server.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
 1.6.0-dev,true,tls,tls.server.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
-1.6.0-dev,true,tls,tls.server.x509.subject.common_name,keyword,extended,array,r2.shared.global.fastly.net,List of common names (CN) of subject.
+1.6.0-dev,true,tls,tls.server.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 1.6.0-dev,true,tls,tls.server.x509.subject.country,keyword,extended,array,US,List of country (C) code
-1.6.0-dev,true,tls,tls.server.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net",Distinguished name (DN) of the certificate subject entity.
+1.6.0-dev,true,tls,tls.server.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 1.6.0-dev,true,tls,tls.server.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
-1.6.0-dev,true,tls,tls.server.x509.subject.organization,keyword,extended,array,"Fastly, Inc.",List of organizations (O) of subject.
+1.6.0-dev,true,tls,tls.server.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 1.6.0-dev,true,tls,tls.server.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 1.6.0-dev,true,tls,tls.server.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 1.6.0-dev,true,tls,tls.server.x509.version_number,keyword,extended,,3,Version of x509 format.
@@ -623,7 +623,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,url,url.path,keyword,extended,,,"Path of the request, such as ""/search""."
 1.6.0-dev,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 1.6.0-dev,true,url,url.query,keyword,extended,,,Query string of the request.
-1.6.0-dev,true,url,url.registered_domain,keyword,extended,,google.com,"The highest registered url domain, stripped of the subdomain."
+1.6.0-dev,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
 1.6.0-dev,true,url,url.scheme,keyword,extended,,https,Scheme of the url.
 1.6.0-dev,true,url,url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 1.6.0-dev,true,url,url.username,keyword,extended,,,Username of the request.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2076,7 +2076,7 @@ event.reference:
 
     This URL links to a static definition of the this event. Alert events, indicated
     by `event.kind:alert`, are a common use case for this field.'
-  example: https://system.vendor.com/event/#0001234
+  example: https://system.example.com/event/#0001234
   flat_name: event.reference
   ignore_above: 1024
   level: extended
@@ -2314,7 +2314,7 @@ event.url:
     This URL links to another system where in-depth investigation of the specific
     occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
     are a common use case for this field.'
-  example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+  example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
   flat_name: event.url
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6912,7 +6912,7 @@ tls.client.issuer:
   dashed_name: tls-client-issuer
   description: Distinguished name of subject of the issuer of the x.509 certificate
     presented by the client.
-  example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+  example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.client.issuer
   ignore_above: 1024
   level: extended
@@ -6971,7 +6971,7 @@ tls.client.subject:
   dashed_name: tls-client-subject
   description: Distinguished name of subject of the x.509 certificate presented by
     the client.
-  example: CN=myclient, OU=Documentation Team, DC=mydomain, DC=com
+  example: CN=myclient, OU=Documentation Team, DC=example, DC=com
   flat_name: tls.client.subject
   ignore_above: 1024
   level: extended
@@ -7421,7 +7421,7 @@ tls.server.hash.sha256:
 tls.server.issuer:
   dashed_name: tls-server-issuer
   description: Subject of the issuer of the x.509 certificate presented by the server.
-  example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+  example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.server.issuer
   ignore_above: 1024
   level: extended
@@ -7465,7 +7465,7 @@ tls.server.not_before:
 tls.server.subject:
   dashed_name: tls-server-subject
   description: Subject of the x.509 certificate presented by the server.
-  example: CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com
+  example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.server.subject
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2312,7 +2312,7 @@ event.url:
     event.
 
     This URL links to another system where in-depth investigation of the specific
-    occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+    occurrence of this event can take place. Alert events, indicated by `event.kind:alert`,
     are a common use case for this field.'
   example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
   flat_name: event.url

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -335,12 +335,12 @@ client.registered_domain:
   dashed_name: client-registered-domain
   description: 'The highest registered client domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: client.registered_domain
   ignore_above: 1024
   level: extended
@@ -351,7 +351,7 @@ client.registered_domain:
 client.top_level_domain:
   dashed_name: client-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -899,12 +899,12 @@ destination.registered_domain:
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: destination.registered_domain
   ignore_above: 1024
   level: extended
@@ -915,7 +915,7 @@ destination.registered_domain:
 destination.top_level_domain:
   dashed_name: destination-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1322,7 +1322,7 @@ dns.answers.name:
     If a chain of CNAME is being resolved, each answer''s `name` should be the one
     that corresponds with the answer''s `data`. It should not simply be the original
     `question.name` repeated.'
-  example: www.google.com
+  example: www.example.com
   flat_name: dns.answers.name
   ignore_above: 1024
   level: extended
@@ -1413,7 +1413,7 @@ dns.question.name:
     characters should be represented as escaped base 10 integers (\DDD). Back slashes
     and quotes should be escaped. Tabs, carriage returns, and line feeds should be
     converted to \t, \r, and \n respectively.'
-  example: www.google.com
+  example: www.example.com
   flat_name: dns.question.name
   ignore_above: 1024
   level: extended
@@ -1425,12 +1425,12 @@ dns.question.registered_domain:
   dashed_name: dns-question-registered-domain
   description: 'The highest registered domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: dns.question.registered_domain
   ignore_above: 1024
   level: extended
@@ -1455,7 +1455,7 @@ dns.question.subdomain:
 dns.question.top_level_domain:
   dashed_name: dns-question-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -2792,7 +2792,7 @@ file.x509.alternative_names:
 file.x509.issuer.common_name:
   dashed_name: file-x509-issuer-common-name
   description: List of common name (CN) of issuing certificate authority.
-  example: DigiCert SHA2 High Assurance Server CA
+  example: Example SHA2 High Assurance Server CA
   flat_name: file.x509.issuer.common_name
   ignore_above: 1024
   level: extended
@@ -2818,7 +2818,7 @@ file.x509.issuer.country:
 file.x509.issuer.distinguished_name:
   dashed_name: file-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
-  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+  example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: file.x509.issuer.distinguished_name
   ignore_above: 1024
@@ -2844,7 +2844,7 @@ file.x509.issuer.locality:
 file.x509.issuer.organization:
   dashed_name: file-x509-issuer-organization
   description: List of organizations (O) of issuing certificate authority.
-  example: DigiCert Inc
+  example: Example Inc
   flat_name: file.x509.issuer.organization
   ignore_above: 1024
   level: extended
@@ -2857,7 +2857,7 @@ file.x509.issuer.organization:
 file.x509.issuer.organizational_unit:
   dashed_name: file-x509-issuer-organizational-unit
   description: List of organizational units (OU) of issuing certificate authority.
-  example: www.digicert.com
+  example: www.example.com
   flat_name: file.x509.issuer.organizational_unit
   ignore_above: 1024
   level: extended
@@ -2982,7 +2982,7 @@ file.x509.signature_algorithm:
 file.x509.subject.common_name:
   dashed_name: file-x509-subject-common-name
   description: List of common names (CN) of subject.
-  example: r2.shared.global.fastly.net
+  example: shared.global.example.net
   flat_name: file.x509.subject.common_name
   ignore_above: 1024
   level: extended
@@ -3008,7 +3008,7 @@ file.x509.subject.country:
 file.x509.subject.distinguished_name:
   dashed_name: file-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
-  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: file.x509.subject.distinguished_name
   ignore_above: 1024
   level: extended
@@ -3033,7 +3033,7 @@ file.x509.subject.locality:
 file.x509.subject.organization:
   dashed_name: file-x509-subject-organization
   description: List of organizations (O) of subject.
-  example: Fastly, Inc.
+  example: Example, Inc.
   flat_name: file.x509.subject.organization
   ignore_above: 1024
   level: extended
@@ -6056,12 +6056,12 @@ server.registered_domain:
   dashed_name: server-registered-domain
   description: 'The highest registered server domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: server.registered_domain
   ignore_above: 1024
   level: extended
@@ -6072,7 +6072,7 @@ server.registered_domain:
 server.top_level_domain:
   dashed_name: server-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -6551,12 +6551,12 @@ source.registered_domain:
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: source.registered_domain
   ignore_above: 1024
   level: extended
@@ -6567,7 +6567,7 @@ source.registered_domain:
 source.top_level_domain:
   dashed_name: source-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -7012,7 +7012,7 @@ tls.client.x509.alternative_names:
 tls.client.x509.issuer.common_name:
   dashed_name: tls-client-x509-issuer-common-name
   description: List of common name (CN) of issuing certificate authority.
-  example: DigiCert SHA2 High Assurance Server CA
+  example: Example SHA2 High Assurance Server CA
   flat_name: tls.client.x509.issuer.common_name
   ignore_above: 1024
   level: extended
@@ -7038,7 +7038,7 @@ tls.client.x509.issuer.country:
 tls.client.x509.issuer.distinguished_name:
   dashed_name: tls-client-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
-  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+  example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: tls.client.x509.issuer.distinguished_name
   ignore_above: 1024
@@ -7064,7 +7064,7 @@ tls.client.x509.issuer.locality:
 tls.client.x509.issuer.organization:
   dashed_name: tls-client-x509-issuer-organization
   description: List of organizations (O) of issuing certificate authority.
-  example: DigiCert Inc
+  example: Example Inc
   flat_name: tls.client.x509.issuer.organization
   ignore_above: 1024
   level: extended
@@ -7077,7 +7077,7 @@ tls.client.x509.issuer.organization:
 tls.client.x509.issuer.organizational_unit:
   dashed_name: tls-client-x509-issuer-organizational-unit
   description: List of organizational units (OU) of issuing certificate authority.
-  example: www.digicert.com
+  example: www.example.com
   flat_name: tls.client.x509.issuer.organizational_unit
   ignore_above: 1024
   level: extended
@@ -7202,7 +7202,7 @@ tls.client.x509.signature_algorithm:
 tls.client.x509.subject.common_name:
   dashed_name: tls-client-x509-subject-common-name
   description: List of common names (CN) of subject.
-  example: r2.shared.global.fastly.net
+  example: shared.global.example.net
   flat_name: tls.client.x509.subject.common_name
   ignore_above: 1024
   level: extended
@@ -7228,7 +7228,7 @@ tls.client.x509.subject.country:
 tls.client.x509.subject.distinguished_name:
   dashed_name: tls-client-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
-  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: tls.client.x509.subject.distinguished_name
   ignore_above: 1024
   level: extended
@@ -7253,7 +7253,7 @@ tls.client.x509.subject.locality:
 tls.client.x509.subject.organization:
   dashed_name: tls-client-x509-subject-organization
   description: List of organizations (O) of subject.
-  example: Fastly, Inc.
+  example: Example, Inc.
   flat_name: tls.client.x509.subject.organization
   ignore_above: 1024
   level: extended
@@ -7491,7 +7491,7 @@ tls.server.x509.alternative_names:
 tls.server.x509.issuer.common_name:
   dashed_name: tls-server-x509-issuer-common-name
   description: List of common name (CN) of issuing certificate authority.
-  example: DigiCert SHA2 High Assurance Server CA
+  example: Example SHA2 High Assurance Server CA
   flat_name: tls.server.x509.issuer.common_name
   ignore_above: 1024
   level: extended
@@ -7517,7 +7517,7 @@ tls.server.x509.issuer.country:
 tls.server.x509.issuer.distinguished_name:
   dashed_name: tls-server-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
-  example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+  example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: tls.server.x509.issuer.distinguished_name
   ignore_above: 1024
@@ -7543,7 +7543,7 @@ tls.server.x509.issuer.locality:
 tls.server.x509.issuer.organization:
   dashed_name: tls-server-x509-issuer-organization
   description: List of organizations (O) of issuing certificate authority.
-  example: DigiCert Inc
+  example: Example Inc
   flat_name: tls.server.x509.issuer.organization
   ignore_above: 1024
   level: extended
@@ -7556,7 +7556,7 @@ tls.server.x509.issuer.organization:
 tls.server.x509.issuer.organizational_unit:
   dashed_name: tls-server-x509-issuer-organizational-unit
   description: List of organizational units (OU) of issuing certificate authority.
-  example: www.digicert.com
+  example: www.example.com
   flat_name: tls.server.x509.issuer.organizational_unit
   ignore_above: 1024
   level: extended
@@ -7681,7 +7681,7 @@ tls.server.x509.signature_algorithm:
 tls.server.x509.subject.common_name:
   dashed_name: tls-server-x509-subject-common-name
   description: List of common names (CN) of subject.
-  example: r2.shared.global.fastly.net
+  example: shared.global.example.net
   flat_name: tls.server.x509.subject.common_name
   ignore_above: 1024
   level: extended
@@ -7707,7 +7707,7 @@ tls.server.x509.subject.country:
 tls.server.x509.subject.distinguished_name:
   dashed_name: tls-server-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
-  example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+  example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: tls.server.x509.subject.distinguished_name
   ignore_above: 1024
   level: extended
@@ -7732,7 +7732,7 @@ tls.server.x509.subject.locality:
 tls.server.x509.subject.organization:
   dashed_name: tls-server-x509-subject-organization
   description: List of organizations (O) of subject.
-  example: Fastly, Inc.
+  example: Example, Inc.
   flat_name: tls.server.x509.subject.organization
   ignore_above: 1024
   level: extended
@@ -7960,12 +7960,12 @@ url.registered_domain:
   dashed_name: url-registered-domain
   description: 'The highest registered url domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: url.registered_domain
   ignore_above: 1024
   level: extended
@@ -7989,7 +7989,7 @@ url.scheme:
 url.top_level_domain:
   dashed_name: url-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -481,12 +481,12 @@ client:
       dashed_name: client-registered-domain
       description: 'The highest registered client domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: client.registered_domain
       ignore_above: 1024
       level: extended
@@ -498,7 +498,7 @@ client:
       dashed_name: client-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -1181,12 +1181,12 @@ destination:
       dashed_name: destination-registered-domain
       description: 'The highest registered destination domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: destination.registered_domain
       ignore_above: 1024
       level: extended
@@ -1198,7 +1198,7 @@ destination:
       dashed_name: destination-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -1666,7 +1666,7 @@ dns:
         If a chain of CNAME is being resolved, each answer''s `name` should be the
         one that corresponds with the answer''s `data`. It should not simply be the
         original `question.name` repeated.'
-      example: www.google.com
+      example: www.example.com
       flat_name: dns.answers.name
       ignore_above: 1024
       level: extended
@@ -1759,7 +1759,7 @@ dns:
         those characters should be represented as escaped base 10 integers (\DDD).
         Back slashes and quotes should be escaped. Tabs, carriage returns, and line
         feeds should be converted to \t, \r, and \n respectively.'
-      example: www.google.com
+      example: www.example.com
       flat_name: dns.question.name
       ignore_above: 1024
       level: extended
@@ -1771,12 +1771,12 @@ dns:
       dashed_name: dns-question-registered-domain
       description: 'The highest registered domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: dns.question.registered_domain
       ignore_above: 1024
       level: extended
@@ -1802,7 +1802,7 @@ dns:
       dashed_name: dns-question-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -3210,7 +3210,7 @@ file:
     file.x509.issuer.common_name:
       dashed_name: file-x509-issuer-common-name
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       flat_name: file.x509.issuer.common_name
       ignore_above: 1024
       level: extended
@@ -3236,7 +3236,7 @@ file:
     file.x509.issuer.distinguished_name:
       dashed_name: file-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: file.x509.issuer.distinguished_name
       ignore_above: 1024
@@ -3262,7 +3262,7 @@ file:
     file.x509.issuer.organization:
       dashed_name: file-x509-issuer-organization
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       flat_name: file.x509.issuer.organization
       ignore_above: 1024
       level: extended
@@ -3275,7 +3275,7 @@ file:
     file.x509.issuer.organizational_unit:
       dashed_name: file-x509-issuer-organizational-unit
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       flat_name: file.x509.issuer.organizational_unit
       ignore_above: 1024
       level: extended
@@ -3400,7 +3400,7 @@ file:
     file.x509.subject.common_name:
       dashed_name: file-x509-subject-common-name
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       flat_name: file.x509.subject.common_name
       ignore_above: 1024
       level: extended
@@ -3426,7 +3426,7 @@ file:
     file.x509.subject.distinguished_name:
       dashed_name: file-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: file.x509.subject.distinguished_name
       ignore_above: 1024
       level: extended
@@ -3451,7 +3451,7 @@ file:
     file.x509.subject.organization:
       dashed_name: file-x509-subject-organization
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       flat_name: file.x509.subject.organization
       ignore_above: 1024
       level: extended
@@ -7185,12 +7185,12 @@ server:
       dashed_name: server-registered-domain
       description: 'The highest registered server domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: server.registered_domain
       ignore_above: 1024
       level: extended
@@ -7202,7 +7202,7 @@ server:
       dashed_name: server-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -7718,12 +7718,12 @@ source:
       dashed_name: source-registered-domain
       description: 'The highest registered source domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: source.registered_domain
       ignore_above: 1024
       level: extended
@@ -7735,7 +7735,7 @@ source:
       dashed_name: source-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -8196,7 +8196,7 @@ tls:
     tls.client.x509.issuer.common_name:
       dashed_name: tls-client-x509-issuer-common-name
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       flat_name: tls.client.x509.issuer.common_name
       ignore_above: 1024
       level: extended
@@ -8222,7 +8222,7 @@ tls:
     tls.client.x509.issuer.distinguished_name:
       dashed_name: tls-client-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: tls.client.x509.issuer.distinguished_name
       ignore_above: 1024
@@ -8248,7 +8248,7 @@ tls:
     tls.client.x509.issuer.organization:
       dashed_name: tls-client-x509-issuer-organization
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       flat_name: tls.client.x509.issuer.organization
       ignore_above: 1024
       level: extended
@@ -8261,7 +8261,7 @@ tls:
     tls.client.x509.issuer.organizational_unit:
       dashed_name: tls-client-x509-issuer-organizational-unit
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       flat_name: tls.client.x509.issuer.organizational_unit
       ignore_above: 1024
       level: extended
@@ -8386,7 +8386,7 @@ tls:
     tls.client.x509.subject.common_name:
       dashed_name: tls-client-x509-subject-common-name
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       flat_name: tls.client.x509.subject.common_name
       ignore_above: 1024
       level: extended
@@ -8412,7 +8412,7 @@ tls:
     tls.client.x509.subject.distinguished_name:
       dashed_name: tls-client-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: tls.client.x509.subject.distinguished_name
       ignore_above: 1024
       level: extended
@@ -8437,7 +8437,7 @@ tls:
     tls.client.x509.subject.organization:
       dashed_name: tls-client-x509-subject-organization
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       flat_name: tls.client.x509.subject.organization
       ignore_above: 1024
       level: extended
@@ -8678,7 +8678,7 @@ tls:
     tls.server.x509.issuer.common_name:
       dashed_name: tls-server-x509-issuer-common-name
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       flat_name: tls.server.x509.issuer.common_name
       ignore_above: 1024
       level: extended
@@ -8704,7 +8704,7 @@ tls:
     tls.server.x509.issuer.distinguished_name:
       dashed_name: tls-server-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: tls.server.x509.issuer.distinguished_name
       ignore_above: 1024
@@ -8730,7 +8730,7 @@ tls:
     tls.server.x509.issuer.organization:
       dashed_name: tls-server-x509-issuer-organization
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       flat_name: tls.server.x509.issuer.organization
       ignore_above: 1024
       level: extended
@@ -8743,7 +8743,7 @@ tls:
     tls.server.x509.issuer.organizational_unit:
       dashed_name: tls-server-x509-issuer-organizational-unit
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       flat_name: tls.server.x509.issuer.organizational_unit
       ignore_above: 1024
       level: extended
@@ -8868,7 +8868,7 @@ tls:
     tls.server.x509.subject.common_name:
       dashed_name: tls-server-x509-subject-common-name
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       flat_name: tls.server.x509.subject.common_name
       ignore_above: 1024
       level: extended
@@ -8894,7 +8894,7 @@ tls:
     tls.server.x509.subject.distinguished_name:
       dashed_name: tls-server-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: tls.server.x509.subject.distinguished_name
       ignore_above: 1024
       level: extended
@@ -8919,7 +8919,7 @@ tls:
     tls.server.x509.subject.organization:
       dashed_name: tls-server-x509-subject-organization
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       flat_name: tls.server.x509.subject.organization
       ignore_above: 1024
       level: extended
@@ -9196,12 +9196,12 @@ url:
       dashed_name: url-registered-domain
       description: 'The highest registered url domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
         the last two labels will not work well for TLDs such as "co.uk".'
-      example: google.com
+      example: example.com
       flat_name: url.registered_domain
       ignore_above: 1024
       level: extended
@@ -9226,7 +9226,7 @@ url:
       dashed_name: url-top-level-domain
       description: 'The effective top level domain (eTLD), also known as the domain
         suffix, is the last part of the domain name. For example, the top level domain
-        for google.com is "com".
+        for example.com is "com".
 
         This value can be determined precisely with a list like the public suffix
         list (http://publicsuffix.org). Trying to approximate this by simply taking
@@ -9828,7 +9828,7 @@ x509:
     x509.issuer.common_name:
       dashed_name: x509-issuer-common-name
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
       flat_name: x509.issuer.common_name
       ignore_above: 1024
       level: extended
@@ -9852,7 +9852,7 @@ x509:
     x509.issuer.distinguished_name:
       dashed_name: x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: x509.issuer.distinguished_name
       ignore_above: 1024
@@ -9876,7 +9876,7 @@ x509:
     x509.issuer.organization:
       dashed_name: x509-issuer-organization
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
       flat_name: x509.issuer.organization
       ignore_above: 1024
       level: extended
@@ -9888,7 +9888,7 @@ x509:
     x509.issuer.organizational_unit:
       dashed_name: x509-issuer-organizational-unit
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
       flat_name: x509.issuer.organizational_unit
       ignore_above: 1024
       level: extended
@@ -10003,7 +10003,7 @@ x509:
     x509.subject.common_name:
       dashed_name: x509-subject-common-name
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
       flat_name: x509.subject.common_name
       ignore_above: 1024
       level: extended
@@ -10027,7 +10027,7 @@ x509:
     x509.subject.distinguished_name:
       dashed_name: x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: x509.subject.distinguished_name
       ignore_above: 1024
       level: extended
@@ -10050,7 +10050,7 @@ x509:
     x509.subject.organization:
       dashed_name: x509-subject-organization
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
       flat_name: x509.subject.organization
       ignore_above: 1024
       level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2473,7 +2473,7 @@ event:
 
         This URL links to a static definition of the this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
-      example: https://system.vendor.com/event/#0001234
+      example: https://system.example.com/event/#0001234
       flat_name: event.reference
       ignore_above: 1024
       level: extended
@@ -2717,7 +2717,7 @@ event:
         This URL links to another system where in-depth investigation of the specific
         occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
-      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       flat_name: event.url
       ignore_above: 1024
       level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8093,7 +8093,7 @@ tls:
       dashed_name: tls-client-issuer
       description: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
-      example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.client.issuer
       ignore_above: 1024
       level: extended
@@ -8154,7 +8154,7 @@ tls:
       dashed_name: tls-client-subject
       description: Distinguished name of subject of the x.509 certificate presented
         by the client.
-      example: CN=myclient, OU=Documentation Team, DC=mydomain, DC=com
+      example: CN=myclient, OU=Documentation Team, DC=example, DC=com
       flat_name: tls.client.subject
       ignore_above: 1024
       level: extended
@@ -8606,7 +8606,7 @@ tls:
       dashed_name: tls-server-issuer
       description: Subject of the issuer of the x.509 certificate presented by the
         server.
-      example: CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.server.issuer
       ignore_above: 1024
       level: extended
@@ -8652,7 +8652,7 @@ tls:
     tls.server.subject:
       dashed_name: tls-server-subject
       description: Subject of the x.509 certificate presented by the server.
-      example: CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com
+      example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.server.subject
       ignore_above: 1024
       level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2715,7 +2715,7 @@ event:
         this event.
 
         This URL links to another system where in-depth investigation of the specific
-        occurence of this event can take place. Alert events, indicated by `event.kind:alert`,
+        occurrence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
       flat_name: event.url

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -64,12 +64,12 @@
       description: >
         The highest registered client domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: top_level_domain
       level: extended
@@ -78,7 +78,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -55,12 +55,12 @@
       description: >
         The highest registered destination domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: top_level_domain
       level: extended
@@ -69,7 +69,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -76,7 +76,7 @@
         as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped.
         Tabs, carriage returns, and line feeds should be converted to \t, \r, and
         \n respectively.
-      example: www.google.com
+      example: www.example.com
 
     - name: question.type
       level: extended
@@ -97,12 +97,12 @@
       description: >
         The highest registered domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: question.top_level_domain
       level: extended
@@ -111,7 +111,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
@@ -158,7 +158,7 @@
         If a chain of CNAME is being resolved, each answer's `name` should be
         the one that corresponds with the answer's `data`. It should not simply
         be the original `question.name` repeated.
-      example: www.google.com
+      example: www.example.com
 
     - name: answers.type
       level: extended

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -690,7 +690,7 @@
         This URL links to a static definition of the this event.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
-      example: https://system.vendor.com/event/#0001234
+      example: "https://system.example.com/event/#0001234"
 
     - name: url
       level: extended
@@ -703,7 +703,7 @@
         system where in-depth investigation of the specific occurence of this event can take place.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
-      example: https://mysystem.mydomain.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      example: "https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe"
 
     - name: reason
       level: extended

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -700,7 +700,7 @@
         URL linking to an external system to continue investigation of this event.
 
         This URL links to another
-        system where in-depth investigation of the specific occurence of this event can take place.
+        system where in-depth investigation of the specific occurrence of this event can take place.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
       example: "https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe"

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -64,12 +64,12 @@
       description: >
         The highest registered server domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: top_level_domain
       level: extended
@@ -78,7 +78,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -55,12 +55,12 @@
       description: >
         The highest registered source domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: top_level_domain
       level: extended
@@ -69,7 +69,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -81,13 +81,13 @@
       type: keyword
       level: extended
       description: Distinguished name of subject of the x.509 certificate presented by the client.
-      example: "CN=myclient, OU=Documentation Team, DC=mydomain, DC=com"
+      example: "CN=myclient, OU=Documentation Team, DC=example, DC=com"
 
     - name: client.issuer
       type: keyword
       level: extended
       description: Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
-      example: "CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com"
+      example: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
 
     - name: client.not_before
       type: date
@@ -160,13 +160,13 @@
       type: keyword
       level: extended
       description: Subject of the x.509 certificate presented by the server.
-      example: "CN=www.mydomain.com, OU=Infrastructure Team, DC=mydomain, DC=com"
+      example: "CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com"
 
     - name: server.issuer
       type: keyword
       level: extended
       description: Subject of the issuer of the x.509 certificate presented by the server.
-      example: "CN=MyDomain Root CA, OU=Infrastructure Team, DC=mydomain, DC=com"
+      example: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
 
     - name: server.not_before
       type: date

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -67,12 +67,12 @@
       description: >
         The highest registered url domain, stripped of the subdomain.
 
-        For example, the registered domain for "foo.google.com" is "google.com".
+        For example, the registered domain for "foo.example.com" is "example.com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by
         simply taking the last two labels will not work well for TLDs such as "co.uk".
-      example: google.com
+      example: example.com
 
     - name: top_level_domain
       level: extended
@@ -81,7 +81,7 @@
       description: >
         The effective top level domain (eTLD), also known as the domain suffix,
         is the last part of the domain name.
-        For example, the top level domain for google.com is "com".
+        For example, the top level domain for example.com is "com".
 
         This value can be determined precisely with a list like the public
         suffix list (http://publicsuffix.org). Trying to approximate this by

--- a/schemas/x509.yml
+++ b/schemas/x509.yml
@@ -37,7 +37,7 @@
       level: extended
       type: keyword
       description: Distinguished name (DN) of issuing certificate authority.
-      example: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert SHA2 High Assurance Server CA
+      example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA
 
     - name: issuer.common_name
       level: extended
@@ -45,7 +45,7 @@
       normalize:
         - array
       description: List of common name (CN) of issuing certificate authority.
-      example: DigiCert SHA2 High Assurance Server CA
+      example: Example SHA2 High Assurance Server CA
 
     - name: issuer.organizational_unit
       level: extended
@@ -53,7 +53,7 @@
       normalize:
         - array
       description: List of organizational units (OU) of issuing certificate authority.
-      example: www.digicert.com
+      example: www.example.com
 
     - name: issuer.organization
       level: extended
@@ -61,7 +61,7 @@
       normalize:
         - array
       description: List of organizations (O) of issuing certificate authority.
-      example: DigiCert Inc
+      example: Example Inc
 
     - name: issuer.locality
       level: extended
@@ -113,7 +113,7 @@
       level: extended
       type: keyword
       description: Distinguished name (DN) of the certificate subject entity.
-      example: C=US, ST=California, L=San Francisco, O=Fastly, Inc., CN=r2.shared.global.fastly.net
+      example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
 
     - name: subject.common_name
       level: extended
@@ -121,7 +121,7 @@
       normalize:
         - array
       description: List of common names (CN) of subject.
-      example: r2.shared.global.fastly.net
+      example: shared.global.example.net
 
     - name: subject.organizational_unit
       level: extended
@@ -136,7 +136,7 @@
       normalize:
         - array
       description: List of organizations (O) of subject.
-      example: Fastly, Inc.
+      example: Example, Inc.
 
     - name: subject.locality
       level: extended


### PR DESCRIPTION
**Summary**

Two minor documentation changes for the `event.*` field set:

* ~Removed the "live" URL links by adding quotes to the string.~ This is actually incorrect. Our documentation generator is handling this by always wrapping example strings with backticks (`). As long as we ensure the examples don't use potentially valid domains, I don't think we need to worry about being "defensive" for other doc locations which may render a hyperlink for the URLs (e.g. [Beats](https://www.elastic.co/guide/en/beats/filebeat/current/exported-fields-ecs.html)).

* Switched example URLs to use the IANA reserved `*.example.com` 
