### PR TITLE
Adjust issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/schema-changes-additions.md
+++ b/.github/ISSUE_TEMPLATE/schema-changes-additions.md
@@ -1,6 +1,6 @@
 ---
-name: "Minor Schema Changes and Additions"
-about: "Minor changes or additions to ECS."
+name: "Suggest a change"
+about: "Suggest changes or additions to ECS."
 labels: "enhancement"
 
 ---
@@ -13,11 +13,11 @@ Please fill in the following sections describing your proposed changes: -->
 
 **Summary**
 
-Provide a brief, high-level description of your proposed additions or changes.
+<!-- Provide a brief, high-level description of your proposed additions or changes. -->
 
 **Motivation**:
 
-Include any context around the suggestion and motivation for opening an issue.
+<!-- Include any context around the suggestion and motivation for opening an issue. -->
 
 **Detailed Design**:
 

--- a/.github/ISSUE_TEMPLATE/schema-issue.md
+++ b/.github/ISSUE_TEMPLATE/schema-issue.md
@@ -1,6 +1,6 @@
 ---
-name: Schema Issue
-about: "Report an issue with ECS."
+name: Report a Problem
+about: "Report a problem, inconsistency or typo in ECS."
 labels: "bug"
 
 ---


### PR DESCRIPTION
The goal of this PR is for the wording of the two issue types to better guide contributors to the normal suggestions/issues vs reporting problems.

The previous wording had most folks click "Schema Issue" which sounds innocuous, but would be labelled "bug" :-)