### PR TITLE
[1.5] Add [discrete] headers to Asciidoc generator

### DIFF
--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -231,6 +231,7 @@ def field_details_table_header():
 
 {fieldset_description}
 
+[discrete]
 ==== {fieldset_title} Field Details
 
 [options="header"]
@@ -273,6 +274,7 @@ To learn more about when to use which value, visit the page
 
 def field_reuse_section():
     return '''
+[discrete]
 ==== Field Reuse
 
 {reuse_of_fieldset}
@@ -285,6 +287,7 @@ def field_reuse_section():
 def nestings_table_header():
     return '''
 [[ecs-{fieldset_name}-nestings]]
+[discrete]
 ===== Field sets that can be nested under {fieldset_title}
 
 [options="header"]


### PR DESCRIPTION
I made these changes locally but failed to include them in https://github.com/elastic/ecs/pull/1003.

These changes ensure any subsequent changes to the documentations will also include the `[discrete]` markers in the field details documentation section.