### PR TITLE
[1.x] 6.x index template data type fallback (#1171)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -47,6 +47,7 @@ Thanks, you're awesome :-) -->
 
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
+* ES 6.x template data types will fallback to supported types. #1171
 
 #### Deprecated
 

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -157,6 +157,71 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         exp = {'type': 'constant_keyword'}
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_es6_fallback_base_case_wildcard(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "wildcard"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "keyword",
+                "ignore_above": 1024
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_recursive_case_wildcard(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "wildcard"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "keyword",
+                        "ignore_above": 1024
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_base_case_constant_keyword(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "constant_keyword"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "keyword",
+                "ignore_above": 1024
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Backports the following commits to 1.x:
 - 6.x index template data type fallback (#1171)