### PR TITLE
[1.x] Add support for constant_keyword's 'value' parameter (#1112)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,7 @@ Thanks, you're awesome :-) -->
 * Added support for `scaled_float`'s mandatory parameter `scaling_factor`. #1042
 * Added ability for --oss flag to fall back `constant_keyword` to `keyword`. #1046
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
+* Added support for `constant_keyword`'s optional parameter `value`. #1112
 
 #### Improvements
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -57,6 +57,8 @@ def entry_for(field):
 
         if field['type'] == 'keyword':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above'])
+        elif field['type'] == 'constant_keyword':
+            ecs_helpers.dict_copy_existing_keys(field, field_entry, ['value'])
         elif field['type'] == 'text':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['norms'])
         elif field['type'] == 'alias':

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -135,6 +135,28 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         }
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_constant_keyword_with_value(self):
+        test_map = {
+            'name': 'field_with_value',
+            'type': 'constant_keyword',
+            'value': 'foo'
+        }
+
+        exp = {
+            'type': 'constant_keyword',
+            'value': 'foo'
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+    def test_constant_keyword_no_value(self):
+        test_map = {
+            'name': 'field_without_value',
+            'type': 'constant_keyword'
+        }
+
+        exp = {'type': 'constant_keyword'}
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Backports the following commits to 1.x:

* Add support for constant_keyword's 'value' parameter (#1112)