### PR TITLE
Add --ref support for experimental artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file based on the
 
 * Field details Jinja2 template components have been consolidated into one template #897
 * Add `[discrete]` marker before each section header in field details. #989
+* `--ref` now loads `experimental/schemas` based on git ref in addition to `schemas`. #1063
 
 
 ## [1.6.0](https://github.com/elastic/ecs/compare/v1.5.0...v1.6.0)

--- a/USAGE.md
+++ b/USAGE.md
@@ -277,7 +277,7 @@ It's also possible to combine `--include` and `--subset` together! Do note that 
 
 #### Ref
 
-The `--ref` argument allows for passing a specific `git` tag (e.g. `v.1.5.0`) or commit hash (`1454f8b`) that will be used to build ECS artifacts.
+The `--ref` argument allows for passing a specific `git` tag (e.g. `v1.5.0`) or commit hash (`1454f8b`) that will be used to build ECS artifacts.
 
 ```
 $ python scripts/generator.py --ref v1.5.0
@@ -285,16 +285,10 @@ $ python scripts/generator.py --ref v1.5.0
 
 The `--ref` argument loads field definitions from the specified git reference (branch, tag, etc.) from directories [`./schemas`](./schemas) and [`./experimental/schemas`](./experimental/schemas) (when specified via `--include`).
 
-Here's an example of building artifacts based on ECS `v1.6.0` and adding custom fields from the `myproject` directory:
-
-```
-$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
-```
-
 Here's another example loading both ECS fields and [experimental](experimental/README.md) changes *from branch "1.7"*, then adds custom fields on top.
 
 ```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
+$ python scripts/generator.py --ref 1.7 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
 ```
 
 The command above will produce artifacts based on:
@@ -302,10 +296,6 @@ The command above will produce artifacts based on:
 * main ECS field definitions as of branch 1.7
 * experimental ECS changes as of branch 1.7
 * custom fields in `../myproject/fields/custom` as they are on the filesystem
-
-```
-$ python scripts/generator.py --ref 1.7 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
-```
 
 > Note: `--ref` does have a dependency on `git` being installed and all expected commits/tags fetched from the ECS upstream repo. This will unlikely be an issue unless you downloaded the ECS as a zip archive from GitHub vs. cloning it.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -425,7 +425,7 @@ Use cases and examples in this section detail more advanced usage of the ECS too
 
 #### Using ref and include with experimental fields
 
-The `-ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` ref. This allows for any custom fieldsets to be merged using `--include`.
+The `--ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` reference. This allows for merging custom fieldsets (outside the git ref tree) using `--include`.
 
 Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
 
@@ -433,15 +433,14 @@ Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a
 $ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
 ```
 
-There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the `experimental/schemas` fields will be loaded from the specified git ref.
-
-This example merges ECS v1.7.0 fields with the v1.7.0 experimental fields:
+There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This
+example merges ECS v1.7.0 fields with the v1.7.0 experimental fields:
 
 ```
 $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
 ```
 
-Additionally, custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
+Custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
 
 ```
 $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out

--- a/USAGE.md
+++ b/USAGE.md
@@ -291,7 +291,7 @@ Here's an example of building artifacts based on ECS `v1.6.0` and adding custom 
 $ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
 ```
 
-There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This example would merge ECS v1.7.0 fields with the v1.7.0 experimental fields:
+Here's another example loading both ECS fields and [experimental](experimental/README.md) changes *from branch "1.7"*, then adds custom fields on top.
 
 ```
 $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out

--- a/USAGE.md
+++ b/USAGE.md
@@ -33,8 +33,6 @@ relevant artifacts for their unique set of data sources.
     + [OSS](#oss)
     + [Strict Mode](#strict-mode)
     + [Intermediate-Only](#intermediate-only)
-  * [Advanced Usage](#advanced-usage)
-    + [Using ref and include with experimental fields](#using-ref-and-include-with-experimental-fields)
 
 ## TLDR Example
 
@@ -285,9 +283,26 @@ The `--ref` argument allows for passing a specific `git` tag (e.g. `v.1.5.0`) or
 $ python scripts/generator.py --ref v1.5.0
 ```
 
-The `-ref` argument will only loads field definitions from the [`./schemas`](./schemas) subdirectory. This allows for `--ref` to be paired with the `--include` flag to merge custom fields with a specific ECS version.
+The `--ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` reference. This allows for merging custom fieldsets (outside the git ref tree) using `--include`.
 
-For details of using `--ref` and `--include` with experimental fields, see [Using ref and include with experimental fields](#using-ref-and-include-with-experimental-fields).
+Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
+
+```
+$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
+```
+
+There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This
+example would merge ECS v1.7.0 fields with the v1.7.0 experimental fields:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
+```
+
+Custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
+```
 
 > Note: `--ref` does have a dependency on `git` being installed and all expected commits/tags fetched from the ECS upstream repo. This will unlikely be an issue unless you downloaded the ECS as a zip archive from GitHub vs. cloning it.
 
@@ -418,30 +433,3 @@ This will cause an exception when running in strict mode.
 
 The `--intermediate-only` argument is used for debugging purposes. It only generates the ["intermediate files"](generated/ecs), `ecs_flat.yml` and `ecs_nested.yml`, without generating the rest of the artifacts.
 More information on the different intermediate files can be found in the generated directory's [README](generated/README.md).
-
-### Advanced Usage
-
-Use cases and examples in this section detail more advanced usage of the ECS tooling.
-
-#### Using ref and include with experimental fields
-
-The `--ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` reference. This allows for merging custom fieldsets (outside the git ref tree) using `--include`.
-
-Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
-
-```
-$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
-```
-
-There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This
-example merges ECS v1.7.0 fields with the v1.7.0 experimental fields:
-
-```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
-```
-
-Custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
-
-```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
-```

--- a/USAGE.md
+++ b/USAGE.md
@@ -291,8 +291,7 @@ Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a
 $ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
 ```
 
-There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This
-example would merge ECS v1.7.0 fields with the v1.7.0 experimental fields:
+There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the experimental fields will also load from the specified git ref. This example would merge ECS v1.7.0 fields with the v1.7.0 experimental fields:
 
 ```
 $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out

--- a/USAGE.md
+++ b/USAGE.md
@@ -283,7 +283,7 @@ The `--ref` argument allows for passing a specific `git` tag (e.g. `v.1.5.0`) or
 $ python scripts/generator.py --ref v1.5.0
 ```
 
-The `--ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` reference. This allows for merging custom fieldsets (outside the git ref tree) using `--include`.
+The `--ref` argument loads field definitions from the specified git reference (branch, tag, etc.) from directories [`./schemas`](./schemas) and [`./experimental/schemas`](./experimental/schemas) (when specified via `--include`).
 
 Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -285,7 +285,7 @@ $ python scripts/generator.py --ref v1.5.0
 
 The `--ref` argument loads field definitions from the specified git reference (branch, tag, etc.) from directories [`./schemas`](./schemas) and [`./experimental/schemas`](./experimental/schemas) (when specified via `--include`).
 
-Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
+Here's an example of building artifacts based on ECS `v1.6.0` and adding custom fields from the `myproject` directory:
 
 ```
 $ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out

--- a/USAGE.md
+++ b/USAGE.md
@@ -29,11 +29,12 @@ relevant artifacts for their unique set of data sources.
     + [Include](#include)
     + [Subset](#subset)
     + [Ref](#ref)
-      - [Using ref with include](#using-ref-with-include)
     + [Mapping & Template Settings](#mapping--template-settings)
     + [OSS](#oss)
     + [Strict Mode](#strict-mode)
     + [Intermediate-Only](#intermediate-only)
+  * [Advanced Usage](#advanced-usage)
+    + [Using ref with include](#using-ref-and-include-for-experimental-fields)
 
 ## TLDR Example
 
@@ -229,7 +230,7 @@ And looking at a specific artifact, `../myprojects/out/generated/elasticsearch/7
 ...
 ```
 
-Include can be used with together with the `--ref` flag to merge custom and/or experimental fields into a targeted ECS version. See [Using ref with include](#using-ref-with-include).
+Include can be used together with the `--ref` flag to merge custom fields into a targeted ECS version. See [`Ref`](#ref).
 
 > NOTE: The `--include` mechanism will not validate custom YAML files prior to merging. This allows for modifying existing ECS fields in a custom schema without having to redefine all the mandatory field attributes.
 
@@ -284,29 +285,9 @@ The `--ref` argument allows for passing a specific `git` tag (e.g. `v.1.5.0`) or
 $ python scripts/generator.py --ref v1.5.0
 ```
 
-##### Using ref with include
+The `-ref` argument will only loads field definitions from the [`./schemas`](./schemas) subdirectory. This allows for `--ref` to be paired with the `--include` flag to merge custom fields with a specific ECS version.
 
-Be aware that `--ref` only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` ref. Any custom fieldsets from other locations can be merged using `--include`.
-
-For example, merging ECS v1.6.0 fields with custom fields maintained in a separate `myproject` directory:
-
-```
-$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
-```
-
-There one is one exception that supports the [experimental](experimental/README.md) fields. If using `--ref` alongside with including the `experimental/schemas` directory, the fields in `experimental/schemas` will also be loaded from the target git ref.
-
-Here's another example, which merges ECS v1.7.0 with the experimental fields as of v1.7.0:
-
-```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas
-```
-
-One final example here merges ECS v1.7.0 fields, ECS v1.7.0 experimental fields, and custom fields:
-
-```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
-```
+For details of using `--ref` and `--include` with experimental fields, see [Using ref and include with experimental fields](#using-ref-and-include-with-experimental-fields).
 
 > Note: `--ref` does have a dependency on `git` being installed and all expected commits/tags fetched from the ECS upstream repo. This will unlikely be an issue unless you downloaded the ECS as a zip archive from GitHub vs. cloning it.
 
@@ -437,3 +418,31 @@ This will cause an exception when running in strict mode.
 
 The `--intermediate-only` argument is used for debugging purposes. It only generates the ["intermediate files"](generated/ecs), `ecs_flat.yml` and `ecs_nested.yml`, without generating the rest of the artifacts.
 More information on the different intermediate files can be found in the generated directory's [README](generated/README.md).
+
+### Advanced Use Cases
+
+Use cases and examples in this section detail more advanced usage of the ECS tooling.
+
+#### Using ref and include with experimental fields
+
+The `-ref` argument only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` ref. This allows for any custom fieldsets to be merged using `--include`.
+
+Here's an example merging ECS `v1.6.0` fields with custom fields maintained in a separate `myproject` directory:
+
+```
+$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
+```
+
+There one is one exception supporting the [experimental](experimental/README.md) fields. If using `--ref` and including the `experimental/schemas` directory, the `experimental/schemas` fields will be loaded from the specified git ref.
+
+This example merges ECS v1.7.0 fields with the v1.7.0 experimental fields:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
+```
+
+Additionally, custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
+```

--- a/USAGE.md
+++ b/USAGE.md
@@ -297,7 +297,11 @@ Here's another example loading both ECS fields and [experimental](experimental/R
 $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../myproject/out
 ```
 
-Custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
+The command above will produce artifacts based on:
+
+* main ECS field definitions as of branch 1.7
+* experimental ECS changes as of branch 1.7
+* custom fields in `../myproject/fields/custom` as they are on the filesystem
 
 ```
 $ python scripts/generator.py --ref 1.7 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out

--- a/USAGE.md
+++ b/USAGE.md
@@ -29,6 +29,7 @@ relevant artifacts for their unique set of data sources.
     + [Include](#include)
     + [Subset](#subset)
     + [Ref](#ref)
+      - [Using ref with include](#using-ref-with-include)
     + [Mapping & Template Settings](#mapping--template-settings)
     + [OSS](#oss)
     + [Strict Mode](#strict-mode)
@@ -228,6 +229,8 @@ And looking at a specific artifact, `../myprojects/out/generated/elasticsearch/7
 ...
 ```
 
+Include can be used with together with the `--ref` flag to merge custom and/or experimental fields into a targeted ECS version. See [Using ref with include](#using-ref-with-include).
+
 > NOTE: The `--include` mechanism will not validate custom YAML files prior to merging. This allows for modifying existing ECS fields in a custom schema without having to redefine all the mandatory field attributes.
 
 #### Subset
@@ -279,6 +282,30 @@ The `--ref` argument allows for passing a specific `git` tag (e.g. `v.1.5.0`) or
 
 ```
 $ python scripts/generator.py --ref v1.5.0
+```
+
+##### Using ref with include
+
+Be aware that `--ref` only loads field definitions from the [`./schemas`](./schemas) subdirectory in the target `git` ref. Any custom fieldsets from other locations can be merged using `--include`.
+
+For example, merging ECS v1.6.0 fields with custom fields maintained in a separate `myproject` directory:
+
+```
+$ python scripts/generator.py --ref v1.6.0 --include ../myproject/fields/custom`  --out ../myproject/out
+```
+
+There one is one exception that supports the [experimental](experimental/README.md) fields. If using `--ref` alongside with including the `experimental/schemas` directory, the fields in `experimental/schemas` will also be loaded from the target git ref.
+
+Here's another example, which merges ECS v1.7.0 with the experimental fields as of v1.7.0:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas
+```
+
+One final example here merges ECS v1.7.0 fields, ECS v1.7.0 experimental fields, and custom fields:
+
+```
+$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
 ```
 
 > Note: `--ref` does have a dependency on `git` being installed and all expected commits/tags fetched from the ECS upstream repo. This will unlikely be an issue unless you downloaded the ECS as a zip archive from GitHub vs. cloning it.

--- a/USAGE.md
+++ b/USAGE.md
@@ -300,7 +300,7 @@ $ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out 
 Custom fields can also be passed using `--include` with the experimental ones. This command merges v1.7.0 fields, v1.7.0 experimental fields, and custom fields from `../myproject/fields/custom`:
 
 ```
-$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
+$ python scripts/generator.py --ref 1.7 --include experimental/schemas ../myproject/fields/custom --out ../myproject/out
 ```
 
 > Note: `--ref` does have a dependency on `git` being installed and all expected commits/tags fetched from the ECS upstream repo. This will unlikely be an issue unless you downloaded the ECS as a zip archive from GitHub vs. cloning it.

--- a/USAGE.md
+++ b/USAGE.md
@@ -34,7 +34,7 @@ relevant artifacts for their unique set of data sources.
     + [Strict Mode](#strict-mode)
     + [Intermediate-Only](#intermediate-only)
   * [Advanced Usage](#advanced-usage)
-    + [Using ref with include](#using-ref-and-include-for-experimental-fields)
+    + [Using ref and include with experimental fields](#using-ref-and-include-with-experimental-fields)
 
 ## TLDR Example
 
@@ -419,7 +419,7 @@ This will cause an exception when running in strict mode.
 The `--intermediate-only` argument is used for debugging purposes. It only generates the ["intermediate files"](generated/ecs), `ecs_flat.yml` and `ecs_nested.yml`, without generating the rest of the artifacts.
 More information on the different intermediate files can be found in the generated directory's [README](generated/README.md).
 
-### Advanced Use Cases
+### Advanced Usage
 
 Use cases and examples in this section detail more advanced usage of the ECS tooling.
 

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -63,7 +63,8 @@ def main():
 
 def argument_parser():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--ref', action='store', help='git reference to use when building schemas')
+    parser.add_argument('--ref', action='store', help='Loads fields definitions from `./schemas` subdirectory from specified git reference. \
+                                                       Use with `--include experimental/schemas` to additionally load experimental fields from the target ref.')
     parser.add_argument('--include', nargs='+',
                         help='include user specified directory of custom field definitions')
     parser.add_argument('--subset', nargs='+',

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -64,7 +64,7 @@ def main():
 def argument_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument('--ref', action='store', help='Loads fields definitions from `./schemas` subdirectory from specified git reference. \
-                                                       Use with `--include experimental/schemas` to additionally load experimental fields from the target ref.')
+                                                       Note that "--include experimental/schemas" will also respect this git ref.')
     parser.add_argument('--include', nargs='+',
                         help='include user specified directory of custom field definitions')
     parser.add_argument('--subset', nargs='+',

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -113,6 +113,13 @@ def get_tree_by_ref(ref):
     commit = repo.commit(ref)
     return commit.tree
 
+def path_exists_in_git_tree(tree, file_path):
+    try:
+        _ = tree[file_path]
+    except KeyError:
+        return False
+    return True
+
 
 def usage_doc_files():
     usage_docs_dir = os.path.join(os.path.dirname(__file__), '../../docs/usage')

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -113,6 +113,7 @@ def get_tree_by_ref(ref):
     commit = repo.commit(ref)
     return commit.tree
 
+
 def path_exists_in_git_tree(tree, file_path):
     try:
         _ = tree[file_path]

--- a/scripts/schema/loader.py
+++ b/scripts/schema/loader.py
@@ -88,7 +88,7 @@ def load_schemas_from_git(ref, target_dir='schemas'):
                 new_fields = read_schema_blob(blob, ref)
                 fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
     else:
-        raise KeyError(f"Target directory './{target_dir}' not present in current git ref!")
+        raise KeyError(f"Target directory './{target_dir}' not present in git ref '{ref}'!")
     return fields_nested
 
 

--- a/scripts/schema/loader.py
+++ b/scripts/schema/loader.py
@@ -51,9 +51,18 @@ def load_schemas(ref=None, included_files=[]):
         schema_files_raw = load_schema_files(ecs_helpers.ecs_files())
     fields = deep_nesting_representation(schema_files_raw)
 
-    # Custom additional files (never from git ref)
+    EXPERIMENTAL_SCHEMA_DIR = 'experimental/schemas'
+
+    # Custom additional files
     if included_files and len(included_files) > 0:
         print('Loading user defined schemas: {0}'.format(included_files))
+        # If --ref provided and --include loading experimental schemas
+        if ref and EXPERIMENTAL_SCHEMA_DIR in included_files:
+            exp_schema_files_raw = load_schemas_from_git(ref, target_dir=EXPERIMENTAL_SCHEMA_DIR)
+            exp_fields = deep_nesting_representation(exp_schema_files_raw)
+            fields = merge_fields(fields, exp_fields)
+            included_files.remove(EXPERIMENTAL_SCHEMA_DIR)
+        # Remaining additional custom files (never from git ref)
         custom_files = ecs_helpers.get_glob_files(included_files, ecs_helpers.YAML_EXT)
         custom_fields = deep_nesting_representation(load_schema_files(custom_files))
         fields = merge_fields(fields, custom_fields)
@@ -68,13 +77,18 @@ def load_schema_files(files):
     return fields_nested
 
 
-def load_schemas_from_git(ref):
+def load_schemas_from_git(ref, target_dir='schemas'):
     tree = ecs_helpers.get_tree_by_ref(ref)
     fields_nested = {}
-    for blob in tree['schemas'].blobs:
-        if blob.name.endswith('.yml'):
-            new_fields = read_schema_blob(blob, ref)
-            fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
+
+    # Handles case if target dir doesn't exists in git ref
+    if ecs_helpers.path_exists_in_git_tree(tree, target_dir):
+        for blob in tree[target_dir].blobs:
+            if blob.name.endswith('.yml'):
+                new_fields = read_schema_blob(blob, ref)
+                fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
+    else:
+        raise KeyError(f"Target directory './{target_dir}' not present in current git ref!")
     return fields_nested
 
 

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -99,11 +99,18 @@ class TestECSHelpers(unittest.TestCase):
         self.assertEqual(ecs_helpers.list_subtract(['a', 'b'], ['a']), ['b'])
         self.assertEqual(ecs_helpers.list_subtract(['a', 'b'], ['a', 'c']), ['b'])
 
+    # git helper tests
+
     def test_get_tree_by_ref(self):
         ref = 'v1.5.0'
         tree = ecs_helpers.get_tree_by_ref(ref)
         self.assertEqual(tree.hexsha, '4449df245f6930d59bcd537a5958891261a9476b')
 
+    def test_path_exists_in_git_tree(self):
+        ref = 'v1.6.0'
+        tree = ecs_helpers.get_tree_by_ref(ref)
+        self.assertFalse(ecs_helpers.path_exists_in_git_tree(tree, 'nonexistant'))
+        self.assertTrue(ecs_helpers.path_exists_in_git_tree(tree, 'schemas'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_ecs_helpers.py
+++ b/scripts/tests/test_ecs_helpers.py
@@ -112,5 +112,6 @@ class TestECSHelpers(unittest.TestCase):
         self.assertFalse(ecs_helpers.path_exists_in_git_tree(tree, 'nonexistant'))
         self.assertTrue(ecs_helpers.path_exists_in_git_tree(tree, 'schemas'))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/unit/test_schema_loader.py
+++ b/scripts/tests/unit/test_schema_loader.py
@@ -79,6 +79,21 @@ class TestSchemaLoader(unittest.TestCase):
             fields['process']['fields']['thread'].keys(),
             "Fields containing nested fields should at least have the 'fields' subkey")
 
+    def test_load_schemas_git_ref(self):
+        fields = loader.load_schemas(ref='v1.6.0')
+        self.assertEqual(
+            ['field_details', 'fields', 'schema_details'],
+            sorted(fields['process'].keys()),
+            "Schemas should have 'field_details', 'fields' and 'schema_details' subkeys")
+        self.assertEqual(
+            ['field_details'],
+            list(fields['process']['fields']['pid'].keys()),
+            "Leaf fields should have only the 'field_details' subkey")
+        self.assertIn(
+            'fields',
+            fields['process']['fields']['thread'].keys(),
+            "Fields containing nested fields should at least have the 'fields' subkey")
+
     @mock.patch('schema.loader.read_schema_file')
     def test_load_schemas_fail_on_accidental_fieldset_redefinition(self, mock_read_schema):
         mock_read_schema.side_effect = [
@@ -123,6 +138,43 @@ class TestSchemaLoader(unittest.TestCase):
     def test_nest_schema_raises_on_missing_schema_name(self):
         with self.assertRaisesRegex(ValueError, 'incomplete.yml'):
             loader.nest_schema([{'description': 'just a description'}], 'incomplete.yml')
+
+    def test_load_schemas_from_git(self):
+        fields = loader.load_schemas_from_git('v1.0.0', target_dir='schemas')
+        self.assertEqual(
+            ['agent',
+             'base',
+             'client',
+             'cloud',
+             'container',
+             'destination',
+             'ecs',
+             'error',
+             'event',
+             'file',
+             'geo',
+             'group',
+             'host',
+             'http',
+             'log',
+             'network',
+             'observer',
+             'organization',
+             'os',
+             'process',
+             'related',
+             'server',
+             'service',
+             'source',
+             'url',
+             'user',
+             'user_agent'],
+            sorted(fields.keys()),
+            "Raw schema fields should have expected fieldsets for v1.0.0")
+
+    def test_load_schemas_from_git_missing_target_directory(self):
+        with self.assertRaisesRegex(KeyError, 'not present in current git ref'):
+            loader.load_schemas_from_git('v1.5.0', target_dir='experimental')
 
     # nesting stuff
 

--- a/scripts/tests/unit/test_schema_loader.py
+++ b/scripts/tests/unit/test_schema_loader.py
@@ -173,7 +173,7 @@ class TestSchemaLoader(unittest.TestCase):
             "Raw schema fields should have expected fieldsets for v1.0.0")
 
     def test_load_schemas_from_git_missing_target_directory(self):
-        with self.assertRaisesRegex(KeyError, 'not present in current git ref'):
+        with self.assertRaisesRegex(KeyError, "not present in git ref 'v1.5.0'"):
             loader.load_schemas_from_git('v1.5.0', target_dir='experimental')
 
     # nesting stuff


### PR DESCRIPTION
#### Summary of Changes

When `--ref` argument is set and the `experimental/schemas` directory is loaded with `--include`, these changes ensure the experimental field definitions are pulling from the target git ref and not the local file system.

#### Background

`--ref` is restricted to loading the field definitions from the `schemas` directory. Custom field definition can be supplied but will always load from the local file system. This works well for users managing independent custom definitions outside of the ECS field definitions.

The `experimental/schemas` directory was introduced to hold ECS field definition changes considered experimental, but not beta or GA. Users can use `--include experimental/schemas` if they wish to generate artifacts using these experimental fields.

A problem is introduced if a user wishes to generate artifacts released for a specific version of ECS and include the experimental artifacts from that same version.

#### Example

A user, starting from scratch by cloning the ECS repo and installing dependencies, attempts to generate artifacts for a specific version:

```
$ git clone https://github.com/elastic/ecs
$ cd ecs
$ make ve
$ python scripts/generator.py --ref v1.7.0 --include experimental/schemas --out ../my-project/
```

If the `v1.7.0` exists, `--ref` will properly checkout that git tree and load the field definitions in the `schemas` directory. However, `--include` loads custom field definitions from the user's local file system. The user would have inadvertently merged `v1.7.0` fields with the latest experimental fields in the repo's default branch.

#### Proposed Solution

Add logic in `schema.loader.load_schemas` for when a `--ref` is provided and `--include` includes `experiment/schemas`, the contents of `experiment/schemas` is loaded from the target git ref. Other custom field definitions will continue to be loaded from the local file system.