### PR TITLE
[master] Cut 1.8 FF changelog.next.md (#1199)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -9,8 +9,22 @@ Thanks, you're awesome :-) -->
 ## Unreleased
 
 ### Schema Changes
+### Tooling and Artifact Changes
 
 #### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
+#### Improvements
+
+#### Deprecated
+
+
+## 1.8.0 (Feature Freeze)
+
+### Schema Changes
 
 #### Bugfixes
 
@@ -27,15 +41,15 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Event categorization fields GA. #1067
+* `wildcard` field type adoption. #1098
 * Note `[` and `]` bracket characters may enclose a literal IPv6 address when populating `url.domain`. #1131
+* Reinforce the exclusion of the leading dot from `url.extension`. #1151
 
 #### Deprecated
 
 * Deprecated `host.user.*` fields for removal at the next major. #1066
 
 ### Tooling and Artifact Changes
-
-#### Breaking changes
 
 #### Bugfixes
 
@@ -50,16 +64,15 @@ Thanks, you're awesome :-) -->
 * Added support in the generated Go source go for `wildcard`, `version`, and `constant_keyword` data types. #1050
 * Added support for marking fields, field sets, or field reuse as beta in the documentation. #1051
 * Added support for `constant_keyword`'s optional parameter `value`. #1112
-* Added component templates for ECS field sets. #1156, #1186
+* Added component templates for ECS field sets. #1156, #1186, #1191
 
 #### Improvements
 
+* Make all fields linkable directly. #1148
 * Added a notice highlighting that the `tracing` fields are not nested under the
   namespace `tracing.` #1162
 * ES 6.x template data types will fallback to supported types. #1171, #1176, #1186
 * Add a documentation page discussing the experimental artifacts. #1189
-
-#### Deprecated
 
 
 <!-- All empty sections:


### PR DESCRIPTION
Forward ports the following commits to master:

* Cut 1.8 FF changelog.next.md #1199
