### PR TITLE
[1.7] Clarify that file extension should exclude the dot. (#1016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file based on the
 #### Bugfixes
 
 * The `protocol` allowed value under `event.type` should not have the `expected_event_types` defined. #964
+* Clarify the definition of `file.extension` (no dots). #1016
 
 #### Added
 

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -55,7 +55,9 @@ type File struct {
 	// Target path for symlinks.
 	TargetPath string `ecs:"target_path"`
 
-	// File extension.
+	// File extension, excluding the leading dot.
+	// Note that when the file name has multiple extensions (example.tar.gz),
+	// only the last one should be captured ("gz", not "tar.gz").
 	Extension string `ecs:"extension"`
 
 	// File type (file, dir, or symlink).

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2109,7 +2109,9 @@ example: `C`
 // ===============================================================
 
 | file.extension
-| File extension.
+| File extension, excluding the leading dot.
+
+Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1568,7 +1568,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
     - name: gid
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -174,7 +174,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.7.0-dev,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
 1.7.0-dev,true,file,file.directory,wildcard,extended,,/home/alice,Directory where the file is located.
 1.7.0-dev,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
-1.7.0-dev,true,file,file.extension,keyword,extended,,png,File extension.
+1.7.0-dev,true,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
 1.7.0-dev,true,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.7.0-dev,true,file,file.group,keyword,extended,,alice,Primary group name of the file.
 1.7.0-dev,true,file,file.hash.md5,keyword,extended,,,MD5 hash.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2502,14 +2502,17 @@ file.drive_letter:
   type: keyword
 file.extension:
   dashed_name: file-extension
-  description: File extension.
+  description: 'File extension, excluding the leading dot.
+
+    Note that when the file name has multiple extensions (example.tar.gz), only the
+    last one should be captured ("gz", not "tar.gz").'
   example: png
   flat_name: file.extension
   ignore_above: 1024
   level: extended
   name: extension
   normalize: []
-  short: File extension.
+  short: File extension, excluding the leading dot.
   type: keyword
 file.gid:
   dashed_name: file-gid

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2925,14 +2925,17 @@ file:
       type: keyword
     file.extension:
       dashed_name: file-extension
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
       flat_name: file.extension
       ignore_above: 1024
       level: extended
       name: extension
       normalize: []
-      short: File extension.
+      short: File extension, excluding the leading dot.
       type: keyword
     file.gid:
       dashed_name: file-gid

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1604,7 +1604,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
     - name: gid
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -175,7 +175,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.7.0-dev,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
 1.7.0-dev,true,file,file.directory,keyword,extended,,/home/alice,Directory where the file is located.
 1.7.0-dev,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
-1.7.0-dev,true,file,file.extension,keyword,extended,,png,File extension.
+1.7.0-dev,true,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
 1.7.0-dev,true,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.7.0-dev,true,file,file.group,keyword,extended,,alice,Primary group name of the file.
 1.7.0-dev,true,file,file.hash.md5,keyword,extended,,,MD5 hash.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2544,14 +2544,17 @@ file.drive_letter:
   type: keyword
 file.extension:
   dashed_name: file-extension
-  description: File extension.
+  description: 'File extension, excluding the leading dot.
+
+    Note that when the file name has multiple extensions (example.tar.gz), only the
+    last one should be captured ("gz", not "tar.gz").'
   example: png
   flat_name: file.extension
   ignore_above: 1024
   level: extended
   name: extension
   normalize: []
-  short: File extension.
+  short: File extension, excluding the leading dot.
   type: keyword
 file.gid:
   dashed_name: file-gid

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2968,14 +2968,17 @@ file:
       type: keyword
     file.extension:
       dashed_name: file-extension
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
       flat_name: file.extension
       ignore_above: 1024
       level: extended
       name: extension
       normalize: []
-      short: File extension.
+      short: File extension, excluding the leading dot.
       type: keyword
     file.gid:
       dashed_name: file-gid

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -74,7 +74,12 @@
     - name: extension
       level: extended
       type: keyword
-      description: File extension.
+      short: File extension, excluding the leading dot.
+      description: >
+        File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz),
+        only the last one should be captured ("gz", not "tar.gz").
       example: png
 
     - name: type


### PR DESCRIPTION
Backports the following commits to 1.7:
* Clarify that file extension should exclude the dot. (#1016)