### PR TITLE
[1.x] Add ssdeep hash (#1169)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,6 +40,7 @@ Thanks, you're awesome :-) -->
 * Added usage documentation for `user` fields. #1066
 * Added `user` fields at `user.effective.*`, `user.target.*` and `user.changes.*`. #1066
 * Added `os.type`. #1111
+* Added `hash.ssdeep`. #1169
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -19,6 +19,7 @@ Thanks, you're awesome :-) -->
 
 * Added `http.request.id`. #1208
 * Added `cloud.service.name`. #1204
+* Added `hash.ssdeep`. #1169
 
 #### Improvements
 
@@ -40,7 +41,6 @@ Thanks, you're awesome :-) -->
 * Added usage documentation for `user` fields. #1066
 * Added `user` fields at `user.effective.*`, `user.target.*` and `user.changes.*`. #1066
 * Added `os.type`. #1111
-* Added `hash.ssdeep`. #1169
 
 #### Improvements
 

--- a/code/go/ecs/hash.go
+++ b/code/go/ecs/hash.go
@@ -19,10 +19,14 @@
 
 package ecs
 
-// The hash fields represent different hash algorithms and their values.
+// The hash fields represent different bitwise hash algorithms and their
+// values.
 // Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields
 // for other hashes by lowercasing the hash algorithm name and using underscore
 // separators as appropriate (snake case, e.g. sha3_512).
+// Note that this fieldset is used for common hashes that may be computed over
+// a range of generic bytes. Entity-specific hashes such as ja3 or imphash are
+// placed in the fieldsets to which they relate (tls and pe, respectively).
 type Hash struct {
 	// MD5 hash.
 	Md5 string `ecs:"md5"`
@@ -35,4 +39,7 @@ type Hash struct {
 
 	// SHA512 hash.
 	Sha512 string `ecs:"sha512"`
+
+	// SSDEEP hash.
+	Ssdeep string `ecs:"ssdeep"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3023,9 +3023,11 @@ Note also that the `group` fields may be used directly at the root of the events
 [[ecs-hash]]
 === Hash Fields
 
-The hash fields represent different hash algorithms and their values.
+The hash fields represent different bitwise hash algorithms and their values.
 
 Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for other hashes by lowercasing the hash algorithm name and using underscore separators as appropriate (snake case, e.g. sha3_512).
+
+Note that this fieldset is used for common hashes that may be computed over a range of generic bytes. Entity-specific hashes such as ja3 or imphash are placed in the fieldsets to which they relate (tls and pe, respectively).
 
 [discrete]
 ==== Hash Field Details
@@ -3089,6 +3091,22 @@ type: keyword
 <<field-hash-sha512, hash.sha512>>
 
 | SHA512 hash.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-hash-ssdeep]]
+<<field-hash-ssdeep, hash.ssdeep>>
+
+| SSDEEP hash.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -951,6 +951,12 @@
       ignore_above: 1024
       description: SHA512 hash.
       default_field: false
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: name
       level: core
       type: keyword
@@ -1682,6 +1688,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: inode
       level: extended
       type: keyword
@@ -2068,11 +2080,16 @@
   - name: hash
     title: Hash
     group: 2
-    description: 'The hash fields represent different hash algorithms and their values.
+    description: 'The hash fields represent different bitwise hash algorithms and
+      their values.
 
       Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for
       other hashes by lowercasing the hash algorithm name and using underscore separators
-      as appropriate (snake case, e.g. sha3_512).'
+      as appropriate (snake case, e.g. sha3_512).
+
+      Note that this fieldset is used for common hashes that may be computed over
+      a range of generic bytes. Entity-specific hashes such as ja3 or imphash are
+      placed in the fieldsets to which they relate (tls and pe, respectively).'
     type: group
     fields:
     - name: md5
@@ -2095,6 +2112,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
   - name: host
     title: Host
     group: 2
@@ -3500,6 +3523,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: name
       level: extended
       type: wildcard
@@ -3644,6 +3673,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+      default_field: false
+    - name: parent.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
       default_field: false
     - name: parent.name
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -108,6 +108,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,dll,dll.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev+exp,true,dll,dll.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev+exp,true,dll,dll.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev+exp,true,dll,dll.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev+exp,true,dll,dll.name,keyword,core,,kernel32.dll,Name of the library.
 1.9.0-dev+exp,true,dll,dll.path,keyword,extended,,C:\Windows\System32\kernel32.dll,Full file path of the library.
 1.9.0-dev+exp,true,dll,dll.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
@@ -186,6 +187,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,file,file.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev+exp,true,file,file.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev+exp,true,file,file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev+exp,true,file,file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev+exp,true,file,file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.9.0-dev+exp,true,file,file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.9.0-dev+exp,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
@@ -395,6 +397,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev+exp,true,process,process.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev+exp,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev+exp,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev+exp,true,process,process.name,wildcard,extended,,ssh,Process name.
 1.9.0-dev+exp,true,process,process.name.text,text,extended,,ssh,Process name.
 1.9.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -414,6 +417,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev+exp,true,process,process.parent.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev+exp,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev+exp,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev+exp,true,process,process.parent.name,wildcard,extended,,ssh,Process name.
 1.9.0-dev+exp,true,process,process.parent.name.text,text,extended,,ssh,Process name.
 1.9.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1298,6 +1298,17 @@ dll.hash.sha512:
   original_fieldset: hash
   short: SHA512 hash.
   type: keyword
+dll.hash.ssdeep:
+  dashed_name: dll-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: dll.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 dll.name:
   dashed_name: dll-name
   description: 'Name of the library.
@@ -2721,6 +2732,17 @@ file.hash.sha512:
   normalize: []
   original_fieldset: hash
   short: SHA512 hash.
+  type: keyword
+file.hash.ssdeep:
+  dashed_name: file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 file.inode:
   dashed_name: file-inode
@@ -5283,6 +5305,17 @@ process.hash.sha512:
   original_fieldset: hash
   short: SHA512 hash.
   type: keyword
+process.hash.ssdeep:
+  dashed_name: process-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 process.name:
   beta: Note the usage of `wildcard` type is considered beta. This field used to be
     type `keyword`.
@@ -5517,6 +5550,17 @@ process.parent.hash.sha512:
   normalize: []
   original_fieldset: hash
   short: SHA512 hash.
+  type: keyword
+process.parent.hash.ssdeep:
+  dashed_name: process-parent-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.parent.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 process.parent.name:
   beta: Note the usage of `wildcard` type is considered beta. This field used to be

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1644,6 +1644,17 @@ dll:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    dll.hash.ssdeep:
+      dashed_name: dll-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: dll.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     dll.name:
       dashed_name: dll-name
       description: 'Name of the library.
@@ -3170,6 +3181,17 @@ file:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    file.hash.ssdeep:
+      dashed_name: file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     file.inode:
       dashed_name: file-inode
       description: Inode representing the file in the filesystem.
@@ -3902,11 +3924,16 @@ group:
   title: Group
   type: group
 hash:
-  description: 'The hash fields represent different hash algorithms and their values.
+  description: 'The hash fields represent different bitwise hash algorithms and their
+    values.
 
     Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for
     other hashes by lowercasing the hash algorithm name and using underscore separators
-    as appropriate (snake case, e.g. sha3_512).'
+    as appropriate (snake case, e.g. sha3_512).
+
+    Note that this fieldset is used for common hashes that may be computed over a
+    range of generic bytes. Entity-specific hashes such as ja3 or imphash are placed
+    in the fieldsets to which they relate (tls and pe, respectively).'
   fields:
     hash.md5:
       dashed_name: hash-md5
@@ -3947,6 +3974,16 @@ hash:
       name: sha512
       normalize: []
       short: SHA512 hash.
+      type: keyword
+    hash.ssdeep:
+      dashed_name: hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      short: SSDEEP hash.
       type: keyword
   group: 2
   name: hash
@@ -6379,6 +6416,17 @@ process:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    process.hash.ssdeep:
+      dashed_name: process-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     process.name:
       beta: Note the usage of `wildcard` type is considered beta. This field used
         to be type `keyword`.
@@ -6613,6 +6661,17 @@ process:
       normalize: []
       original_fieldset: hash
       short: SHA512 hash.
+      type: keyword
+    process.parent.hash.ssdeep:
+      dashed_name: process-parent-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.parent.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
       type: keyword
     process.parent.name:
       beta: Note the usage of `wildcard` type is considered beta. This field used

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -523,6 +523,10 @@
               "sha512": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "ssdeep": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -851,6 +855,10 @@
                 "type": "keyword"
               },
               "sha512": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ssdeep": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1843,6 +1851,10 @@
               "sha512": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "ssdeep": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -1925,6 +1937,10 @@
                     "type": "keyword"
                   },
                   "sha512": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "ssdeep": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/experimental/generated/elasticsearch/component/dll.json
+++ b/experimental/generated/elasticsearch/component/dll.json
@@ -46,6 +46,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -82,6 +82,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -78,6 +78,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -160,6 +164,10 @@
                       "type": "keyword"
                     },
                     "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -899,6 +899,12 @@
       ignore_above: 1024
       description: SHA512 hash.
       default_field: false
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: name
       level: core
       type: keyword
@@ -1630,6 +1636,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: inode
       level: extended
       type: keyword
@@ -2016,11 +2028,16 @@
   - name: hash
     title: Hash
     group: 2
-    description: 'The hash fields represent different hash algorithms and their values.
+    description: 'The hash fields represent different bitwise hash algorithms and
+      their values.
 
       Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for
       other hashes by lowercasing the hash algorithm name and using underscore separators
-      as appropriate (snake case, e.g. sha3_512).'
+      as appropriate (snake case, e.g. sha3_512).
+
+      Note that this fieldset is used for common hashes that may be computed over
+      a range of generic bytes. Entity-specific hashes such as ja3 or imphash are
+      placed in the fieldsets to which they relate (tls and pe, respectively).'
     type: group
     fields:
     - name: md5
@@ -2043,6 +2060,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
   - name: host
     title: Host
     group: 2
@@ -3402,6 +3425,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+    - name: hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: name
       level: extended
       type: wildcard
@@ -3546,6 +3575,12 @@
       type: keyword
       ignore_above: 1024
       description: SHA512 hash.
+      default_field: false
+    - name: parent.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
       default_field: false
     - name: parent.name
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -105,6 +105,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,dll,dll.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev,true,dll,dll.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev,true,dll,dll.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev,true,dll,dll.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev,true,dll,dll.name,keyword,core,,kernel32.dll,Name of the library.
 1.9.0-dev,true,dll,dll.path,keyword,extended,,C:\Windows\System32\kernel32.dll,Full file path of the library.
 1.9.0-dev,true,dll,dll.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
@@ -183,6 +184,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,file,file.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev,true,file,file.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev,true,file,file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev,true,file,file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev,true,file,file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.9.0-dev,true,file,file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.9.0-dev,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
@@ -385,6 +387,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev,true,process,process.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev,true,process,process.name,wildcard,extended,,ssh,Process name.
 1.9.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
 1.9.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -404,6 +407,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
 1.9.0-dev,true,process,process.parent.hash.sha256,keyword,extended,,,SHA256 hash.
 1.9.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
+1.9.0-dev,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.9.0-dev,true,process,process.parent.name,wildcard,extended,,ssh,Process name.
 1.9.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
 1.9.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1252,6 +1252,17 @@ dll.hash.sha512:
   original_fieldset: hash
   short: SHA512 hash.
   type: keyword
+dll.hash.ssdeep:
+  dashed_name: dll-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: dll.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 dll.name:
   dashed_name: dll-name
   description: 'Name of the library.
@@ -2675,6 +2686,17 @@ file.hash.sha512:
   normalize: []
   original_fieldset: hash
   short: SHA512 hash.
+  type: keyword
+file.hash.ssdeep:
+  dashed_name: file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 file.inode:
   dashed_name: file-inode
@@ -5163,6 +5185,17 @@ process.hash.sha512:
   original_fieldset: hash
   short: SHA512 hash.
   type: keyword
+process.hash.ssdeep:
+  dashed_name: process-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 process.name:
   beta: Note the usage of `wildcard` type is considered beta. This field used to be
     type `keyword`.
@@ -5397,6 +5430,17 @@ process.parent.hash.sha512:
   normalize: []
   original_fieldset: hash
   short: SHA512 hash.
+  type: keyword
+process.parent.hash.ssdeep:
+  dashed_name: process-parent-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.parent.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 process.parent.name:
   beta: Note the usage of `wildcard` type is considered beta. This field used to be

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1575,6 +1575,17 @@ dll:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    dll.hash.ssdeep:
+      dashed_name: dll-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: dll.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     dll.name:
       dashed_name: dll-name
       description: 'Name of the library.
@@ -3101,6 +3112,17 @@ file:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    file.hash.ssdeep:
+      dashed_name: file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     file.inode:
       dashed_name: file-inode
       description: Inode representing the file in the filesystem.
@@ -3833,11 +3855,16 @@ group:
   title: Group
   type: group
 hash:
-  description: 'The hash fields represent different hash algorithms and their values.
+  description: 'The hash fields represent different bitwise hash algorithms and their
+    values.
 
     Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for
     other hashes by lowercasing the hash algorithm name and using underscore separators
-    as appropriate (snake case, e.g. sha3_512).'
+    as appropriate (snake case, e.g. sha3_512).
+
+    Note that this fieldset is used for common hashes that may be computed over a
+    range of generic bytes. Entity-specific hashes such as ja3 or imphash are placed
+    in the fieldsets to which they relate (tls and pe, respectively).'
   fields:
     hash.md5:
       dashed_name: hash-md5
@@ -3878,6 +3905,16 @@ hash:
       name: sha512
       normalize: []
       short: SHA512 hash.
+      type: keyword
+    hash.ssdeep:
+      dashed_name: hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      short: SSDEEP hash.
       type: keyword
   group: 2
   name: hash
@@ -6236,6 +6273,17 @@ process:
       original_fieldset: hash
       short: SHA512 hash.
       type: keyword
+    process.hash.ssdeep:
+      dashed_name: process-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     process.name:
       beta: Note the usage of `wildcard` type is considered beta. This field used
         to be type `keyword`.
@@ -6470,6 +6518,17 @@ process:
       normalize: []
       original_fieldset: hash
       short: SHA512 hash.
+      type: keyword
+    process.parent.hash.ssdeep:
+      dashed_name: process-parent-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.parent.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
       type: keyword
     process.parent.name:
       beta: Note the usage of `wildcard` type is considered beta. This field used

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -526,6 +526,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -862,6 +866,10 @@
                   "type": "keyword"
                 },
                 "sha512": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ssdeep": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1827,6 +1835,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -1912,6 +1924,10 @@
                       "type": "keyword"
                     },
                     "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -510,6 +510,10 @@
               "sha512": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "ssdeep": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -838,6 +842,10 @@
                 "type": "keyword"
               },
               "sha512": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ssdeep": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1780,6 +1788,10 @@
               "sha512": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "ssdeep": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -1862,6 +1874,10 @@
                     "type": "keyword"
                   },
                   "sha512": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "ssdeep": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -46,6 +46,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -82,6 +82,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -78,6 +78,10 @@
                 "sha512": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "ssdeep": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -160,6 +164,10 @@
                       "type": "keyword"
                     },
                     "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/schemas/hash.yml
+++ b/schemas/hash.yml
@@ -5,11 +5,15 @@
   type: group
   short: Hashes, usually file hashes.
   description: >
-    The hash fields represent different hash algorithms and their values.
+    The hash fields represent different bitwise hash algorithms and their values.
 
     Field names for common hashes (e.g. MD5, SHA1) are predefined. Add fields for other hashes
     by lowercasing the hash algorithm name and using underscore separators as appropriate
     (snake case, e.g. sha3_512).
+
+    Note that this fieldset is used for common hashes that may be computed
+    over a range of generic bytes. Entity-specific hashes such as ja3 or imphash are
+    placed in the fieldsets to which they relate (tls and pe, respectively).
 
   reusable:
     top_level: false
@@ -39,3 +43,8 @@
       level: extended
       type: keyword
       description: SHA512 hash.
+
+    - name: ssdeep
+      level: extended
+      type: keyword
+      description: SSDEEP hash.


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add ssdeep hash (#1169)