### PR TITLE
6.x index template data type fallback

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,6 +48,7 @@ Thanks, you're awesome :-) -->
 
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
+* ES 6.x template data types will fallback to supported types. #1171
 
 #### Deprecated
 

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -222,33 +222,6 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         es_template.es6_type_fallback(test_map)
         self.assertEqual(test_map, exp)
 
-    def test_es6_fallback_recursive_case_constant_keyword(self):
-        test_map = {
-            "top_field": {
-                "properties": {
-                    "field": {
-                        "name": "field",
-                        "type": "constant_keyword"
-                    }
-                }
-            }
-        }
-
-        exp = {
-            "top_field": {
-                "properties": {
-                    "field": {
-                        "name": "field",
-                        "type": "keyword",
-                        "ignore_above": 1024
-                    }
-                }
-            }
-        }
-
-        es_template.es6_type_fallback(test_map)
-        self.assertEqual(test_map, exp)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -203,52 +203,6 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         es_template.es6_type_fallback(test_map)
         self.assertEqual(test_map, exp)
 
-    def test_es6_fallback_base_case_version(self):
-        test_map = {
-            "field": {
-                "name": "field",
-                "type": "version"
-            }
-        }
-
-        exp = {
-            "field": {
-                "name": "field",
-                "type": "keyword",
-                "ignore_above": 1024
-            }
-        }
-
-        es_template.es6_type_fallback(test_map)
-        self.assertEqual(test_map, exp)
-
-    def test_es6_fallback_recursive_case_version(self):
-        test_map = {
-            "top_field": {
-                "properties": {
-                    "field": {
-                        "name": "field",
-                        "type": "version"
-                    }
-                }
-            }
-        }
-
-        exp = {
-            "top_field": {
-                "properties": {
-                    "field": {
-                        "name": "field",
-                        "type": "keyword",
-                        "ignore_above": 1024
-                    }
-                }
-            }
-        }
-
-        es_template.es6_type_fallback(test_map)
-        self.assertEqual(test_map, exp)
-
     def test_es6_fallback_base_case_constant_keyword(self):
         test_map = {
             "field": {

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -157,6 +157,145 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         exp = {'type': 'constant_keyword'}
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_es6_fallback_base_case_wildcard(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "wildcard"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "keyword",
+                "ignore_above": 1024
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_recursive_case_wildcard(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "wildcard"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "keyword",
+                        "ignore_above": 1024
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_base_case_version(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "version"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "keyword",
+                "ignore_above": 1024
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_recursive_case_version(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "version"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "keyword",
+                        "ignore_above": 1024
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_base_case_constant_keyword(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "constant_keyword"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "keyword",
+                "ignore_above": 1024
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_recursive_case_constant_keyword(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "constant_keyword"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "keyword",
+                        "ignore_above": 1024
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -296,6 +296,5 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         self.assertEqual(test_map, exp)
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

Adds logic when generating the 6.x index template artifact to fallback on a compatible type if one exists. Soon, ECS fields will begin using data types introduced in Elasticsearch 7.x, and this change will ensure the ES 6 template will only use types available in 6.x.

### Background & Considerations

The first considered approach was reusing the `--oss` fallback mechanism to generate a second, 6.x-compatible copy of the `fields` object. However, the OSS-fallback takes place much earlier in the chain and would have required a copy of the `fields` objects to go through the identical chain of steps as the original `fields` object.

Next, I looked at incorporating a function to pass along to `visitor.visit_fields` from `generators.es_template`, but `es_template` uses the `flat` representation incompatible with `visitor.visit_fields` without refactoring.

### Approach

This approach is a variation of the earlier-used visitor function but adopted for the field mappings generated in the ES template genator.

Two details:

* `TYPE_FALLBACKS` is imported from `schema.oss` to avoid defining the available fallbacks in two places.
* Another pass through `schema.cleaner.field_or_multi_field_datatype_defaults` is necessary to restore any missing defaults after updating the type (e.g., `wildcard` => `keyword` will need `ignore_above` added).

I want to revisit this approach in the future. New types will be introduced in later major versions that don't exist in 7.x, and types with no fallback will also need handling.