### PR TITLE
add http.request.id

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Added `http.request.id`. #1208
+
 #### Improvements
 
 #### Deprecated

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -22,6 +22,9 @@ package ecs
 // Fields related to HTTP activity. Use the `url` field set to store the url of
 // the request.
 type Http struct {
+	// A unique identifier for each HTTP request.
+	RequestID string `ecs:"request.id"`
+
 	// HTTP request method.
 	// Prior to ECS 1.6.0 the following guidance was provided:
 	// "The field value must be normalized to lowercase for querying."

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -22,7 +22,10 @@ package ecs
 // Fields related to HTTP activity. Use the `url` field set to store the url of
 // the request.
 type Http struct {
-	// A unique identifier for each HTTP request.
+	// A unique identifier for each HTTP request to correlate logs between
+	// clients and servers in transactions.
+	// The id may be contained in a non-standard HTTP header, such as
+	// `X-Request-ID` or `X-Correlation-ID`.
 	RequestID string `ecs:"request.id"`
 
 	// HTTP request method.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3387,7 +3387,9 @@ example: `1437`
 [[field-http-request-id]]
 <<field-http-request-id, http.request.id>>
 
-| A unique identifier for each HTTP request.
+| A unique identifier for each HTTP request to correlate logs between clients and servers in transactions.
+
+The id may be contained in a non-standard HTTP header, such as `X-Request-ID` or `X-Correlation-ID`.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3384,6 +3384,22 @@ example: `1437`
 // ===============================================================
 
 |
+[[field-http-request-id]]
+<<field-http-request-id, http.request.id>>
+
+| A unique identifier for each HTTP request.
+
+type: keyword
+
+
+
+example: `123e4567-e89b-12d3-a456-426614174000`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-http-request-method]]
 <<field-http-request-method, http.request.method>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2365,7 +2365,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A unique identifier for each HTTP request.
+      description: 'A unique identifier for each HTTP request to correlate logs between
+        clients and servers in transactions.
+
+        The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+        or `X-Correlation-ID`.'
       example: 123e4567-e89b-12d3-a456-426614174000
       default_field: false
     - name: request.method

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2361,6 +2361,13 @@
       format: bytes
       description: Total size in bytes of the request (body and headers).
       example: 1437
+    - name: request.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A unique identifier for each HTTP request.
+      example: 123e4567-e89b-12d3-a456-426614174000
+      default_field: false
     - name: request.method
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -278,6 +278,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
 2.0.0-dev+exp,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
 2.0.0-dev+exp,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
+2.0.0-dev+exp,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 2.0.0-dev+exp,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
 2.0.0-dev+exp,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 2.0.0-dev+exp,true,http,http.request.referrer,wildcard,extended,,https://blog.example.com/,Referrer for this HTTP request.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3788,7 +3788,11 @@ http.request.bytes:
   type: long
 http.request.id:
   dashed_name: http-request-id
-  description: A unique identifier for each HTTP request.
+  description: 'A unique identifier for each HTTP request to correlate logs between
+    clients and servers in transactions.
+
+    The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+    or `X-Correlation-ID`.'
   example: 123e4567-e89b-12d3-a456-426614174000
   flat_name: http.request.id
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3786,6 +3786,17 @@ http.request.bytes:
   normalize: []
   short: Total size in bytes of the request (body and headers).
   type: long
+http.request.id:
+  dashed_name: http-request-id
+  description: A unique identifier for each HTTP request.
+  example: 123e4567-e89b-12d3-a456-426614174000
+  flat_name: http.request.id
+  ignore_above: 1024
+  level: extended
+  name: request.id
+  normalize: []
+  short: HTTP request ID.
+  type: keyword
 http.request.method:
   dashed_name: http-request-method
   description: 'HTTP request method.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4479,6 +4479,17 @@ http:
       normalize: []
       short: Total size in bytes of the request (body and headers).
       type: long
+    http.request.id:
+      dashed_name: http-request-id
+      description: A unique identifier for each HTTP request.
+      example: 123e4567-e89b-12d3-a456-426614174000
+      flat_name: http.request.id
+      ignore_above: 1024
+      level: extended
+      name: request.id
+      normalize: []
+      short: HTTP request ID.
+      type: keyword
     http.request.method:
       dashed_name: http-request-method
       description: 'HTTP request method.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4481,7 +4481,11 @@ http:
       type: long
     http.request.id:
       dashed_name: http-request-id
-      description: A unique identifier for each HTTP request.
+      description: 'A unique identifier for each HTTP request to correlate logs between
+        clients and servers in transactions.
+
+        The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+        or `X-Correlation-ID`.'
       example: 123e4567-e89b-12d3-a456-426614174000
       flat_name: http.request.id
       ignore_above: 1024

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1283,6 +1283,10 @@
               "bytes": {
                 "type": "long"
               },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "method": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/experimental/generated/elasticsearch/component/http.json
+++ b/experimental/generated/elasticsearch/component/http.json
@@ -29,6 +29,10 @@
                 "bytes": {
                   "type": "long"
                 },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2315,6 +2315,13 @@
       format: bytes
       description: Total size in bytes of the request (body and headers).
       example: 1437
+    - name: request.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A unique identifier for each HTTP request.
+      example: 123e4567-e89b-12d3-a456-426614174000
+      default_field: false
     - name: request.method
       level: extended
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2319,7 +2319,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A unique identifier for each HTTP request.
+      description: 'A unique identifier for each HTTP request to correlate logs between
+        clients and servers in transactions.
+
+        The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+        or `X-Correlation-ID`.'
       example: 123e4567-e89b-12d3-a456-426614174000
       default_field: false
     - name: request.method

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -271,6 +271,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
+2.0.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 2.0.0-dev,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
 2.0.0-dev,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 2.0.0-dev,true,http,http.request.referrer,wildcard,extended,,https://blog.example.com/,Referrer for this HTTP request.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3714,7 +3714,11 @@ http.request.bytes:
   type: long
 http.request.id:
   dashed_name: http-request-id
-  description: A unique identifier for each HTTP request.
+  description: 'A unique identifier for each HTTP request to correlate logs between
+    clients and servers in transactions.
+
+    The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+    or `X-Correlation-ID`.'
   example: 123e4567-e89b-12d3-a456-426614174000
   flat_name: http.request.id
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3712,6 +3712,17 @@ http.request.bytes:
   normalize: []
   short: Total size in bytes of the request (body and headers).
   type: long
+http.request.id:
+  dashed_name: http-request-id
+  description: A unique identifier for each HTTP request.
+  example: 123e4567-e89b-12d3-a456-426614174000
+  flat_name: http.request.id
+  ignore_above: 1024
+  level: extended
+  name: request.id
+  normalize: []
+  short: HTTP request ID.
+  type: keyword
 http.request.method:
   dashed_name: http-request-method
   description: 'HTTP request method.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4405,6 +4405,17 @@ http:
       normalize: []
       short: Total size in bytes of the request (body and headers).
       type: long
+    http.request.id:
+      dashed_name: http-request-id
+      description: A unique identifier for each HTTP request.
+      example: 123e4567-e89b-12d3-a456-426614174000
+      flat_name: http.request.id
+      ignore_above: 1024
+      level: extended
+      name: request.id
+      normalize: []
+      short: HTTP request ID.
+      type: keyword
     http.request.method:
       dashed_name: http-request-method
       description: 'HTTP request method.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4407,7 +4407,11 @@ http:
       type: long
     http.request.id:
       dashed_name: http-request-id
-      description: A unique identifier for each HTTP request.
+      description: 'A unique identifier for each HTTP request to correlate logs between
+        clients and servers in transactions.
+
+        The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+        or `X-Correlation-ID`.'
       example: 123e4567-e89b-12d3-a456-426614174000
       flat_name: http.request.id
       ignore_above: 1024

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1270,6 +1270,10 @@
                 "bytes": {
                   "type": "long"
                 },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1233,6 +1233,10 @@
               "bytes": {
                 "type": "long"
               },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "method": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -29,6 +29,10 @@
                 "bytes": {
                   "type": "long"
                 },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "method": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -13,7 +13,11 @@
       type: keyword
       short: HTTP request ID.
       description: >
-        A unique identifier for each HTTP request.
+        A unique identifier for each HTTP request to correlate logs between clients
+        and servers in transactions.
+        
+        The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
+        or `X-Correlation-ID`. 
 
       example: 123e4567-e89b-12d3-a456-426614174000
 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -8,6 +8,15 @@
   type: group
   fields:
 
+    - name: request.id
+      level: extended
+      type: keyword
+      short: HTTP request ID.
+      description: >
+        A unique identifier for each HTTP request.
+
+      example: 123e4567-e89b-12d3-a456-426614174000
+
     - name: request.method
       level: extended
       type: keyword


### PR DESCRIPTION
It is very common for web servers to generate a unique id for all incoming requests.  For example, [heroku](https://devcenter.heroku.com/articles/http-request-id) standardizes this in `X-Request-ID`.  Elastic APM Server itself has assigned unique request ids since v6.2.

This information is useful for analyzing per-request logs.