### PR TITLE
Docs: Remove ifeval from getting-starting

### DIFF
--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,10 +285,6 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-ifeval::["{branch}"=="7.9"]
-* {logs-guide}/logs-fields-reference.html[Log Monitoring Field Reference]
-endif::[]
-ifeval::["{branch}"!="7.9"]
 * {observability-guide}/logs-app-fields.html[Log Monitoring Field Reference]
-endif::[]
+* {observability-guide}/metrics-app-fields.html[Metrics Monitoring Field Reference]
 * {security-guide}/siem-field-reference.html[Elastic Security Field Reference]


### PR DESCRIPTION
### Summary

This PR is a follow-up to https://github.com/elastic/ecs/pull/1073 and:

- removes the `ifeval` that fixed potential broken links when 7.10 became the `current` stack version.
- adds an additional link to the [Metrics Monitoring Field Reference](https://www.elastic.co/guide/en/observability/current/metrics-app-fields.html) in the Observability Guide.

### Target
This PR will need to be backported to `1.7`, `1.6`, `1.5`, and `1.x`.