### PR TITLE
Mention Logstash support for ECS in the 'products' page

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -13,6 +13,7 @@ Server]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 * {observability-guide}/analyze-metrics.html[Metrics Monitoring]
+* {ls}' {es} output has an {logstash-ref}/plugins-outputs-elasticsearch.html#_compatibility_with_the_elastic_common_schema_ecs[ECS compatibility mode]
 
 // TODO Insert community & partner solutions here
 


### PR DESCRIPTION
The ECS compatibility mode was introduced in 7.9.

[Doc Preview](https://ecs_1147.docs-preview.app.elstc.co/guide/en/ecs/master/ecs-products-solutions.html)