### PR TITLE
Fix composable template settings override (#1203)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Honor `--template-settings` option from `scripts/generator.py`. #1203
+
 #### Added
 
 #### Improvements

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -56,7 +56,7 @@ def main():
         exit()
 
     csv_generator.generate(flat, ecs_version, out_dir)
-    es_template.generate(nested, ecs_version, out_dir, args.mapping_settings)
+    es_template.generate(nested, ecs_version, out_dir, args.template_settings, args.mapping_settings)
     es_template.generate_legacy(flat, ecs_version, out_dir, args.template_settings, args.mapping_settings)
     beats.generate(nested, ecs_version, out_dir)
     if args.include or args.subset:


### PR DESCRIPTION
This is an attempt to fix composable template settings override (see #1203).

I did not reuse `default_template_settings()` methods as it look specific to legacy templates (and not used here previously anyway...).