### PR TITLE
Remove experimental event.original definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file based on the
 #### Bugfixes
 
 * Addressed issue where foreign reuses weren't using the user-supplied `as` value for their destination. #960
+* Experimental artifacts failed to install due to `event.original` index setting. #1053
 
 #### Added
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1324,7 +1324,7 @@
         but it can be retrieved from `_source`.'
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
-      index: false
+      index: true
     - name: outcome
       level: core
       type: keyword

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1317,14 +1317,15 @@
       example: apache
     - name: original
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Raw text message of entire event. Used to demonstrate log integrity.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`.'
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
-      index: true
+      index: false
     - name: outcome
       level: core
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -149,7 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
 2.0.0-dev,true,event,event.kind,keyword,core,,alert,The kind of the event. The highest categorization field in the hierarchy.
 2.0.0-dev,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
-2.0.0-dev,false,event,event.original,wildcard,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+2.0.0-dev,true,event,event.original,wildcard,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 2.0.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 2.0.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
 2.0.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -149,7 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
 2.0.0-dev,true,event,event.kind,keyword,core,,alert,The kind of the event. The highest categorization field in the hierarchy.
 2.0.0-dev,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
-2.0.0-dev,true,event,event.original,wildcard,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+2.0.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 2.0.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 2.0.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
 2.0.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2038,12 +2038,13 @@ event.original:
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
   flat_name: event.original
-  index: true
+  ignore_above: 1024
+  index: false
   level: core
   name: original
   normalize: []
   short: Raw text message of entire event.
-  type: wildcard
+  type: keyword
 event.outcome:
   allowed_values:
   - description: Indicates that this event describes a failed result. A common example

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2038,7 +2038,7 @@ event.original:
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
   flat_name: event.original
-  index: false
+  index: true
   level: core
   name: original
   normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2436,7 +2436,7 @@ event:
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       flat_name: event.original
-      index: false
+      index: true
       level: core
       name: original
       normalize: []

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2436,12 +2436,13 @@ event:
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       flat_name: event.original
-      index: true
+      ignore_above: 1024
+      index: false
       level: core
       name: original
       normalize: []
       short: Raw text message of entire event.
-      type: wildcard
+      type: keyword
     event.outcome:
       allowed_values:
       - description: Indicates that this event describes a failed result. A common

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -705,7 +705,10 @@
             "type": "keyword"
           },
           "original": {
-            "type": "wildcard"
+            "doc_values": false,
+            "ignore_above": 1024,
+            "index": false,
+            "type": "keyword"
           },
           "outcome": {
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -705,8 +705,6 @@
             "type": "keyword"
           },
           "original": {
-            "doc_values": false,
-            "index": false,
             "type": "wildcard"
           },
           "outcome": {

--- a/experimental/schemas/event.yml
+++ b/experimental/schemas/event.yml
@@ -1,5 +1,0 @@
----
-- name: event
-  fields:
-    - name: original
-      type: wildcard

--- a/rfcs/text/0001/event.yml
+++ b/rfcs/text/0001/event.yml
@@ -2,5 +2,4 @@
 - name: event
   fields:
     - name: original
-      index: true
       type: wildcard

--- a/rfcs/text/0001/event.yml
+++ b/rfcs/text/0001/event.yml
@@ -2,4 +2,5 @@
 - name: event
   fields:
     - name: original
+      index: true
       type: wildcard


### PR DESCRIPTION
#### Summary

While testing the experimental build artifacts, I discovered the generated experimental ES index templates will not install.

#### Error Details

Elasticsearch returns a HTTP 400 error when attempting to install the generated ES index template:

```
 curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_template/test -d @experimental/generated/elasticsearch/7/template.json 
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"The field [original] cannot have index = false"}],"type":"mapper_parsing_exception","reason":"Failed to parse mapping [_doc]: The field [original] cannot have index = false","caused_by":{"type":"mapper_parsing_exception","reason":"The field [original] cannot have index = false"}},"status":400}
```

#### Proposed Solution

~Set `index: true` in the experimental schema for `event.original` to override. Also correct in the stage 2 wildcard RFC field definitions.~

**UPDATED**: Agreement reached in #1015 to remove `event.original` from the initial wildcard field migration. Updating this PR to remove the field from the experimental definitions for 1.7 to avoid users encountering this issue.
