### PR TITLE
Usage of brackets for a URL containing IPv6 address

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -22,6 +22,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Note `[` and `]` bracket characters may enclose a literal IPv6 address when populating `url.domain`. #1131
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -42,9 +42,9 @@ type Url struct {
 	// In some cases a URL may refer to an IP and/or port directly, without a
 	// domain name. In this case, the IP address would go to the `domain`
 	// field.
-	// If the URL contains a literal IPv6 address, `domain` may include the `[`
-	// and `]` characters enclosing the address
-	// (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
+	// If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF
+	// RFC 2732), the `[` and `]` characters should also be captured in the
+	// `domain` field.
 	Domain string `ecs:"domain"`
 
 	// The highest registered url domain, stripped of the subdomain.

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -42,6 +42,9 @@ type Url struct {
 	// In some cases a URL may refer to an IP and/or port directly, without a
 	// domain name. In this case, the IP address would go to the `domain`
 	// field.
+	// If the URL contains a literal IPv6 address, `domain` may include the `[`
+	// and `]` characters enclosing the address
+	// (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
 	Domain string `ecs:"domain"`
 
 	// The highest registered url domain, stripped of the subdomain.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6236,6 +6236,8 @@ URL fields provide support for complete or partial URLs, and supports the breaki
 
 In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.
 
+If the URL contains a literal IPv6 address, `domain` may include the `[` and `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
+
 type: keyword
 
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6236,7 +6236,7 @@ URL fields provide support for complete or partial URLs, and supports the breaki
 
 In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.
 
-If the URL contains a literal IPv6 address, `domain` may include the `[` and `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
+If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5262,7 +5262,11 @@
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address, `domain` may include the `[` and
+        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
+        2732]).'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5264,9 +5264,9 @@
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.
 
-        If the URL contains a literal IPv6 address, `domain` may include the `[` and
-        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
-        2732]).'
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8029,8 +8029,8 @@ url.domain:
     In some cases a URL may refer to an IP and/or port directly, without a domain
     name. In this case, the IP address would go to the `domain` field.
 
-    If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
-    characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).'
+    If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+    the `[` and `]` characters should also be captured in the `domain` field.'
   example: www.elastic.co
   flat_name: url.domain
   level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8027,7 +8027,10 @@ url.domain:
   description: 'Domain of the url, such as "www.elastic.co".
 
     In some cases a URL may refer to an IP and/or port directly, without a domain
-    name. In this case, the IP address would go to the `domain` field.'
+    name. In this case, the IP address would go to the `domain` field.
+
+    If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
+    characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).'
   example: www.elastic.co
   flat_name: url.domain
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9293,9 +9293,9 @@ url:
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.
 
-        If the URL contains a literal IPv6 address, `domain` may include the `[` and
-        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
-        2732]).'
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
       flat_name: url.domain
       level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9291,7 +9291,11 @@ url:
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address, `domain` may include the `[` and
+        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
+        2732]).'
       example: www.elastic.co
       flat_name: url.domain
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5352,9 +5352,9 @@
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.
 
-        If the URL contains a literal IPv6 address, `domain` may include the `[` and
-        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
-        2732]).'
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5350,7 +5350,11 @@
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address, `domain` may include the `[` and
+        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
+        2732]).'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8112,8 +8112,8 @@ url.domain:
     In some cases a URL may refer to an IP and/or port directly, without a domain
     name. In this case, the IP address would go to the `domain` field.
 
-    If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
-    characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).'
+    If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+    the `[` and `]` characters should also be captured in the `domain` field.'
   example: www.elastic.co
   flat_name: url.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8110,7 +8110,10 @@ url.domain:
   description: 'Domain of the url, such as "www.elastic.co".
 
     In some cases a URL may refer to an IP and/or port directly, without a domain
-    name. In this case, the IP address would go to the `domain` field.'
+    name. In this case, the IP address would go to the `domain` field.
+
+    If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
+    characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).'
   example: www.elastic.co
   flat_name: url.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9379,7 +9379,11 @@ url:
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address, `domain` may include the `[` and
+        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
+        2732]).'
       example: www.elastic.co
       flat_name: url.domain
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9381,9 +9381,9 @@ url:
         In some cases a URL may refer to an IP and/or port directly, without a domain
         name. In this case, the IP address would go to the `domain` field.
 
-        If the URL contains a literal IPv6 address, `domain` may include the `[` and
-        `]` characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC
-        2732]).'
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
       flat_name: url.domain
       ignore_above: 1024

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -58,6 +58,9 @@
 
         In some cases a URL may refer to an IP and/or port directly, without a
         domain name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
+        characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
       example: www.elastic.co
 
     - name: registered_domain

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -59,8 +59,8 @@
         In some cases a URL may refer to an IP and/or port directly, without a
         domain name. In this case, the IP address would go to the `domain` field.
 
-        If the URL contains a literal IPv6 address, `domain` may include the `[` and `]`
-        characters enclosing the address (https://www.ietf.org/rfc/rfc2732.txt[RFC 2732]).
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+        the `[` and `]` characters should also be captured in the `domain` field.
       example: www.elastic.co
 
     - name: registered_domain


### PR DESCRIPTION
#### Summary

Detail that the `[` and `]` characters may enclose a literal IPv6 address populating `url.domain`.

#### Background

The current `url.domain` field description doesn't have guidance for this case (e.g. https://github.com/elastic/elasticsearch/pull/65150#discussion_r525635429). The format is defined in [RFC 2732](https://www.ietf.org/rfc/rfc2732.txt) and has been adopted by the major web browsers.

Example:

* Literal IPv6 address: `FEDC:BA98:7654:3210:FEDC:BA98:7654:3210`
* Formatted in a URL: `http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]/index.html`

