### PR TITLE
Two small documentation backports

### DIFF
--- a/docs/converting.asciidoc
+++ b/docs/converting.asciidoc
@@ -35,8 +35,10 @@ Here's the recommended approach for converting an existing implementation to {ec
 
   - Review your original event data again
   - Consider populating the field based on additional meta-data such as static
-    information (e.g. add `event.type:syslog` even if syslog events don't mention this fact),
-    or information gathered from the environment (e.g. host information).
+    information (e.g. add `event.category:authentication` even if your auth events
+    don't mention the word "authentication")
+  - Consider capturing additional environment meta-data, such as information about the
+    host, container or cloud instance.
 
 . Review other extended fields from any field set you are already using, and
   attempt to populate it as well.

--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -13,6 +13,7 @@ Server]
 * Log formatters that support ECS out of the box for various languages can be found
   https://github.com/elastic/ecs-logging/blob/master/README.md[here].
 * {observability-guide}/analyze-metrics.html[Metrics Monitoring]
+* {ls}' {es} output has an {logstash-ref}/plugins-outputs-elasticsearch.html#_compatibility_with_the_elastic_common_schema_ecs[ECS compatibility mode]
 
 // TODO Insert community & partner solutions here
 


### PR DESCRIPTION
Backports the following commits to 1.7:

* Mention Logstash support for ECS in the 'products' page (#1147)
* Remove an incorrect `event.type` from the 'converting' page (#1146)