### PR TITLE
Add event category configuration

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,7 @@ Thanks, you're awesome :-) -->
 
 * Added Mime Type fields to HTTP request and response. #944
 * Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
+* Added `configuration` as an allowed `event.category`. #963
 
 #### Improvements
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1546,7 +1546,7 @@ Note: this field should contain an array of values.
 
 *Important*: The field value must be one of the following:
 
-authentication, database, driver, file, host, iam, intrusion_detection, malware, network, package, process, web
+authentication, configuration, database, driver, file, host, iam, intrusion_detection, malware, network, package, process, web
 
 To learn more about when to use which value, visit the page
 <<ecs-allowed-values-event-category,allowed values for event.category>>

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -133,6 +133,7 @@ that will require subsequent breaking changes.
 *Allowed Values*
 
 * <<ecs-event-category-authentication,authentication>>
+* <<ecs-event-category-configuration,configuration>>
 * <<ecs-event-category-database,database>>
 * <<ecs-event-category-driver,driver>>
 * <<ecs-event-category-file,file>>
@@ -155,6 +156,20 @@ Events in this category are related to the challenge and response process in whi
 *Expected event types for category authentication:*
 
 start, end, info
+
+
+[float]
+[[ecs-event-category-configuration]]
+==== configuration
+
+Events in the configuration category have to deal with creating, modifying, or deleting the settings or parameters of an application, process, or system.
+
+Example sources include security policy change logs, configuration auditing logging, and system integrity monitoring.
+
+
+*Expected event types for category configuration:*
+
+access, change, creation, deletion, info
 
 
 [float]

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1655,6 +1655,19 @@ event.category:
     - end
     - info
     name: authentication
+  - description: 'Events in the configuration category have to deal with creating,
+      modifying, or deleting the settings or parameters of an application, process,
+      or system.
+
+      Example sources include security policy change logs, configuration auditing
+      logging, and system integrity monitoring.'
+    expected_event_types:
+    - access
+    - change
+    - creation
+    - deletion
+    - info
+    name: configuration
   - description: The database category denotes events and metrics relating to a data
       storage and retrieval system. Note that use of this category is not limited
       to relational database systems. Examples include event logs from MS SQL, MySQL,

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2042,6 +2042,19 @@ event:
         - end
         - info
         name: authentication
+      - description: 'Events in the configuration category have to deal with creating,
+          modifying, or deleting the settings or parameters of an application, process,
+          or system.
+
+          Example sources include security policy change logs, configuration auditing
+          logging, and system integrity monitoring.'
+        expected_event_types:
+        - access
+        - change
+        - creation
+        - deletion
+        - info
+        name: configuration
       - description: The database category denotes events and metrics relating to
           a data storage and retrieval system. Note that use of this category is not
           limited to relational database systems. Examples include event logs from

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -141,6 +141,19 @@
             - start
             - end
             - info
+        - name: configuration
+          description: >
+            Events in the configuration category have to deal with creating, modifying, or
+            deleting the settings or parameters of an application, process, or system.
+
+            Example sources include security policy change logs, configuration auditing logging,
+            and system integrity monitoring.
+          expected_event_types:
+            - access
+            - change
+            - creation
+            - deletion
+            - info
         - name: database
           description: >
             The database category denotes events and metrics relating to a data storage


### PR DESCRIPTION
#### Summary

Add a new event category allowed value, `configuration`. The category is aimed at classifying configuration events from applications, processes, or systems.

#### Discussion Points

* Any feedback on the description for `configuration`?
* I have added these allowed `event.types` as a starting point. Feedback welcome on additions or subtractions here:

```
- access
- change
- creation
- deletion
- info
```

Closes #799 