### PR TITLE
Artifacts docs page

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -54,6 +54,7 @@ Thanks, you're awesome :-) -->
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
 * ES 6.x template data types will fallback to supported types. #1171, #1176, #1186
+* Add a documentation page discussing the experimental artifacts. #1189
 
 #### Deprecated
 

--- a/docs/additional.asciidoc
+++ b/docs/additional.asciidoc
@@ -9,3 +9,4 @@
 include::faq.asciidoc[]
 include::glossary.asciidoc[]
 include::contributing.asciidoc[]
+include::artifacts.asciidoc[]

--- a/docs/additional.asciidoc
+++ b/docs/additional.asciidoc
@@ -4,6 +4,7 @@
 * <<ecs-faq>>
 * <<ecs-glossary>>
 * <<ecs-contributing>>
+* <<ecs-artifacts>>
 
 // include::use-cases.asciidoc[]
 include::faq.asciidoc[]

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -1,8 +1,6 @@
 [[ecs-artifacts]]
 === Generated Artifacts
 
-ECS maintains a collection of artifact files generated directly from the ECS schema, including index templates and CSV files.
+ECS maintains a collection of artifacts which are generated based on the schema. Examples include Elasticsearch index templates, CSV, and Beats field mappings. The maintained artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs[ECS Github repo].
 
-The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs[ECS Github repo].
-
-Users can generate custom artifacts, unique for their own deployments, using the project's tooling. See the ECS tooling {ecs_github_repo_link}/USAGE.md[usage documentation] for more detail.
+Users can generate custom versions of these artifacts using the ECS project's tooling. See the tooling {ecs_github_repo_link}/USAGE.md[usage documentation] for more detail.

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -1,8 +1,8 @@
 [[ecs-artifacts]]
-=== ECS Experimental Artifacts
+=== Generated Artifacts
 
-ECS maintains a collection of experimental artifacts. These artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files.
+ECS maintains a collection of artifact files generated directly from the ECS schema, including index templates and CSV files.
 
 The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs[ECS Github repo].
 
-Users can generate their own custom artifacts using the project's tooling. See the ECS tooling {ecs_github_repo_link}/USAGE.md[usage documentation] for more detail.
+Users can generate custom artifacts, unique for their own deployments, using the project's tooling. See the ECS tooling {ecs_github_repo_link}/USAGE.md[usage documentation] for more detail.

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -1,5 +1,5 @@
 [[ecs-artifacts]]
-== Experimental Artifacts
+=== Experimental Artifacts
 
 ECS maintains a collection of experimental artifacts. The ECS artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files. Users can also generate their own custom artifacts using the scripts also available in the project's repo.
 

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -1,0 +1,6 @@
+[[ecs-artifacts]]
+== Experimental Artifacts
+
+ECS maintains a collection of experimental artifacts. The ECS artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files. Users can also generate their own custom artifacts using the scripts also available in the project's repo.
+
+The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs ECS Github repo.

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -1,6 +1,8 @@
 [[ecs-artifacts]]
-=== Experimental Artifacts
+=== ECS Experimental Artifacts
 
-ECS maintains a collection of experimental artifacts. The ECS artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files. Users can also generate their own custom artifacts using the scripts also available in the project's repo.
+ECS maintains a collection of experimental artifacts. These artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files.
 
 The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs[ECS Github repo].
+
+Users can generate their own custom artifacts using the project's tooling. See the ECS tooling {ecs_github_repo_link}/USAGE.md[usage documentation] for more detail.

--- a/docs/artifacts.asciidoc
+++ b/docs/artifacts.asciidoc
@@ -3,4 +3,4 @@
 
 ECS maintains a collection of experimental artifacts. The ECS artifacts are various files generated directly based on the ECS schema, such as index templates and CSV files. Users can also generate their own custom artifacts using the scripts also available in the project's repo.
 
-The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs ECS Github repo.
+The artifacts can be found in the {ecs_github_repo_link}/generated#artifacts-generated-from-ecs[ECS Github repo].

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -5,6 +5,8 @@
 include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+:ecs_github_repo_link: https://github.com/elastic/ecs/blob/master
+
 [[ecs-reference]]
 == Overview
 

--- a/docs/using-conventions.asciidoc
+++ b/docs/using-conventions.asciidoc
@@ -42,7 +42,7 @@ Elasticsearch can index text using datatypes:
 ===== Default Elasticsearch convention for indexing text fields
 
 Unless your index mapping or index template specifies otherwise
-(as the ECS index template does),
+(as the <<ecs-artifacts, ECS index template>> does),
 Elasticsearch indexes a text field as `text` at the canonical field name,
 and indexes a second time as `keyword`, nested in a multi-field.
 


### PR DESCRIPTION
Add a docs page that describes and links to the experimental artifacts maintained on GitHub. 

Describes the artifacts in general versus solely the index templates artifacts. Open to discussion if we should adjust.

[Docs preview link](https://ecs_1189.docs-preview.app.elstc.co/diff)

Closes #1030 