### PR TITLE
Adds container.is_vulnerable

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -28,7 +28,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Added ability to supply free-form usage documentation per fieldset. #988
+* Added container.is_vulnerable
 
 #### Improvements
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -791,6 +791,14 @@ Note: this field should contain an array of values.
 type: object
 
 
+| extended
+
+// ===============================================================
+
+| container.is_vulnerable
+| Is the container vulnerable
+
+type: boolean
 
 
 

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -50,3 +50,10 @@
       object_type: keyword
       description: >
         Image labels.
+
+    - name: is_vulnerable
+      level: extended
+      type: boolean
+      description: >
+        Identified as vulnerable.
+


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md)? Y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/master/rfcs/README.md)? Y
- If submitting code/script changes, have you verified all tests pass locally using `make test`? Y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? N (bugged)
- Is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed. Y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/master/CHANGELOG.next.md)?


# Description
[FedRAMP Guidance](https://www.fedramp.gov/assets/resources/documents/DRAFT_FedRAMP_Vulnerbility_Scanning_Requirements_for_the_Development_and_Use_of_Containers.pdf) is now pushing to maintain an inventory of containers and introduce additional assurance requirements that containers are not Vulnerable.

This field is intended to be used by in conjunction with Vulnerability Scanners (Twistlock, Nessus, etc) in order to log which containers have been identified as containing vulnerable code. 

# Extended Thoughts
Technically this could apply to instances, vms, hosts, and devices as well. Any time an asset is identified as vulnerable. 

Could this be done at a higher level context like [vulnerability](https://github.com/elastic/ecs/blob/master/schemas/vulnerability.yml)? Potentially, but that top level field would need to be re-worked a bit to be intelligent enough to know whether its the container or host that is vulnerable. Simple boolean at the host.* or container.* level would suffice to meet the FedRAMP control. `vulnerability.*` still makes sense to clarify what was found, but it's unclear as to what asset it might associate (host, vm, container, device). 

## make generate bugs
`make generate` fails in a few places on Linux. This may be a Linux vs. Mac issue.

The code I'm referring to is..
```
# Generate Go code from the schema.
.PHONY: gocodegen
gocodegen:
    find code/go/ecs -name '*.go' -not -name 'doc.go' | xargs rm
    cd scripts \
      && $(FORCE_GO_MODULES) go run cmd/gocodegen/gocodegen.go \
            -version=$(VERSION) \
            -schema=../schemas \
            -out=../code/go/ecs
```

The `rm` command is missing an operand. This might work on mac, but not linux. 
```
$ find code/go/ecs -name '*.go' -not -name 'doc.go' | xargs rm
rm: missing operand
Try 'rm --help' for more information.
```

## make setup hang
`make setup` is also hanging on the beats module
```
$ make setup
cd scripts && GO111MODULE=on go mod download
go: finding github.com/elastic/beats v7.0.0-alpha1.0.20181217223741-58573a9f3f15+incompatible
```