### PR TITLE
[1.7] Backport #1134 and #1135

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -9,14 +9,10 @@ The following Elastic products support ECS out of the box, as of version 7.0:
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
 Server]
-ifeval::["{branch}"=="7.9"]
-* {logs-guide}/logs-app-overview.html[Log Monitoring]
-endif::[]
-ifeval::["{branch}"!="7.9"]
 * {observability-guide}/monitor-logs.html[Log Monitoring]
-endif::[]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
+* {observability-guide}/analyze-metrics.html[Metrics Monitoring]
 
 // TODO Insert community & partner solutions here
 

--- a/docs/using-getting-started.asciidoc
+++ b/docs/using-getting-started.asciidoc
@@ -285,10 +285,6 @@ Here are some examples of additional fields processed by metadata or parser proc
 We've covered at a high level how to map your events to ECS. Now if you'd like your events to render well in the Elastic
 solutions, check out the reference guides below to learn more about each:
 
-ifeval::["{branch}"=="7.9"]
-* {logs-guide}/logs-fields-reference.html[Log Monitoring Field Reference]
-endif::[]
-ifeval::["{branch}"!="7.9"]
 * {observability-guide}/logs-app-fields.html[Log Monitoring Field Reference]
-endif::[]
+* {observability-guide}/metrics-app-fields.html[Metrics Monitoring Field Reference]
 * {security-guide}/siem-field-reference.html[Elastic Security Field Reference]


### PR DESCRIPTION
* Remove temporary ifeval in "getting started" page, add link to Metrics docs (#1134)
* Remove temporary ifeval from products page, add link to Metrics (#1135)