### PR TITLE
[1.6] Clarify that file extension should exclude the dot. (#1016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,50 +3,6 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.7.0](https://github.com/elastic/ecs/compare/v1.6.0...v1.7.0)
-
-### Schema Changes
-
-#### Bugfixes
-
-* The `protocol` allowed value under `event.type` should not have the `expected_event_types` defined. #964
-* Clarify the definition of `file.extension` (no dots). #1016
-
-#### Added
-
-* Added Mime Type fields to HTTP request and response. #944
-* Added network directions ingress and egress. #945
-* Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
-* Added `configuration` as an allowed `event.category`. #963
-
-#### Improvements
-
-* Expanded field set definitions for `source.*` and `destination.*`. #967
-* Provided better guidance for mapping network events. #969
-* Added the field `.subdomain` under `client`, `destination`, `server`, `source`
-  and `url`, to match its presence at `dns.question.subdomain`. #981
-
-### Tooling and Artifact Changes
-
-#### Bugfixes
-
-* Addressed issue where foreign reuses weren't using the user-supplied `as` value for their destination. #960
-
-#### Added
-
-* Introduced `--strict` flag to perform stricter schema validation when running the generator script. #937
-* Added check under `--strict` that ensures composite types in example fields are quoted. #966
-* Added `ignore_above` and `normalizer` support for keyword multi-fields. #971
-* Added `--oss` flag for users who want to generate ECS templates for use on OSS clusters. #991
-* Added a new directory with experimental artifacts, which includes all changes
-  from RFCs that have reached stage 2. #993
-
-#### Improvements
-
-* Field details Jinja2 template components have been consolidated into one template #897
-* Add `[discrete]` marker before each section header in field details. #989
-
-
 ## [1.6.0](https://github.com/elastic/ecs/compare/v1.5.0...v1.6.0)
 
 ### Schema Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.7.0](https://github.com/elastic/ecs/compare/v1.6.0...v1.7.0)
+
+### Schema Changes
+
+#### Bugfixes
+
+* The `protocol` allowed value under `event.type` should not have the `expected_event_types` defined. #964
+* Clarify the definition of `file.extension` (no dots). #1016
+
+#### Added
+
+* Added Mime Type fields to HTTP request and response. #944
+* Added network directions ingress and egress. #945
+* Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
+* Added `configuration` as an allowed `event.category`. #963
+
+#### Improvements
+
+* Expanded field set definitions for `source.*` and `destination.*`. #967
+* Provided better guidance for mapping network events. #969
+* Added the field `.subdomain` under `client`, `destination`, `server`, `source`
+  and `url`, to match its presence at `dns.question.subdomain`. #981
+
+### Tooling and Artifact Changes
+
+#### Bugfixes
+
+* Addressed issue where foreign reuses weren't using the user-supplied `as` value for their destination. #960
+
+#### Added
+
+* Introduced `--strict` flag to perform stricter schema validation when running the generator script. #937
+* Added check under `--strict` that ensures composite types in example fields are quoted. #966
+* Added `ignore_above` and `normalizer` support for keyword multi-fields. #971
+* Added `--oss` flag for users who want to generate ECS templates for use on OSS clusters. #991
+* Added a new directory with experimental artifacts, which includes all changes
+  from RFCs that have reached stage 2. #993
+
+#### Improvements
+
+* Field details Jinja2 template components have been consolidated into one template #897
+* Add `[discrete]` marker before each section header in field details. #989
+
+
 ## [1.6.0](https://github.com/elastic/ecs/compare/v1.5.0...v1.6.0)
 
 ### Schema Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable changes to this project will be documented in this file based on the
 #### Bugfixes
 
 * Field `registry.data.strings` should have been marked as an array field. #790
+* Clarify the definition of `file.extension` (no dots). #1016
 
 #### Added
 

--- a/code/go/ecs/file.go
+++ b/code/go/ecs/file.go
@@ -55,7 +55,9 @@ type File struct {
 	// Target path for symlinks.
 	TargetPath string `ecs:"target_path"`
 
-	// File extension.
+	// File extension, excluding the leading dot.
+	// Note that when the file name has multiple extensions (example.tar.gz),
+	// only the last one should be captured ("gz", not "tar.gz").
 	Extension string `ecs:"extension"`
 
 	// File type (file, dir, or symlink).

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2080,7 +2080,9 @@ example: `C`
 // ===============================================================
 
 | file.extension
-| File extension.
+| File extension, excluding the leading dot.
+
+Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
 
 type: keyword
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1574,7 +1574,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
     - name: gid
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -173,7 +173,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.6.0,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
 1.6.0,true,file,file.directory,keyword,extended,,/home/alice,Directory where the file is located.
 1.6.0,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
-1.6.0,true,file,file.extension,keyword,extended,,png,File extension.
+1.6.0,true,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
 1.6.0,true,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.6.0,true,file,file.group,keyword,extended,,alice,Primary group name of the file.
 1.6.0,true,file,file.hash.md5,keyword,extended,,,MD5 hash.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2505,14 +2505,17 @@ file.drive_letter:
   type: keyword
 file.extension:
   dashed_name: file-extension
-  description: File extension.
+  description: 'File extension, excluding the leading dot.
+
+    Note that when the file name has multiple extensions (example.tar.gz), only the
+    last one should be captured ("gz", not "tar.gz").'
   example: png
   flat_name: file.extension
   ignore_above: 1024
   level: extended
   name: extension
   normalize: []
-  short: File extension.
+  short: File extension, excluding the leading dot.
   type: keyword
 file.gid:
   dashed_name: file-gid

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2923,14 +2923,17 @@ file:
       type: keyword
     file.extension:
       dashed_name: file-extension
-      description: File extension.
+      description: 'File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
       flat_name: file.extension
       ignore_above: 1024
       level: extended
       name: extension
       normalize: []
-      short: File extension.
+      short: File extension, excluding the leading dot.
       type: keyword
     file.gid:
       dashed_name: file-gid

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -74,7 +74,12 @@
     - name: extension
       level: extended
       type: keyword
-      description: File extension.
+      short: File extension, excluding the leading dot.
+      description: >
+        File extension, excluding the leading dot.
+
+        Note that when the file name has multiple extensions (example.tar.gz),
+        only the last one should be captured ("gz", not "tar.gz").
       example: png
 
     - name: type


### PR DESCRIPTION
Backports the following commits to 1.6:
* Clarify that file extension should exclude the dot. (#1016)