### PR TITLE
[1.7] Remove index parameter for wildcard fields (#1115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file based on the
 * Added `threat.technique.subtechnique` to capture MITRE ATT&CK® subtechniques. #951
 * Added `configuration` as an allowed `event.category`. #963
 * Added a new directory with experimental artifacts, which includes all changes
-  from RFCs that have reached stage 2. #993, #1053
+  from RFCs that have reached stage 2. #993, #1053, #1115
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1160,7 +1160,6 @@
         norms: false
         default_field: false
       description: The stack trace of this error in plain text.
-      index: true
     - name: type
       level: extended
       type: wildcard

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1599,7 +1599,6 @@ error.stack_trace:
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
-  index: true
   level: extended
   multi_fields:
   - flat_name: error.stack_trace.text

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1971,7 +1971,6 @@ error:
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
-      index: true
       level: extended
       multi_fields:
       - flat_name: error.stack_trace.text

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -129,7 +129,8 @@ Supported keys to describe fields
   Example values that are composite types (array, object) should be quoted to avoid YAML interpretation
   in ECS-generated artifacts and other downstream projects depending on the schema.
 - multi\_fields (optional): Specify additional ways to index the field.
-- index (optional): If `False`, means field is not indexed (overrides type)
+- index (optional): If `False`, means field is not indexed (overrides type). This parameter has no effect
+  on a `wildcard` field.
 - format: Field format that can be used in a Kibana index template.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -144,6 +144,9 @@ def field_or_multi_field_datatype_defaults(field_details):
         field_details.setdefault('ignore_above', 1024)
     if field_details['type'] == 'text':
         field_details.setdefault('norms', False)
+    # wildcard needs the index param stripped
+    if field_details['type'] == 'wildcard':
+        field_details.pop('index', None)
     if 'index' in field_details and not field_details['index']:
         field_details.setdefault('doc_values', False)
 

--- a/scripts/tests/unit/test_schema_cleaner.py
+++ b/scripts/tests/unit/test_schema_cleaner.py
@@ -209,6 +209,10 @@ class TestSchemaCleaner(unittest.TestCase):
         cleaner.field_defaults({'field_details': field_details})
         self.assertEqual(field_details['doc_values'], False)
 
+        field_details = {**field_min_details, **{'type': 'wildcard', 'index': True}}
+        cleaner.field_defaults({'field_details': field_details})
+        self.assertNotIn('index', field_details)
+
     def test_field_defaults_dont_override(self):
         field_details = {
             'description': 'description',


### PR DESCRIPTION
Backports the following commits to 1.7:
 - Remove index parameter for wildcard fields (#1115)