### PR TITLE
[1.5] Prepare link to Logs docs changing with the 7.10 release in "getting-started" (#1073)

### DIFF
--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,5 +285,10 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-* {logs-guide}/logs-fields-reference.html[Logs Monitoring Field Reference]
+ifeval::["{branch}"=="7.9"]
+* {logs-guide}/logs-fields-reference.html[Log Monitoring Field Reference]
+endif::[]
+ifeval::["{branch}"!="7.9"]
+* {observability-guide}/logs-app-fields.html[Log Monitoring Field Reference]
+endif::[]
 * {security-guide}/siem-field-reference.html[Elastic Security Field Reference]


### PR DESCRIPTION
Backports the following commits to 1.5:

* Prepare link to Logs docs changing with the 7.10 release in "getting-started" (#1073)