### PR TITLE
[1.x] Remove experimental event.original definition (#1053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable changes to this project will be documented in this file based on the
 #### Bugfixes
 
 * Addressed issue where foreign reuses weren't using the user-supplied `as` value for their destination. #960
+* Experimental artifacts failed to install due to `event.original` index setting. #1053
 
 #### Added
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1317,7 +1317,8 @@
       example: apache
     - name: original
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Raw text message of entire event. Used to demonstrate log integrity.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -149,7 +149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
 1.8.0-dev,true,event,event.kind,keyword,core,,alert,The kind of the event. The highest categorization field in the hierarchy.
 1.8.0-dev,true,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
-1.8.0-dev,false,event,event.original,wildcard,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+1.8.0-dev,false,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
 1.8.0-dev,true,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
 1.8.0-dev,true,event,event.provider,keyword,extended,,kernel,Source of the event.
 1.8.0-dev,true,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2038,12 +2038,13 @@ event.original:
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
   flat_name: event.original
+  ignore_above: 1024
   index: false
   level: core
   name: original
   normalize: []
   short: Raw text message of entire event.
-  type: wildcard
+  type: keyword
 event.outcome:
   allowed_values:
   - description: Indicates that this event describes a failed result. A common example

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2436,12 +2436,13 @@ event:
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       flat_name: event.original
+      ignore_above: 1024
       index: false
       level: core
       name: original
       normalize: []
       short: Raw text message of entire event.
-      type: wildcard
+      type: keyword
     event.outcome:
       allowed_values:
       - description: Indicates that this event describes a failed result. A common

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -706,8 +706,9 @@
           },
           "original": {
             "doc_values": false,
+            "ignore_above": 1024,
             "index": false,
-            "type": "wildcard"
+            "type": "keyword"
           },
           "outcome": {
             "ignore_above": 1024,

--- a/experimental/schemas/event.yml
+++ b/experimental/schemas/event.yml
@@ -1,5 +1,0 @@
----
-- name: event
-  fields:
-    - name: original
-      type: wildcard


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Remove experimental event.original definition (#1053)