### PR TITLE
Docs: Add ifeval to products page

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -9,10 +9,14 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
-* {logs-guide}/logs-app-overview.html[Logs Monitoring]
+ifeval::["{branch}"=="7.9"]
+* {logs-guide}/logs-app-overview.html[Log Monitoring]
+endif::[]
+ifeval::["{branch}"!="7.9"]
+* {observability-guide}/monitor-logs.html[Log Monitoring]
+endif::[]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 
 // TODO Insert community & partner solutions here
-
 


### PR DESCRIPTION
### Summary

This PR fixes a documentation link that will break when 7.10 becomes the `current` stack version. It conditionally changes the link location of the Log Monitoring page based on the stack version defined in github.com/elastic/docs ([here](https://github.com/elastic/docs/blob/master/shared/versions/stack/current.asciidoc)).

```asciidoc
ifeval::["{branch}"=="7.9"]
{logs-guide}/logs-app-overview.html[Log Monitoring]
endif::[]
ifeval::["{branch}"!="7.9"]
{observability-guide}/monitor-logs.html[Log Monitoring]
endif::[]
```
This ensures the link continues to work for users who click it before and after the 7.10 release.

Tested by building locally with `:branch:` overridden to `7.9`, `7.10`, and `master`.

### Target

This PR will need to be backported to `1.7`, `1.6`, `1.5`, `1.4`, `1.3`, and `1.x`.

### Related issues

https://github.com/elastic/observability-docs/issues/215
https://github.com/elastic/docs/pull/1994

### Follow ups

After the release of 7.10, I will backport a fix that removes the conditional code.