### PR TITLE
Add related.event field

### DIFF
--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -42,4 +42,7 @@ type Related struct {
 	// All hostnames or other host identifiers seen on your event. Example
 	// identifiers include FQDNs, domain names, workstation names, or aliases.
 	Hosts string `ecs:"hosts"`
+
+	// Previous event IDs that are related to this event.
+	Event string `ecs:"event"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4627,6 +4627,22 @@ A concrete example is IP addresses, which can be under host, observer, source, d
 
 // ===============================================================
 
+| related.event
+| Previous event IDs hat are related to this event.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
 | related.hash
 | All the hashes seen on your event. Populating this field, then using it to search for hashes can help in situations where you're unsure what the hash algorithm is (and therefore which key name to search).
 

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -53,3 +53,12 @@
         identifiers include FQDNs, domain names, workstation names, or aliases.
       normalize:
         - array
+
+    - name: event
+      level: extended
+      type: keyword
+      description: >
+        Previous event IDs that are related to this event.
+      normalize:
+        - array
+


### PR DESCRIPTION
This is a non-breaking, minor change to add a new keyword `event` field under the `related` object for tracking related, previous events. While I understand `related.user`, `related.ip`, etc (related but no context like source, destination), one of the first things I wanted to relate events to was other events. For example, and authorization event to an authentication event. Or something as generic as a file closed event related to a file open event. 

My primary use-case is security-related and much more complex where we enrich events with information from previous events. By relating event entries to previous events, this provides an investigative pivot point. Relationships could be based on session ID, or similar information.

Since this is only a minor change and hopefully not controversial, I've decided to add this via PR.