### PR TITLE
[1.x] Usage of brackets for a URL containing IPv6 address (#1131)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -22,6 +22,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Note `[` and `]` bracket characters may enclose a literal IPv6 address when populating `url.domain`. #1131
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/code/go/ecs/url.go
+++ b/code/go/ecs/url.go
@@ -42,6 +42,9 @@ type Url struct {
 	// In some cases a URL may refer to an IP and/or port directly, without a
 	// domain name. In this case, the IP address would go to the `domain`
 	// field.
+	// If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF
+	// RFC 2732), the `[` and `]` characters should also be captured in the
+	// `domain` field.
 	Domain string `ecs:"domain"`
 
 	// The highest registered url domain, stripped of the subdomain.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -7276,6 +7276,8 @@ URL fields provide support for complete or partial URLs, and supports the breaki
 
 In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.
 
+If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field.
+
 type: keyword
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5253,7 +5253,11 @@
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8027,7 +8027,10 @@ url.domain:
   description: 'Domain of the url, such as "www.elastic.co".
 
     In some cases a URL may refer to an IP and/or port directly, without a domain
-    name. In this case, the IP address would go to the `domain` field.'
+    name. In this case, the IP address would go to the `domain` field.
+
+    If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+    the `[` and `]` characters should also be captured in the `domain` field.'
   example: www.elastic.co
   flat_name: url.domain
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9295,7 +9295,11 @@ url:
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
       flat_name: url.domain
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5341,7 +5341,11 @@
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
     - name: extension
       level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8110,7 +8110,10 @@ url.domain:
   description: 'Domain of the url, such as "www.elastic.co".
 
     In some cases a URL may refer to an IP and/or port directly, without a domain
-    name. In this case, the IP address would go to the `domain` field.'
+    name. In this case, the IP address would go to the `domain` field.
+
+    If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+    the `[` and `]` characters should also be captured in the `domain` field.'
   example: www.elastic.co
   flat_name: url.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9383,7 +9383,11 @@ url:
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
-        name. In this case, the IP address would go to the `domain` field.'
+        name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC
+        2732), the `[` and `]` characters should also be captured in the `domain`
+        field.'
       example: www.elastic.co
       flat_name: url.domain
       ignore_above: 1024

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -58,6 +58,9 @@
 
         In some cases a URL may refer to an IP and/or port directly, without a
         domain name. In this case, the IP address would go to the `domain` field.
+
+        If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732),
+        the `[` and `]` characters should also be captured in the `domain` field.
       example: www.elastic.co
 
     - name: registered_domain


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Usage of brackets for a URL containing IPv6 address (#1131)