### PR TITLE
[1.7] Add missing `process.thread.name` to experimental definitions (#1103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project will be documented in this file based on the
 * Added network directions ingress and egress. #945
 * Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
 * Added `configuration` as an allowed `event.category`. #963
+* Added a new directory with experimental artifacts, which includes all changes
+  from RFCs that have reached stage 2. #993, #1053
 
 #### Improvements
 
@@ -45,8 +47,6 @@ All notable changes to this project will be documented in this file based on the
 * Added `ignore_above` and `normalizer` support for keyword multi-fields. #971
 * Added ability to supply free-form usage documentation per fieldset. #988
 * Added `--oss` flag for users who want to generate ECS templates for use on OSS clusters. #991
-* Added a new directory with experimental artifacts, which includes all changes
-  from RFCs that have reached stage 2. #993
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3566,8 +3566,7 @@
       default_field: false
     - name: parent.thread.name
       level: extended
-      type: keyword
-      ignore_above: 1024
+      type: wildcard
       description: Thread name.
       example: thread-0
       default_field: false
@@ -3681,8 +3680,7 @@
       example: 4242
     - name: thread.name
       level: extended
-      type: keyword
-      ignore_above: 1024
+      type: wildcard
       description: Thread name.
       example: thread-0
     - name: title

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -413,7 +413,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.7.0-dev,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.
 1.7.0-dev,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 1.7.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
-1.7.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
+1.7.0-dev,true,process,process.parent.thread.name,wildcard,extended,,thread-0,Thread name.
 1.7.0-dev,true,process,process.parent.title,wildcard,extended,,,Process title.
 1.7.0-dev,true,process,process.parent.title.text,text,extended,,,Process title.
 1.7.0-dev,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
@@ -431,7 +431,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.7.0-dev,true,process,process.ppid,long,extended,,4241,Parent process' pid.
 1.7.0-dev,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 1.7.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
-1.7.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
+1.7.0-dev,true,process,process.thread.name,wildcard,extended,,thread-0,Thread name.
 1.7.0-dev,true,process,process.title,wildcard,extended,,,Process title.
 1.7.0-dev,true,process,process.title.text,text,extended,,,Process title.
 1.7.0-dev,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5366,13 +5366,12 @@ process.parent.thread.name:
   description: Thread name.
   example: thread-0
   flat_name: process.parent.thread.name
-  ignore_above: 1024
   level: extended
   name: thread.name
   normalize: []
   original_fieldset: process
   short: Thread name.
-  type: keyword
+  type: wildcard
 process.parent.title:
   dashed_name: process-parent-title
   description: 'Process title.
@@ -5563,12 +5562,11 @@ process.thread.name:
   description: Thread name.
   example: thread-0
   flat_name: process.thread.name
-  ignore_above: 1024
   level: extended
   name: thread.name
   normalize: []
   short: Thread name.
-  type: keyword
+  type: wildcard
 process.title:
   dashed_name: process-title
   description: 'Process title.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6408,13 +6408,12 @@ process:
       description: Thread name.
       example: thread-0
       flat_name: process.parent.thread.name
-      ignore_above: 1024
       level: extended
       name: thread.name
       normalize: []
       original_fieldset: process
       short: Thread name.
-      type: keyword
+      type: wildcard
     process.parent.title:
       dashed_name: process-parent-title
       description: 'Process title.
@@ -6605,12 +6604,11 @@ process:
       description: Thread name.
       example: thread-0
       flat_name: process.thread.name
-      ignore_above: 1024
       level: extended
       name: thread.name
       normalize: []
       short: Thread name.
-      type: keyword
+      type: wildcard
     process.title:
       dashed_name: process-title
       description: 'Process title.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1904,8 +1904,7 @@
                     "type": "long"
                   },
                   "name": {
-                    "ignore_above": 1024,
-                    "type": "keyword"
+                    "type": "wildcard"
                   }
                 }
               },
@@ -1981,8 +1980,7 @@
                 "type": "long"
               },
               "name": {
-                "ignore_above": 1024,
-                "type": "keyword"
+                "type": "wildcard"
               }
             }
           },

--- a/experimental/schemas/process.yml
+++ b/experimental/schemas/process.yml
@@ -7,6 +7,8 @@
       type: wildcard
     - name: name
       type: wildcard
+    - name: thread.name
+      type: wildcard
     - name: title
       type: wildcard
     - name: working_directory


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Add missing `process.thread.name` to experimental definitions (#1103)