### PR TITLE
add cloud.service.name

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,7 +18,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `http.request.id`. #1208
-* Added `cloud.platform`. #1204
+* Added `cloud.service.name`. #1204
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -37,6 +37,7 @@ Thanks, you're awesome :-) -->
 * Added usage documentation for `user` fields. #1066
 * Added `user` fields at `user.effective.*`, `user.target.*` and `user.changes.*`. #1066
 * Added `os.type`. #1111
+* Added `cloud.platform`. #1204
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Added `cloud.platform`. #1204
+
 #### Improvements
 
 #### Deprecated
@@ -37,7 +39,6 @@ Thanks, you're awesome :-) -->
 * Added usage documentation for `user` fields. #1066
 * Added `user` fields at `user.effective.*`, `user.target.*` and `user.changes.*`. #1066
 * Added `os.type`. #1111
-* Added `cloud.platform`. #1204
 
 #### Improvements
 

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -51,7 +51,9 @@ type Cloud struct {
 	// Examples: AWS account name, Google Cloud ORG display name.
 	AccountName string `ecs:"account.name"`
 
-	// The cloud platform name.
+	// The cloud platform name is intended to distinguish services running on
+	// different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+	// App Engine, Azure VM vs App Server.
 	// Examples: app engine, app service, cloud run, fargate, lambda.
 	Platform string `ecs:"platform"`
 

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -51,6 +51,10 @@ type Cloud struct {
 	// Examples: AWS account name, Google Cloud ORG display name.
 	AccountName string `ecs:"account.name"`
 
+	// The cloud platform name.
+	// Examples: app engine, app service, cloud run, fargate, lambda.
+	Platform string `ecs:"platform"`
+
 	// The cloud project identifier.
 	// Examples: Google Cloud Project id, Azure Project id.
 	ProjectID string `ecs:"project.id"`

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -51,11 +51,11 @@ type Cloud struct {
 	// Examples: AWS account name, Google Cloud ORG display name.
 	AccountName string `ecs:"account.name"`
 
-	// The cloud platform name is intended to distinguish services running on
+	// The cloud service name is intended to distinguish services running on
 	// different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
 	// App Engine, Azure VM vs App Server.
 	// Examples: app engine, app service, cloud run, fargate, lambda.
-	Platform string `ecs:"platform"`
+	ServiceName string `ecs:"service.name"`
 
 	// The cloud project identifier.
 	// Examples: Google Cloud Project id, Azure Project id.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -671,24 +671,6 @@ example: `t2.medium`
 // ===============================================================
 
 |
-[[field-cloud-platform]]
-<<field-cloud-platform, cloud.platform>>
-
-| The cloud platform name is intended to distinguish services running on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server.
-
-Examples: app engine, app service, cloud run, fargate, lambda.
-
-type: keyword
-
-
-
-example: `lambda`
-
-| extended
-
-// ===============================================================
-
-|
 [[field-cloud-project-id]]
 <<field-cloud-project-id, cloud.project.id>>
 
@@ -751,6 +733,24 @@ type: keyword
 
 
 example: `us-east-1`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-cloud-service-name]]
+<<field-cloud-service-name, cloud.service.name>>
+
+| The cloud service name is intended to distinguish services running on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server.
+
+Examples: app engine, app service, cloud run, fargate, lambda.
+
+type: keyword
+
+
+
+example: `lambda`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -671,6 +671,24 @@ example: `t2.medium`
 // ===============================================================
 
 |
+[[field-cloud-platform]]
+<<field-cloud-platform, cloud.platform>>
+
+| The cloud platform name.
+
+Examples: app engine, app service, cloud run, fargate, lambda.
+
+type: keyword
+
+
+
+example: `lambda`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-cloud-project-id]]
 <<field-cloud-project-id, cloud.project.id>>
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -674,7 +674,7 @@ example: `t2.medium`
 [[field-cloud-platform]]
 <<field-cloud-platform, cloud.platform>>
 
-| The cloud platform name.
+| The cloud platform name is intended to distinguish services running on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server.
 
 Examples: app engine, app service, cloud run, fargate, lambda.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -449,7 +449,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud platform name.
+      description: 'The cloud platform name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
 
         Examples: app engine, app service, cloud run, fargate, lambda.'
       example: lambda

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -445,6 +445,15 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
+    - name: platform
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud platform name.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
     - name: project.id
       level: extended
       type: keyword

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -445,17 +445,6 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
-    - name: platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud platform name is intended to distinguish services running
-        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
-        App Engine, Azure VM vs App Server.
-
-        Examples: app engine, app service, cloud run, fargate, lambda.'
-      example: lambda
-      default_field: false
     - name: project.id
       level: extended
       type: keyword
@@ -487,6 +476,17 @@
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
+    - name: service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
   - name: code_signature
     title: Code Signature
     group: 2

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -50,11 +50,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
-2.0.0-dev+exp,true,cloud,cloud.platform,keyword,extended,,lambda,The cloud platform name.
 2.0.0-dev+exp,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev+exp,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev+exp,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 2.0.0-dev+exp,true,cloud,cloud.region,keyword,extended,,us-east-1,Region in which this host is running.
+2.0.0-dev+exp,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
 2.0.0-dev+exp,true,container,container.id,keyword,core,,,Unique container id.
 2.0.0-dev+exp,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 2.0.0-dev+exp,true,container,container.image.tag,keyword,extended,array,,Container image tags.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -50,6 +50,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+2.0.0-dev+exp,true,cloud,cloud.platform,keyword,extended,,lambda,The cloud platform name.
 2.0.0-dev+exp,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev+exp,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev+exp,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -594,21 +594,6 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
-cloud.platform:
-  dashed_name: cloud-platform
-  description: 'The cloud platform name is intended to distinguish services running
-    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
-    Engine, Azure VM vs App Server.
-
-    Examples: app engine, app service, cloud run, fargate, lambda.'
-  example: lambda
-  flat_name: cloud.platform
-  ignore_above: 1024
-  level: extended
-  name: platform
-  normalize: []
-  short: The cloud platform name.
-  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.
@@ -657,6 +642,21 @@ cloud.region:
   name: region
   normalize: []
   short: Region in which this host is running.
+  type: keyword
+cloud.service.name:
+  dashed_name: cloud-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  short: The cloud service name.
   type: keyword
 container.id:
   dashed_name: container-id

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -594,6 +594,19 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
+cloud.platform:
+  dashed_name: cloud-platform
+  description: 'The cloud platform name.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.platform
+  ignore_above: 1024
+  level: extended
+  name: platform
+  normalize: []
+  short: The cloud platform name.
+  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -596,7 +596,9 @@ cloud.machine.type:
   type: keyword
 cloud.platform:
   dashed_name: cloud-platform
-  description: 'The cloud platform name.
+  description: 'The cloud platform name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
 
     Examples: app engine, app service, cloud run, fargate, lambda.'
   example: lambda

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -767,7 +767,9 @@ cloud:
       type: keyword
     cloud.platform:
       dashed_name: cloud-platform
-      description: 'The cloud platform name.
+      description: 'The cloud platform name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
 
         Examples: app engine, app service, cloud run, fargate, lambda.'
       example: lambda

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -765,21 +765,6 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
-    cloud.platform:
-      dashed_name: cloud-platform
-      description: 'The cloud platform name is intended to distinguish services running
-        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
-        App Engine, Azure VM vs App Server.
-
-        Examples: app engine, app service, cloud run, fargate, lambda.'
-      example: lambda
-      flat_name: cloud.platform
-      ignore_above: 1024
-      level: extended
-      name: platform
-      normalize: []
-      short: The cloud platform name.
-      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.
@@ -828,6 +813,21 @@ cloud:
       name: region
       normalize: []
       short: Region in which this host is running.
+      type: keyword
+    cloud.service.name:
+      dashed_name: cloud-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      short: The cloud service name.
       type: keyword
   footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from
     its host, the cloud info contains the data about this machine. If Metricbeat runs

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -765,6 +765,19 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
+    cloud.platform:
+      dashed_name: cloud-platform
+      description: 'The cloud platform name.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.platform
+      ignore_above: 1024
+      level: extended
+      name: platform
+      normalize: []
+      short: The cloud platform name.
+      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -250,10 +250,6 @@
               }
             }
           },
-          "platform": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
           "project": {
             "properties": {
               "id": {
@@ -273,6 +269,14 @@
           "region": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "service": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -250,6 +250,10 @@
               }
             }
           },
+          "platform": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "project": {
             "properties": {
               "id": {

--- a/experimental/generated/elasticsearch/component/cloud.json
+++ b/experimental/generated/elasticsearch/component/cloud.json
@@ -44,10 +44,6 @@
                 }
               }
             },
-            "platform": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "project": {
               "properties": {
                 "id": {
@@ -67,6 +63,14 @@
             "region": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "service": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/experimental/generated/elasticsearch/component/cloud.json
+++ b/experimental/generated/elasticsearch/component/cloud.json
@@ -44,6 +44,10 @@
                 }
               }
             },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "project": {
               "properties": {
                 "id": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -449,7 +449,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The cloud platform name.
+      description: 'The cloud platform name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
 
         Examples: app engine, app service, cloud run, fargate, lambda.'
       example: lambda

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -445,6 +445,15 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
+    - name: platform
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud platform name.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
     - name: project.id
       level: extended
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -445,17 +445,6 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
-    - name: platform
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The cloud platform name is intended to distinguish services running
-        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
-        App Engine, Azure VM vs App Server.
-
-        Examples: app engine, app service, cloud run, fargate, lambda.'
-      example: lambda
-      default_field: false
     - name: project.id
       level: extended
       type: keyword
@@ -487,6 +476,17 @@
       ignore_above: 1024
       description: Region in which this host is running.
       example: us-east-1
+    - name: service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
   - name: code_signature
     title: Code Signature
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -50,11 +50,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
-2.0.0-dev,true,cloud,cloud.platform,keyword,extended,,lambda,The cloud platform name.
 2.0.0-dev,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 2.0.0-dev,true,cloud,cloud.region,keyword,extended,,us-east-1,Region in which this host is running.
+2.0.0-dev,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
 2.0.0-dev,true,container,container.id,keyword,core,,,Unique container id.
 2.0.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 2.0.0-dev,true,container,container.image.tag,keyword,extended,array,,Container image tags.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -50,6 +50,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+2.0.0-dev,true,cloud,cloud.platform,keyword,extended,,lambda,The cloud platform name.
 2.0.0-dev,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -594,21 +594,6 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
-cloud.platform:
-  dashed_name: cloud-platform
-  description: 'The cloud platform name is intended to distinguish services running
-    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
-    Engine, Azure VM vs App Server.
-
-    Examples: app engine, app service, cloud run, fargate, lambda.'
-  example: lambda
-  flat_name: cloud.platform
-  ignore_above: 1024
-  level: extended
-  name: platform
-  normalize: []
-  short: The cloud platform name.
-  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.
@@ -657,6 +642,21 @@ cloud.region:
   name: region
   normalize: []
   short: Region in which this host is running.
+  type: keyword
+cloud.service.name:
+  dashed_name: cloud-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  short: The cloud service name.
   type: keyword
 container.id:
   dashed_name: container-id

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -594,6 +594,19 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
+cloud.platform:
+  dashed_name: cloud-platform
+  description: 'The cloud platform name.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.platform
+  ignore_above: 1024
+  level: extended
+  name: platform
+  normalize: []
+  short: The cloud platform name.
+  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -596,7 +596,9 @@ cloud.machine.type:
   type: keyword
 cloud.platform:
   dashed_name: cloud-platform
-  description: 'The cloud platform name.
+  description: 'The cloud platform name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
 
     Examples: app engine, app service, cloud run, fargate, lambda.'
   example: lambda

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -767,7 +767,9 @@ cloud:
       type: keyword
     cloud.platform:
       dashed_name: cloud-platform
-      description: 'The cloud platform name.
+      description: 'The cloud platform name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
 
         Examples: app engine, app service, cloud run, fargate, lambda.'
       example: lambda

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -765,21 +765,6 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
-    cloud.platform:
-      dashed_name: cloud-platform
-      description: 'The cloud platform name is intended to distinguish services running
-        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
-        App Engine, Azure VM vs App Server.
-
-        Examples: app engine, app service, cloud run, fargate, lambda.'
-      example: lambda
-      flat_name: cloud.platform
-      ignore_above: 1024
-      level: extended
-      name: platform
-      normalize: []
-      short: The cloud platform name.
-      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.
@@ -828,6 +813,21 @@ cloud:
       name: region
       normalize: []
       short: Region in which this host is running.
+      type: keyword
+    cloud.service.name:
+      dashed_name: cloud-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      short: The cloud service name.
       type: keyword
   footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from
     its host, the cloud info contains the data about this machine. If Metricbeat runs

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -765,6 +765,19 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
+    cloud.platform:
+      dashed_name: cloud-platform
+      description: 'The cloud platform name.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.platform
+      ignore_above: 1024
+      level: extended
+      name: platform
+      normalize: []
+      short: The cloud platform name.
+      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -259,6 +259,10 @@
                 }
               }
             },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "project": {
               "properties": {
                 "id": {

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -259,10 +259,6 @@
                 }
               }
             },
-            "platform": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "project": {
               "properties": {
                 "id": {
@@ -282,6 +278,14 @@
             "region": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "service": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -250,10 +250,6 @@
               }
             }
           },
-          "platform": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
           "project": {
             "properties": {
               "id": {
@@ -273,6 +269,14 @@
           "region": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "service": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -250,6 +250,10 @@
               }
             }
           },
+          "platform": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "project": {
             "properties": {
               "id": {

--- a/generated/elasticsearch/component/cloud.json
+++ b/generated/elasticsearch/component/cloud.json
@@ -44,10 +44,6 @@
                 }
               }
             },
-            "platform": {
-              "ignore_above": 1024,
-              "type": "keyword"
-            },
             "project": {
               "properties": {
                 "id": {
@@ -67,6 +63,14 @@
             "region": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "service": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         }

--- a/generated/elasticsearch/component/cloud.json
+++ b/generated/elasticsearch/component/cloud.json
@@ -44,6 +44,10 @@
                 }
               }
             },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "project": {
               "properties": {
                 "id": {

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -86,7 +86,9 @@
       example: lambda
       short: The cloud platform name.
       description: >
-        The cloud platform name.
+        The cloud platform name is intended to distinguish services running on
+        different platforms within a provider, eg AWS EC2 vs Lambda,
+        GCP GCE vs App Engine, Azure VM vs App Server.
 
         Examples: app engine, app service, cloud run, fargate, lambda.
 

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -80,13 +80,13 @@
 
         Examples: AWS account name, Google Cloud ORG display name.
 
-    - name: platform
+    - name: service.name
       level: extended
       type: keyword
       example: lambda
-      short: The cloud platform name.
+      short: The cloud service name.
       description: >
-        The cloud platform name is intended to distinguish services running on
+        The cloud service name is intended to distinguish services running on
         different platforms within a provider, eg AWS EC2 vs Lambda,
         GCP GCE vs App Engine, Azure VM vs App Server.
 

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -80,6 +80,16 @@
 
         Examples: AWS account name, Google Cloud ORG display name.
 
+    - name: platform
+      level: extended
+      type: keyword
+      example: lambda
+      short: The cloud platform name.
+      description: >
+        The cloud platform name.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.
+
     - name: project.id
       level: extended
       type: keyword


### PR DESCRIPTION
~`cloud.platform`~ `cloud.service.name` is intended to distinguish services running on different platforms within a provider.  For example, it is important to know if an application is running on EC2 or under Lambda though both are within AWS so that contextual information about cold starts can be displayed.  This isn't limited to serverless, for example Azure VM vs App Service vs Function enables greater insight into deployed infrastructure inventory.