### PR TITLE
Stage 2 changes for RFC 0009 - data_stream fields

### DIFF
--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -567,45 +567,51 @@
   - name: data_stream
     title: Data Stream
     group: 2
-    description: 'The data_stream fields are part defining the new data stream naming
-      scheme. In the new data stream naming scheme the value of the data stream fields
-      combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
+    description: 'The data_stream fields take part in defining the new data stream
+      naming scheme.
+
+      In the new data stream naming scheme the value of the data stream fields combine
+      to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
       This means the fields can only contain characters that are valid as part of
-      names of data streams. More details about this can be found in this blog post.
-      TODO: Add link to blog post Due to the fact that the values of the `data_stream`
-      fields make up the data stream name, the restrictions on data stream names also
-      apply to values for the `data_stream` fields. As an example, they cannot include
-      \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions
-      on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).'
+      names of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog
+      post].
+
+      Due to the fact that the values of the `data_stream` fields make up the data
+      stream name, the restrictions on data stream names also apply to values for
+      the `data_stream` fields. As an example, they cannot include \, /, *, ?, ",
+      <, >, |, ` `. Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions
+      on index/data stream names].'
     type: group
     fields:
     - name: dataset
       level: extended
       type: constant_keyword
-      description: 'The field can contain anything that makes sense to signify the
-        source of the data. Examples include `nginx.access`, `prometheus`, `endpoint`
-        etc. For data streams that otherwise fit, but that do not have dataset set
-        we use the value "generic" for the dataset value. `event.dataset` should have
-        the same value as `data_stream.dataset`. Data dataset value has the following
-        restrictions: * Must not contain `-` * No longer than 100 chars'
+      description: "The field can contain anything that makes sense to signify the\
+        \ source of the data.\nExamples include `nginx.access`, `prometheus`, `endpoint`\
+        \ etc. For data streams that otherwise fit, but that do not have dataset set\
+        \ we use the value \"generic\" for the dataset value. `event.dataset` should\
+        \ have the same value as `data_stream.dataset`.\nBeyond the Elasticsearch\
+        \ index naming criteria noted above, the `dataset` value has additional restrictions:\n\
+        \  * Must not contain `-`\n  * No longer than 100 characters"
       example: nginx.access
       default_field: false
     - name: namespace
       level: extended
       type: constant_keyword
-      description: 'A user defined namespace. Namespaces are useful to allow grouping
-        of data. Many of our customers already organize their indices this way, and
-        now we are providing this best practice as a default. Many people will use
-        `default` as the value. Data namespace value has the following restrictions:
-        * Must not contain `-` * No longer than 100 chars'
-      example: logs
+      description: "A user defined namespace. Namespaces are useful to allow grouping\
+        \ of data.\nMany users already organize their indices this way, and the data\
+        \ stream naming scheme now provides this best practice as a default. Many\
+        \ users will populate this field with `default`.\nBeyond the Elasticsearch\
+        \ index naming criteria noted above, `namespace` value has the additional\
+        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
+      example: production
       default_field: false
     - name: type
       level: extended
       type: constant_keyword
-      description: "An overarching type for the data stream. Currently allowed values\
+      description: "An overarching type for the data stream.\nCurrently allowed values\
         \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-        \ in the near future Any future values for `data_stream.type` should also\
+        \ in the near future\nAny future values for `data_stream.type` should also\
         \ adhere to the following restrictions (these are derived from the Elasticsearch\
         \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
         \ `+` or `_`"

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -576,11 +576,11 @@
       names of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog
       post].
 
-      Due to the fact that the values of the `data_stream` fields make up the data
-      stream name, the restrictions on data stream names also apply to values for
-      the `data_stream` fields. As an example, they cannot include \, /, *, ?, ",
-      <, >, |, ` `. Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions
-      on index/data stream names].'
+      An Elasticsearch data stream consists of one or more backing indices, and a
+      data stream name forms part of the backing indices names. Due to this convention,
+      data streams must also follow index naming restrictions. For example, data stream
+      names cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch
+      reference for additional https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions].'
     type: group
     fields:
     - name: dataset
@@ -591,8 +591,8 @@
         \ etc. For data streams that otherwise fit, but that do not have dataset set\
         \ we use the value \"generic\" for the dataset value. `event.dataset` should\
         \ have the same value as `data_stream.dataset`.\nBeyond the Elasticsearch\
-        \ index naming criteria noted above, the `dataset` value has additional restrictions:\n\
-        \  * Must not contain `-`\n  * No longer than 100 characters"
+        \ data stream naming criteria noted above, the `dataset` value has additional\
+        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
       example: nginx.access
       default_field: false
     - name: namespace
@@ -601,20 +601,19 @@
       description: "A user defined namespace. Namespaces are useful to allow grouping\
         \ of data.\nMany users already organize their indices this way, and the data\
         \ stream naming scheme now provides this best practice as a default. Many\
-        \ users will populate this field with `default`.\nBeyond the Elasticsearch\
-        \ index naming criteria noted above, `namespace` value has the additional\
-        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
+        \ users will populate this field with `default`. If no value is used, it falls\
+        \ back to `default`.\nBeyond the Elasticsearch index naming criteria noted\
+        \ above, `namespace` value has the additional restrictions:\n  * Must not\
+        \ contain `-`\n  * No longer than 100 characters"
       example: production
       default_field: false
     - name: type
       level: extended
       type: constant_keyword
-      description: "An overarching type for the data stream.\nCurrently allowed values\
-        \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-        \ in the near future\nAny future values for `data_stream.type` should also\
-        \ adhere to the following restrictions (these are derived from the Elasticsearch\
-        \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
-        \ `+` or `_`"
+      description: 'An overarching type for the data stream.
+
+        Currently allowed values include "logs", "metrics". We expect to also add
+        "traces" and "synthetics" in the near future.'
       example: logs
       default_field: false
   - name: destination

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -564,6 +564,53 @@
       ignore_above: 1024
       description: Runtime managing this container.
       example: docker
+  - name: data_stream
+    title: Data Stream
+    group: 2
+    description: 'The data_stream fields are part defining the new data stream naming
+      scheme. In the new data stream naming scheme the value of the data stream fields
+      combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
+      This means the fields can only contain characters that are valid as part of
+      names of data streams. More details about this can be found in this blog post.
+      TODO: Add link to blog post Due to the fact that the values of the `data_stream`
+      fields make up the data stream name, the restrictions on data stream names also
+      apply to values for the `data_stream` fields. As an example, they cannot include
+      \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions
+      on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).'
+    type: group
+    fields:
+    - name: dataset
+      level: extended
+      type: constant_keyword
+      description: 'The field can contain anything that makes sense to signify the
+        source of the data. Examples include `nginx.access`, `prometheus`, `endpoint`
+        etc. For data streams that otherwise fit, but that do not have dataset set
+        we use the value "generic" for the dataset value. `event.dataset` should have
+        the same value as `data_stream.dataset`. Data dataset value has the following
+        restrictions: * Must not contain `-` * No longer than 100 chars'
+      example: nginx.access
+      default_field: false
+    - name: namespace
+      level: extended
+      type: constant_keyword
+      description: 'A user defined namespace. Namespaces are useful to allow grouping
+        of data. Many of our customers already organize their indices this way, and
+        now we are providing this best practice as a default. Many people will use
+        `default` as the value. Data namespace value has the following restrictions:
+        * Must not contain `-` * No longer than 100 chars'
+      example: logs
+      default_field: false
+    - name: type
+      level: extended
+      type: constant_keyword
+      description: "An overarching type for the data stream. Currently allowed values\
+        \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
+        \ in the near future Any future values for `data_stream.type` should also\
+        \ adhere to the following restrictions (these are derived from the Elasticsearch\
+        \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
+        \ `+` or `_`"
+      example: logs
+      default_field: false
   - name: destination
     title: Destination
     group: 2

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -612,8 +612,8 @@
       type: constant_keyword
       description: 'An overarching type for the data stream.
 
-        Currently allowed values include "logs", "metrics". We expect to also add
-        "traces" and "synthetics" in the near future.'
+        Currently allowed values are "logs" and "metrics". We expect to also add "traces"
+        and "synthetics" in the near future.'
       example: logs
       default_field: false
   - name: destination

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -60,6 +60,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,container,container.labels,object,extended,,,Image labels.
 2.0.0-dev+exp,true,container,container.name,keyword,extended,,,Container name.
 2.0.0-dev+exp,true,container,container.runtime,keyword,extended,,docker,Runtime managing this container.
+2.0.0-dev+exp,true,data_stream,data_stream.dataset,constant_keyword,extended,,nginx.access,The field can contain anything that makes sense to signify the source of the data.
+2.0.0-dev+exp,true,data_stream,data_stream.namespace,constant_keyword,extended,,logs,A user defined namespace. Namespaces are useful to allow grouping of data.
+2.0.0-dev+exp,true,data_stream,data_stream.type,constant_keyword,extended,,logs,An overarching type for the data stream.
 2.0.0-dev+exp,true,destination,destination.address,keyword,extended,,,Destination network address.
 2.0.0-dev+exp,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 2.0.0-dev+exp,true,destination,destination.as.organization.name,wildcard,extended,,Google LLC,Organization name.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -61,7 +61,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,container,container.name,keyword,extended,,,Container name.
 2.0.0-dev+exp,true,container,container.runtime,keyword,extended,,docker,Runtime managing this container.
 2.0.0-dev+exp,true,data_stream,data_stream.dataset,constant_keyword,extended,,nginx.access,The field can contain anything that makes sense to signify the source of the data.
-2.0.0-dev+exp,true,data_stream,data_stream.namespace,constant_keyword,extended,,logs,A user defined namespace. Namespaces are useful to allow grouping of data.
+2.0.0-dev+exp,true,data_stream,data_stream.namespace,constant_keyword,extended,,production,A user defined namespace. Namespaces are useful to allow grouping of data.
 2.0.0-dev+exp,true,data_stream,data_stream.type,constant_keyword,extended,,logs,An overarching type for the data stream.
 2.0.0-dev+exp,true,destination,destination.address,keyword,extended,,,Destination network address.
 2.0.0-dev+exp,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -705,6 +705,50 @@ container.runtime:
   normalize: []
   short: Runtime managing this container.
   type: keyword
+data_stream.dataset:
+  dashed_name: data-stream-dataset
+  description: 'The field can contain anything that makes sense to signify the source
+    of the data. Examples include `nginx.access`, `prometheus`, `endpoint` etc. For
+    data streams that otherwise fit, but that do not have dataset set we use the value
+    "generic" for the dataset value. `event.dataset` should have the same value as
+    `data_stream.dataset`. Data dataset value has the following restrictions: * Must
+    not contain `-` * No longer than 100 chars'
+  example: nginx.access
+  flat_name: data_stream.dataset
+  level: extended
+  name: dataset
+  normalize: []
+  short: The field can contain anything that makes sense to signify the source of
+    the data.
+  type: constant_keyword
+data_stream.namespace:
+  dashed_name: data-stream-namespace
+  description: 'A user defined namespace. Namespaces are useful to allow grouping
+    of data. Many of our customers already organize their indices this way, and now
+    we are providing this best practice as a default. Many people will use `default`
+    as the value. Data namespace value has the following restrictions: * Must not
+    contain `-` * No longer than 100 chars'
+  example: logs
+  flat_name: data_stream.namespace
+  level: extended
+  name: namespace
+  normalize: []
+  short: A user defined namespace. Namespaces are useful to allow grouping of data.
+  type: constant_keyword
+data_stream.type:
+  dashed_name: data-stream-type
+  description: "An overarching type for the data stream. Currently allowed values\
+    \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
+    \ in the near future Any future values for `data_stream.type` should also adhere\
+    \ to the following restrictions (these are derived from the Elasticsearch index\
+    \ restrictions):\n  * Must not contain `-`\n  * Must not start with `+` or `_`"
+  example: logs
+  flat_name: data_stream.type
+  level: extended
+  name: type
+  normalize: []
+  short: An overarching type for the data stream.
+  type: constant_keyword
 destination.address:
   dashed_name: destination-address
   description: 'Some event destination addresses are defined ambiguously. The event

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -742,7 +742,7 @@ data_stream.type:
   dashed_name: data-stream-type
   description: 'An overarching type for the data stream.
 
-    Currently allowed values include "logs", "metrics". We expect to also add "traces"
+    Currently allowed values are "logs" and "metrics". We expect to also add "traces"
     and "synthetics" in the near future.'
   example: logs
   flat_name: data_stream.type

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -711,7 +711,7 @@ data_stream.dataset:
     \ of the data.\nExamples include `nginx.access`, `prometheus`, `endpoint` etc.\
     \ For data streams that otherwise fit, but that do not have dataset set we use\
     \ the value \"generic\" for the dataset value. `event.dataset` should have the\
-    \ same value as `data_stream.dataset`.\nBeyond the Elasticsearch index naming\
+    \ same value as `data_stream.dataset`.\nBeyond the Elasticsearch data stream naming\
     \ criteria noted above, the `dataset` value has additional restrictions:\n  *\
     \ Must not contain `-`\n  * No longer than 100 characters"
   example: nginx.access
@@ -727,9 +727,10 @@ data_stream.namespace:
   description: "A user defined namespace. Namespaces are useful to allow grouping\
     \ of data.\nMany users already organize their indices this way, and the data stream\
     \ naming scheme now provides this best practice as a default. Many users will\
-    \ populate this field with `default`.\nBeyond the Elasticsearch index naming criteria\
-    \ noted above, `namespace` value has the additional restrictions:\n  * Must not\
-    \ contain `-`\n  * No longer than 100 characters"
+    \ populate this field with `default`. If no value is used, it falls back to `default`.\n\
+    Beyond the Elasticsearch index naming criteria noted above, `namespace` value\
+    \ has the additional restrictions:\n  * Must not contain `-`\n  * No longer than\
+    \ 100 characters"
   example: production
   flat_name: data_stream.namespace
   level: extended
@@ -739,11 +740,10 @@ data_stream.namespace:
   type: constant_keyword
 data_stream.type:
   dashed_name: data-stream-type
-  description: "An overarching type for the data stream.\nCurrently allowed values\
-    \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-    \ in the near future\nAny future values for `data_stream.type` should also adhere\
-    \ to the following restrictions (these are derived from the Elasticsearch index\
-    \ restrictions):\n  * Must not contain `-`\n  * Must not start with `+` or `_`"
+  description: 'An overarching type for the data stream.
+
+    Currently allowed values include "logs", "metrics". We expect to also add "traces"
+    and "synthetics" in the near future.'
   example: logs
   flat_name: data_stream.type
   level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -707,12 +707,13 @@ container.runtime:
   type: keyword
 data_stream.dataset:
   dashed_name: data-stream-dataset
-  description: 'The field can contain anything that makes sense to signify the source
-    of the data. Examples include `nginx.access`, `prometheus`, `endpoint` etc. For
-    data streams that otherwise fit, but that do not have dataset set we use the value
-    "generic" for the dataset value. `event.dataset` should have the same value as
-    `data_stream.dataset`. Data dataset value has the following restrictions: * Must
-    not contain `-` * No longer than 100 chars'
+  description: "The field can contain anything that makes sense to signify the source\
+    \ of the data.\nExamples include `nginx.access`, `prometheus`, `endpoint` etc.\
+    \ For data streams that otherwise fit, but that do not have dataset set we use\
+    \ the value \"generic\" for the dataset value. `event.dataset` should have the\
+    \ same value as `data_stream.dataset`.\nBeyond the Elasticsearch index naming\
+    \ criteria noted above, the `dataset` value has additional restrictions:\n  *\
+    \ Must not contain `-`\n  * No longer than 100 characters"
   example: nginx.access
   flat_name: data_stream.dataset
   level: extended
@@ -723,12 +724,13 @@ data_stream.dataset:
   type: constant_keyword
 data_stream.namespace:
   dashed_name: data-stream-namespace
-  description: 'A user defined namespace. Namespaces are useful to allow grouping
-    of data. Many of our customers already organize their indices this way, and now
-    we are providing this best practice as a default. Many people will use `default`
-    as the value. Data namespace value has the following restrictions: * Must not
-    contain `-` * No longer than 100 chars'
-  example: logs
+  description: "A user defined namespace. Namespaces are useful to allow grouping\
+    \ of data.\nMany users already organize their indices this way, and the data stream\
+    \ naming scheme now provides this best practice as a default. Many users will\
+    \ populate this field with `default`.\nBeyond the Elasticsearch index naming criteria\
+    \ noted above, `namespace` value has the additional restrictions:\n  * Must not\
+    \ contain `-`\n  * No longer than 100 characters"
+  example: production
   flat_name: data_stream.namespace
   level: extended
   name: namespace
@@ -737,9 +739,9 @@ data_stream.namespace:
   type: constant_keyword
 data_stream.type:
   dashed_name: data-stream-type
-  description: "An overarching type for the data stream. Currently allowed values\
+  description: "An overarching type for the data stream.\nCurrently allowed values\
     \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-    \ in the near future Any future values for `data_stream.type` should also adhere\
+    \ in the near future\nAny future values for `data_stream.type` should also adhere\
     \ to the following restrictions (these are derived from the Elasticsearch index\
     \ restrictions):\n  * Must not contain `-`\n  * Must not start with `+` or `_`"
   example: logs

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -993,11 +993,11 @@ data_stream:
     of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog
     post].
 
-    Due to the fact that the values of the `data_stream` fields make up the data stream
-    name, the restrictions on data stream names also apply to values for the `data_stream`
-    fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please
-    see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions
-    on index/data stream names].'
+    An Elasticsearch data stream consists of one or more backing indices, and a data
+    stream name forms part of the backing indices names. Due to this convention, data
+    streams must also follow index naming restrictions. For example, data stream names
+    cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference
+    for additional https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions].'
   fields:
     data_stream.dataset:
       dashed_name: data-stream-dataset
@@ -1006,8 +1006,8 @@ data_stream:
         \ etc. For data streams that otherwise fit, but that do not have dataset set\
         \ we use the value \"generic\" for the dataset value. `event.dataset` should\
         \ have the same value as `data_stream.dataset`.\nBeyond the Elasticsearch\
-        \ index naming criteria noted above, the `dataset` value has additional restrictions:\n\
-        \  * Must not contain `-`\n  * No longer than 100 characters"
+        \ data stream naming criteria noted above, the `dataset` value has additional\
+        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
       example: nginx.access
       flat_name: data_stream.dataset
       level: extended
@@ -1021,9 +1021,10 @@ data_stream:
       description: "A user defined namespace. Namespaces are useful to allow grouping\
         \ of data.\nMany users already organize their indices this way, and the data\
         \ stream naming scheme now provides this best practice as a default. Many\
-        \ users will populate this field with `default`.\nBeyond the Elasticsearch\
-        \ index naming criteria noted above, `namespace` value has the additional\
-        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
+        \ users will populate this field with `default`. If no value is used, it falls\
+        \ back to `default`.\nBeyond the Elasticsearch index naming criteria noted\
+        \ above, `namespace` value has the additional restrictions:\n  * Must not\
+        \ contain `-`\n  * No longer than 100 characters"
       example: production
       flat_name: data_stream.namespace
       level: extended
@@ -1034,12 +1035,10 @@ data_stream:
       type: constant_keyword
     data_stream.type:
       dashed_name: data-stream-type
-      description: "An overarching type for the data stream.\nCurrently allowed values\
-        \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-        \ in the near future\nAny future values for `data_stream.type` should also\
-        \ adhere to the following restrictions (these are derived from the Elasticsearch\
-        \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
-        \ `+` or `_`"
+      description: 'An overarching type for the data stream.
+
+        Currently allowed values include "logs", "metrics". We expect to also add
+        "traces" and "synthetics" in the near future.'
       example: logs
       flat_name: data_stream.type
       level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1037,8 +1037,8 @@ data_stream:
       dashed_name: data-stream-type
       description: 'An overarching type for the data stream.
 
-        Currently allowed values include "logs", "metrics". We expect to also add
-        "traces" and "synthetics" in the near future.'
+        Currently allowed values are "logs" and "metrics". We expect to also add "traces"
+        and "synthetics" in the near future.'
       example: logs
       flat_name: data_stream.type
       level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -984,25 +984,30 @@ container:
   title: Container
   type: group
 data_stream:
-  description: 'The data_stream fields are part defining the new data stream naming
-    scheme. In the new data stream naming scheme the value of the data stream fields
-    combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
+  description: 'The data_stream fields take part in defining the new data stream naming
+    scheme.
+
+    In the new data stream naming scheme the value of the data stream fields combine
+    to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
     This means the fields can only contain characters that are valid as part of names
-    of data streams. More details about this can be found in this blog post. TODO:
-    Add link to blog post Due to the fact that the values of the `data_stream` fields
-    make up the data stream name, the restrictions on data stream names also apply
-    to values for the `data_stream` fields. As an example, they cannot include \,
-    /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions
-    on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).'
+    of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog
+    post].
+
+    Due to the fact that the values of the `data_stream` fields make up the data stream
+    name, the restrictions on data stream names also apply to values for the `data_stream`
+    fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please
+    see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions
+    on index/data stream names].'
   fields:
     data_stream.dataset:
       dashed_name: data-stream-dataset
-      description: 'The field can contain anything that makes sense to signify the
-        source of the data. Examples include `nginx.access`, `prometheus`, `endpoint`
-        etc. For data streams that otherwise fit, but that do not have dataset set
-        we use the value "generic" for the dataset value. `event.dataset` should have
-        the same value as `data_stream.dataset`. Data dataset value has the following
-        restrictions: * Must not contain `-` * No longer than 100 chars'
+      description: "The field can contain anything that makes sense to signify the\
+        \ source of the data.\nExamples include `nginx.access`, `prometheus`, `endpoint`\
+        \ etc. For data streams that otherwise fit, but that do not have dataset set\
+        \ we use the value \"generic\" for the dataset value. `event.dataset` should\
+        \ have the same value as `data_stream.dataset`.\nBeyond the Elasticsearch\
+        \ index naming criteria noted above, the `dataset` value has additional restrictions:\n\
+        \  * Must not contain `-`\n  * No longer than 100 characters"
       example: nginx.access
       flat_name: data_stream.dataset
       level: extended
@@ -1013,12 +1018,13 @@ data_stream:
       type: constant_keyword
     data_stream.namespace:
       dashed_name: data-stream-namespace
-      description: 'A user defined namespace. Namespaces are useful to allow grouping
-        of data. Many of our customers already organize their indices this way, and
-        now we are providing this best practice as a default. Many people will use
-        `default` as the value. Data namespace value has the following restrictions:
-        * Must not contain `-` * No longer than 100 chars'
-      example: logs
+      description: "A user defined namespace. Namespaces are useful to allow grouping\
+        \ of data.\nMany users already organize their indices this way, and the data\
+        \ stream naming scheme now provides this best practice as a default. Many\
+        \ users will populate this field with `default`.\nBeyond the Elasticsearch\
+        \ index naming criteria noted above, `namespace` value has the additional\
+        \ restrictions:\n  * Must not contain `-`\n  * No longer than 100 characters"
+      example: production
       flat_name: data_stream.namespace
       level: extended
       name: namespace
@@ -1028,9 +1034,9 @@ data_stream:
       type: constant_keyword
     data_stream.type:
       dashed_name: data-stream-type
-      description: "An overarching type for the data stream. Currently allowed values\
+      description: "An overarching type for the data stream.\nCurrently allowed values\
         \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
-        \ in the near future Any future values for `data_stream.type` should also\
+        \ in the near future\nAny future values for `data_stream.type` should also\
         \ adhere to the following restrictions (these are derived from the Elasticsearch\
         \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
         \ `+` or `_`"
@@ -1044,7 +1050,7 @@ data_stream:
   group: 2
   name: data_stream
   prefix: data_stream.
-  short: The data_stream fields are part defining the new data stream naming scheme.
+  short: The data_stream fields take part in defining the new data stream naming scheme.
   title: Data Stream
   type: group
 destination:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -983,6 +983,70 @@ container:
   short: Fields describing the container that generated this event.
   title: Container
   type: group
+data_stream:
+  description: 'The data_stream fields are part defining the new data stream naming
+    scheme. In the new data stream naming scheme the value of the data stream fields
+    combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`.
+    This means the fields can only contain characters that are valid as part of names
+    of data streams. More details about this can be found in this blog post. TODO:
+    Add link to blog post Due to the fact that the values of the `data_stream` fields
+    make up the data stream name, the restrictions on data stream names also apply
+    to values for the `data_stream` fields. As an example, they cannot include \,
+    /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions
+    on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).'
+  fields:
+    data_stream.dataset:
+      dashed_name: data-stream-dataset
+      description: 'The field can contain anything that makes sense to signify the
+        source of the data. Examples include `nginx.access`, `prometheus`, `endpoint`
+        etc. For data streams that otherwise fit, but that do not have dataset set
+        we use the value "generic" for the dataset value. `event.dataset` should have
+        the same value as `data_stream.dataset`. Data dataset value has the following
+        restrictions: * Must not contain `-` * No longer than 100 chars'
+      example: nginx.access
+      flat_name: data_stream.dataset
+      level: extended
+      name: dataset
+      normalize: []
+      short: The field can contain anything that makes sense to signify the source
+        of the data.
+      type: constant_keyword
+    data_stream.namespace:
+      dashed_name: data-stream-namespace
+      description: 'A user defined namespace. Namespaces are useful to allow grouping
+        of data. Many of our customers already organize their indices this way, and
+        now we are providing this best practice as a default. Many people will use
+        `default` as the value. Data namespace value has the following restrictions:
+        * Must not contain `-` * No longer than 100 chars'
+      example: logs
+      flat_name: data_stream.namespace
+      level: extended
+      name: namespace
+      normalize: []
+      short: A user defined namespace. Namespaces are useful to allow grouping of
+        data.
+      type: constant_keyword
+    data_stream.type:
+      dashed_name: data-stream-type
+      description: "An overarching type for the data stream. Currently allowed values\
+        \ include \"logs\", \"metrics\". We expect to also add \"traces\" and \"synthetics\"\
+        \ in the near future Any future values for `data_stream.type` should also\
+        \ adhere to the following restrictions (these are derived from the Elasticsearch\
+        \ index restrictions):\n  * Must not contain `-`\n  * Must not start with\
+        \ `+` or `_`"
+      example: logs
+      flat_name: data_stream.type
+      level: extended
+      name: type
+      normalize: []
+      short: An overarching type for the data stream.
+      type: constant_keyword
+  group: 2
+  name: data_stream
+  prefix: data_stream.
+  short: The data_stream fields are part defining the new data stream naming scheme.
+  title: Data Stream
+  type: group
 destination:
   description: 'Destination fields capture details about the receiver of a network
     exchange/packet. These fields are populated from a network event, packet, or other

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -303,6 +303,19 @@
           }
         }
       },
+      "data_stream": {
+        "properties": {
+          "dataset": {
+            "type": "constant_keyword"
+          },
+          "namespace": {
+            "type": "constant_keyword"
+          },
+          "type": {
+            "type": "constant_keyword"
+          }
+        }
+      },
       "destination": {
         "properties": {
           "address": {

--- a/experimental/generated/elasticsearch/component/data_stream.json
+++ b/experimental/generated/elasticsearch/component/data_stream.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-data_stream.html",
+    "ecs_version": "2.0.0-dev+exp"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "data_stream": {
+          "properties": {
+            "dataset": {
+              "type": "constant_keyword"
+            },
+            "namespace": {
+              "type": "constant_keyword"
+            },
+            "type": {
+              "type": "constant_keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experimental/generated/elasticsearch/template.json
+++ b/experimental/generated/elasticsearch/template.json
@@ -37,7 +37,8 @@
     "ecs_2.0.0-dev-exp_url",
     "ecs_2.0.0-dev-exp_user",
     "ecs_2.0.0-dev-exp_user_agent",
-    "ecs_2.0.0-dev-exp_vulnerability"
+    "ecs_2.0.0-dev-exp_vulnerability",
+    "ecs_2.0.0-dev-exp_data_stream"
   ],
   "index_patterns": [
     "try-ecs-*"

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -1,11 +1,13 @@
 ---
 - name: data_stream
   title: Data Stream
-  short: The data_stream fields are part defining the new data stream naming scheme.
+  short: The data_stream fields take part in defining the new data stream naming scheme.
   description: >
-    The data_stream fields are part defining the new data stream naming scheme.
-    In the new data stream naming scheme the value of the data stream fields combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`. This means the fields can only contain characters that are valid as part of names of data streams. More details about this can be found in this blog post. TODO: Add link to blog post
-    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).
+    The data_stream fields take part in defining the new data stream naming scheme.
+
+    In the new data stream naming scheme the value of the data stream fields combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`. This means the fields can only contain characters that are valid as part of names of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog post].
+
+    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions on index/data stream names].
   fields:
 
     - name: type

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -40,9 +40,9 @@
         do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the
         same value as `data_stream.dataset`.
 
-        Data dataset value has the following restrictions:
+        Beyond the Elasticsearch index naming criteria noted above, the `dataset` value has additional restrictions:
           * Must not contain `-`
-          * No longer than 100 chars
+          * No longer than 100 characters
       short: The field can contain anything that makes sense to signify the source of the data.
 
     - name: namespace
@@ -52,10 +52,10 @@
       description: >
         A user defined namespace. Namespaces are useful to allow grouping of data.
 
-        Many of our customers already organize their indices this way, and now we are providing this best practice as a default.
-        Many people will use `default` as the value.
+        Many users already organize their indices this way, and the data stream naming scheme now provides this
+        best practice as a default. Many users will populate this field with `default`.
 
-        Data namespace value has the following restrictions:
+        Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:
           * Must not contain `-`
-          * No longer than 100 chars
+          * No longer than 100 characters
       short: A user defined namespace. Namespaces are useful to allow grouping of data.

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -25,7 +25,7 @@
       description: >
         An overarching type for the data stream.
 
-        Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future.
+        Currently allowed values are "logs" and "metrics". We expect to also add "traces" and "synthetics" in the near future.
       short: An overarching type for the data stream.
 
     - name: dataset

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -1,0 +1,45 @@
+---
+- name: data_stream
+  title: Data Stream
+  short: The data_stream fields are part defining the new data stream naming scheme.
+  description: >
+    The data_stream fields are part defining the new data stream naming scheme.
+    In the new data stream naming scheme the value of the data stream fields combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`. This means the fields can only contain characters that are valid as part of names of data streams. More details about this can be found in this blog post. TODO: Add link to blog post
+    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for [restrictions on index/data stream names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params).
+  fields:
+
+    - name: type
+      level: extended
+      type: constant_keyword
+      example: logs
+      description: >
+        An overarching type for the data stream.
+        Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future
+        Any future values for `data_stream.type` should also adhere to the following restrictions (these are derived from the Elasticsearch index restrictions):
+          * Must not contain `-`
+          * Must not start with `+` or `_`
+      short: An overarching type for the data stream.
+
+    - name: dataset
+      level: extended
+      type: constant_keyword
+      example: nginx.access
+      description: >
+        The field can contain anything that makes sense to signify the source of the data.
+        Examples include `nginx.access`, `prometheus`, `endpoint` etc. For data streams that otherwise fit, but that do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the same value as `data_stream.dataset`.
+        Data dataset value has the following restrictions:
+        * Must not contain `-`
+        * No longer than 100 chars
+      short: The field can contain anything that makes sense to signify the source of the data.
+
+    - name: namespace
+      level: extended
+      type: constant_keyword
+      example: logs
+      description: >
+        A user defined namespace. Namespaces are useful to allow grouping of data.
+        Many of our customers already organize their indices this way, and now we are providing this best practice as a default. Many people will use `default` as the value.
+        Data namespace value has the following restrictions:
+        * Must not contain `-`
+        * No longer than 100 chars
+      short: A user defined namespace. Namespaces are useful to allow grouping of data.

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -10,11 +10,9 @@
     can only contain characters that are valid as part of names of data streams. More details about this can be found in
     this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog post].
 
-    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream
-    names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `.
-    Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions on index/data stream names].
-
-
+    An Elasticsearch data stream consists of one or more backing indices, and a data stream name forms part of the backing indices names.
+    Due to this convention, data streams must also follow index naming restrictions. For example, data stream names cannot include \, /, *, ?, ", <, >, |, ` `.
+    Please see the Elasticsearch reference for additional https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions].
   fields:
 
     - name: type

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -35,7 +35,11 @@
       example: nginx.access
       description: >
         The field can contain anything that makes sense to signify the source of the data.
-        Examples include `nginx.access`, `prometheus`, `endpoint` etc. For data streams that otherwise fit, but that do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the same value as `data_stream.dataset`.
+
+        Examples include `nginx.access`, `prometheus`, `endpoint` etc. For data streams that otherwise fit, but that
+        do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the
+        same value as `data_stream.dataset`.
+
         Data dataset value has the following restrictions:
         * Must not contain `-`
         * No longer than 100 chars

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -21,7 +21,9 @@
       example: logs
       description: >
         An overarching type for the data stream.
+
         Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future
+
         Any future values for `data_stream.type` should also adhere to the following restrictions (these are derived from the Elasticsearch index restrictions):
           * Must not contain `-`
           * Must not start with `+` or `_`
@@ -42,7 +44,7 @@
     - name: namespace
       level: extended
       type: constant_keyword
-      example: logs
+      example: production
       description: >
         A user defined namespace. Namespaces are useful to allow grouping of data.
         Many of our customers already organize their indices this way, and now we are providing this best practice as a default. Many people will use `default` as the value.

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -39,7 +39,7 @@
         do not have dataset set we use the value "generic" for the dataset value. `event.dataset` should have the
         same value as `data_stream.dataset`.
 
-        Beyond the Elasticsearch index naming criteria noted above, the `dataset` value has additional restrictions:
+        Beyond the Elasticsearch data stream naming criteria noted above, the `dataset` value has additional restrictions:
           * Must not contain `-`
           * No longer than 100 characters
       short: The field can contain anything that makes sense to signify the source of the data.

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -19,14 +19,13 @@
       level: extended
       type: constant_keyword
       example: logs
+      # Any future values for `data_stream.type` should also adhere to the following restrictions (these are derived from the Elasticsearch index restrictions):
+      # * Must not contain `-`
+      # * Must not start with `+` or `_`
       description: >
         An overarching type for the data stream.
 
         Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future
-
-        Any future values for `data_stream.type` should also adhere to the following restrictions (these are derived from the Elasticsearch index restrictions):
-          * Must not contain `-`
-          * Must not start with `+` or `_`
       short: An overarching type for the data stream.
 
     - name: dataset

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -5,9 +5,14 @@
   description: >
     The data_stream fields take part in defining the new data stream naming scheme.
 
-    In the new data stream naming scheme the value of the data stream fields combine to the name of the actual data stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`. This means the fields can only contain characters that are valid as part of names of data streams. More details about this can be found in this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog post].
+    In the new data stream naming scheme the value of the data stream fields combine to the name of the actual data
+    stream in the following manner `{data_stream.type}-{data_stream.dataset}-{data_stream.namespace}`. This means the fields
+    can only contain characters that are valid as part of names of data streams. More details about this can be found in
+    this https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme[blog post].
 
-    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `. Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions on index/data stream names].
+    Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream
+    names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `.
+    Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions on index/data stream names].
   fields:
 
     - name: type

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -51,8 +51,11 @@
       example: production
       description: >
         A user defined namespace. Namespaces are useful to allow grouping of data.
-        Many of our customers already organize their indices this way, and now we are providing this best practice as a default. Many people will use `default` as the value.
+
+        Many of our customers already organize their indices this way, and now we are providing this best practice as a default.
+        Many people will use `default` as the value.
+
         Data namespace value has the following restrictions:
-        * Must not contain `-`
-        * No longer than 100 chars
+          * Must not contain `-`
+          * No longer than 100 chars
       short: A user defined namespace. Namespaces are useful to allow grouping of data.

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -41,8 +41,8 @@
         same value as `data_stream.dataset`.
 
         Data dataset value has the following restrictions:
-        * Must not contain `-`
-        * No longer than 100 chars
+          * Must not contain `-`
+          * No longer than 100 chars
       short: The field can contain anything that makes sense to signify the source of the data.
 
     - name: namespace

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -13,6 +13,8 @@
     Due to the fact that the values of the `data_stream` fields make up the data stream name, the restrictions on data stream
     names also apply to values for the `data_stream` fields. As an example, they cannot include \, /, *, ?, ", <, >, |, ` `.
     Please see the Elasticsearch reference for https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-api-path-params[restrictions on index/data stream names].
+
+
   fields:
 
     - name: type
@@ -25,7 +27,7 @@
       description: >
         An overarching type for the data stream.
 
-        Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future
+        Currently allowed values include "logs", "metrics". We expect to also add "traces" and "synthetics" in the near future.
       short: An overarching type for the data stream.
 
     - name: dataset

--- a/experimental/schemas/data_stream.yml
+++ b/experimental/schemas/data_stream.yml
@@ -52,7 +52,7 @@
         A user defined namespace. Namespaces are useful to allow grouping of data.
 
         Many users already organize their indices this way, and the data stream naming scheme now provides this
-        best practice as a default. Many users will populate this field with `default`.
+        best practice as a default. Many users will populate this field with `default`. If no value is used, it falls back to `default`.
 
         Beyond the Elasticsearch index naming criteria noted above, `namespace` value has the additional restrictions:
           * Must not contain `-`


### PR DESCRIPTION
Adding the `data_stream` fields from [RFC 0009](https://github.com/elastic/ecs/blob/master/rfcs/text/0009-data_stream-fields.md) (#1145) to the experimental artifacts.
