### PR TITLE
Move _meta section back inside mappings, in legacy templates.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -47,13 +47,13 @@ Thanks, you're awesome :-) -->
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
 * Added support for marking fields, field sets, or field reuse as beta in the documentation. #1051
 * Added support for `constant_keyword`'s optional parameter `value`. #1112
-* Added component templates for ECS field sets. #1156
+* Added component templates for ECS field sets. #1156, #1186
 
 #### Improvements
 
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
-* ES 6.x template data types will fallback to supported types. #1171, #1176
+* ES 6.x template data types will fallback to supported types. #1171, #1176, #1186
 
 #### Deprecated
 

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1,11 +1,11 @@
 {
-  "_meta": {
-    "version": "2.0.0-dev+exp"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
+    "_meta": {
+      "version": "2.0.0-dev+exp"
+    },
     "date_detection": false,
     "dynamic_templates": [
       {

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1,12 +1,12 @@
 {
-  "_meta": {
-    "version": "2.0.0-dev"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
     "_doc": {
+      "_meta": {
+        "version": "2.0.0-dev"
+      },
       "date_detection": false,
       "dynamic_templates": [
         {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1,11 +1,11 @@
 {
-  "_meta": {
-    "version": "2.0.0-dev"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
+    "_meta": {
+      "version": "2.0.0-dev"
+    },
     "date_detection": false,
     "dynamic_templates": [
       {

--- a/generated/elasticsearch/component/agent.json
+++ b/generated/elasticsearch/component/agent.json
@@ -11,8 +11,7 @@
             "build": {
               "properties": {
                 "original": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 }
               }
             },

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -26,8 +26,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 }
@@ -37,8 +36,7 @@
               "type": "long"
             },
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "geo": {
               "properties": {
@@ -62,8 +60,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -99,8 +96,7 @@
               "type": "long"
             },
             "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -117,8 +113,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -127,8 +122,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -161,8 +155,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -26,8 +26,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 }
@@ -37,8 +36,7 @@
               "type": "long"
             },
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "geo": {
               "properties": {
@@ -62,8 +60,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -99,8 +96,7 @@
               "type": "long"
             },
             "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -117,8 +113,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -127,8 +122,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -161,8 +155,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -80,8 +80,7 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "product": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/dns.json
+++ b/generated/elasticsearch/component/dns.json
@@ -15,8 +15,7 @@
                   "type": "keyword"
                 },
                 "data": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "name": {
                   "ignore_above": 1024,
@@ -51,8 +50,7 @@
                   "type": "keyword"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "registered_domain": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/error.json
+++ b/generated/elasticsearch/component/error.json
@@ -21,20 +21,16 @@
               "type": "text"
             },
             "stack_trace": {
-              "doc_values": false,
               "fields": {
                 "text": {
                   "norms": false,
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "index": false,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "type": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         }

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -47,8 +47,7 @@
               "type": "keyword"
             },
             "directory": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "drive_letter": {
               "ignore_above": 1,
@@ -116,8 +115,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "pe": {
               "properties": {
@@ -142,8 +140,7 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "product": {
                   "ignore_above": 1024,
@@ -161,8 +158,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "type": {
               "ignore_above": 1024,
@@ -189,8 +185,7 @@
                       "type": "keyword"
                     },
                     "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     },
                     "locality": {
                       "ignore_above": 1024,
@@ -251,8 +246,7 @@
                       "type": "keyword"
                     },
                     "distinguished_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     },
                     "locality": {
                       "ignore_above": 1024,

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -38,8 +38,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -52,8 +51,7 @@
               }
             },
             "hostname": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "id": {
               "ignore_above": 1024,
@@ -83,8 +81,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -97,8 +94,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "platform": {
                   "ignore_above": 1024,
@@ -128,8 +124,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -138,8 +133,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -172,8 +166,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -22,8 +22,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 },
@@ -39,8 +38,7 @@
                   "type": "keyword"
                 },
                 "referrer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 }
               }
             },
@@ -58,8 +56,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 },

--- a/generated/elasticsearch/component/log.json
+++ b/generated/elasticsearch/component/log.json
@@ -11,8 +11,7 @@
             "file": {
               "properties": {
                 "path": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 }
               }
             },
@@ -21,8 +20,7 @@
               "type": "keyword"
             },
             "logger": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "origin": {
               "properties": {

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -67,8 +67,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -145,8 +144,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -159,8 +157,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "platform": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/organization.json
+++ b/generated/elasticsearch/component/organization.json
@@ -19,8 +19,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         }

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -43,8 +43,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "entity_id": {
               "ignore_above": 1024,
@@ -57,8 +56,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "exit_code": {
               "type": "long"
@@ -90,8 +88,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "parent": {
               "properties": {
@@ -130,8 +127,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "entity_id": {
                   "ignore_above": 1024,
@@ -144,8 +140,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "exit_code": {
                   "type": "long"
@@ -177,8 +172,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "pe": {
                   "properties": {
@@ -203,8 +197,7 @@
                       "type": "keyword"
                     },
                     "original_file_name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     },
                     "product": {
                       "ignore_above": 1024,
@@ -230,8 +223,7 @@
                       "type": "long"
                     },
                     "name": {
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 },
@@ -242,8 +234,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "uptime": {
                   "type": "long"
@@ -255,8 +246,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 }
               }
             },
@@ -283,8 +273,7 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "product": {
                   "ignore_above": 1024,
@@ -310,8 +299,7 @@
                   "type": "long"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 }
               }
             },
@@ -322,8 +310,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "uptime": {
               "type": "long"
@@ -335,8 +322,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             }
           }
         }

--- a/generated/elasticsearch/component/registry.json
+++ b/generated/elasticsearch/component/registry.json
@@ -15,8 +15,7 @@
                   "type": "keyword"
                 },
                 "strings": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -29,12 +28,10 @@
               "type": "keyword"
             },
             "key": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "value": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -26,8 +26,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 }
@@ -37,8 +36,7 @@
               "type": "long"
             },
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "geo": {
               "properties": {
@@ -62,8 +60,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -99,8 +96,7 @@
               "type": "long"
             },
             "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -117,8 +113,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -127,8 +122,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -161,8 +155,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -26,8 +26,7 @@
                           "type": "text"
                         }
                       },
-                      "ignore_above": 1024,
-                      "type": "keyword"
+                      "type": "wildcard"
                     }
                   }
                 }
@@ -37,8 +36,7 @@
               "type": "long"
             },
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "geo": {
               "properties": {
@@ -62,8 +60,7 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -99,8 +96,7 @@
               "type": "long"
             },
             "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -117,8 +113,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -127,8 +122,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -161,8 +155,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/tls.json
+++ b/generated/elasticsearch/component/tls.json
@@ -39,8 +39,7 @@
                   }
                 },
                 "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "ja3": {
                   "ignore_above": 1024,
@@ -57,8 +56,7 @@
                   "type": "keyword"
                 },
                 "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
@@ -81,8 +79,7 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "type": "wildcard"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -143,8 +140,7 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "type": "wildcard"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -213,8 +209,7 @@
                   }
                 },
                 "issuer": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "ja3s": {
                   "ignore_above": 1024,
@@ -227,8 +222,7 @@
                   "type": "date"
                 },
                 "subject": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "x509": {
                   "properties": {
@@ -247,8 +241,7 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "type": "wildcard"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -309,8 +302,7 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
+                          "type": "wildcard"
                         },
                         "locality": {
                           "ignore_above": 1024,

--- a/generated/elasticsearch/component/url.json
+++ b/generated/elasticsearch/component/url.json
@@ -9,8 +9,7 @@
         "url": {
           "properties": {
             "domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "extension": {
               "ignore_above": 1024,
@@ -27,8 +26,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "original": {
               "fields": {
@@ -37,16 +35,14 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "password": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "path": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "port": {
               "type": "long"
@@ -56,8 +52,7 @@
               "type": "keyword"
             },
             "registered_domain": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "scheme": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/user.json
+++ b/generated/elasticsearch/component/user.json
@@ -15,8 +15,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -25,8 +24,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -59,8 +57,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,
@@ -79,8 +76,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -89,8 +85,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -123,8 +118,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,
@@ -133,8 +127,7 @@
               }
             },
             "email": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "full_name": {
               "fields": {
@@ -143,8 +136,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "group": {
               "properties": {
@@ -177,8 +169,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "roles": {
               "ignore_above": 1024,
@@ -191,8 +182,7 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "full_name": {
                   "fields": {
@@ -201,8 +191,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "group": {
                   "properties": {
@@ -235,8 +224,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/user_agent.json
+++ b/generated/elasticsearch/component/user_agent.json
@@ -27,8 +27,7 @@
                   "type": "text"
                 }
               },
-              "ignore_above": 1024,
-              "type": "keyword"
+              "type": "wildcard"
             },
             "os": {
               "properties": {
@@ -43,8 +42,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -57,8 +55,7 @@
                       "type": "text"
                     }
                   },
-                  "ignore_above": 1024,
-                  "type": "keyword"
+                  "type": "wildcard"
                 },
                 "platform": {
                   "ignore_above": 1024,

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -192,19 +192,24 @@ def template_settings(es_version, ecs_version, mappings_section, template_settin
             template = json.load(f)
     else:
         template = default_template_settings(ecs_version)
+
     if es_version == 6:
-        es6_mappings_section = copy.deepcopy(mappings_section)
-        es6_type_fallback(es6_mappings_section['properties'])
+        mappings_section = copy.deepcopy(mappings_section)
+        es6_type_fallback(mappings_section['properties'])
 
         # error.stack_trace needs special handling to set
         # index: false and doc_values: false
-        error_stack_trace_mappings = es6_mappings_section['properties']['error']['properties']['stack_trace']
+        error_stack_trace_mappings = mappings_section['properties']['error']['properties']['stack_trace']
         error_stack_trace_mappings.setdefault('index', False)
         error_stack_trace_mappings.setdefault('doc_values', False)
 
-        template['mappings'] = {'_doc': es6_mappings_section}
+        template['mappings'] = {'_doc': mappings_section}
     else:
         template['mappings'] = mappings_section
+
+    # _meta can't be at template root in legacy templates, so moving back to mappings section
+    mappings_section['_meta'] = template.pop('_meta')
+
     return template
 
 


### PR DESCRIPTION
This fixes an issue introduced by #1156, discovered in #1180. Composable templates support `_meta` at the template's root, but legacy templates don't. So we're just putting it back inside the mappings for legacy templates.

This also fixes missing updates to the component template, after the introduction of wildcard in #1098.