### PR TITLE
Tracing fields should be at top level in Beats artifact

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,7 +30,7 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
-* `tracing` fields should be at top level of Beats `fields.ecs.yml` artifacts. #1164
+* `tracing` fields should be at root of Beats `fields.ecs.yml` artifacts. #1164
 
 #### Added
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* `tracing` fields should be at top level of Beats `fields.ecs.yml` artifacts. #1164
+
 #### Added
 
 * Added ability to supply free-form usage documentation per fieldset. #988

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -48,6 +48,34 @@
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
+  - name: span.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the span within the scope of its trace.
+
+      A span represents an operation within a transaction, such as a request to another
+      service, or a database query.'
+    example: 3ff9a8981b7ccd5a
+    default_field: false
+  - name: trace.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the trace.
+
+      A trace groups multiple events like transactions that belong together. For example,
+      a user request handled by multiple inter-connected services.'
+    example: 4bf92f3577b34da6a3ce929d0e0e4736
+  - name: transaction.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the transaction within the scope of its trace.
+
+      A transaction is the highest level of work measured within a service, such as
+      a request to a server.'
+    example: 00f067aa0ba902b7
   - name: agent
     title: Agent
     group: 2
@@ -5212,47 +5240,6 @@
       description: Normalized lowercase protocol name parsed from original string.
       example: tls
       default_field: false
-  - name: tracing
-    title: Tracing
-    group: 2
-    description: 'Distributed tracing makes it possible to analyze performance throughout
-      a microservice architecture all in one view. This is accomplished by tracing
-      all of the requests - from the initial web request in the front-end service
-      - to queries made through multiple back-end services.
-
-      Unlike most field sets in ECS, the tracing fields are *not* nested under the
-      field set name. In other words, the correct field name is `trace.id`, not `tracing.trace.id`,
-      and so on.'
-    type: group
-    fields:
-    - name: span.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the span within the scope of its trace.
-
-        A span represents an operation within a transaction, such as a request to
-        another service, or a database query.'
-      example: 3ff9a8981b7ccd5a
-      default_field: false
-    - name: trace.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the trace.
-
-        A trace groups multiple events like transactions that belong together. For
-        example, a user request handled by multiple inter-connected services.'
-      example: 4bf92f3577b34da6a3ce929d0e0e4736
-    - name: transaction.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the transaction within the scope of its trace.
-
-        A transaction is the highest level of work measured within a service, such
-        as a request to a server.'
-      example: 00f067aa0ba902b7
   - name: url
     title: URL
     group: 2

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -48,34 +48,6 @@
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
-  - name: span.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the span within the scope of its trace.
-
-      A span represents an operation within a transaction, such as a request to another
-      service, or a database query.'
-    example: 3ff9a8981b7ccd5a
-    default_field: false
-  - name: trace.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the trace.
-
-      A trace groups multiple events like transactions that belong together. For example,
-      a user request handled by multiple inter-connected services.'
-    example: 4bf92f3577b34da6a3ce929d0e0e4736
-  - name: transaction.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the transaction within the scope of its trace.
-
-      A transaction is the highest level of work measured within a service, such as
-      a request to a server.'
-    example: 00f067aa0ba902b7
   - name: agent
     title: Agent
     group: 2
@@ -5240,6 +5212,34 @@
       description: Normalized lowercase protocol name parsed from original string.
       example: tls
       default_field: false
+  - name: span.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the span within the scope of its trace.
+
+      A span represents an operation within a transaction, such as a request to another
+      service, or a database query.'
+    example: 3ff9a8981b7ccd5a
+    default_field: false
+  - name: trace.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the trace.
+
+      A trace groups multiple events like transactions that belong together. For example,
+      a user request handled by multiple inter-connected services.'
+    example: 4bf92f3577b34da6a3ce929d0e0e4736
+  - name: transaction.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the transaction within the scope of its trace.
+
+      A transaction is the highest level of work measured within a service, such as
+      a request to a server.'
+    example: 00f067aa0ba902b7
   - name: url
     title: URL
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -48,34 +48,6 @@
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
-  - name: span.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the span within the scope of its trace.
-
-      A span represents an operation within a transaction, such as a request to another
-      service, or a database query.'
-    example: 3ff9a8981b7ccd5a
-    default_field: false
-  - name: trace.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the trace.
-
-      A trace groups multiple events like transactions that belong together. For example,
-      a user request handled by multiple inter-connected services.'
-    example: 4bf92f3577b34da6a3ce929d0e0e4736
-  - name: transaction.id
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Unique identifier of the transaction within the scope of its trace.
-
-      A transaction is the highest level of work measured within a service, such as
-      a request to a server.'
-    example: 00f067aa0ba902b7
   - name: agent
     title: Agent
     group: 2
@@ -5327,6 +5299,34 @@
       description: Normalized lowercase protocol name parsed from original string.
       example: tls
       default_field: false
+  - name: span.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the span within the scope of its trace.
+
+      A span represents an operation within a transaction, such as a request to another
+      service, or a database query.'
+    example: 3ff9a8981b7ccd5a
+    default_field: false
+  - name: trace.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the trace.
+
+      A trace groups multiple events like transactions that belong together. For example,
+      a user request handled by multiple inter-connected services.'
+    example: 4bf92f3577b34da6a3ce929d0e0e4736
+  - name: transaction.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the transaction within the scope of its trace.
+
+      A transaction is the highest level of work measured within a service, such as
+      a request to a server.'
+    example: 00f067aa0ba902b7
   - name: url
     title: URL
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -48,6 +48,34 @@
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
+  - name: span.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the span within the scope of its trace.
+
+      A span represents an operation within a transaction, such as a request to another
+      service, or a database query.'
+    example: 3ff9a8981b7ccd5a
+    default_field: false
+  - name: trace.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the trace.
+
+      A trace groups multiple events like transactions that belong together. For example,
+      a user request handled by multiple inter-connected services.'
+    example: 4bf92f3577b34da6a3ce929d0e0e4736
+  - name: transaction.id
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'Unique identifier of the transaction within the scope of its trace.
+
+      A transaction is the highest level of work measured within a service, such as
+      a request to a server.'
+    example: 00f067aa0ba902b7
   - name: agent
     title: Agent
     group: 2
@@ -5299,47 +5327,6 @@
       description: Normalized lowercase protocol name parsed from original string.
       example: tls
       default_field: false
-  - name: tracing
-    title: Tracing
-    group: 2
-    description: 'Distributed tracing makes it possible to analyze performance throughout
-      a microservice architecture all in one view. This is accomplished by tracing
-      all of the requests - from the initial web request in the front-end service
-      - to queries made through multiple back-end services.
-
-      Unlike most field sets in ECS, the tracing fields are *not* nested under the
-      field set name. In other words, the correct field name is `trace.id`, not `tracing.trace.id`,
-      and so on.'
-    type: group
-    fields:
-    - name: span.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the span within the scope of its trace.
-
-        A span represents an operation within a transaction, such as a request to
-        another service, or a database query.'
-      example: 3ff9a8981b7ccd5a
-      default_field: false
-    - name: trace.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the trace.
-
-        A trace groups multiple events like transactions that belong together. For
-        example, a user request handled by multiple inter-connected services.'
-      example: 4bf92f3577b34da6a3ce929d0e0e4736
-    - name: transaction.id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique identifier of the transaction within the scope of its trace.
-
-        A transaction is the highest level of work measured within a service, such
-        as a request to a server.'
-      example: 00f067aa0ba902b7
   - name: url
     title: URL
     group: 2

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -13,8 +13,7 @@ def generate(ecs_nested, ecs_version, out_dir):
     allowed_fieldset_keys = ['name', 'title', 'group', 'description', 'footnote', 'type']
     # other fieldsets
     for fieldset_name in sorted(ecs_nested):
-        # skip fieldsets already added
-        if 'base' in fieldset_name:
+        if 'base' == fieldset_name:
             continue
         fieldset = ecs_nested[fieldset_name]
 

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -10,10 +10,17 @@ def generate(ecs_nested, ecs_version, out_dir):
     # base first
     beats_fields = fieldset_field_array(ecs_nested['base']['fields'], df_whitelist, ecs_nested['base']['prefix'])
 
+    # tracing fields also need top-level handling
+    tracing_fields = fieldset_field_array(
+        ecs_nested['tracing']['fields'], df_whitelist, ecs_nested['tracing']['prefix'])
+    beats_fields.extend(tracing_fields)
+
     allowed_fieldset_keys = ['name', 'title', 'group', 'description', 'footnote', 'type']
+    fieldsets_to_skip = ['base', 'tracing']
     # other fieldsets
     for fieldset_name in sorted(ecs_nested):
-        if 'base' == fieldset_name:
+        # skip fieldsets already added
+        if fieldset_name in fieldsets_to_skip:
             continue
         fieldset = ecs_nested[fieldset_name]
 

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -10,19 +10,18 @@ def generate(ecs_nested, ecs_version, out_dir):
     # base first
     beats_fields = fieldset_field_array(ecs_nested['base']['fields'], df_whitelist, ecs_nested['base']['prefix'])
 
-    # tracing fields also need top-level handling
-    tracing_fields = fieldset_field_array(
-        ecs_nested['tracing']['fields'], df_whitelist, ecs_nested['tracing']['prefix'])
-    beats_fields.extend(tracing_fields)
-
     allowed_fieldset_keys = ['name', 'title', 'group', 'description', 'footnote', 'type']
-    fieldsets_to_skip = ['base', 'tracing']
     # other fieldsets
     for fieldset_name in sorted(ecs_nested):
         # skip fieldsets already added
-        if fieldset_name in fieldsets_to_skip:
+        if 'base' in fieldset_name:
             continue
         fieldset = ecs_nested[fieldset_name]
+
+        # Handle when `root:true`
+        if fieldset.get('root', False):
+            beats_fields.extend(fieldset_field_array(fieldset['fields'], df_whitelist, fieldset['prefix']))
+            continue
 
         beats_field = ecs_helpers.dict_copy_keys_ordered(fieldset, allowed_fieldset_keys)
         beats_field['fields'] = fieldset_field_array(fieldset['fields'], df_whitelist, fieldset['prefix'])


### PR DESCRIPTION
The `fields.ecs.yml` artifact was erroneously adding the [tracing](https://www.elastic.co/guide/en/ecs/current/ecs-tracing.html) fields into a `tracing` object.

Like `base` fields, the `tracing` fields should exist at the top-level and require special handling when generating the template.

Closes #1163 
