### PR TITLE
Handle `error.stack_trace` case for ES 6.x template

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -52,7 +52,7 @@ Thanks, you're awesome :-) -->
 
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
-* ES 6.x template data types will fallback to supported types. #1171
+* ES 6.x template data types will fallback to supported types. #1171, #1176
 
 #### Deprecated
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -97,6 +97,13 @@ def generate_template_version(elasticsearch_version, mappings_section, out_dir, 
     if elasticsearch_version == 6:
         es6_mappings_section = copy.deepcopy(mappings_section)
         es6_type_fallback(es6_mappings_section['properties'])
+
+        # error.stack_trace needs special handling to set
+        # index: false and doc_values: false
+        error_stack_trace_mappings = es6_mappings_section['properties']['error']['properties']['stack_trace']
+        error_stack_trace_mappings.setdefault('index', False)
+        error_stack_trace_mappings.setdefault('doc_values', False)
+
         template['mappings'] = {'_doc': es6_mappings_section}
     else:
         template['mappings'] = mappings_section


### PR DESCRIPTION
`error.stack_trace` needs special handling to re-add `index: false` and `doc_values: false` after the type fallback when the Elasticsearch 6.x legacy index template is generated.

Adding the logic to `generate_template_version` simplified the implementation, but to unit test would require investing additional time into mocking the file write at the end of the function. I opted not to invest that time now, but it is something I'd like to revisit.