### PR TITLE
[1.x] Add support for `scaling_factor` in the generator (#1042)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -29,6 +29,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added the `path` key when type is `alias`, to support the [alias field type](https://www.elastic.co/guide/en/elasticsearch/reference/current/alias.html). #877
+* Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 
 #### Improvements
 

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -34,7 +34,7 @@ def fieldset_field_array(source_fields, df_whitelist, fieldset_prefix):
     allowed_keys = ['name', 'level', 'required', 'type', 'object_type',
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
-                    'example', 'enabled', 'index', 'path']
+                    'example', 'enabled', 'index', 'path', 'scaling_factor']
     multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer', 'ignore_above']
 
     fields = []

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -61,6 +61,8 @@ def entry_for(field):
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['norms'])
         elif field['type'] == 'alias':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['path'])
+        elif field['type'] == 'scaled_float':
+            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['scaling_factor'])
 
         if 'multi_fields' in field:
             field_entry['fields'] = {}

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -159,10 +159,12 @@ def field_mandatory_attributes(field):
     current_field_attributes = sorted(field['field_details'].keys())
     missing_attributes = ecs_helpers.list_subtract(FIELD_MANDATORY_ATTRIBUTES, current_field_attributes)
 
-    # The `alias` type requires a target path.
-    # https://github.com/elastic/ecs/issues/876
+    # `alias` fields require a target `path` attribute.
     if field['field_details'].get('type') == 'alias' and 'path' not in current_field_attributes:
         missing_attributes.append('path')
+    # `scaled_float` fields require a `scaling_factor` attribute.
+    if field['field_details'].get('type') == 'scaled_float' and 'scaling_factor' not in current_field_attributes:
+        missing_attributes.append('scaling_factor')
 
     if len(missing_attributes) > 0:
         msg = "Field is missing the following mandatory attributes: {}.\nFound these: {}.\nField details: {}"

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -122,6 +122,19 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         }
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_entry_for_scaled_float(self):
+        test_map = {
+            'name': 'test.scaled_float',
+            'type': 'scaled_float',
+            'scaling_factor': 1000
+        }
+
+        exp = {
+            'type': 'scaled_float',
+            'scaling_factor': 1000
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/unit/test_schema_cleaner.py
+++ b/scripts/tests/unit/test_schema_cleaner.py
@@ -164,6 +164,13 @@ class TestSchemaCleaner(unittest.TestCase):
                                     "mandatory attributes: {}".format("path")):
             cleaner.field_mandatory_attributes(field)
 
+    def test_raises_on_missing_scaling_factor(self):
+        field = self.schema_process()['process']['fields']['pid']
+        field['field_details']['type'] = "scaled_float"
+        with self.assertRaisesRegex(ValueError,
+                                    "mandatory attributes: {}".format("scaling_factor")):
+            cleaner.field_mandatory_attributes(field)
+
     def test_field_simple_cleanup(self):
         my_field = {
             'field_details': {


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add support for `scaling_factor` in the generator (#1042)