### PR TITLE
Add support for constant_keyword's 'value' parameter

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,7 @@ Thanks, you're awesome :-) -->
 * Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 * Added ability for --oss flag to fall back `constant_keyword` to `keyword`. #1046
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
+* Added support for `constant_keyword`'s optional parameter `value`. #1112
 
 #### Improvements
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -57,6 +57,8 @@ def entry_for(field):
 
         if field['type'] == 'keyword':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above'])
+        elif field['type'] == 'constant_keyword':
+            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['value'])
         elif field['type'] == 'text':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['norms'])
         elif field['type'] == 'alias':

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -136,5 +136,29 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         self.assertEqual(es_template.entry_for(test_map), exp)
 
 
+    def test_constant_keyword_with_value(self):
+        test_map = {
+            'name': 'field_with_value',
+            'type': 'constant_keyword',
+            'value': 'foo'
+        }
+
+        exp = {
+            'type': 'constant_keyword',
+            'value': 'foo'
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+
+    def test_constant_keyword_no_value(self):
+        test_map = {
+            'name': 'field_without_value',
+            'type': 'constant_keyword'
+        }
+
+        exp = { 'type': 'constant_keyword' }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -135,7 +135,6 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         }
         self.assertEqual(es_template.entry_for(test_map), exp)
 
-
     def test_constant_keyword_with_value(self):
         test_map = {
             'name': 'field_with_value',
@@ -149,14 +148,13 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         }
         self.assertEqual(es_template.entry_for(test_map), exp)
 
-
     def test_constant_keyword_no_value(self):
         test_map = {
             'name': 'field_without_value',
             'type': 'constant_keyword'
         }
 
-        exp = { 'type': 'constant_keyword' }
+        exp = {'type': 'constant_keyword'}
         self.assertEqual(es_template.entry_for(test_map), exp)
 
 


### PR DESCRIPTION
This PR adds support for setting the `value` parameter for `constant_keyword` fields.

The PR right now only lets the parameter through to the ES templates, but not the Beats field definitions. This is intentional, as ECS cannot logically set the type of some fields to `constant_keyword` on the behalf of Beats. This would have to be an override on the Beats side, according to the relevant indexing strategy.

Closes #1052