### PR TITLE
Change the index pattern in the sample template.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ All notable changes to this project will be documented in this file based on the
 
 ### Tooling and Artifact Changes
 
+#### Breaking changes
+
+* Changed the index pattern of the sample Elasticsearch template from `ecs-*` to
+  `try-ecs-*` to avoid conflicting with Logstash' `ecs-logstash-*`. #1048
+
 #### Bugfixes
 
 * Addressed issue where foreign reuses weren't using the user-supplied `as` value for their destination. #960

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_doc": {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/elasticsearch/README.md
+++ b/generated/elasticsearch/README.md
@@ -3,33 +3,52 @@
 Crafting the perfect Elasticsearch template is an art. But here's a good starting
 point for experimentation.
 
+When you're ready to customize this template to the precise needs of your use case,
+please check out [USAGE.md](../../USAGE.md).
+
+## Notes on index naming
+
+This sample Elasticsearch template will apply to any index named `try-ecs-*`.
+This is good for experimentation.
+
+Note that an index following ECS can be named however you need. There's no requirement
+to have "ecs" in the index name.
+
 ## Instructions
 
-Load the template from your shell
+If you want to play with a specific version of ECS, check out the proper branch first.
+
+```
+git checkout 1.6
+```
+
+Load the template in Elasticsearch from your shell.
 
 ```bash
 # Elasticsearch 7
-curl -XPOST 'localhost:9200/_template/ecs-test' --header "Content-Type: application/json" \
+curl -XPOST 'localhost:9200/_template/try-ecs' \
+  --header "Content-Type: application/json" \
   -d @'generated/elasticsearch/7/template.json'
 
 # or Elasticsearch 6
-curl -XPOST 'localhost:9200/_template/ecs-test' --header "Content-Type: application/json" \
+curl -XPOST 'localhost:9200/_template/try-ecs' \
+  --header "Content-Type: application/json" \
   -d @'generated/elasticsearch/6/template.json'
 ```
 
 Play from Kibana Dev Tools
 
 ```
-# 👀
-GET _template/ecs-test
+# Look at the template you just uploaded 👀
+GET _template/try-ecs
 
-# index
-PUT ecs-test
-GET ecs-test
-POST ecs-test/_doc
-{ "@timestamp": "2019-02-26T22:38:39.000Z", "message": "Hello ECS World", "host": { "ip": "10.42.42.42"} }
+# index a document
+PUT try-ecs-test
+GET try-ecs-test
+POST try-ecs-test/_doc
+{ "@timestamp": "2020-10-26T22:38:39.000Z", "message": "Hello ECS World", "host": { "ip": "10.42.42.42"} }
 
 # enjoy
-GET ecs-test/_search
+GET try-ecs-test/_search
 { "query": { "term": { "host.ip": "10.0.0.0/8" } } }
 ```

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -109,7 +109,7 @@ def save_json(file, data):
 
 def default_template_settings():
     return {
-        "index_patterns": ["ecs-*"],
+        "index_patterns": ["try-ecs-*"],
         "order": 1,
         "settings": {
             "index": {


### PR DESCRIPTION
Logstash with ECS support creates a template that targets the index pattern `ecs-logstash-*`.

A user experimenting with our sample template (which previously targeted `ecs-*`) and using Logstash in ECS mode on the same cluster would likely have issues. Indeed, both templates would match their index name `ecs-logstash-*`.

I'm changing our sample template's pattern to `try-ecs-*`, which will avoid the above issue. It will also reinforce that when used as is, this template is appropriate for experimentation, more than production use.

I've added a bit of text in these instructions to better explain how to use this template, and where to go if users want to customize that template.