### PR TITLE
[1.3] Prepare link to Logs docs changing with the 7.10 release in "products-solutions" page (#1074)

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -7,11 +7,16 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 * {apm-get-started-ref}/overview.html[APM]
 * {security-guide}/es-overview.html[Elastic Security]
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
-* https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security Server]
-* {logs-guide}/logs-app-overview.html[Logs Monitoring]
+* https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
+Server]
+ifeval::["{branch}"=="7.9"]
+* {logs-guide}/logs-app-overview.html[Log Monitoring]
+endif::[]
+ifeval::["{branch}"!="7.9"]
+* {observability-guide}/monitor-logs.html[Log Monitoring]
+endif::[]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 
 // TODO Insert community & partner solutions here
-
 


### PR DESCRIPTION
Backports the following commits to 1.3:

* Prepare link to Logs docs changing with the 7.10 release in "products-solutions" page (#1074)