### PR TITLE
Reinforce the exclusion of the leading dot from url.extension

### DIFF
--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -87,11 +87,14 @@ type Url struct {
 	// differentiate between the two cases.
 	Query string `ecs:"query"`
 
-	// The field contains the file extension from the original request url.
+	// The field contains the file extension from the original request url,
+	// excluding the leading dot.
 	// The file extension is only set if it exists, as not every url has a file
 	// extension.
 	// The leading period must not be included. For example, the value must be
 	// "png", not ".png".
+	// Note that when the file name has multiple extensions (example.tar.gz),
+	// only the last one should be captured ("gz", not "tar.gz").
 	Extension string `ecs:"extension"`
 
 	// Portion of the url after the `#`, such as "top".

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6247,11 +6247,13 @@ example: `www.elastic.co`
 // ===============================================================
 
 | url.extension
-| The field contains the file extension from the original request url.
+| The field contains the file extension from the original request url, excluding the leading dot.
 
 The file extension is only set if it exists, as not every url has a file extension.
 
 The leading period must not be included. For example, the value must be "png", not ".png".
+
+Note that when the file name has multiple extensions (example.tar.gz), only the last one should be captured ("gz", not "tar.gz").
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5269,12 +5269,15 @@
       type: keyword
       ignore_above: 1024
       description: 'The field contains the file extension from the original request
-        url.
+        url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
         The leading period must not be included. For example, the value must be "png",
-        not ".png".'
+        not ".png".
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
     - name: fragment
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -631,7 +631,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,trace,trace.id,keyword,extended,,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
 2.0.0-dev+exp,true,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction within the scope of its trace.
 2.0.0-dev+exp,true,url,url.domain,wildcard,extended,,www.elastic.co,Domain of the url.
-2.0.0-dev+exp,true,url,url.extension,keyword,extended,,png,File extension from the original request url.
+2.0.0-dev+exp,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 2.0.0-dev+exp,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 2.0.0-dev+exp,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 2.0.0-dev+exp,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8037,19 +8037,23 @@ url.domain:
   type: wildcard
 url.extension:
   dashed_name: url-extension
-  description: 'The field contains the file extension from the original request url.
+  description: 'The field contains the file extension from the original request url,
+    excluding the leading dot.
 
     The file extension is only set if it exists, as not every url has a file extension.
 
     The leading period must not be included. For example, the value must be "png",
-    not ".png".'
+    not ".png".
+
+    Note that when the file name has multiple extensions (example.tar.gz), only the
+    last one should be captured ("gz", not "tar.gz").'
   example: png
   flat_name: url.extension
   ignore_above: 1024
   level: extended
   name: extension
   normalize: []
-  short: File extension from the original request url.
+  short: File extension from the request url, excluding the leading dot.
   type: keyword
 url.fragment:
   dashed_name: url-fragment

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9302,19 +9302,22 @@ url:
     url.extension:
       dashed_name: url-extension
       description: 'The field contains the file extension from the original request
-        url.
+        url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
         The leading period must not be included. For example, the value must be "png",
-        not ".png".'
+        not ".png".
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
       flat_name: url.extension
       ignore_above: 1024
       level: extended
       name: extension
       normalize: []
-      short: File extension from the original request url.
+      short: File extension from the request url, excluding the leading dot.
       type: keyword
     url.fragment:
       dashed_name: url-fragment

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5357,12 +5357,15 @@
       type: keyword
       ignore_above: 1024
       description: 'The field contains the file extension from the original request
-        url.
+        url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
         The leading period must not be included. For example, the value must be "png",
-        not ".png".'
+        not ".png".
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
     - name: fragment
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -631,7 +631,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,trace,trace.id,keyword,extended,,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
 2.0.0-dev,true,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction within the scope of its trace.
 2.0.0-dev,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
-2.0.0-dev,true,url,url.extension,keyword,extended,,png,File extension from the original request url.
+2.0.0-dev,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 2.0.0-dev,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 2.0.0-dev,true,url,url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 2.0.0-dev,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8121,19 +8121,23 @@ url.domain:
   type: keyword
 url.extension:
   dashed_name: url-extension
-  description: 'The field contains the file extension from the original request url.
+  description: 'The field contains the file extension from the original request url,
+    excluding the leading dot.
 
     The file extension is only set if it exists, as not every url has a file extension.
 
     The leading period must not be included. For example, the value must be "png",
-    not ".png".'
+    not ".png".
+
+    Note that when the file name has multiple extensions (example.tar.gz), only the
+    last one should be captured ("gz", not "tar.gz").'
   example: png
   flat_name: url.extension
   ignore_above: 1024
   level: extended
   name: extension
   normalize: []
-  short: File extension from the original request url.
+  short: File extension from the request url, excluding the leading dot.
   type: keyword
 url.fragment:
   dashed_name: url-fragment

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9391,19 +9391,22 @@ url:
     url.extension:
       dashed_name: url-extension
       description: 'The field contains the file extension from the original request
-        url.
+        url, excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
         The leading period must not be included. For example, the value must be "png",
-        not ".png".'
+        not ".png".
+
+        Note that when the file name has multiple extensions (example.tar.gz), only
+        the last one should be captured ("gz", not "tar.gz").'
       example: png
       flat_name: url.extension
       ignore_above: 1024
       level: extended
       name: extension
       normalize: []
-      short: File extension from the original request url.
+      short: File extension from the request url, excluding the leading dot.
       type: keyword
     url.fragment:
       dashed_name: url-fragment

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -133,13 +133,17 @@
     - name: extension
       level: extended
       type: keyword
-      short: File extension from the original request url.
+      short: File extension from the request url, excluding the leading dot.
       description: >
-        The field contains the file extension from the original request url.
+        The field contains the file extension from the original request url,
+        excluding the leading dot.
 
         The file extension is only set if it exists, as not every url has a file extension.
 
         The leading period must not be included. For example, the value must be "png", not ".png".
+
+        Note that when the file name has multiple extensions (example.tar.gz),
+        only the last one should be captured ("gz", not "tar.gz").
       example: png
 
     - name: fragment


### PR DESCRIPTION
This adjustment is meant to match the improved guidance on `file.extension` we introduced in #1016.

I think we should backport this to 1.7 for it to be reflected in current docs. This guidance was already present in the description for `url.extension`, just not as obvious. It was in the long description, but not in the short description.