### PR TITLE
Add field `user.roles`

### DIFF
--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -45,11 +45,6 @@ type User struct {
 	// For example, an LDAP or Active Directory domain name.
 	Domain string `ecs:"domain"`
 
-	// Array of user roles or groups, at the time of the event.
-	// `user.group.*` fields are meant to capture one group's full details,
-	// rather than capturing an array of groups associated with a user.
-	// When it's necessary to capture a list of roles or groups assigned to the
-	// user at the time an event or audit log is recorded, use the array field
-	// `user.roles`.
+	// Array of user roles at the time of the event.
 	Roles string `ecs:"roles"`
 }

--- a/code/go/ecs/user.go
+++ b/code/go/ecs/user.go
@@ -44,4 +44,12 @@ type User struct {
 	// Name of the directory the user is a member of.
 	// For example, an LDAP or Active Directory domain name.
 	Domain string `ecs:"domain"`
+
+	// Array of user roles or groups, at the time of the event.
+	// `user.group.*` fields are meant to capture one group's full details,
+	// rather than capturing an array of groups associated with a user.
+	// When it's necessary to capture a list of roles or groups assigned to the
+	// user at the time an event or audit log is recorded, use the array field
+	// `user.roles`.
+	Roles string `ecs:"roles"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6294,11 +6294,7 @@ example: `albert`
 // ===============================================================
 
 | user.roles
-| Array of user roles or groups, at the time of the event.
-
-`user.group.*` fields are meant to capture one group's full details, rather than capturing an array of groups associated with a user.
-
-When it's necessary to capture a list of roles or groups assigned to the user at the time an event or audit log is recorded, use the array field `user.roles`.
+| Array of user roles at the time of the event.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6293,6 +6293,26 @@ example: `albert`
 
 // ===============================================================
 
+| user.roles
+| Array of user roles or groups, at the time of the event.
+
+`user.group.*` fields are meant to capture one group's full details, rather than capturing an array of groups associated with a user.
+
+When it's necessary to capture a list of roles or groups assigned to the user at the time an event or audit log is recorded, use the array field `user.roles`.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `["kibana_admin", "reporting_user"]`
+
+| extended
+
+// ===============================================================
+
 |=====
 
 ==== Field Reuse

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -379,6 +379,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: user.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: cloud
     title: Cloud
     group: 2
@@ -773,6 +786,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: user.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: dll
     title: DLL
     group: 2
@@ -2252,6 +2278,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: user.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: http
     title: HTTP
     group: 2
@@ -4137,6 +4176,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: user.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: service
     title: Service
     group: 2
@@ -4446,6 +4498,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: user.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: threat
     title: Threat
     group: 2
@@ -5343,6 +5408,19 @@
         default_field: false
       description: Short name or login of the user.
       example: albert
+    - name: roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      default_field: false
   - name: user_agent
     title: User agent
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -383,13 +383,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: cloud
@@ -790,13 +784,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: dll
@@ -2282,13 +2270,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: http
@@ -4180,13 +4162,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: service
@@ -4502,13 +4478,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: threat
@@ -5412,13 +5382,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       default_field: false
   - name: user_agent

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -42,6 +42,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 1.6.0-dev,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
 1.6.0-dev,true,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,Availability zone in which this host is running.
@@ -91,6 +92,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.6.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.6.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
@@ -261,6 +263,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,host,host.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,host,host.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,host,host.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 1.6.0-dev,true,http,http.request.body.content,keyword,extended,,Hello world,The full HTTP request body.
 1.6.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
@@ -484,6 +487,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 1.6.0-dev,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 1.6.0-dev,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
@@ -524,6 +528,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 1.6.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 1.6.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
@@ -638,6 +643,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0-dev,true,user,user.id,keyword,core,,,Unique identifier of the user.
 1.6.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
 1.6.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+1.6.0-dev,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.6.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 1.6.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 1.6.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -486,13 +486,7 @@ client.user.name:
   type: keyword
 client.user.roles:
   dashed_name: client-user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: client.user.roles
   ignore_above: 1024
@@ -1069,13 +1063,7 @@ destination.user.name:
   type: keyword
 destination.user.roles:
   dashed_name: destination-user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: destination.user.roles
   ignore_above: 1024
@@ -3562,13 +3550,7 @@ host.user.name:
   type: keyword
 host.user.roles:
   dashed_name: host-user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: host.user.roles
   ignore_above: 1024
@@ -6264,13 +6246,7 @@ server.user.name:
   type: keyword
 server.user.roles:
   dashed_name: server-user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: server.user.roles
   ignore_above: 1024
@@ -6778,13 +6754,7 @@ source.user.name:
   type: keyword
 source.user.roles:
   dashed_name: source-user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: source.user.roles
   ignore_above: 1024
@@ -8223,13 +8193,7 @@ user.name:
   type: keyword
 user.roles:
   dashed_name: user-roles
-  description: 'Array of user roles or groups, at the time of the event.
-
-    `user.group.*` fields are meant to capture one group''s full details, rather than
-    capturing an array of groups associated with a user.
-
-    When it''s necessary to capture a list of roles or groups assigned to the user
-    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  description: Array of user roles at the time of the event.
   example: '["kibana_admin", "reporting_user"]'
   flat_name: user.roles
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -484,6 +484,25 @@ client.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+client.user.roles:
+  dashed_name: client-user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: client.user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  original_fieldset: user
+  short: Array of user roles at the time of the event.
+  type: keyword
 cloud.account.id:
   dashed_name: cloud-account-id
   description: 'The cloud account or organization id used to identify different entities
@@ -1047,6 +1066,25 @@ destination.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
+  type: keyword
+destination.user.roles:
+  dashed_name: destination-user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: destination.user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  original_fieldset: user
+  short: Array of user roles at the time of the event.
   type: keyword
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
@@ -3521,6 +3559,25 @@ host.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
+  type: keyword
+host.user.roles:
+  dashed_name: host-user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: host.user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  original_fieldset: user
+  short: Array of user roles at the time of the event.
   type: keyword
 http.request.body.bytes:
   dashed_name: http-request-body-bytes
@@ -6205,6 +6262,25 @@ server.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+server.user.roles:
+  dashed_name: server-user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: server.user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  original_fieldset: user
+  short: Array of user roles at the time of the event.
+  type: keyword
 service.ephemeral_id:
   dashed_name: service-ephemeral-id
   description: 'Ephemeral identifier of this service (if one exists).
@@ -6699,6 +6775,25 @@ source.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
+  type: keyword
+source.user.roles:
+  dashed_name: source-user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: source.user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  original_fieldset: user
+  short: Array of user roles at the time of the event.
   type: keyword
 span.id:
   dashed_name: span-id
@@ -8125,6 +8220,24 @@ user.name:
   name: name
   normalize: []
   short: Short name or login of the user.
+  type: keyword
+user.roles:
+  dashed_name: user-roles
+  description: 'Array of user roles or groups, at the time of the event.
+
+    `user.group.*` fields are meant to capture one group''s full details, rather than
+    capturing an array of groups associated with a user.
+
+    When it''s necessary to capture a list of roles or groups assigned to the user
+    at the time an event or audit log is recorded, use the array field `user.roles`.'
+  example: '["kibana_admin", "reporting_user"]'
+  flat_name: user.roles
+  ignore_above: 1024
+  level: extended
+  name: roles
+  normalize:
+  - array
+  short: Array of user roles at the time of the event.
   type: keyword
 user_agent.device.name:
   dashed_name: user-agent-device-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -630,6 +630,25 @@ client:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    client.user.roles:
+      dashed_name: client-user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: client.user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      original_fieldset: user
+      short: Array of user roles at the time of the event.
+      type: keyword
   group: 2
   name: client
   nestings:
@@ -1329,6 +1348,25 @@ destination:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
+      type: keyword
+    destination.user.roles:
+      dashed_name: destination-user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: destination.user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      original_fieldset: user
+      short: Array of user roles at the time of the event.
       type: keyword
   group: 2
   name: destination
@@ -4181,6 +4219,25 @@ host:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
+      type: keyword
+    host.user.roles:
+      dashed_name: host-user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: host.user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      original_fieldset: user
+      short: Array of user roles at the time of the event.
       type: keyword
   group: 2
   name: host
@@ -7334,6 +7391,25 @@ server:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    server.user.roles:
+      dashed_name: server-user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: server.user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      original_fieldset: user
+      short: Array of user roles at the time of the event.
+      type: keyword
   group: 2
   name: server
   nestings:
@@ -7866,6 +7942,25 @@ source:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
+      type: keyword
+    source.user.roles:
+      dashed_name: source-user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: source.user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      original_fieldset: user
+      short: Array of user roles at the time of the event.
       type: keyword
   group: 2
   name: source
@@ -9374,6 +9469,24 @@ user:
       name: name
       normalize: []
       short: Short name or login of the user.
+      type: keyword
+    user.roles:
+      dashed_name: user-roles
+      description: 'Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group''s full details, rather
+        than capturing an array of groups associated with a user.
+
+        When it''s necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      example: '["kibana_admin", "reporting_user"]'
+      flat_name: user.roles
+      ignore_above: 1024
+      level: extended
+      name: roles
+      normalize:
+      - array
+      short: Array of user roles at the time of the event.
       type: keyword
   group: 2
   name: user

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -632,13 +632,7 @@ client:
       type: keyword
     client.user.roles:
       dashed_name: client-user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: client.user.roles
       ignore_above: 1024
@@ -1351,13 +1345,7 @@ destination:
       type: keyword
     destination.user.roles:
       dashed_name: destination-user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: destination.user.roles
       ignore_above: 1024
@@ -4222,13 +4210,7 @@ host:
       type: keyword
     host.user.roles:
       dashed_name: host-user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: host.user.roles
       ignore_above: 1024
@@ -7393,13 +7375,7 @@ server:
       type: keyword
     server.user.roles:
       dashed_name: server-user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: server.user.roles
       ignore_above: 1024
@@ -7945,13 +7921,7 @@ source:
       type: keyword
     source.user.roles:
       dashed_name: source-user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: source.user.roles
       ignore_above: 1024
@@ -9472,13 +9442,7 @@ user:
       type: keyword
     user.roles:
       dashed_name: user-roles
-      description: 'Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group''s full details, rather
-        than capturing an array of groups associated with a user.
-
-        When it''s necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded, use the array field `user.roles`.'
+      description: Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'
       flat_name: user.roles
       ignore_above: 1024

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -208,6 +208,10 @@
                   },
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -455,6 +459,10 @@
                       "type": "text"
                     }
                   },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1215,6 +1223,10 @@
                       "type": "text"
                     }
                   },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -2287,6 +2299,10 @@
                   },
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             }
@@ -2479,6 +2495,10 @@
                       "type": "text"
                     }
                   },
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -3020,6 +3040,10 @@
                   "type": "text"
                 }
               },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "roles": {
               "ignore_above": 1024,
               "type": "keyword"
             }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -207,6 +207,10 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "roles": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }
@@ -454,6 +458,10 @@
                     "type": "text"
                   }
                 },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1214,6 +1222,10 @@
                     "type": "text"
                   }
                 },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2286,6 +2298,10 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "roles": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }
@@ -2478,6 +2494,10 @@
                     "type": "text"
                   }
                 },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -3019,6 +3039,10 @@
                 "type": "text"
               }
             },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "roles": {
             "ignore_above": 1024,
             "type": "keyword"
           }

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -81,3 +81,20 @@
           Name of the directory the user is a member of.
 
           For example, an LDAP or Active Directory domain name.
+
+    - name: roles
+      level: extended
+      type: keyword
+      normalize:
+        - array
+      short: Array of user roles at the time of the event.
+      description: >
+        Array of user roles or groups, at the time of the event.
+
+        `user.group.*` fields are meant to capture one group's full details,
+        rather than capturing an array of groups associated with a user.
+
+        When it's necessary to capture a list of roles or groups assigned to the
+        user at the time an event or audit log is recorded,
+        use the array field `user.roles`.
+      example: '["kibana_admin", "reporting_user"]'

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -87,14 +87,6 @@
       type: keyword
       normalize:
         - array
-      short: Array of user roles at the time of the event.
       description: >
-        Array of user roles or groups, at the time of the event.
-
-        `user.group.*` fields are meant to capture one group's full details,
-        rather than capturing an array of groups associated with a user.
-
-        When it's necessary to capture a list of roles or groups assigned to the
-        user at the time an event or audit log is recorded,
-        use the array field `user.roles`.
+        Array of user roles at the time of the event.
       example: '["kibana_admin", "reporting_user"]'


### PR DESCRIPTION
This array field is meant to capture a list of role names that apply to the user, in an audit log or other RBAC event.

Closes #915