### PR TITLE
Add usage docs section

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -28,6 +28,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Added ability to supply free-form usage documentation per fieldset. #988
+
 #### Improvements
 
 #### Deprecated

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ docs:
 	if [ ! -d $(PWD)/build/docs ]; then \
 		git clone --depth=1 https://github.com/elastic/docs.git ./build/docs ; \
 	fi
-	./build/docs/build_docs --asciidoctor --doc ./docs/index.asciidoc --chunk=1 $(OPEN_DOCS) --out ./build/html_docs
+	./build/docs/build_docs --asciidoctor --doc ./docs/index.asciidoc --chunk=2 $(OPEN_DOCS) --out ./build/html_docs
 
 # Alias to generate experimental artifacts
 .PHONY: experimental

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -5,7 +5,7 @@ ECS fields can benefit from additional context and examples which describe their
 ## Adding a Usage Doc
 
 1. Create an AsciiDoc formatted file with the `.asciidoc` file extension.
-2. Save the file in this directory (`docs/usage`), naming it after the its associated fieldset (e.g. a usage document for the `base.*` fields would be named `base.asciidoc`).
+2. Save the file in this directory (`docs/usage`), naming it after its associated field set (e.g. a usage document for the fields defined in `schemas/base.yml` fields would be named `docs/usage/base.asciidoc`).
 3. Run `make`. The asciidoc generator will generate the ECS field reference, including the present usage docs.
 
 If the filename doesn't match a currently defined fieldset, the usage document will not appear on the ECS docs site. This logic is handled in the AsciiDoc generator scripts, `scripts/generators/asciidoc_fields.py`.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,39 @@
+# Usage Docs
+
+ECS fields can benefit from additional context and examples which describe their real-world usage. This directory provides a place in the documentation to capture these usage details. AsciiDoc markdown files can be added for any fieldset defined in ECS.
+
+## Adding a Usage Doc
+
+1. Create an AsciiDoc formatted file with the `.asciidoc` file extension.
+2. Save the file in this directory (`docs/usage`), naming it after the its associated fieldset (e.g. a usage document for the `base.*` fields would be named `base.asciidoc`).
+3. Run `make`. The asciidoc generator will generate the ECS field reference, including the present usage docs.
+
+If the filename doesn't match a currently defined fieldset, the usage document will not appear on the ECS docs site. This logic is handled in the AsciiDoc generator scripts, `scripts/generators/asciidoc_fields.py`.
+
+## Template
+
+The following is a simple AsciiDoc template as a starting point:
+
+```asciidoc
+
+[ecs-usage-template]
+==== Fieldset Usage
+
+Add relevant text here.
+
+[discrete]
+===== New Section header
+
+Text for the new section.
+
+[discrete]
+===== Examples
+
+[source,sh]
+-----------
+{
+    "key": "value"
+}
+-----------
+
+```

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -6,7 +6,8 @@ ECS fields can benefit from additional context and examples which describe their
 
 1. Create an AsciiDoc formatted file with the `.asciidoc` file extension.
 2. Save the file in this directory (`docs/usage`), naming it after its associated field set (e.g. a usage document for the fields defined in `schemas/base.yml` fields would be named `docs/usage/base.asciidoc`).
-3. Run `make`. The asciidoc generator will generate the ECS field reference, including the present usage docs.
+3. The anchor at the top of the file (e.g. `[[ecs-base-usage]]`) must use the following convention for valid link references in the generated docs: `[[ecs-<<fieldset-name>>-usage]]`.
+4. Run `make`. The asciidoc generator will generate the ECS field reference, including the present usage docs.
 
 If the filename doesn't match a currently defined fieldset, the usage document will not appear on the ECS docs site. This logic is handled in the AsciiDoc generator scripts, `scripts/generators/asciidoc_fields.py`.
 
@@ -16,7 +17,7 @@ The following is a simple AsciiDoc template as a starting point:
 
 ```asciidoc
 
-[[ecs-usage-template]]
+[[ecs-fieldset-usage]]
 ==== Fieldset Usage
 
 Add relevant text here.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -16,7 +16,7 @@ The following is a simple AsciiDoc template as a starting point:
 
 ```asciidoc
 
-[ecs-usage-template]
+[[ecs-usage-template]]
 ==== Fieldset Usage
 
 Add relevant text here.

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -71,6 +71,13 @@ def sort_fields(fieldset):
         field['allowed_value_names'] = extract_allowed_values_key_names(field)
     return sorted(fields_list, key=lambda field: field['name'])
 
+def check_for_usage_doc(fieldset_name, usage_file_list=ecs_helpers.usage_doc_files()):
+    """Checks if a usage doc exists for the specified
+       fieldset.
+
+    :param fieldset_name: The name of the target fieldset
+    """
+    return f"{fieldset_name}.asciidoc" in usage_file_list
 
 def templated(template_name):
     """Decorator function to simplify rendering a template.
@@ -138,10 +145,12 @@ def generate_field_details_page(fieldset):
     sorted_reuse_fields = render_fieldset_reuse_text(fieldset)
     render_nestings_reuse_fields = render_nestings_reuse_section(fieldset)
     sorted_fields = sort_fields(fieldset)
+    usage_doc = check_for_usage_doc(fieldset.get('name'))
     return dict(fieldset=fieldset,
                 sorted_reuse_fields=sorted_reuse_fields,
                 render_nestings_reuse_section=render_nestings_reuse_fields,
-                sorted_fields=sorted_fields)
+                sorted_fields=sorted_fields,
+                usage_doc=usage_doc)
 
 
 # Allowed values section

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -71,6 +71,7 @@ def sort_fields(fieldset):
         field['allowed_value_names'] = extract_allowed_values_key_names(field)
     return sorted(fields_list, key=lambda field: field['name'])
 
+
 def check_for_usage_doc(fieldset_name, usage_file_list=ecs_helpers.usage_doc_files()):
     """Checks if a usage doc exists for the specified
        fieldset.
@@ -78,6 +79,7 @@ def check_for_usage_doc(fieldset_name, usage_file_list=ecs_helpers.usage_doc_fil
     :param fieldset_name: The name of the target fieldset
     """
     return f"{fieldset_name}.asciidoc" in usage_file_list
+
 
 def templated(template_name):
     """Decorator function to simplify rendering a template.

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -127,6 +127,7 @@ def ecs_files():
     schema_glob = os.path.join(os.path.dirname(__file__), '../../schemas/*.yml')
     return sorted(glob.glob(schema_glob))
 
+
 def make_dirs(path):
     try:
         os.makedirs(path, exist_ok=True)

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -2,6 +2,7 @@ import glob
 import os
 import yaml
 import git
+import pathlib
 import warnings
 
 from collections import OrderedDict
@@ -113,11 +114,18 @@ def get_tree_by_ref(ref):
     return commit.tree
 
 
+def usage_doc_files():
+    usage_docs_dir = os.path.join(os.path.dirname(__file__), '../../docs/usage')
+    usage_docs_path = pathlib.Path(usage_docs_dir)
+    if usage_docs_path.is_dir():
+        return [x.name for x in usage_docs_path.glob('*.asciidoc') if x.is_file()]
+    return []
+
+
 def ecs_files():
     """Return the schema file list to load"""
     schema_glob = os.path.join(os.path.dirname(__file__), '../../schemas/*.yml')
     return sorted(glob.glob(schema_glob))
-
 
 def make_dirs(path):
     try:

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -113,9 +113,8 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 |=====
 
 {% endif %}{# if 'nestings' #}
-{%- endif %}{# if 'nestings' or 'reusable' in fieldset #}
-
-{% if usage_doc -%}
+{%- endif -%}{# if 'nestings' or 'reusable' in fieldset #}
+{%- if usage_doc %}
 
 include::usage/{{ fieldset['name'] }}.asciidoc[]
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -114,3 +114,9 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 {% endif %}{# if 'nestings' #}
 {%- endif %}{# if 'nestings' or 'reusable' in fieldset #}
+
+{% if usage_doc -%}
+
+include::usage/{{ fieldset['name'] }}.asciidoc[]
+
+{% endif %}

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -4,6 +4,12 @@
 
 {{ fieldset['description']|replace("\n", "\n\n") }}
 
+{%- if usage_doc %}
+
+Find additional usage and examples in the {{ fieldset['name'] }} fields <<ecs-{{ fieldset['name']|replace("_", "-") }}-usage,usage>> section.
+
+{% endif %}
+
 {# Field Details Table Header -#}
 [discrete]
 ==== {{ fieldset['title'] }} Field Details

--- a/scripts/tests/test_asciidoc_fields.py
+++ b/scripts/tests/test_asciidoc_fields.py
@@ -137,5 +137,6 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
         foo_name = self.foo_fieldset.get('name')
         self.assertFalse(asciidoc_fields.check_for_usage_doc(foo_name, usage_file_list=usage_files))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_asciidoc_fields.py
+++ b/scripts/tests/test_asciidoc_fields.py
@@ -127,6 +127,15 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
         self.assertEqual('as', foo_nesting_fields[0]['name'])
         self.assertEqual('Fields describing an AS', foo_nesting_fields[0]['short'])
 
+    def test_check_for_usage_doc_true(self):
+        usage_files = ["foo.asciidoc"]
+        foo_name = self.foo_fieldset.get('name')
+        self.assertTrue(asciidoc_fields.check_for_usage_doc(foo_name, usage_file_list=usage_files))
+
+    def test_check_for_usage_doc_false(self):
+        usage_files = ["notfoo.asciidoc"]
+        foo_name = self.foo_fieldset.get('name')
+        self.assertFalse(asciidoc_fields.check_for_usage_doc(foo_name, usage_file_list=usage_files))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
#### Summary

Adds a free-text section to the ECS field reference docs for each fieldset, called `usage`. The `usage` directory will allow for any current ECS fieldset to have a paired usage document which will appear as a subsection in the ECS docs table of contents.

#### Format/Appearance

The ECS documentation book will add an additional level of chunking:

<img width="357" alt="Screen Shot 2020-09-30 at 1 21 20 PM" src="https://user-images.githubusercontent.com/7226265/94724621-305a6780-0320-11eb-8907-c706dc066b7b.png">

This additional, nested documentation page will only be added when a usage document is created for that particular field set.

#### Implementation Notes

* A new directory named `docs/usage` is being added and includes a `README.md` describing the intent and how-to for the usage asciidoc files.
* The `asciidoc_fields` generator will check the contents of `docs/usage` and create the necessary `include` statements in `docs/field-details.asciidoc`.
* No usage documentation is included; this PR focuses on putting the framework in place. Changes to `docs/field-details.asciidoc` were done to align with the changes in the `field_details.j2` template.
* The field details Jinja2 template has added the `[discrete]` section attribute to allow the necessary `include` statement to work as expected.
* The `Makefile` has been updated to use the higher chunking level: `--chunk=2`

Relates to #943 