### PR TITLE
Removing unneeded link under `Additional Information`

### DIFF
--- a/docs/additional.asciidoc
+++ b/docs/additional.asciidoc
@@ -2,7 +2,6 @@
 == Additional Information
 
 * <<ecs-faq>>
-* <<ecs-mapping-network-events>>
 * <<ecs-glossary>>
 * <<ecs-contributing>>
 


### PR DESCRIPTION
Missed removing this asciidoc link on the `Additional Information` page for `ecs-mapping-network-events` when moving section underneath `Using ECS` in #969 