### PR TITLE
Add normalizer multi-field capability

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,6 +40,7 @@ Thanks, you're awesome :-) -->
 
 * Introduced `--strict` flag to perform stricter schema validation when running the generator script. #937
 * Added check under `--strict` that ensures composite types in example fields are quoted. #966
+* Added `ignore_above` and `normalizer` support for keyword multi-fields. #971
 
 #### Improvements
 

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -35,7 +35,7 @@ def fieldset_field_array(source_fields, df_whitelist, fieldset_prefix):
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
                     'example', 'enabled', 'index']
-    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field']
+    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer']
 
     fields = []
     for nested_field_name in source_fields:

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -35,7 +35,7 @@ def fieldset_field_array(source_fields, df_whitelist, fieldset_prefix):
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
                     'example', 'enabled', 'index']
-    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer']
+    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer', `ignore_above`]
 
     fields = []
     for nested_field_name in source_fields:

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -35,7 +35,7 @@ def fieldset_field_array(source_fields, df_whitelist, fieldset_prefix):
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
                     'example', 'enabled', 'index']
-    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer', `ignore_above`]
+    multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer', 'ignore_above']
 
     fields = []
     for nested_field_name in source_fields:

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -64,6 +64,9 @@ def entry_for(field):
             field_entry['fields'] = {}
             for mf in field['multi_fields']:
                 mf_entry = {'type': mf['type']}
+                mf_normalizer = mf.get('normalizer')
+                if mf_normalizer:
+                    mf_entry['normalizer'] = mf_normalizer
                 if mf['type'] == 'text':
                     ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['norms'])
                 field_entry['fields'][mf['name']] = mf_entry

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -63,11 +63,11 @@ def entry_for(field):
         if 'multi_fields' in field:
             field_entry['fields'] = {}
             for mf in field['multi_fields']:
-                mf_entry = {'type': mf['type']}
-                mf_normalizer = mf.get('normalizer')
-                if mf_normalizer:
-                    mf_entry['normalizer'] = mf_normalizer
-                if mf['type'] == 'text':
+                mf_type = mf['type']
+                mf_entry = {'type': mf_type}
+                if mf_type == 'keyword':
+                    ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['normalizer', 'ignore_above'])
+                elif mf_type == 'text':
                     ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['norms'])
                 field_entry['fields'][mf['name']] = mf_entry
 


### PR DESCRIPTION
This PR adds the capability for custom schemas to define a `normalizer` for a specific `multi_field`.

Related: https://github.com/elastic/endpoint-package/pull/79