### PR TITLE
[1.x] Add os.type field, with list of allowed values (#1111)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,7 @@ Thanks, you're awesome :-) -->
 
 * Added `event.category` "registry". #1040
 * Added `event.category` "session". #1049
+* Added `os.type`. #1111
 
 #### Improvements
 

--- a/code/go/ecs/os.go
+++ b/code/go/ecs/os.go
@@ -21,6 +21,15 @@ package ecs
 
 // The OS fields contain information about the operating system.
 type Os struct {
+	// Use the `os.type` field to categorize the operating system into one of
+	// the broad commercial families.
+	// One of these following values should be used (lowercase): linux, macos,
+	// unix, windows.
+	// If the OS you're dealing with is not in the list, the field should not
+	// be populated. Please let us know by opening an issue with ECS, to
+	// propose its addition.
+	Type string `ecs:"type"`
+
 	// Operating system platform (such centos, ubuntu, windows).
 	Platform string `ecs:"platform"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3930,6 +3930,23 @@ example: `darwin`
 
 // ===============================================================
 
+| os.type
+| Use the `os.type` field to categorize the operating system into one of the broad commercial families.
+
+One of these following values should be used (lowercase): linux, macos, unix, windows.
+
+If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition.
+
+type: keyword
+
+
+
+example: `macos`
+
+| extended
+
+// ===============================================================
+
 | os.version
 | Operating system version as a raw string.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2181,6 +2181,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword
@@ -2929,6 +2944,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword
@@ -3034,6 +3064,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: version
       level: extended
       type: keyword
@@ -5716,6 +5761,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -251,6 +251,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev+exp,true,host,host.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev+exp,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev+exp,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev+exp,true,host,host.type,keyword,core,,,Type of host.
 1.8.0-dev+exp,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
@@ -342,6 +343,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev+exp,true,observer,observer.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev+exp,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev+exp,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev+exp,true,observer,observer.product,keyword,extended,,s200,The product name of the observer.
 1.8.0-dev+exp,true,observer,observer.serial_number,keyword,extended,,,Observer serial number.
@@ -703,6 +705,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev+exp,true,user_agent,user_agent.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev+exp,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev+exp,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev+exp,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev+exp,true,user_agent,user_agent.version,keyword,extended,,12.0,Version of the user agent.
 1.8.0-dev+exp,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3423,6 +3423,25 @@ host.os.platform:
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
+host.os.type:
+  dashed_name: host-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: host.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  type: keyword
 host.os.version:
   dashed_name: host-os-version
   description: Operating system version as a raw string.
@@ -4558,6 +4577,25 @@ observer.os.platform:
   normalize: []
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
+  type: keyword
+observer.os.type:
+  dashed_name: observer-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: observer.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
   type: keyword
 observer.os.version:
   dashed_name: observer-os-version
@@ -8795,6 +8833,25 @@ user_agent.os.platform:
   normalize: []
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
+  type: keyword
+user_agent.os.type:
+  dashed_name: user-agent-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: user_agent.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
   type: keyword
 user_agent.os.version:
   dashed_name: user-agent-os-version

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4086,6 +4086,26 @@ host:
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
+    host.os.type:
+      dashed_name: host-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: host.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      type: keyword
     host.os.version:
       dashed_name: host-os-version
       description: Operating system version as a raw string.
@@ -5339,6 +5359,26 @@ observer:
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
+    observer.os.type:
+      dashed_name: observer-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: observer.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      type: keyword
     observer.os.version:
       dashed_name: observer-os-version
       description: Operating system version as a raw string.
@@ -5541,6 +5581,25 @@ os:
       name: platform
       normalize: []
       short: Operating system platform (such centos, ubuntu, windows).
+      type: keyword
+    os.type:
+      dashed_name: os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
       type: keyword
     os.version:
       dashed_name: os-version
@@ -10109,6 +10168,26 @@ user_agent:
       normalize: []
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
+      type: keyword
+    user_agent.os.type:
+      dashed_name: user-agent-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: user_agent.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
       type: keyword
     user_agent.os.version:
       dashed_name: user-agent-os-version

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1134,6 +1134,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "version": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1586,6 +1590,10 @@
                 "type": "wildcard"
               },
               "platform": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -3234,6 +3242,10 @@
                 "type": "wildcard"
               },
               "platform": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2214,6 +2214,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword
@@ -2973,6 +2988,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword
@@ -3081,6 +3111,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: version
       level: extended
       type: keyword
@@ -5586,6 +5631,21 @@
       ignore_above: 1024
       description: Operating system platform (such centos, ubuntu, windows).
       example: darwin
+    - name: os.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      default_field: false
     - name: os.version
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -251,6 +251,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev,true,host,host.type,keyword,core,,,Type of host.
 1.8.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
@@ -342,6 +343,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev,true,observer,observer.product,keyword,extended,,s200,The product name of the observer.
 1.8.0-dev,true,observer,observer.serial_number,keyword,extended,,,Observer serial number.
@@ -667,6 +669,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.8.0-dev,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 1.8.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.8.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.8.0-dev,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.8.0-dev,true,user_agent,user_agent.version,keyword,extended,,12.0,Version of the user agent.
 1.8.0-dev,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3455,6 +3455,25 @@ host.os.platform:
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
   type: keyword
+host.os.type:
+  dashed_name: host-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: host.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  type: keyword
 host.os.version:
   dashed_name: host-os-version
   description: Operating system version as a raw string.
@@ -4601,6 +4620,25 @@ observer.os.platform:
   normalize: []
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
+  type: keyword
+observer.os.type:
+  dashed_name: observer-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: observer.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
   type: keyword
 observer.os.version:
   dashed_name: observer-os-version
@@ -8502,6 +8540,25 @@ user_agent.os.platform:
   normalize: []
   original_fieldset: os
   short: Operating system platform (such centos, ubuntu, windows).
+  type: keyword
+user_agent.os.type:
+  dashed_name: user-agent-os-type
+  description: 'Use the `os.type` field to categorize the operating system into one
+    of the broad commercial families.
+
+    One of these following values should be used (lowercase): linux, macos, unix,
+    windows.
+
+    If the OS you''re dealing with is not in the list, the field should not be populated.
+    Please let us know by opening an issue with ECS, to propose its addition.'
+  example: macos
+  flat_name: user_agent.os.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  original_fieldset: os
+  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
   type: keyword
 user_agent.os.version:
   dashed_name: user-agent-os-version

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4120,6 +4120,26 @@ host:
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
+    host.os.type:
+      dashed_name: host-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: host.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      type: keyword
     host.os.version:
       dashed_name: host-os-version
       description: Operating system version as a raw string.
@@ -5384,6 +5404,26 @@ observer:
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
       type: keyword
+    observer.os.type:
+      dashed_name: observer-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: observer.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      type: keyword
     observer.os.version:
       dashed_name: observer-os-version
       description: Operating system version as a raw string.
@@ -5589,6 +5629,25 @@ os:
       name: platform
       normalize: []
       short: Operating system platform (such centos, ubuntu, windows).
+      type: keyword
+    os.type:
+      dashed_name: os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
       type: keyword
     os.version:
       dashed_name: os-version
@@ -9800,6 +9859,26 @@ user_agent:
       normalize: []
       original_fieldset: os
       short: Operating system platform (such centos, ubuntu, windows).
+      type: keyword
+    user_agent.os.type:
+      dashed_name: user-agent-os-type
+      description: 'Use the `os.type` field to categorize the operating system into
+        one of the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix,
+        windows.
+
+        If the OS you''re dealing with is not in the list, the field should not be
+        populated. Please let us know by opening an issue with ECS, to propose its
+        addition.'
+      example: macos
+      flat_name: user_agent.os.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      original_fieldset: os
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
       type: keyword
     user_agent.os.version:
       dashed_name: user-agent-os-version

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1167,6 +1167,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "version": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -1630,6 +1634,10 @@
                   "type": "keyword"
                 },
                 "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -3158,6 +3166,10 @@
                   "type": "keyword"
                 },
                 "platform": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1166,6 +1166,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "version": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1629,6 +1633,10 @@
                 "type": "keyword"
               },
               "platform": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -3157,6 +3165,10 @@
                 "type": "keyword"
               },
               "platform": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -13,6 +13,20 @@
   type: group
   fields:
 
+    - name: type
+      level: extended
+      type: keyword
+      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      description: >
+        Use the `os.type` field to categorize the operating system into one of
+        the broad commercial families.
+
+        One of these following values should be used (lowercase): linux, macos, unix, windows.
+
+        If the OS you're dealing with is not in the list, the field should not be populated.
+        Please let us know by opening an issue with ECS, to propose its addition.
+      example: macos
+
     - name: platform
       level: extended
       type: keyword


### PR DESCRIPTION
Backports the following commits to 1.x:

* Add os.type field, with list of allowed values (#1111)