### PR TITLE
[1.x] Add wildcard type support to go code generator (#1050)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -31,6 +31,7 @@ Thanks, you're awesome :-) -->
 * Added the `path` key when type is `alias`, to support the [alias field type](https://www.elastic.co/guide/en/elasticsearch/reference/current/alias.html). #877
 * Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 * Added ability for --oss flag to fall back `constant_keyword` to `keyword`. #1046
+* Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
 
 #### Improvements
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -274,7 +274,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "text", "ip", "geo_point":
+	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point":
 		return "string"
 	case "long":
 		return "int64"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add wildcard type support to go code generator (#1050)