### PR TITLE
[1.7] Remove `expected_event_types` from protocol (#964)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* The `protocol` allowed value under `event.type` should not have the `expected_event_types` defined. #964
+
 #### Added
 
 #### Improvements


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Remove `expected_event_types` from protocol (#964)