### PR TITLE
Remove `expected_event_types` from protocol

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* The `protocol` allowed value under `event.type` should not have the `expected_event_types` defined. #964
+
 #### Added
 
 * Added Mime Type fields to HTTP request and response. #944

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -439,10 +439,6 @@ The installation event type is used for the subset of events within a category t
 The protocol event type is used for the subset of events within a category that indicate that they contain protocol details or analysis, beyond simply identifying the protocol. Generally, network events that contain specific protocol details will fall into this subcategory. A common example is `event.category:network AND event.type:protocol AND event.type:connection AND event.type:end` (to indicate that the event is a network connection event sent at the end of a connection that also includes a protocol detail breakdown). Note that events that only indicate the name or id of the protocol should not use the protocol value. Further note that when the protocol subcategory is used, the identified protocol is populated in the ECS `network.protocol` field.
 
 
-*Expected event types for category protocol:*
-
-access, change, end, info, start
-
 
 [float]
 [[ecs-event-type-start]]

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2298,12 +2298,6 @@ event.type:
       indicate the name or id of the protocol should not use the protocol value. Further
       note that when the protocol subcategory is used, the identified protocol is
       populated in the ECS `network.protocol` field.
-    expected_event_types:
-    - access
-    - change
-    - end
-    - info
-    - start
     name: protocol
   - description: The start event type is used for the subset of events within a category
       that indicate something has started. A common example is `event.category:process

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2701,12 +2701,6 @@ event:
           should not use the protocol value. Further note that when the protocol subcategory
           is used, the identified protocol is populated in the ECS `network.protocol`
           field.
-        expected_event_types:
-        - access
-        - change
-        - end
-        - info
-        - start
         name: protocol
       - description: The start event type is used for the subset of events within
           a category that indicate something has started. A common example is `event.category:process

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -469,12 +469,6 @@
             Note that events that only indicate the name or id of the protocol should not use the protocol value.
             Further note that when the protocol subcategory is used, the identified protocol is populated in
             the ECS `network.protocol` field.
-          expected_event_types:
-            - access
-            - change
-            - end
-            - info
-            - start
         - name: start
           description: >
             The start event type is used for the subset of events within a category


### PR DESCRIPTION
As an `allowed_value` under `event.type`, `protocol` shouldn't have the `expected_event_types` section defined.

This change will remove from the schema as well as in the ECS documentation.