### PR TITLE
Set the correct merge date for RFC 0005 stage 1

### DIFF
--- a/rfcs/text/0005-host-metric-fields.md
+++ b/rfcs/text/0005-host-metric-fields.md
@@ -2,7 +2,7 @@
 <!-- Leave this ID at 0000. The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC. -->
 
 - Stage: **1 (proposal)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
-- Date: **2020-08-21** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
+- Date: **2020-10-13** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
 
 <!--
 As you work on your RFC, use the "Stage N" comments to guide you in what you should focus on, for the stage you're targeting.


### PR DESCRIPTION
This PR is simply meant to set the merge date for this stage 1 document.
I forgot to do this when merging https://github.com/elastic/ecs/pull/950, a few days ago.