### PR TITLE
Add wildcard type support to go code generator

### DIFF
--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -274,7 +274,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "text", "ip", "geo_point":
+	case "keyword", "wildcard", "text", "ip", "geo_point":
 		return "string"
 	case "long":
 		return "int64"


### PR DESCRIPTION
#### Summary

Add support for the `wildcard` data type for the Go code generator.

#### Why is this change needed?

When `wildcard` appears once or more in the field definitions under `schemas`, the `gocodegen` Makefile directive will cause a `make` run to fail with the exception:

```
cd scripts \
          && GO111MODULE=on go run cmd/gocodegen/gocodegen.go \
                -version=2.0.0-dev \
                -schema=../schemas \
                -out=../code/go/ecs
no translation for wildcard (field executable)
exit status 1
make: *** [gocodegen] Error 1
```