### PR TITLE
[1.x] Prepare link to Logs docs changing with the 7.10 release in "products-solutions" page (#1074)

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -9,10 +9,14 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
-* {logs-guide}/logs-app-overview.html[Logs Monitoring]
+ifeval::["{branch}"=="7.9"]
+* {logs-guide}/logs-app-overview.html[Log Monitoring]
+endif::[]
+ifeval::["{branch}"!="7.9"]
+* {observability-guide}/monitor-logs.html[Log Monitoring]
+endif::[]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 
 // TODO Insert community & partner solutions here
-
 


### PR DESCRIPTION
Backports the following commits to 1.x:

* Prepare link to Logs docs changing with the 7.10 release in "products-solutions" page (#1074)