### PR TITLE
Conditional handling in es_template.template_settings

### DIFF
--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -212,7 +212,9 @@ def template_settings(es_version, ecs_version, mappings_section, template_settin
         template['mappings'] = mappings_section
 
     # _meta can't be at template root in legacy templates, so moving back to mappings section
-    mappings_section['_meta'] = template.pop('_meta')
+    # if present
+    if '_meta' in template:
+        mappings_section['_meta'] = template.pop('_meta')
 
     return template
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -198,10 +198,14 @@ def template_settings(es_version, ecs_version, mappings_section, template_settin
         es6_type_fallback(mappings_section['properties'])
 
         # error.stack_trace needs special handling to set
-        # index: false and doc_values: false
-        error_stack_trace_mappings = mappings_section['properties']['error']['properties']['stack_trace']
-        error_stack_trace_mappings.setdefault('index', False)
-        error_stack_trace_mappings.setdefault('doc_values', False)
+        # index: false and doc_values: false if the field
+        # is present in the mappings
+        try:
+            error_stack_trace_mappings = mappings_section['properties']['error']['properties']['stack_trace']
+            error_stack_trace_mappings.setdefault('index', False)
+            error_stack_trace_mappings.setdefault('doc_values', False)
+        except KeyError:
+           pass
 
         template['mappings'] = {'_doc': mappings_section}
     else:

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -205,7 +205,7 @@ def template_settings(es_version, ecs_version, mappings_section, template_settin
             error_stack_trace_mappings.setdefault('index', False)
             error_stack_trace_mappings.setdefault('doc_values', False)
         except KeyError:
-           pass
+            pass
 
         template['mappings'] = {'_doc': mappings_section}
     else:


### PR DESCRIPTION
Address two bugs in `es_template.template_settings`:

* `error.stack_trace` handling from #1176 caused a `KeyError` exception when `properties.error.properties.stack_trace` wasn't present in the loaded mappings.
* `_meta` handling from #1186 caused a `KeyError` exception when a user-supplied template settings file doesn't include `_meta`. 

Closes #1190