### PR TITLE
Docs: Add ifeval for 7.10 release

### DIFF
--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,5 +285,10 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-* {logs-guide}/logs-fields-reference.html[Logs Monitoring Field Reference]
+ifeval::["{branch}"=="7.9"]
+* {logs-guide}/logs-fields-reference.html[Log Monitoring Field Reference]
+endif::[]
+ifeval::["{branch}"!="7.9"]
+* {observability-guide}/logs-app-fields.html[Log Monitoring Field Reference]
+endif::[]
 * {security-guide}/siem-field-reference.html[Elastic Security Field Reference]


### PR DESCRIPTION
### Summary

This PR fixes a documentation link that will break when 7.10 becomes the `current` stack version. It conditionally changes the link location of the Logs Monitoring Field Reference page based on the stack version defined in github.com/elastic/docs ([here](https://github.com/elastic/docs/blob/master/shared/versions/stack/current.asciidoc)).

```asciidoc
ifeval::["{branch}"=="7.9"]
{logs-guide}/logs-fields-reference.html[Log Monitoring Field Reference]
endif::[]
ifeval::["{branch}"!="7.9"]
{observability-guide}/logs-app-fields.html[Log Monitoring Field Reference]
endif::[]
```
This ensures the link continues to work for users who click it before and after the 7.10 release.

Tested by building locally with `:branch:` overridden to `7.9`, `7.10`, and `master`.

### Target

This PR will need to be backported to `1.7`, `1.6`, `1.5`, and `1.x`.

### Related issues

https://github.com/elastic/observability-docs/issues/215
https://github.com/elastic/docs/pull/1994

### Follow ups

After the release of 7.10, I will backport a fix that removes the conditional code.


