### PR TITLE
Add network directions ingress and egress

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -21,6 +21,7 @@ Thanks, you're awesome :-) -->
 * Added Mime Type fields to HTTP request and response. #944
 * Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
 * Added `configuration` as an allowed `event.category`. #963
+* Added network directions ingress and egress. #945
 
 #### Improvements
 

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -73,14 +73,14 @@ type Network struct {
 	// field from the host's point of view, using the values "ingress" or
 	// "egress".
 	// When mapping events from a network or perimeter-based monitoring
-	// context, populate this field from the point of view of your network
+	// context, populate this field from the point of view of the network
 	// perimeter, using the values "inbound", "outbound", "internal" or
 	// "external".
 	// Note that "internal" is not crossing perimeter boundaries, and is meant
 	// to describe communication between two hosts within the perimeter. Note
 	// also that "external" is meant to describe traffic between two hosts that
-	// are external to their perimeter. This could for example be useful for
-	// ISPs or VPN service providers.
+	// are external to the perimeter. This could for example be useful for ISPs
+	// or VPN service providers.
 	Direction string `ecs:"direction"`
 
 	// Host IP address when the source IP address is the proxy.

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -70,10 +70,17 @@ type Network struct {
 	//   * unknown
 	//
 	// When mapping events from a host-based monitoring context, populate this
-	// field from the host's point of view, using the values ingress or egress.
+	// field from the host's point of view, using the values "ingress" or
+	// "egress".
 	// When mapping events from a network or perimeter-based monitoring
 	// context, populate this field from the point of view of your network
-	// perimeter, using the values inbound, outbound, internal or external.
+	// perimeter, using the values "inbound", "outbound", "internal" or
+	// "external".
+	// Note that "internal" is not crossing perimeter boundaries, and is meant
+	// to describe communication between two hosts within the perimeter. Note
+	// also that "external" is meant to describe traffic between two hosts that
+	// are external to their perimeter. This could for example be useful for
+	// ISPs or VPN service providers.
 	Direction string `ecs:"direction"`
 
 	// Host IP address when the source IP address is the proxy.

--- a/code/go/ecs/network.go
+++ b/code/go/ecs/network.go
@@ -61,6 +61,8 @@ type Network struct {
 
 	// Direction of the network traffic.
 	// Recommended values are:
+	//   * ingress
+	//   * egress
 	//   * inbound
 	//   * outbound
 	//   * internal
@@ -68,10 +70,10 @@ type Network struct {
 	//   * unknown
 	//
 	// When mapping events from a host-based monitoring context, populate this
-	// field from the host's point of view.
+	// field from the host's point of view, using the values ingress or egress.
 	// When mapping events from a network or perimeter-based monitoring
 	// context, populate this field from the point of view of your network
-	// perimeter.
+	// perimeter, using the values inbound, outbound, internal or external.
 	Direction string `ecs:"direction"`
 
 	// Host IP address when the source IP address is the proxy.
@@ -94,9 +96,9 @@ type Network struct {
 	Packets int64 `ecs:"packets"`
 
 	// Network.inner fields are added in addition to network.vlan fields to
-	// describe  the innermost VLAN when q-in-q VLAN tagging is present.
-	// Allowed fields include  vlan.id and vlan.name. Inner vlan fields are
-	// typically used when sending traffic with multiple 802.1q encapsulations
-	// to a network sensor (e.g. Zeek, Wireshark.)
+	// describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed
+	// fields include vlan.id and vlan.name. Inner vlan fields are typically
+	// used when sending traffic with multiple 802.1q encapsulations to a
+	// network sensor (e.g. Zeek, Wireshark.)
 	Inner map[string]interface{} `ecs:"inner"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3326,6 +3326,10 @@ example: `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=`
 
 Recommended values are:
 
+  * ingress
+
+  * egress
+
   * inbound
 
   * outbound
@@ -3338,9 +3342,9 @@ Recommended values are:
 
 
 
-When mapping events from a host-based monitoring context, populate this field from the host's point of view.
+When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values ingress or egress.
 
-When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter.
+When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter, using the values inbound, outbound, internal or external.
 
 type: keyword
 
@@ -3379,7 +3383,7 @@ example: `6`
 // ===============================================================
 
 | network.inner
-| Network.inner fields are added in addition to network.vlan fields to describe  the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include  vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)
+| Network.inner fields are added in addition to network.vlan fields to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)
 
 type: object
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3344,9 +3344,9 @@ Recommended values are:
 
 When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress".
 
-When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter, using the values "inbound", "outbound", "internal" or "external".
+When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of the network perimeter, using the values "inbound", "outbound", "internal" or "external".
 
-Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to their perimeter. This could for example be useful for ISPs or VPN service providers.
+Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to the perimeter. This could for example be useful for ISPs or VPN service providers.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3342,9 +3342,11 @@ Recommended values are:
 
 
 
-When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values ingress or egress.
+When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress".
 
-When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter, using the values inbound, outbound, internal or external.
+When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of your network perimeter, using the values "inbound", "outbound", "internal" or "external".
+
+Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to their perimeter. This could for example be useful for ISPs or VPN service providers.
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2594,11 +2594,12 @@
       type: keyword
       ignore_above: 1024
       description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\nWhen\
-        \ mapping events from a host-based monitoring context, populate this field\
-        \ from the host's point of view.\nWhen mapping events from a network or perimeter-based\
-        \ monitoring context, populate this field from the point of view of your network\
-        \ perimeter."
+        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
+        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
+        \ populate this field from the host's point of view, using the values ingress\
+        \ or egress.\nWhen mapping events from a network or perimeter-based monitoring\
+        \ context, populate this field from the point of view of your network perimeter,\
+        \ using the values inbound, outbound, internal or external."
       example: inbound
     - name: forwarded_ip
       level: core
@@ -2617,8 +2618,8 @@
       level: extended
       type: object
       description: Network.inner fields are added in addition to network.vlan fields
-        to describe  the innermost VLAN when q-in-q VLAN tagging is present. Allowed
-        fields include  vlan.id and vlan.name. Inner vlan fields are typically used
+        to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed
+        fields include vlan.id and vlan.name. Inner vlan fields are typically used
         when sending traffic with multiple 802.1q encapsulations to a network sensor
         (e.g. Zeek, Wireshark.)
       default_field: false

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2596,10 +2596,15 @@
       description: "Direction of the network traffic.\nRecommended values are:\n \
         \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
         \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values ingress\
-        \ or egress.\nWhen mapping events from a network or perimeter-based monitoring\
+        \ populate this field from the host's point of view, using the values \"ingress\"\
+        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
         \ context, populate this field from the point of view of your network perimeter,\
-        \ using the values inbound, outbound, internal or external."
+        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
+        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
+        \ to describe communication between two hosts within the perimeter. Note also\
+        \ that \"external\" is meant to describe traffic between two hosts that are\
+        \ external to their perimeter. This could for example be useful for ISPs or\
+        \ VPN service providers."
       example: inbound
     - name: forwarded_ip
       level: core

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2598,12 +2598,12 @@
         \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
         \ populate this field from the host's point of view, using the values \"ingress\"\
         \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of your network perimeter,\
+        \ context, populate this field from the point of view of the network perimeter,\
         \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
         .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
         \ to describe communication between two hosts within the perimeter. Note also\
         \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to their perimeter. This could for example be useful for ISPs or\
+        \ external to the perimeter. This could for example be useful for ISPs or\
         \ VPN service providers."
       example: inbound
     - name: forwarded_ip

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3983,11 +3983,13 @@ network.community_id:
   type: keyword
 network.direction:
   dashed_name: network-direction
-  description: "Direction of the network traffic.\nRecommended values are:\n  * inbound\n\
-    \  * outbound\n  * internal\n  * external\n  * unknown\n\nWhen mapping events\
-    \ from a host-based monitoring context, populate this field from the host's point\
-    \ of view.\nWhen mapping events from a network or perimeter-based monitoring context,\
-    \ populate this field from the point of view of your network perimeter."
+  description: "Direction of the network traffic.\nRecommended values are:\n  * ingress\n\
+    \  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\
+    \nWhen mapping events from a host-based monitoring context, populate this field\
+    \ from the host's point of view, using the values ingress or egress.\nWhen mapping\
+    \ events from a network or perimeter-based monitoring context, populate this field\
+    \ from the point of view of your network perimeter, using the values inbound,\
+    \ outbound, internal or external."
   example: inbound
   flat_name: network.direction
   ignore_above: 1024
@@ -4022,8 +4024,8 @@ network.iana_number:
 network.inner:
   dashed_name: network-inner
   description: Network.inner fields are added in addition to network.vlan fields to
-    describe  the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields
-    include  vlan.id and vlan.name. Inner vlan fields are typically used when sending
+    describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields
+    include vlan.id and vlan.name. Inner vlan fields are typically used when sending
     traffic with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)
   flat_name: network.inner
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3988,12 +3988,12 @@ network.direction:
     \nWhen mapping events from a host-based monitoring context, populate this field\
     \ from the host's point of view, using the values \"ingress\" or \"egress\".\n\
     When mapping events from a network or perimeter-based monitoring context, populate\
-    \ this field from the point of view of your network perimeter, using the values\
+    \ this field from the point of view of the network perimeter, using the values\
     \ \"inbound\", \"outbound\", \"internal\" or \"external\".\nNote that \"internal\"\
     \ is not crossing perimeter boundaries, and is meant to describe communication\
     \ between two hosts within the perimeter. Note also that \"external\" is meant\
-    \ to describe traffic between two hosts that are external to their perimeter.\
-    \ This could for example be useful for ISPs or VPN service providers."
+    \ to describe traffic between two hosts that are external to the perimeter. This\
+    \ could for example be useful for ISPs or VPN service providers."
   example: inbound
   flat_name: network.direction
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3986,10 +3986,14 @@ network.direction:
   description: "Direction of the network traffic.\nRecommended values are:\n  * ingress\n\
     \  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\
     \nWhen mapping events from a host-based monitoring context, populate this field\
-    \ from the host's point of view, using the values ingress or egress.\nWhen mapping\
-    \ events from a network or perimeter-based monitoring context, populate this field\
-    \ from the point of view of your network perimeter, using the values inbound,\
-    \ outbound, internal or external."
+    \ from the host's point of view, using the values \"ingress\" or \"egress\".\n\
+    When mapping events from a network or perimeter-based monitoring context, populate\
+    \ this field from the point of view of your network perimeter, using the values\
+    \ \"inbound\", \"outbound\", \"internal\" or \"external\".\nNote that \"internal\"\
+    \ is not crossing perimeter boundaries, and is meant to describe communication\
+    \ between two hosts within the perimeter. Note also that \"external\" is meant\
+    \ to describe traffic between two hosts that are external to their perimeter.\
+    \ This could for example be useful for ISPs or VPN service providers."
   example: inbound
   flat_name: network.direction
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4736,12 +4736,12 @@ network:
         \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
         \ populate this field from the host's point of view, using the values \"ingress\"\
         \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of your network perimeter,\
+        \ context, populate this field from the point of view of the network perimeter,\
         \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
         .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
         \ to describe communication between two hosts within the perimeter. Note also\
         \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to their perimeter. This could for example be useful for ISPs or\
+        \ external to the perimeter. This could for example be useful for ISPs or\
         \ VPN service providers."
       example: inbound
       flat_name: network.direction

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4734,10 +4734,15 @@ network:
       description: "Direction of the network traffic.\nRecommended values are:\n \
         \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
         \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values ingress\
-        \ or egress.\nWhen mapping events from a network or perimeter-based monitoring\
+        \ populate this field from the host's point of view, using the values \"ingress\"\
+        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
         \ context, populate this field from the point of view of your network perimeter,\
-        \ using the values inbound, outbound, internal or external."
+        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
+        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
+        \ to describe communication between two hosts within the perimeter. Note also\
+        \ that \"external\" is meant to describe traffic between two hosts that are\
+        \ external to their perimeter. This could for example be useful for ISPs or\
+        \ VPN service providers."
       example: inbound
       flat_name: network.direction
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4732,11 +4732,12 @@ network:
     network.direction:
       dashed_name: network-direction
       description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\nWhen\
-        \ mapping events from a host-based monitoring context, populate this field\
-        \ from the host's point of view.\nWhen mapping events from a network or perimeter-based\
-        \ monitoring context, populate this field from the point of view of your network\
-        \ perimeter."
+        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
+        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
+        \ populate this field from the host's point of view, using the values ingress\
+        \ or egress.\nWhen mapping events from a network or perimeter-based monitoring\
+        \ context, populate this field from the point of view of your network perimeter,\
+        \ using the values inbound, outbound, internal or external."
       example: inbound
       flat_name: network.direction
       ignore_above: 1024
@@ -4771,8 +4772,8 @@ network:
     network.inner:
       dashed_name: network-inner
       description: Network.inner fields are added in addition to network.vlan fields
-        to describe  the innermost VLAN when q-in-q VLAN tagging is present. Allowed
-        fields include  vlan.id and vlan.name. Inner vlan fields are typically used
+        to describe the innermost VLAN when q-in-q VLAN tagging is present. Allowed
+        fields include vlan.id and vlan.name. Inner vlan fields are typically used
         when sending traffic with multiple 802.1q encapsulations to a network sensor
         (e.g. Zeek, Wireshark.)
       flat_name: network.inner

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -94,11 +94,17 @@
           * unknown
 
         When mapping events from a host-based monitoring context, populate this
-        field from the host's point of view, using the values ingress or egress.
+        field from the host's point of view, using the values "ingress" or "egress".
 
         When mapping events from a network or perimeter-based monitoring context,
         populate this field from the point of view of your network perimeter,
-        using the values inbound, outbound, internal or external.
+        using the values "inbound", "outbound", "internal" or "external".
+
+        Note that "internal" is not crossing perimeter boundaries, and is meant
+        to describe communication between two hosts within the perimeter. Note also
+        that "external" is meant to describe traffic between two hosts that are
+        external to their perimeter. This could for example be useful for ISPs or
+        VPN service providers.
       example: inbound
 
     - name: forwarded_ip

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -97,13 +97,13 @@
         field from the host's point of view, using the values "ingress" or "egress".
 
         When mapping events from a network or perimeter-based monitoring context,
-        populate this field from the point of view of your network perimeter,
+        populate this field from the point of view of the network perimeter,
         using the values "inbound", "outbound", "internal" or "external".
 
         Note that "internal" is not crossing perimeter boundaries, and is meant
         to describe communication between two hosts within the perimeter. Note also
         that "external" is meant to describe traffic between two hosts that are
-        external to their perimeter. This could for example be useful for ISPs or
+        external to the perimeter. This could for example be useful for ISPs or
         VPN service providers.
       example: inbound
 

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -85,6 +85,8 @@
         Direction of the network traffic.
 
         Recommended values are:
+          * ingress
+          * egress
           * inbound
           * outbound
           * internal
@@ -92,10 +94,11 @@
           * unknown
 
         When mapping events from a host-based monitoring context, populate this
-        field from the host's point of view.
+        field from the host's point of view, using the values ingress or egress.
 
         When mapping events from a network or perimeter-based monitoring context,
-        populate this field from the point of view of your network perimeter.
+        populate this field from the point of view of your network perimeter,
+        using the values inbound, outbound, internal or external.
       example: inbound
 
     - name: forwarded_ip
@@ -138,14 +141,14 @@
 
         If `source.packets` and `destination.packets` are known, `network.packets` is their sum.
       example: 24
-    
+
     # q-in-q vlan fields for identifying 802.1q nested vlans
     - name: inner
       level: extended
       type: object
       short: Inner VLAN tag information
       description: >
-        Network.inner fields are added in addition to network.vlan fields to describe 
-        the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include 
+        Network.inner fields are added in addition to network.vlan fields to describe
+        the innermost VLAN when q-in-q VLAN tagging is present. Allowed fields include
         vlan.id and vlan.name. Inner vlan fields are typically used when sending traffic
         with multiple 802.1q encapsulations to a network sensor (e.g. Zeek, Wireshark.)


### PR DESCRIPTION
Adding these two values based on the discussion in #791.

I've only lightly modified the description to associate which values to use for host based, and which ones should be associated to perimeter based. Feedback welcome, if folks would like more adjustments to the description.

I think we should discuss whether this should be considered a breaking change. My opinion is that for folks that have dutifully been populating inbound/outbound, this will feel like a breaking change. On the other hand based on feedback so far, the usefulness of the field was hampered by the difficulty of using the same pair of values "depending on context". So I would lean towards getting this into ECS in the 1.x line, and not waiting for 2.0.

Closes #791