### PR TITLE
Add threat.technique.subtechnique

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -11,6 +11,7 @@ Thanks, you're awesome :-) -->
 ### Schema Changes
 
 * Added `log.file.path` to capture the log file an event came from. #802
+* Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtecqhniques. #951
 
 #### Breaking changes
 

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -34,30 +34,45 @@ type Threat struct {
 	// retrospectively tagged to events.
 	Framework string `ecs:"framework"`
 
+	// The id of tactic used by this threat. You can use a MITRE ATT&CK®
+	// tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )
+	TacticID string `ecs:"tactic.id"`
+
 	// Name of the type of tactic used by this threat. You can use a MITRE
 	// ATT&CK® tactic, for example. (ex.
-	// https://attack.mitre.org/tactics/TA0040/)
+	// https://attack.mitre.org/tactics/TA0002/)
 	TacticName string `ecs:"tactic.name"`
-
-	// The id of tactic used by this threat. You can use a MITRE ATT&CK®
-	// tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
-	TacticID string `ecs:"tactic.id"`
 
 	// The reference url of tactic used by this threat. You can use a MITRE
 	// ATT&CK® tactic, for example. (ex.
-	// https://attack.mitre.org/tactics/TA0040/ )
+	// https://attack.mitre.org/tactics/TA0002/ )
 	TacticReference string `ecs:"tactic.reference"`
 
-	// The name of technique used by this threat. You can use a MITRE ATT&CK®
-	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
-	TechniqueName string `ecs:"technique.name"`
-
 	// The id of technique used by this threat. You can use a MITRE ATT&CK®
-	// technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
+	// technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 	TechniqueID string `ecs:"technique.id"`
+
+	// The name of technique used by this threat. You can use a MITRE ATT&CK®
+	// technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
+	TechniqueName string `ecs:"technique.name"`
 
 	// The reference url of technique used by this threat. You can use a MITRE
 	// ATT&CK® technique, for example. (ex.
-	// https://attack.mitre.org/techniques/T1499/ )
+	// https://attack.mitre.org/techniques/T1059/)
 	TechniqueReference string `ecs:"technique.reference"`
+
+	// The full id of subtechnique used by this threat. You can use a MITRE
+	// ATT&CK® subtechnique, for example. (ex.
+	// https://attack.mitre.org/techniques/T1059/001/)
+	TechniqueSubtechniqueID string `ecs:"technique.subtechnique.id"`
+
+	// The name of subtechnique used by this threat. You can use a MITRE
+	// ATT&CK® subtechnique, for example. (ex.
+	// https://attack.mitre.org/techniques/T1059/001/)
+	TechniqueSubtechniqueName string `ecs:"technique.subtechnique.name"`
+
+	// The reference url of subtechnique used by this threat. You can use a
+	// MITRE ATT&CK® subtechnique, for example. (ex.
+	// https://attack.mitre.org/techniques/T1059/001/)
+	TechniqueSubtechniqueReference string `ecs:"technique.subtechnique.reference"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5427,7 +5427,7 @@ Note: this field should contain an array of values.
 
 
 
-example: `TA0040`
+example: `TA0002`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5418,7 +5418,7 @@ example: `MITRE ATT&CK`
 // ===============================================================
 
 | threat.tactic.id
-| The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )
 
 type: keyword
 
@@ -5434,7 +5434,7 @@ example: `TA0040`
 // ===============================================================
 
 | threat.tactic.name
-| Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)
+| Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)
 
 type: keyword
 
@@ -5443,14 +5443,14 @@ Note: this field should contain an array of values.
 
 
 
-example: `impact`
+example: `Execution`
 
 | extended
 
 // ===============================================================
 
 | threat.tactic.reference
-| The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )
+| The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )
 
 type: keyword
 
@@ -5459,14 +5459,14 @@ Note: this field should contain an array of values.
 
 
 
-example: `https://attack.mitre.org/tactics/TA0040/`
+example: `https://attack.mitre.org/tactics/TA0002/`
 
 | extended
 
 // ===============================================================
 
 | threat.technique.id
-| The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
+| The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
@@ -5475,14 +5475,14 @@ Note: this field should contain an array of values.
 
 
 
-example: `T1499`
+example: `T1059`
 
 | extended
 
 // ===============================================================
 
 | threat.technique.name
-| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)
+| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
@@ -5497,14 +5497,14 @@ Note: this field should contain an array of values.
 
 
 
-example: `Endpoint Denial of Service`
+example: `Command and Scripting Interpreter`
 
 | extended
 
 // ===============================================================
 
 | threat.technique.reference
-| The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ )
+| The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
@@ -5513,7 +5513,61 @@ Note: this field should contain an array of values.
 
 
 
-example: `https://attack.mitre.org/techniques/T1499/`
+example: `https://attack.mitre.org/techniques/T1059/`
+
+| extended
+
+// ===============================================================
+
+| threat.technique.subtechnique.id
+| The full id of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `T1059.001`
+
+| extended
+
+// ===============================================================
+
+| threat.technique.subtechnique.name
+| The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+type: keyword
+
+Multi-fields:
+
+* threat.technique.subtechnique.name.text (type: text)
+
+
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `PowerShell`
+
+| extended
+
+// ===============================================================
+
+| threat.technique.subtechnique.reference
+| The reference url of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `https://attack.mitre.org/techniques/T1059/001/`
 
 | extended
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4538,30 +4538,30 @@
       type: keyword
       ignore_above: 1024
       description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0040
     - name: tactic.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
-      example: impact
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+      example: Execution
     - name: tactic.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
-      example: https://attack.mitre.org/tactics/TA0040/
+      example: https://attack.mitre.org/tactics/TA0002/
     - name: technique.id
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-      example: T1499
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: T1059
     - name: technique.name
       level: extended
       type: keyword
@@ -4572,16 +4572,43 @@
         norms: false
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-      example: Endpoint Denial of Service
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: Command and Scripting Interpreter
     - name: technique.reference
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
-        \ )"
-      example: https://attack.mitre.org/techniques/T1499/
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: https://attack.mitre.org/techniques/T1059/
+    - name: technique.subtechnique.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The full id of subtechnique used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: T1059.001
+      default_field: false
+    - name: technique.subtechnique.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: "The name of subtechnique used by this threat. You can use a MITRE\
+        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: PowerShell
+      default_field: false
+    - name: technique.subtechnique.reference
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The reference url of subtechnique used by this threat. You can\
+        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: https://attack.mitre.org/techniques/T1059/001/
+      default_field: false
   - name: tls
     title: TLS
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4539,7 +4539,7 @@
       ignore_above: 1024
       description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
         \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
-      example: TA0040
+      example: TA0002
     - name: tactic.name
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -534,7 +534,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 2.0.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
-2.0.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
+2.0.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0002,Threat tactic id.
 2.0.0-dev,true,threat,threat.tactic.name,keyword,extended,array,Execution,Threat tactic.
 2.0.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
 2.0.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -535,12 +535,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 2.0.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 2.0.0-dev,true,threat,threat.tactic.id,keyword,extended,array,TA0040,Threat tactic id.
-2.0.0-dev,true,threat,threat.tactic.name,keyword,extended,array,impact,Threat tactic.
-2.0.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0040/,Threat tactic URL reference.
-2.0.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1499,Threat technique id.
-2.0.0-dev,true,threat,threat.technique.name,keyword,extended,array,Endpoint Denial of Service,Threat technique name.
-2.0.0-dev,true,threat,threat.technique.name.text,text,extended,,Endpoint Denial of Service,Threat technique name.
-2.0.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1499/,Threat technique URL reference.
+2.0.0-dev,true,threat,threat.tactic.name,keyword,extended,array,Execution,Threat tactic.
+2.0.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
+2.0.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
+2.0.0-dev,true,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
+2.0.0-dev,true,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+2.0.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
+2.0.0-dev,true,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
+2.0.0-dev,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
+2.0.0-dev,true,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+2.0.0-dev,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
 2.0.0-dev,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 2.0.0-dev,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
 2.0.0-dev,true,tls,tls.client.certificate_chain,keyword,extended,array,"['MII...', 'MII...']",Array of PEM-encoded certificates that make up the certificate chain offered by the client.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6851,7 +6851,7 @@ threat.tactic.id:
   dashed_name: threat-tactic-id
   description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
     \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
-  example: TA0040
+  example: TA0002
   flat_name: threat.tactic.id
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6850,7 +6850,7 @@ threat.framework:
 threat.tactic.id:
   dashed_name: threat-tactic-id
   description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
   example: TA0040
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -6863,8 +6863,8 @@ threat.tactic.id:
 threat.tactic.name:
   dashed_name: threat-tactic-name
   description: "Name of the type of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
-  example: impact
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+  example: Execution
   flat_name: threat.tactic.name
   ignore_above: 1024
   level: extended
@@ -6876,9 +6876,9 @@ threat.tactic.name:
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
   description: "The reference url of tactic used by this threat. You can use a MITRE\
-    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
     \ )"
-  example: https://attack.mitre.org/tactics/TA0040/
+  example: https://attack.mitre.org/tactics/TA0002/
   flat_name: threat.tactic.reference
   ignore_above: 1024
   level: extended
@@ -6890,8 +6890,8 @@ threat.tactic.reference:
 threat.technique.id:
   dashed_name: threat-technique-id
   description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-  example: T1499
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  example: T1059
   flat_name: threat.technique.id
   ignore_above: 1024
   level: extended
@@ -6903,8 +6903,8 @@ threat.technique.id:
 threat.technique.name:
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-  example: Endpoint Denial of Service
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  example: Command and Scripting Interpreter
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
@@ -6921,9 +6921,8 @@ threat.technique.name:
 threat.technique.reference:
   dashed_name: threat-technique-reference
   description: "The reference url of technique used by this threat. You can use a\
-    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
-    \ )"
-  example: https://attack.mitre.org/techniques/T1499/
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+  example: https://attack.mitre.org/techniques/T1059/
   flat_name: threat.technique.reference
   ignore_above: 1024
   level: extended
@@ -6931,6 +6930,50 @@ threat.technique.reference:
   normalize:
   - array
   short: Threat technique URL reference.
+  type: keyword
+threat.technique.subtechnique.id:
+  dashed_name: threat-technique-subtechnique-id
+  description: "The full id of subtechnique used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+  example: T1059.001
+  flat_name: threat.technique.subtechnique.id
+  ignore_above: 1024
+  level: extended
+  name: technique.subtechnique.id
+  normalize:
+  - array
+  short: Threat subtechnique id.
+  type: keyword
+threat.technique.subtechnique.name:
+  dashed_name: threat-technique-subtechnique-name
+  description: "The name of subtechnique used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+  example: PowerShell
+  flat_name: threat.technique.subtechnique.name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: threat.technique.subtechnique.name.text
+    name: text
+    norms: false
+    type: text
+  name: technique.subtechnique.name
+  normalize:
+  - array
+  short: Threat subtechnique name.
+  type: keyword
+threat.technique.subtechnique.reference:
+  dashed_name: threat-technique-subtechnique-reference
+  description: "The reference url of subtechnique used by this threat. You can use\
+    \ a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+  example: https://attack.mitre.org/techniques/T1059/001/
+  flat_name: threat.technique.subtechnique.reference
+  ignore_above: 1024
+  level: extended
+  name: technique.subtechnique.reference
+  normalize:
+  - array
+  short: Threat subtechnique URL reference.
   type: keyword
 tls.cipher:
   dashed_name: tls-cipher

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8022,7 +8022,7 @@ threat:
     threat.tactic.id:
       dashed_name: threat-tactic-id
       description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
+        \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
       example: TA0040
       flat_name: threat.tactic.id
       ignore_above: 1024
@@ -8035,8 +8035,8 @@ threat:
     threat.tactic.name:
       dashed_name: threat-tactic-name
       description: "Name of the type of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
-      example: impact
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/)"
+      example: Execution
       flat_name: threat.tactic.name
       ignore_above: 1024
       level: extended
@@ -8048,9 +8048,9 @@ threat:
     threat.tactic.reference:
       dashed_name: threat-tactic-reference
       description: "The reference url of tactic used by this threat. You can use a\
-        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+        \ MITRE ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/\
         \ )"
-      example: https://attack.mitre.org/tactics/TA0040/
+      example: https://attack.mitre.org/tactics/TA0002/
       flat_name: threat.tactic.reference
       ignore_above: 1024
       level: extended
@@ -8062,8 +8062,8 @@ threat:
     threat.technique.id:
       dashed_name: threat-technique-id
       description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
-        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-      example: T1499
+        \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: T1059
       flat_name: threat.technique.id
       ignore_above: 1024
       level: extended
@@ -8075,8 +8075,8 @@ threat:
     threat.technique.name:
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
-        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
-      example: Endpoint Denial of Service
+        \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: Command and Scripting Interpreter
       flat_name: threat.technique.name
       ignore_above: 1024
       level: extended
@@ -8093,9 +8093,8 @@ threat:
     threat.technique.reference:
       dashed_name: threat-technique-reference
       description: "The reference url of technique used by this threat. You can use\
-        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
-        \ )"
-      example: https://attack.mitre.org/techniques/T1499/
+        \ a MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
+      example: https://attack.mitre.org/techniques/T1059/
       flat_name: threat.technique.reference
       ignore_above: 1024
       level: extended
@@ -8103,6 +8102,50 @@ threat:
       normalize:
       - array
       short: Threat technique URL reference.
+      type: keyword
+    threat.technique.subtechnique.id:
+      dashed_name: threat-technique-subtechnique-id
+      description: "The full id of subtechnique used by this threat. You can use a\
+        \ MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: T1059.001
+      flat_name: threat.technique.subtechnique.id
+      ignore_above: 1024
+      level: extended
+      name: technique.subtechnique.id
+      normalize:
+      - array
+      short: Threat subtechnique id.
+      type: keyword
+    threat.technique.subtechnique.name:
+      dashed_name: threat-technique-subtechnique-name
+      description: "The name of subtechnique used by this threat. You can use a MITRE\
+        \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: PowerShell
+      flat_name: threat.technique.subtechnique.name
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: threat.technique.subtechnique.name.text
+        name: text
+        norms: false
+        type: text
+      name: technique.subtechnique.name
+      normalize:
+      - array
+      short: Threat subtechnique name.
+      type: keyword
+    threat.technique.subtechnique.reference:
+      dashed_name: threat-technique-subtechnique-reference
+      description: "The reference url of subtechnique used by this threat. You can\
+        \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
+      example: https://attack.mitre.org/techniques/T1059/001/
+      flat_name: threat.technique.subtechnique.reference
+      ignore_above: 1024
+      level: extended
+      name: technique.subtechnique.reference
+      normalize:
+      - array
+      short: Threat subtechnique URL reference.
       type: keyword
   group: 2
   name: threat

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8023,7 +8023,7 @@ threat:
       dashed_name: threat-tactic-id
       description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
         \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0002/ )"
-      example: TA0040
+      example: TA0002
       flat_name: threat.tactic.id
       ignore_above: 1024
       level: extended

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2571,6 +2571,28 @@
                 "reference": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "subtechnique": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "reference": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2570,6 +2570,28 @@
               "reference": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "subtechnique": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "reference": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -24,29 +24,30 @@
 
       example: MITRE ATT&CK
 
-    - name: tactic.name
-      level: extended
-      type: keyword
-      short: Threat tactic.
-      description: >
-          Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
-          (ex. https://attack.mitre.org/tactics/TA0040/)
-
-      example: impact
-      normalize:
-        - array
-
     - name: tactic.id
       level: extended
       type: keyword
       short: Threat tactic id.
       description: >
           The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
-          (ex. https://attack.mitre.org/tactics/TA0040/ )
+          (ex. https://attack.mitre.org/tactics/TA0002/ )
 
       example: TA0040
       normalize:
         - array
+
+    - name: tactic.name
+      level: extended
+      type: keyword
+      short: Threat tactic.
+      description: >
+          Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
+          (ex. https://attack.mitre.org/tactics/TA0002/)
+
+      example: Execution
+      normalize:
+        - array
+
 
     - name: tactic.reference
       level: extended
@@ -54,9 +55,22 @@
       short: Threat tactic URL reference.
       description: >
           The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
-          (ex. https://attack.mitre.org/tactics/TA0040/ )
+          (ex. https://attack.mitre.org/tactics/TA0002/ )
 
-      example: https://attack.mitre.org/tactics/TA0040/
+      example: https://attack.mitre.org/tactics/TA0002/
+      normalize:
+        - array
+
+
+    - name: technique.id
+      level: extended
+      type: keyword
+      short: Threat technique id.
+      description: >
+          The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
+          (ex. https://attack.mitre.org/techniques/T1059/)
+
+      example: T1059
       normalize:
         - array
 
@@ -69,21 +83,9 @@
       short: Threat technique name.
       description: >
           The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
-          (ex. https://attack.mitre.org/techniques/T1499/)
+          (ex. https://attack.mitre.org/techniques/T1059/)
 
-      example: Endpoint Denial of Service
-      normalize:
-        - array
-
-    - name: technique.id
-      level: extended
-      type: keyword
-      short: Threat technique id.
-      description: >
-          The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
-          (ex. https://attack.mitre.org/techniques/T1499/)
-
-      example: T1499
+      example: Command and Scripting Interpreter
       normalize:
         - array
 
@@ -93,8 +95,47 @@
       short: Threat technique URL reference.
       description: >
           The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example.
-          (ex. https://attack.mitre.org/techniques/T1499/ )
+          (ex. https://attack.mitre.org/techniques/T1059/)
 
-      example: https://attack.mitre.org/techniques/T1499/
+      example: https://attack.mitre.org/techniques/T1059/
+      normalize:
+        - array
+
+    - name: technique.subtechnique.id
+      level: extended
+      type: keyword
+      short: Threat subtechnique id.
+      description: >
+          The full id of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
+          (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+      example: T1059.001
+      normalize:
+        - array
+
+    - name: technique.subtechnique.name
+      level: extended
+      type: keyword
+      multi_fields:
+      - type: text
+        name: text
+      short: Threat subtechnique name.
+      description: >
+          The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
+          (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+      example: PowerShell
+      normalize:
+        - array
+
+    - name: technique.subtechnique.reference
+      level: extended
+      type: keyword
+      short: Threat subtechnique URL reference.
+      description: >
+          The reference url of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
+          (ex. https://attack.mitre.org/techniques/T1059/001/)
+
+      example: https://attack.mitre.org/techniques/T1059/001/
       normalize:
         - array

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -32,7 +32,7 @@
           The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example.
           (ex. https://attack.mitre.org/tactics/TA0002/ )
 
-      example: TA0040
+      example: TA0002
       normalize:
         - array
 


### PR DESCRIPTION
Closes #867

For more context on why it makes sense to nest this at `threat.technique.subtechnique`, see #867 and the related Kibana issue.

I also updated the example information, since it was before ATT&CK added subtechniques, and I wanted to make sure everything was fully consistent with one example. PowerShell is one of my gotos (formerly T1086, now T1059.001).

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?  ✔️ 
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md)?  ✔️ 
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/master/rfcs/README.md)? N/A
- If submitting code/script changes, have you verified all tests pass locally using `make test`? ✔️ 
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? ✔️
- Is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.  ✔️ 
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/master/CHANGELOG.next.md)? ✔️
