### PR TITLE
Add event.category registry

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Added `event.category` allowed value "registry". #1040
+
 #### Improvements
 
 #### Deprecated

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -1597,7 +1597,7 @@ Note: this field should contain an array of values.
 
 *Important*: The field value must be one of the following:
 
-authentication, configuration, database, driver, file, host, iam, intrusion_detection, malware, network, package, process, web
+authentication, configuration, database, driver, file, host, iam, intrusion_detection, malware, network, package, process, registry, web
 
 To learn more about when to use which value, visit the page
 <<ecs-allowed-values-event-category,allowed values for event.category>>

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -303,7 +303,7 @@ access, change, end, info, start
 [[ecs-event-category-registry]]
 ==== registry
 
-Use this category of event for events related to the Windows registry.
+Having to do with settings and assets stored in the Windows registry. Use this category to visualize and analyze activity such as registry access and modifications.
 
 
 *Expected event types for category registry:*

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -144,6 +144,7 @@ that will require subsequent breaking changes.
 * <<ecs-event-category-network,network>>
 * <<ecs-event-category-package,package>>
 * <<ecs-event-category-process,process>>
+* <<ecs-event-category-registry,registry>>
 * <<ecs-event-category-web,web>>
 
 [float]
@@ -296,6 +297,18 @@ Use this category of events to visualize and analyze process-specific informatio
 *Expected event types for category process:*
 
 access, change, end, info, start
+
+
+[float]
+[[ecs-event-category-registry]]
+==== registry
+
+Use this category of event for events related to the Windows registry.
+
+
+*Expected event types for category registry:*
+
+access, change, creation, deletion
 
 
 [float]

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1774,7 +1774,9 @@ event.category:
     - info
     - start
     name: process
-  - description: Use this category of event for events related to the Windows registry.
+  - description: Having to do with settings and assets stored in the Windows registry.
+      Use this category to visualize and analyze activity such as registry access
+      and modifications.
     expected_event_types:
     - access
     - change

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1774,6 +1774,13 @@ event.category:
     - info
     - start
     name: process
+  - description: Use this category of event for events related to the Windows registry.
+    expected_event_types:
+    - access
+    - change
+    - creation
+    - deletion
+    name: registry
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2168,8 +2168,9 @@ event:
         - info
         - start
         name: process
-      - description: Use this category of event for events related to the Windows
-          registry.
+      - description: Having to do with settings and assets stored in the Windows registry.
+          Use this category to visualize and analyze activity such as registry access
+          and modifications.
         expected_event_types:
         - access
         - change

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2168,6 +2168,14 @@ event:
         - info
         - start
         name: process
+      - description: Use this category of event for events related to the Windows
+          registry.
+        expected_event_types:
+        - access
+        - change
+        - creation
+        - deletion
+        name: registry
       - description: 'Relating to web server access. Use this category to create a
           dashboard of web server/proxy activity from apache, IIS, nginx web servers,
           etc. Note: events from network observers such as Zeek http log may also

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1814,7 +1814,9 @@ event.category:
     - info
     - start
     name: process
-  - description: Use this category of event for events related to the Windows registry.
+  - description: Having to do with settings and assets stored in the Windows registry.
+      Use this category to visualize and analyze activity such as registry access
+      and modifications.
     expected_event_types:
     - access
     - change

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1814,6 +1814,13 @@ event.category:
     - info
     - start
     name: process
+  - description: Use this category of event for events related to the Windows registry.
+    expected_event_types:
+    - access
+    - change
+    - creation
+    - deletion
+    name: registry
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2209,8 +2209,9 @@ event:
         - info
         - start
         name: process
-      - description: Use this category of event for events related to the Windows
-          registry.
+      - description: Having to do with settings and assets stored in the Windows registry.
+          Use this category to visualize and analyze activity such as registry access
+          and modifications.
         expected_event_types:
         - access
         - change

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2209,6 +2209,14 @@ event:
         - info
         - start
         name: process
+      - description: Use this category of event for events related to the Windows
+          registry.
+        expected_event_types:
+        - access
+        - change
+        - creation
+        - deletion
+        name: registry
       - description: 'Relating to web server access. Use this category to create a
           dashboard of web server/proxy activity from apache, IIS, nginx web servers,
           etc. Note: events from network observers such as Zeek http log may also

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -279,7 +279,8 @@
             - start
         - name: registry
           description: >
-            Use this category of event for events related to the Windows registry.
+            Having to do with settings and assets stored in the Windows registry.
+            Use this category to visualize and analyze activity such as registry access and modifications.
           expected_event_types:
             - access
             - change

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -277,6 +277,14 @@
             - end
             - info
             - start
+        - name: registry
+          description: >
+            Use this category of event for events related to the Windows registry.
+          expected_event_types:
+            - access
+            - change
+            - creation
+            - deletion
         - name: web
           description: >
             Relating to web server access. Use this category to create a dashboard of


### PR DESCRIPTION
This PR adds the allowed value "registry" to `event.category`. It was brought up recently that Endpoint was already using this value.

This value was in previous discussions of categorization. It wasn't included in the initial release of categorization simply because we didn't have data sources that would use it at the time.

[Doc preview](https://ecs_1040.docs-preview.app.elstc.co/diff)

Closes #1019