### PR TITLE
[1.x] Removing unneeded link under `Additional Information` (#984)

### DIFF
--- a/docs/additional.asciidoc
+++ b/docs/additional.asciidoc
@@ -2,7 +2,6 @@
 == Additional Information
 
 * <<ecs-faq>>
-* <<ecs-mapping-network-events>>
 * <<ecs-glossary>>
 * <<ecs-contributing>>
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Removing unneeded link under `Additional Information` (#984)