### PR TITLE
[1.x] Move _meta section back inside mappings, in legacy templates. (#1186)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -46,13 +46,13 @@ Thanks, you're awesome :-) -->
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
 * Added support for marking fields, field sets, or field reuse as beta in the documentation. #1051
 * Added support for `constant_keyword`'s optional parameter `value`. #1112
-* Added component templates for ECS field sets. #1156
+* Added component templates for ECS field sets. #1156, #1186
 
 #### Improvements
 
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
-* ES 6.x template data types will fallback to supported types. #1171, #1176
+* ES 6.x template data types will fallback to supported types. #1171, #1176, #1186
 
 #### Deprecated
 

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1,11 +1,11 @@
 {
-  "_meta": {
-    "version": "1.8.0-dev+exp"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
+    "_meta": {
+      "version": "1.8.0-dev+exp"
+    },
     "date_detection": false,
     "dynamic_templates": [
       {

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1,12 +1,12 @@
 {
-  "_meta": {
-    "version": "1.8.0-dev"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
     "_doc": {
+      "_meta": {
+        "version": "1.8.0-dev"
+      },
       "date_detection": false,
       "dynamic_templates": [
         {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1,11 +1,11 @@
 {
-  "_meta": {
-    "version": "1.8.0-dev"
-  },
   "index_patterns": [
     "try-ecs-*"
   ],
   "mappings": {
+    "_meta": {
+      "version": "1.8.0-dev"
+    },
     "date_detection": false,
     "dynamic_templates": [
       {

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -192,19 +192,24 @@ def template_settings(es_version, ecs_version, mappings_section, template_settin
             template = json.load(f)
     else:
         template = default_template_settings(ecs_version)
+
     if es_version == 6:
-        es6_mappings_section = copy.deepcopy(mappings_section)
-        es6_type_fallback(es6_mappings_section['properties'])
+        mappings_section = copy.deepcopy(mappings_section)
+        es6_type_fallback(mappings_section['properties'])
 
         # error.stack_trace needs special handling to set
         # index: false and doc_values: false
-        error_stack_trace_mappings = es6_mappings_section['properties']['error']['properties']['stack_trace']
+        error_stack_trace_mappings = mappings_section['properties']['error']['properties']['stack_trace']
         error_stack_trace_mappings.setdefault('index', False)
         error_stack_trace_mappings.setdefault('doc_values', False)
 
-        template['mappings'] = {'_doc': es6_mappings_section}
+        template['mappings'] = {'_doc': mappings_section}
     else:
         template['mappings'] = mappings_section
+
+    # _meta can't be at template root in legacy templates, so moving back to mappings section
+    mappings_section['_meta'] = template.pop('_meta')
+
     return template
 
 


### PR DESCRIPTION
Backports the following commits to 1.x:

* Move _meta section back inside mappings, in legacy templates. (#1186)