### PR TITLE
add related.hosts

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -27,6 +27,7 @@ Thanks, you're awesome :-) -->
 * Added missing field reuse of `pe` at `process.parent.pe` #868
 * Added `span.id` to the tracing fieldset, for additional log correlation (#882)
 * Added `event.reason` for the reason why an event's outcome or action was taken. #907
+* Added `related.host` to capture all hostnames and host identifiers on an event. #913
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -27,7 +27,7 @@ Thanks, you're awesome :-) -->
 * Added missing field reuse of `pe` at `process.parent.pe` #868
 * Added `span.id` to the tracing fieldset, for additional log correlation (#882)
 * Added `event.reason` for the reason why an event's outcome or action was taken. #907
-* Added `related.host` to capture all hostnames and host identifiers on an event. #913
+* Added `related.hosts` to capture all hostnames and host identifiers on an event. #913
 
 #### Improvements
 

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -41,5 +41,5 @@ type Related struct {
 
 	// All hostnames or other host identifiers seen on your event. Example
 	// identifiers include FQDNs, domain names, workstation names, or aliases.
-	Host string `ecs:"host"`
+	Hosts string `ecs:"hosts"`
 }

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -38,4 +38,8 @@ type Related struct {
 	// to search for hashes can help in situations where you're unsure what the
 	// hash algorithm is (and therefore which key name to search).
 	Hash string `ecs:"hash"`
+
+	// All hostnames or other host identifiers seen on your event. Example
+	// identifiers include FQDNs, domain names, workstation names, or aliases.
+	Host string `ecs:"host"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4614,6 +4614,22 @@ Note: this field should contain an array of values.
 
 // ===============================================================
 
+| related.host
+| All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
 | related.ip
 | All of the IPs seen on your event.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4614,7 +4614,7 @@ Note: this field should contain an array of values.
 
 // ===============================================================
 
-| related.host
+| related.hosts
 | All hostnames or other host identifiers seen on your event. Example identifiers include FQDNs, domain names, workstation names, or aliases.
 
 type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3798,7 +3798,7 @@
         using it to search for hashes can help in situations where you're unsure what
         the hash algorithm is (and therefore which key name to search).
       default_field: false
-    - name: host
+    - name: hosts
       level: extended
       type: keyword
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3798,6 +3798,13 @@
         using it to search for hashes can help in situations where you're unsure what
         the hash algorithm is (and therefore which key name to search).
       default_field: false
+    - name: host
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: All hostnames or other host identifiers seen on your event. Example
+        identifiers include FQDNs, domain names, workstation names, or aliases.
+      default_field: false
     - name: ip
       level: extended
       type: ip

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -439,6 +439,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,registry,registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
 1.6.0-dev,true,registry,registry.value,keyword,core,,Debugger,Name of the value written.
 1.6.0-dev,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
+1.6.0-dev,true,related,related.host,keyword,extended,array,,All the host identifiers seen on your event.
 1.6.0-dev,true,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
 1.6.0-dev,true,related,related.user,keyword,extended,array,,All the user names seen on your event.
 1.6.0-dev,true,rule,rule.author,keyword,extended,array,['Star-Lord'],Rule author

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -439,7 +439,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,registry,registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
 1.6.0-dev,true,registry,registry.value,keyword,core,,Debugger,Name of the value written.
 1.6.0-dev,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
-1.6.0-dev,true,related,related.host,keyword,extended,array,,All the host identifiers seen on your event.
+1.6.0-dev,true,related,related.hosts,keyword,extended,array,,All the host identifiers seen on your event.
 1.6.0-dev,true,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
 1.6.0-dev,true,related,related.user,keyword,extended,array,,All the user names seen on your event.
 1.6.0-dev,true,rule,rule.author,keyword,extended,array,['Star-Lord'],Rule author

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5678,6 +5678,18 @@ related.hash:
   - array
   short: All the hashes seen on your event.
   type: keyword
+related.host:
+  dashed_name: related-host
+  description: All hostnames or other host identifiers seen on your event. Example
+    identifiers include FQDNs, domain names, workstation names, or aliases.
+  flat_name: related.host
+  ignore_above: 1024
+  level: extended
+  name: host
+  normalize:
+  - array
+  short: All the host identifiers seen on your event.
+  type: keyword
 related.ip:
   dashed_name: related-ip
   description: All of the IPs seen on your event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5678,14 +5678,14 @@ related.hash:
   - array
   short: All the hashes seen on your event.
   type: keyword
-related.host:
-  dashed_name: related-host
+related.hosts:
+  dashed_name: related-hosts
   description: All hostnames or other host identifiers seen on your event. Example
     identifiers include FQDNs, domain names, workstation names, or aliases.
-  flat_name: related.host
+  flat_name: related.hosts
   ignore_above: 1024
   level: extended
-  name: host
+  name: hosts
   normalize:
   - array
   short: All the host identifiers seen on your event.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6768,6 +6768,18 @@ related:
       - array
       short: All the hashes seen on your event.
       type: keyword
+    related.host:
+      dashed_name: related-host
+      description: All hostnames or other host identifiers seen on your event. Example
+        identifiers include FQDNs, domain names, workstation names, or aliases.
+      flat_name: related.host
+      ignore_above: 1024
+      level: extended
+      name: host
+      normalize:
+      - array
+      short: All the host identifiers seen on your event.
+      type: keyword
     related.ip:
       dashed_name: related-ip
       description: All of the IPs seen on your event.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6768,14 +6768,14 @@ related:
       - array
       short: All the hashes seen on your event.
       type: keyword
-    related.host:
-      dashed_name: related-host
+    related.hosts:
+      dashed_name: related-hosts
       description: All hostnames or other host identifiers seen on your event. Example
         identifiers include FQDNs, domain names, workstation names, or aliases.
-      flat_name: related.host
+      flat_name: related.hosts
       ignore_above: 1024
       level: extended
-      name: host
+      name: hosts
       normalize:
       - array
       short: All the host identifiers seen on your event.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2081,7 +2081,7 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
-            "host": {
+            "hosts": {
               "ignore_above": 1024,
               "type": "keyword"
             },

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2081,6 +2081,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "host": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ip": {
               "type": "ip"
             },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2080,7 +2080,7 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
-          "host": {
+          "hosts": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2080,6 +2080,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "host": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "ip": {
             "type": "ip"
           },

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -43,3 +43,13 @@
         the hash algorithm is (and therefore which key name to search).
       normalize:
         - array
+
+    - name: host
+      level: extended
+      type: keyword
+      short: All the host identifiers seen on your event.
+      description: >
+        All hostnames or other host identifiers seen on your event. Example
+        identifiers include FQDNs, domain names, workstation names, or aliases.
+      normalize:
+        - array

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -44,7 +44,7 @@
       normalize:
         - array
 
-    - name: host
+    - name: hosts
       level: extended
       type: keyword
       short: All the host identifiers seen on your event.


### PR DESCRIPTION
**Summary**

Add a ~`related.host`~ `related.hosts` field. Same intention as the existing `related.*` fields: populate with all hostnames and other host identifiers from the event.

Closes #863 
