### PR TITLE
Correct experimental usage example

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -190,7 +190,9 @@ For example, if we defined the following schema definition in a file named `mypr
 Multiple directory targets can also be provided:
 
 ```
-$ python scripts/generator.py --include ../myproject/custom-fields-A/  ../myproject/custom-fields-B --out ../myproject/out/
+$ python scripts/generator.py \
+    --include ../myproject/custom-fields-A/  ../myproject/custom-fields-B \
+    --out ../myproject/out/
 ```
 
 Generate artifacts using `--include` to load our custom definitions in addition to `--out` to place them in the desired output directory:

--- a/USAGE.md
+++ b/USAGE.md
@@ -187,6 +187,12 @@ For example, if we defined the following schema definition in a file named `mypr
         Unique identifier of the widget.
 ```
 
+Multiple directory targets can also be provided:
+
+```
+$ python scripts/generator.py --include ../myproject/custom-fields-A/  ../myproject/custom-fields-B --out ../myproject/out/
+```
+
 Generate artifacts using `--include` to load our custom definitions in addition to `--out` to place them in the desired output directory:
 
 ```

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -14,8 +14,7 @@ The [experimental/schemas](./schemas) directory contains the YAML files for the 
 If you use the ECS generator script as described in [USAGE.md](../USAGE.md) to maintain your custom index templates, here's how you can try these experimental changes in your project:
 
 ```sh
-$ python scripts/generator.py --include experimental/schemas \
-    --include ../myproject/fields/custom/ \
+$ python scripts/generator.py --include experimental/schemas ../myproject/fields/custom/ \
     --out ../myproject/fields/generated
 ```
 


### PR DESCRIPTION
Additional, documentation was added to `USAGE.md` demonstrating using `--include` with multiple target directories.