### PR TITLE
[1.x] Correct wording of `event.reference` description (#1181)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Clean up `event.reference` description. #1181
+
 #### Added
 
 * Added `event.category` "registry". #1040

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -199,7 +199,7 @@ type Event struct {
 	Ingested time.Time `ecs:"ingested"`
 
 	// Reference URL linking to additional information about this event.
-	// This URL links to a static definition of the this event. Alert events,
+	// This URL links to a static definition of this event. Alert events,
 	// indicated by `event.kind:alert`, are a common use case for this field.
 	Reference string `ecs:"reference"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2164,7 +2164,7 @@ example: `Terminated an unexpected process`
 
 | Reference URL linking to additional information about this event.
 
-This URL links to a static definition of the this event. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
+This URL links to a static definition of this event. Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1392,7 +1392,7 @@
       ignore_above: 1024
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event. Alert events, indicated
+        This URL links to a static definition of this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.example.com/event/#0001234
       default_field: false

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2183,8 +2183,8 @@ event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.
 
-    This URL links to a static definition of the this event. Alert events, indicated
-    by `event.kind:alert`, are a common use case for this field.'
+    This URL links to a static definition of this event. Alert events, indicated by
+    `event.kind:alert`, are a common use case for this field.'
   example: https://system.example.com/event/#0001234
   flat_name: event.reference
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2587,7 +2587,7 @@ event:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event. Alert events, indicated
+        This URL links to a static definition of this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.example.com/event/#0001234
       flat_name: event.reference

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1392,7 +1392,7 @@
       ignore_above: 1024
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event. Alert events, indicated
+        This URL links to a static definition of this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.example.com/event/#0001234
       default_field: false

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2183,8 +2183,8 @@ event.reference:
   dashed_name: event-reference
   description: 'Reference URL linking to additional information about this event.
 
-    This URL links to a static definition of the this event. Alert events, indicated
-    by `event.kind:alert`, are a common use case for this field.'
+    This URL links to a static definition of this event. Alert events, indicated by
+    `event.kind:alert`, are a common use case for this field.'
   example: https://system.example.com/event/#0001234
   flat_name: event.reference
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2587,7 +2587,7 @@ event:
       dashed_name: event-reference
       description: 'Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event. Alert events, indicated
+        This URL links to a static definition of this event. Alert events, indicated
         by `event.kind:alert`, are a common use case for this field.'
       example: https://system.example.com/event/#0001234
       flat_name: event.reference

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -714,7 +714,7 @@
       description: >
         Reference URL linking to additional information about this event.
 
-        This URL links to a static definition of the this event.
+        This URL links to a static definition of this event.
         Alert events, indicated by `event.kind:alert`, are a common use case for this field.
 
       example: "https://system.example.com/event/#0001234"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Correct wording of `event.reference` description (#1181)