### PR TITLE
Beta label support

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -37,7 +37,7 @@ Thanks, you're awesome :-) -->
 * Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 * Added ability for --oss flag to fall back `constant_keyword` to `keyword`. #1046
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
-* Added support for marking fields as beta in the documentation. #1051
+* Added support for marking fields, field sets, or field reuse as beta in the documentation. #1051
 * Added support for `constant_keyword`'s optional parameter `value`. #1112
 
 #### Improvements

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -37,6 +37,7 @@ Thanks, you're awesome :-) -->
 * Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 * Added ability for --oss flag to fall back `constant_keyword` to `keyword`. #1046
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
+* Added support for marking fields as beta in the documentation. #1051
 * Added support for `constant_keyword`'s optional parameter `value`. #1112
 
 #### Improvements

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -105,7 +105,17 @@ The above defines all process fields in both places:
 }
 ```
 
-The `beta` marker can also be used along with `at` and `as` to include a beta marker in the documentation containing the provided description.
+The `beta` marker can optionally be used along with `at` and `as` to include a beta marker in the documentation containing the provided description.
+
+```
+  reusable:
+    top_level: true
+    expected:
+    - at: user
+      as: target
+      beta: >
+        Beta description text here.
+```
 
 ### List of fields
 
@@ -137,7 +147,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
-- beta: Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation.
+- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation.
 
 Supported keys to describe expected values for a field
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -33,6 +33,7 @@ Optional field set attributes:
 - reusable (optional): Used to identify which field sets are expected to be reused in multiple places.
   See "Field set reuse" for details.
 - beta: Adds a beta marker for the entire fieldset. The text provided in this attribute is used as content of the beta marker in the documentation.
+  Beta should not have newlines.
 
 ### Field set reuse
 
@@ -106,6 +107,7 @@ The above defines all process fields in both places:
 ```
 
 The `beta` marker can optionally be used along with `at` and `as` to include a beta marker in the field reuses section, marking specific reuse locations as beta.
+Beta should not have newlines.
 
 ```
   reusable:
@@ -113,8 +115,7 @@ The `beta` marker can optionally be used along with `at` and `as` to include a b
     expected:
     - at: user
       as: target
-      beta: >
-        Reusing these fields in this location is currently considered beta.
+      beta: Reusing these fields in this location is currently considered beta.
 ```
 
 ### List of fields
@@ -147,7 +148,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
-- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta.
+- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta. Beta should not have newlines.
 
 Supported keys to describe expected values for a field
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -105,7 +105,7 @@ The above defines all process fields in both places:
 }
 ```
 
-The `beta` marker can optionally be used along with `at` and `as` to include a beta marker in the documentation containing the provided description.
+The `beta` marker can optionally be used along with `at` and `as` to include a beta marker in the field reuses section, marking specific reuse locations as beta.
 
 ```
   reusable:

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -32,6 +32,7 @@ Optional field set attributes:
 - type (ignored): at this level, should always be `group`
 - reusable (optional): Used to identify which field sets are expected to be reused in multiple places.
   See "Field set reuse" for details.
+- beta: Adds a beta marker for the entire fieldset. The text provided in this attribute is used as content of the beta marker in the documentation.
 
 ### Field set reuse
 
@@ -104,6 +105,8 @@ The above defines all process fields in both places:
 }
 ```
 
+The `beta` marker can also be used along with `at` and `as` to include a beta marker in the documentation containing the provided description.
+
 ### List of fields
 
 Array of YAML objects:
@@ -134,7 +137,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
-- beta (optional): If `True`, the field will be marked in the documentation with a `beta` label.
+- beta: Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation.
 
 Supported keys to describe expected values for a field
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -114,7 +114,7 @@ The `beta` marker can optionally be used along with `at` and `as` to include a b
     - at: user
       as: target
       beta: >
-        Beta description text here.
+        Reusing these fields in this location is currently considered beta.
 ```
 
 ### List of fields

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -134,6 +134,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
+- beta (optional): If `True`, the field will be marked in the documentation with a `beta` label.
 
 Supported keys to describe expected values for a field
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -33,7 +33,7 @@ Optional field set attributes:
 - reusable (optional): Used to identify which field sets are expected to be reused in multiple places.
   See "Field set reuse" for details.
 - beta: Adds a beta marker for the entire fieldset. The text provided in this attribute is used as content of the beta marker in the documentation.
-  Beta should not have newlines.
+  Beta notices should not have newlines.
 
 ### Field set reuse
 
@@ -107,7 +107,7 @@ The above defines all process fields in both places:
 ```
 
 The `beta` marker can optionally be used along with `at` and `as` to include a beta marker in the field reuses section, marking specific reuse locations as beta.
-Beta should not have newlines.
+Beta notices should not have newlines.
 
 ```
   reusable:
@@ -148,7 +148,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
-- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta. Beta should not have newlines.
+- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta. Beta notices should not have newlines.
 
 Supported keys to describe expected values for a field
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -147,7 +147,7 @@ Supported keys to describe fields
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
-- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation.
+- beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta.
 
 Supported keys to describe expected values for a field
 

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -39,7 +39,8 @@ def render_nestings_reuse_section(fieldset):
         rows.append({
             'flat_nesting': "{}.*".format(reused_here_entry['full']),
             'name': reused_here_entry['schema_name'],
-            'short': reused_here_entry['short']
+            'short': reused_here_entry['short'],
+            'beta': reused_here_entry.get('beta', '')
         })
 
     return sorted(rows, key=lambda x: x['flat_nesting'])

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -189,5 +189,5 @@ def strict_warning(msg):
     :param msg: custom text which will be displayed with wrapped boilerplate
                 for strict warning messages.
     """
-    warn_message = f"{msg}\n\nThis will cause an exception when running in strict mode."
-    warnings.warn(warn_message)
+    warn_message = f"{msg}\n\nThis will cause an exception when running in strict mode.\nWarning check:"
+    warnings.warn(warn_message, stacklevel=3)

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -76,6 +76,8 @@ def schema_mandatory_attributes(schema):
 def schema_assertions_and_warnings(schema):
     '''Additional checks on a fleshed out schema'''
     single_line_short_description(schema, strict=strict_mode)
+    if 'beta' in schema['field_details']:
+        single_line_beta_description(schema, strict=strict_mode)
 
 
 def normalize_reuse_notation(schema):
@@ -181,6 +183,8 @@ def field_assertions_and_warnings(field):
         # check short description length if in strict mode
         single_line_short_description(field, strict=strict_mode)
         check_example_value(field, strict=strict_mode)
+        if 'beta' in field['field_details']:
+            single_line_beta_description(field, strict=strict_mode)
         if field['field_details']['level'] not in ACCEPTABLE_FIELD_LEVELS:
             msg = "Invalid level for field '{}'.\nValue: {}\nAcceptable values: {}".format(
                 field['field_details']['name'], field['field_details']['level'],
@@ -216,6 +220,16 @@ def check_example_value(field, strict=True):
     if isinstance(example_value, (list, dict)):
         name = field['field_details']['name']
         msg = f"Example value for field `{name}` contains an object or array which must be quoted to avoid YAML interpretation."
+        if strict:
+            raise ValueError(msg)
+        else:
+            ecs_helpers.strict_warning(msg)
+
+
+def single_line_beta_description(schema_or_field, strict=True):
+    if "\n" in schema_or_field['field_details']['beta']:
+        msg = "Beta descriptions must be single line.\n"
+        msg += f"Offending field or field set: {schema_or_field['field_details']['name']}"
         if strict:
             raise ValueError(msg)
         else:

--- a/scripts/schema/finalizer.py
+++ b/scripts/schema/finalizer.py
@@ -128,6 +128,8 @@ def append_reused_here(reused_schema, reuse_entry, destination_schema):
         'full': reuse_entry['full'],
         'short': reused_schema['field_details']['short'],
     }
+    if 'beta' in reuse_entry:
+        reused_here_entry['beta'] = reuse_entry['beta']
     destination_schema['schema_details']['reused_here'].extend([reused_here_entry])
 
 

--- a/scripts/schema/finalizer.py
+++ b/scripts/schema/finalizer.py
@@ -128,6 +128,7 @@ def append_reused_here(reused_schema, reuse_entry, destination_schema):
         'full': reuse_entry['full'],
         'short': reused_schema['field_details']['short'],
     }
+    # Check for beta attribute
     if 'beta' in reuse_entry:
         reused_here_entry['beta'] = reuse_entry['beta']
     destination_schema['schema_details']['reused_here'].extend([reused_here_entry])

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -10,6 +10,13 @@ Find additional usage and examples in the {{ fieldset['name'] }} fields <<ecs-{{
 
 {% endif %}
 
+{# Fieldset label beta header -#}
+{% if fieldset['beta'] -%}
+
+beta::[ {{ fieldset['beta'] }}]
+
+{% endif -%}
+
 {# Field Details Table Header -#}
 [discrete]
 ==== {{ fieldset['title'] }} Field Details
@@ -27,7 +34,7 @@ Find additional usage and examples in the {{ fieldset['name'] }} fields <<ecs-{{
 {# `Field` column -#}
 {#- Beta fields will add the `beta` label -#}
 {%- if field['beta'] -%}
-| {{ field['flat_name'] }} beta:[]
+| {{ field['flat_name'] }} beta:[ {{ field['beta'] }} ]
 {%- else -%}
 | {{ field['flat_name'] }}
 {%- endif %}
@@ -113,7 +120,12 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 {% for entry in render_nestings_reuse_section -%}
 
+{#- Beta marker on nested fields -#}
+{%- if entry['beta'] -%}
+| <<ecs-{{ entry['name'] }},{{ entry['flat_nesting'] }}>>  beta:[ {{ entry['beta'] }}]
+{%- else -%}
 | <<ecs-{{ entry['name'] }},{{ entry['flat_nesting'] }}>>
+{%- endif %}
 | {{ entry['short'] }}
 
 // ===============================================================

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -25,7 +25,12 @@ Find additional usage and examples in the {{ fieldset['name'] }} fields <<ecs-{{
 {% if 'original_fieldset' not in field -%}
 
 {# `Field` column -#}
+{#- Beta fields will add the `beta` label -#}
+{%- if field['beta'] -%}
+| {{ field['flat_name'] }} beta:[]
+{%- else -%}
 | {{ field['flat_name'] }}
+{%- endif %}
 {# `Description` column -#}
 | {{ field['description']|replace("\n", "\n\n") }}
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -32,14 +32,16 @@ beta::[ {{ fieldset['beta'] }}]
 {% if 'original_fieldset' not in field -%}
 
 {# `Field` column -#}
-{#- Beta fields will add the `beta` label -#}
-{%- if field['beta'] -%}
-| {{ field['flat_name'] }} beta:[ {{ field['beta'] }} ]
-{%- else -%}
 | {{ field['flat_name'] }}
-{%- endif %}
 {# `Description` column -#}
+{#- Beta fields will add the `beta` label -#}
+{% if field['beta'] -%}
+| beta:[ {{ field['beta'] }} ]
+
+{{ field['description']|replace("\n", "\n\n") }}
+{%- else -%}
 | {{ field['description']|replace("\n", "\n\n") }}
+{%- endif %}
 
 type: {{ field['type'] }}
 
@@ -121,12 +123,15 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 {% for entry in render_nestings_reuse_section -%}
 
 {#- Beta marker on nested fields -#}
-{%- if entry['beta'] -%}
-| <<ecs-{{ entry['name'] }},{{ entry['flat_nesting'] }}>>  beta:[ {{ entry['beta'] }}]
-{%- else -%}
 | <<ecs-{{ entry['name'] }},{{ entry['flat_nesting'] }}>>
-{%- endif %}
+{#- Beta marker on nested fields -#}
+{%- if entry['beta'] -%}
+| beta:[ {{ entry['beta'] }}]
+
+{{ entry['short'] }}
+{%- else %}
 | {{ entry['short'] }}
+{%- endif %}
 
 // ===============================================================
 

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -211,7 +211,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                       fields['process']['schema_details']['reused_here'])
         self.assertIn({'full': 'user.effective', 'schema_name': 'user', 'short': 'short desc'},
                       fields['user']['schema_details']['reused_here'])
-        self.assertIn({'full': 'user.target', 'schema_name': 'user', 'short': 'short desc', 'beta': 'beta'},
+        self.assertIn({'full': 'user.target', 'schema_name': 'user', 'short': 'short desc', 'beta': 'Some beta notice'},
                       fields['user']['schema_details']['reused_here'])
         self.assertIn({'full': 'server.user', 'schema_name': 'user', 'short': 'short desc'},
                       fields['server']['schema_details']['reused_here'])

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -92,7 +92,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                         'order': 2,
                         'expected': [
                             {'full': 'server.user', 'at': 'server', 'as': 'user'},
-                            {'full': 'user.target', 'at': 'user', 'as': 'target', 'beta': 'beta'},
+                            {'full': 'user.target', 'at': 'user', 'as': 'target', 'beta': 'Some beta notice'},
                             {'full': 'user.effective', 'at': 'user', 'as': 'effective'},
                         ]
                     }

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -92,7 +92,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                         'order': 2,
                         'expected': [
                             {'full': 'server.user', 'at': 'server', 'as': 'user'},
-                            {'full': 'user.target', 'at': 'user', 'as': 'target'},
+                            {'full': 'user.target', 'at': 'user', 'as': 'target', 'beta': 'beta'},
                             {'full': 'user.effective', 'at': 'user', 'as': 'effective'},
                         ]
                     }
@@ -211,7 +211,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                       fields['process']['schema_details']['reused_here'])
         self.assertIn({'full': 'user.effective', 'schema_name': 'user', 'short': 'short desc'},
                       fields['user']['schema_details']['reused_here'])
-        self.assertIn({'full': 'user.target', 'schema_name': 'user', 'short': 'short desc'},
+        self.assertIn({'full': 'user.target', 'schema_name': 'user', 'short': 'short desc', 'beta': 'beta'},
                       fields['user']['schema_details']['reused_here'])
         self.assertIn({'full': 'server.user', 'schema_name': 'user', 'short': 'short desc'},
                       fields['server']['schema_details']['reused_here'])


### PR DESCRIPTION
#### Summary

Introduces a new key, `beta`, which when set to `True` designates a field as being in `beta` support in the ECS field reference documentation.

#### Motivation

Fields introduced in RFCs which have advanced to [stage three](https://elastic.github.io/ecs/stages.html) are to be committed to the schema as beta. The "beta" label should appear in the ECS docs next to any fields which are in beta.

The ECS field definitions need an option to specify if a field is currently considered `beta`. Once an RFC advances to stage four, the beta label will be removed by removing the beta option from the field's definition.

#### Implementation

A field can be marked as beta by specifying the `beta` option:

```yaml
    - name: executable
      level: extended
      type: keyword
      beta: True
      description: >
        Absolute path to the process executable.
      example: /usr/bin/ssh
      multi_fields:
      - type: text
        name: text
```

#### Field Reference Docs Example

Once the field reference documentation is regenerated using `make`, the field now appears in the docs with the `beta` label if we pass text to the `beta:[]` argument:

![Screen Shot 2020-10-26 at 2 48 37 PM](https://user-images.githubusercontent.com/7226265/97221025-61507f80-179a-11eb-97b5-d23ee349eeaf.png)

The label is using the default tooltip text, but we can optionally customize the contents.

![Screen Shot 2020-10-26 at 2 48 44 PM](https://user-images.githubusercontent.com/7226265/97221117-7e854e00-179a-11eb-92b8-6086eb63bf28.png)
 