### PR TITLE
Add dns.answer object into experimental schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
 * Added `configuration` as an allowed `event.category`. #963
 * Added a new directory with experimental artifacts, which includes all changes
-  from RFCs that have reached stage 2. #993, #1053, #1115
+  from RFCs that have reached stage 2. #993, #1053, #1115, #1118
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -967,6 +967,19 @@
       (`dns.type:answer`).'
     type: group
     fields:
+    - name: answers
+      level: extended
+      type: object
+      description: 'An array containing an object for each answer section returned
+        by the server.
+
+        The main keys that should be present in these objects are defined by ECS.
+        Records that have more information may contain more keys than what ECS defines.
+
+        Not all DNS data sources give all details about DNS answers. At minimum, answer
+        objects must contain the `data` key. If more information is available, map
+        as much of it to ECS as possible, and add any additional fields to the answer
+        objects as custom fields.'
     - name: answers.class
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -113,6 +113,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,dll,dll.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
 2.0.0-dev,true,dll,dll.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 2.0.0-dev,true,dll,dll.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+2.0.0-dev,true,dns,dns.answers,object,extended,array,,Array of DNS answers.
 2.0.0-dev,true,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
 2.0.0-dev,true,dns,dns.answers.data,wildcard,extended,,10.10.10.10,The data describing the resource.
 2.0.0-dev,true,dns,dns.answers.name,keyword,extended,,www.example.com,The domain name to which this resource record pertains.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1318,6 +1318,25 @@ dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+dns.answers:
+  dashed_name: dns-answers
+  description: 'An array containing an object for each answer section returned by
+    the server.
+
+    The main keys that should be present in these objects are defined by ECS. Records
+    that have more information may contain more keys than what ECS defines.
+
+    Not all DNS data sources give all details about DNS answers. At minimum, answer
+    objects must contain the `data` key. If more information is available, map as
+    much of it to ECS as possible, and add any additional fields to the answer objects
+    as custom fields.'
+  flat_name: dns.answers
+  level: extended
+  name: answers
+  normalize:
+  - array
+  short: Array of DNS answers.
+  type: object
 dns.answers.class:
   dashed_name: dns-answers-class
   description: The class of DNS data contained in this resource record.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1667,6 +1667,25 @@ dns:
     (`dns.type:query`) or they should represent a full exchange and contain the query
     details as well as all of the answers that were provided for this query (`dns.type:answer`).'
   fields:
+    dns.answers:
+      dashed_name: dns-answers
+      description: 'An array containing an object for each answer section returned
+        by the server.
+
+        The main keys that should be present in these objects are defined by ECS.
+        Records that have more information may contain more keys than what ECS defines.
+
+        Not all DNS data sources give all details about DNS answers. At minimum, answer
+        objects must contain the `data` key. If more information is available, map
+        as much of it to ECS as possible, and add any additional fields to the answer
+        objects as custom fields.'
+      flat_name: dns.answers
+      level: extended
+      name: answers
+      normalize:
+      - array
+      short: Array of DNS answers.
+      type: object
     dns.answers.class:
       dashed_name: dns-answers-class
       description: The class of DNS data contained in this resource record.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -568,7 +568,8 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               }
-            }
+            },
+            "type": "object"
           },
           "header_flags": {
             "ignore_above": 1024,

--- a/experimental/schemas/dns.yml
+++ b/experimental/schemas/dns.yml
@@ -3,5 +3,7 @@
   fields:
     - name: question.name
       type: wildcard
+    - name: answers
+      type: object
     - name: answers.data
       type: wildcard


### PR DESCRIPTION
Implements the workaround identified in #1116, which prevents the `dns.answer` object from being omitted when merging the experimental field definitions.
