### PR TITLE
add time_zone, postal_code, and continent_code

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -20,6 +20,7 @@ Thanks, you're awesome :-) -->
 * Added `http.request.id`. #1208
 * Added `cloud.service.name`. #1204
 * Added `hash.ssdeep`. #1169
+* Added `geo.timezone`, `geo.postal_code`, and `geo.continent_code`. #1229
 
 #### Improvements
 

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -26,6 +26,17 @@ type Geo struct {
 	// Longitude and latitude.
 	Location string `ecs:"location"`
 
+	// Two-letter code representing the continent.
+	// Possible codes are:
+	//   * AF - Africa
+	//   * AN - Antarctica
+	//   * AS - Asia
+	//   * EU - Europe
+	//   * NA - North America
+	//   * OC - Oceania
+	//   * SA - South America
+	ContinentCode string `ecs:"continent_code"`
+
 	// Name of the continent.
 	ContinentName string `ecs:"continent_name"`
 
@@ -41,8 +52,15 @@ type Geo struct {
 	// Country ISO code.
 	CountryIsoCode string `ecs:"country_iso_code"`
 
+	// Postal code. Also known as postcode, post code, or ZIP code.
+	PostalCode string `ecs:"postal_code"`
+
 	// Region ISO code.
 	RegionIsoCode string `ecs:"region_iso_code"`
+
+	// The time zone associated with location, as specified by the IANA Time
+	// Zone Database.
+	TimeZone string `ecs:"time_zone"`
 
 	// User-defined description of a location, at the level of granularity they
 	// care about.

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -46,7 +46,7 @@ type Geo struct {
 
 	// Postal code associated with the location.
 	// Values appropriate for this field may also be known as a postcode or ZIP
-	// code.
+	// code and will vary widely from country to country.
 	PostalCode string `ecs:"postal_code"`
 
 	// Region ISO code.

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -53,7 +53,7 @@ type Geo struct {
 	RegionIsoCode string `ecs:"region_iso_code"`
 
 	// The time zone of the location.
-	TimeZone string `ecs:"time_zone"`
+	Timezone string `ecs:"timezone"`
 
 	// User-defined description of a location, at the level of granularity they
 	// care about.

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -52,7 +52,7 @@ type Geo struct {
 	// Region ISO code.
 	RegionIsoCode string `ecs:"region_iso_code"`
 
-	// The time zone of the location.
+	// The time zone of the location, such as IANA time zone name.
 	Timezone string `ecs:"timezone"`
 
 	// User-defined description of a location, at the level of granularity they

--- a/code/go/ecs/geo.go
+++ b/code/go/ecs/geo.go
@@ -26,15 +26,7 @@ type Geo struct {
 	// Longitude and latitude.
 	Location string `ecs:"location"`
 
-	// Two-letter code representing the continent.
-	// Possible codes are:
-	//   * AF - Africa
-	//   * AN - Antarctica
-	//   * AS - Asia
-	//   * EU - Europe
-	//   * NA - North America
-	//   * OC - Oceania
-	//   * SA - South America
+	// Two-letter code representing continent's name.
 	ContinentCode string `ecs:"continent_code"`
 
 	// Name of the continent.
@@ -52,14 +44,15 @@ type Geo struct {
 	// Country ISO code.
 	CountryIsoCode string `ecs:"country_iso_code"`
 
-	// Postal code. Also known as postcode, post code, or ZIP code.
+	// Postal code associated with the location.
+	// Values appropriate for this field may also be known as a postcode or ZIP
+	// code.
 	PostalCode string `ecs:"postal_code"`
 
 	// Region ISO code.
 	RegionIsoCode string `ecs:"region_iso_code"`
 
-	// The time zone associated with location, as specified by the IANA Time
-	// Zone Database.
+	// The time zone of the location.
 	TimeZone string `ecs:"time_zone"`
 
 	// User-defined description of a location, at the level of granularity they

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2942,7 +2942,7 @@ example: `Quebec`
 [[field-geo-timezone]]
 <<field-geo-timezone, geo.timezone>>
 
-| The time zone of the location.
+| The time zone of the location, such as IANA time zone name.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2792,23 +2792,7 @@ example: `Montreal`
 [[field-geo-continent-code]]
 <<field-geo-continent-code, geo.continent_code>>
 
-| Two-letter code representing the continent.
-
-Possible codes are:
-
-  * AF - Africa
-
-  * AN - Antarctica
-
-  * AS - Asia
-
-  * EU - Europe
-
-  * NA - North America
-
-  * OC - Oceania
-
-  * SA - South America
+| Two-letter code representing continent's name.
 
 type: keyword
 
@@ -2908,13 +2892,15 @@ example: `boston-dc`
 [[field-geo-postal-code]]
 <<field-geo-postal-code, geo.postal_code>>
 
-| Postal code. Also known as postcode, post code, or ZIP code.
+| Postal code associated with the location.
+
+Values appropriate for this field may also be known as a postcode or ZIP code.
 
 type: keyword
 
 
 
-example: `0`
+example: `94040`
 
 | core
 
@@ -2956,7 +2942,7 @@ example: `Quebec`
 [[field-geo-time-zone]]
 <<field-geo-time-zone, geo.time_zone>>
 
-| The time zone associated with location, as specified by the IANA Time Zone Database.
+| The time zone of the location.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2789,6 +2789,38 @@ example: `Montreal`
 // ===============================================================
 
 |
+[[field-geo-continent-code]]
+<<field-geo-continent-code, geo.continent_code>>
+
+| Two-letter code representing the continent.
+
+Possible codes are:
+
+  * AF - Africa
+
+  * AN - Antarctica
+
+  * AS - Asia
+
+  * EU - Europe
+
+  * NA - North America
+
+  * OC - Oceania
+
+  * SA - South America
+
+type: keyword
+
+
+
+example: `NA`
+
+| core
+
+// ===============================================================
+
+|
 [[field-geo-continent-name]]
 <<field-geo-continent-name, geo.continent_name>>
 
@@ -2873,6 +2905,22 @@ example: `boston-dc`
 // ===============================================================
 
 |
+[[field-geo-postal-code]]
+<<field-geo-postal-code, geo.postal_code>>
+
+| Postal code. Also known as postcode, post code, or ZIP code.
+
+type: keyword
+
+
+
+example: `0`
+
+| core
+
+// ===============================================================
+
+|
 [[field-geo-region-iso-code]]
 <<field-geo-region-iso-code, geo.region_iso_code>>
 
@@ -2899,6 +2947,22 @@ type: keyword
 
 
 example: `Quebec`
+
+| core
+
+// ===============================================================
+
+|
+[[field-geo-time-zone]]
+<<field-geo-time-zone, geo.time_zone>>
+
+| The time zone associated with location, as specified by the IANA Time Zone Database.
+
+type: keyword
+
+
+
+example: `America/Chicago`
 
 | core
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2939,8 +2939,8 @@ example: `Quebec`
 // ===============================================================
 
 |
-[[field-geo-time-zone]]
-<<field-geo-time-zone, geo.time_zone>>
+[[field-geo-timezone]]
+<<field-geo-timezone, geo.timezone>>
 
 | The time zone of the location.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2894,7 +2894,7 @@ example: `boston-dc`
 
 | Postal code associated with the location.
 
-Values appropriate for this field may also be known as a postcode or ZIP code.
+Values appropriate for this field may also be known as a postcode or ZIP code and will vary widely from country to country.
 
 type: keyword
 
@@ -2948,7 +2948,7 @@ type: keyword
 
 
 
-example: `America/Chicago`
+example: `America/Argentina/Buenos_Aires`
 
 | core
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -252,7 +252,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -272,7 +273,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -753,7 +754,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -773,7 +775,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -2100,7 +2102,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: region_iso_code
@@ -2120,7 +2123,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
   - name: group
     title: Group
@@ -2289,7 +2292,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -2309,7 +2313,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
       level: core
@@ -3064,7 +3068,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -3084,7 +3089,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
       level: core
@@ -4345,7 +4350,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -4365,7 +4371,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -4697,7 +4703,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -4717,7 +4724,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -272,7 +272,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -774,7 +774,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -2122,7 +2122,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
   - name: group
@@ -2312,7 +2312,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
@@ -3088,7 +3088,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
@@ -4370,7 +4370,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -4723,7 +4723,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -267,7 +267,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -768,7 +768,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -2115,7 +2115,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: time_zone
+    - name: timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -2304,7 +2304,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -3079,7 +3079,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -4360,7 +4360,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -4712,7 +4712,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -209,9 +209,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -252,8 +250,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -271,8 +271,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -711,9 +710,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -754,8 +751,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -773,8 +772,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -2059,9 +2057,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: continent_name
@@ -2102,8 +2098,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: region_iso_code
       level: core
@@ -2121,8 +2119,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
   - name: group
@@ -2249,9 +2246,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -2292,8 +2287,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -2311,8 +2308,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: hostname
@@ -3025,9 +3021,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -3068,8 +3062,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -3087,8 +3083,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: hostname
@@ -4307,9 +4302,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -4350,8 +4343,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -4369,8 +4364,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -4660,9 +4654,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -4703,8 +4695,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -4722,8 +4716,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -205,6 +205,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -239,6 +248,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -251,6 +267,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -683,6 +707,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -717,6 +750,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -729,6 +769,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -2007,6 +2055,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: continent_name
       level: core
       type: keyword
@@ -2041,6 +2098,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: region_iso_code
       level: core
       type: keyword
@@ -2053,6 +2117,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
   - name: group
     title: Group
     group: 2
@@ -2173,6 +2245,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -2207,6 +2288,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -2219,6 +2307,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: hostname
       level: core
       type: wildcard
@@ -2925,6 +3021,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -2959,6 +3064,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -2971,6 +3083,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -4183,6 +4303,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -4217,6 +4346,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -4229,6 +4365,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -4512,6 +4656,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -4546,6 +4699,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -4558,6 +4718,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -16,13 +16,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 2.0.0-dev+exp,true,client,client.domain,wildcard,core,,,Client domain.
 2.0.0-dev+exp,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,client,client.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,client,client.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,client,client.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,client,client.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev+exp,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev+exp,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -71,13 +74,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 2.0.0-dev+exp,true,destination,destination.domain,wildcard,core,,,Destination domain.
 2.0.0-dev+exp,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,destination,destination.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,destination,destination.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,destination,destination.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev+exp,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev+exp,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -241,13 +247,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,host,host.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
 2.0.0-dev+exp,true,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
 2.0.0-dev+exp,true,host,host.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,host,host.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,host,host.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,host,host.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,host,host.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,host,host.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,host,host.hostname,wildcard,core,,,Hostname of the host.
 2.0.0-dev+exp,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev+exp,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -332,13 +341,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.egress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 2.0.0-dev+exp,true,observer,observer.egress.zone,keyword,extended,,Public_Internet,Observer Egress zone
 2.0.0-dev+exp,true,observer,observer.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,observer,observer.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,observer,observer.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,observer,observer.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,observer,observer.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev+exp,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev+exp,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -484,13 +496,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 2.0.0-dev+exp,true,server,server.domain,wildcard,core,,,Server domain.
 2.0.0-dev+exp,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,server,server.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,server,server.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,server,server.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,server,server.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev+exp,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev+exp,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -526,13 +541,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 2.0.0-dev+exp,true,source,source.domain,wildcard,core,,,Source domain.
 2.0.0-dev+exp,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev+exp,true,source,source.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev+exp,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,source,source.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,source,source.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev+exp,true,source,source.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev+exp,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev+exp,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev+exp,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev+exp,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -25,7 +25,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,client,client.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev+exp,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev+exp,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -83,7 +83,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,destination,destination.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev+exp,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev+exp,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -256,7 +256,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,host,host.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,host,host.hostname,wildcard,core,,,Hostname of the host.
 2.0.0-dev+exp,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev+exp,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -350,7 +350,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,observer,observer.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev+exp,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev+exp,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -505,7 +505,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,server,server.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev+exp,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev+exp,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -550,7 +550,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,source,source.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev+exp,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev+exp,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev+exp,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -16,13 +16,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 2.0.0-dev+exp,true,client,client.domain,wildcard,core,,,Client domain.
 2.0.0-dev+exp,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,client,client.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,client,client.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,client,client.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,client,client.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,client,client.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -74,13 +74,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 2.0.0-dev+exp,true,destination,destination.domain,wildcard,core,,,Destination domain.
 2.0.0-dev+exp,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,destination,destination.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,destination,destination.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,destination,destination.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,destination,destination.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -247,13 +247,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,host,host.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
 2.0.0-dev+exp,true,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
 2.0.0-dev+exp,true,host,host.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,host,host.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,host,host.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,host,host.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,host,host.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,host,host.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,host,host.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -341,13 +341,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.egress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 2.0.0-dev+exp,true,observer,observer.egress.zone,keyword,extended,,Public_Internet,Observer Egress zone
 2.0.0-dev+exp,true,observer,observer.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,observer,observer.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,observer,observer.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,observer,observer.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,observer,observer.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,observer,observer.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -496,13 +496,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 2.0.0-dev+exp,true,server,server.domain,wildcard,core,,,Server domain.
 2.0.0-dev+exp,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,server,server.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,server,server.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,server,server.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,server,server.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,server,server.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -541,13 +541,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 2.0.0-dev+exp,true,source,source.domain,wildcard,core,,,Source domain.
 2.0.0-dev+exp,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev+exp,true,source,source.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev+exp,true,source,source.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev+exp,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev+exp,true,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev+exp,true,source,source.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev+exp,true,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev+exp,true,source,source.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev+exp,true,source,source.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev+exp,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev+exp,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -25,7 +25,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,client,client.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,client,client.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev+exp,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev+exp,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -83,7 +83,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,destination,destination.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,destination,destination.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev+exp,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev+exp,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -256,7 +256,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,host,host.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,host,host.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,host,host.hostname,wildcard,core,,,Hostname of the host.
 2.0.0-dev+exp,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev+exp,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -350,7 +350,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,observer,observer.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,observer,observer.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev+exp,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev+exp,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -505,7 +505,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,server,server.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,server,server.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev+exp,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev+exp,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -550,7 +550,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev+exp,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev+exp,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev+exp,true,source,source.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev+exp,true,source,source.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev+exp,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev+exp,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev+exp,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -175,6 +175,20 @@ client.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+client.geo.continent_code:
+  dashed_name: client-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: client.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 client.geo.continent_name:
   dashed_name: client-geo-continent-name
   description: Name of the continent.
@@ -239,6 +253,18 @@ client.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+client.geo.postal_code:
+  dashed_name: client-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: client.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 client.geo.region_iso_code:
   dashed_name: client-geo-region-iso-code
   description: Region ISO code.
@@ -262,6 +288,19 @@ client.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+client.geo.time_zone:
+  dashed_name: client-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: client.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 client.ip:
   dashed_name: client-ip
@@ -825,6 +864,20 @@ destination.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+destination.geo.continent_code:
+  dashed_name: destination-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: destination.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 destination.geo.continent_name:
   dashed_name: destination-geo-continent-name
   description: Name of the continent.
@@ -889,6 +942,18 @@ destination.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+destination.geo.postal_code:
+  dashed_name: destination-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: destination.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 destination.geo.region_iso_code:
   dashed_name: destination-geo-region-iso-code
   description: Region ISO code.
@@ -912,6 +977,19 @@ destination.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+destination.geo.time_zone:
+  dashed_name: destination-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: destination.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 destination.ip:
   dashed_name: destination-ip
@@ -3326,6 +3404,20 @@ host.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+host.geo.continent_code:
+  dashed_name: host-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: host.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 host.geo.continent_name:
   dashed_name: host-geo-continent-name
   description: Name of the continent.
@@ -3390,6 +3482,18 @@ host.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+host.geo.postal_code:
+  dashed_name: host-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: host.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 host.geo.region_iso_code:
   dashed_name: host-geo-region-iso-code
   description: Region ISO code.
@@ -3413,6 +3517,19 @@ host.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+host.geo.time_zone:
+  dashed_name: host-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: host.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -4462,6 +4579,20 @@ observer.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+observer.geo.continent_code:
+  dashed_name: observer-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: observer.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 observer.geo.continent_name:
   dashed_name: observer-geo-continent-name
   description: Name of the continent.
@@ -4526,6 +4657,18 @@ observer.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+observer.geo.postal_code:
+  dashed_name: observer-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: observer.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 observer.geo.region_iso_code:
   dashed_name: observer-geo-region-iso-code
   description: Region ISO code.
@@ -4549,6 +4692,19 @@ observer.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+observer.geo.time_zone:
+  dashed_name: observer-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: observer.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 observer.hostname:
   dashed_name: observer-hostname
@@ -6208,6 +6364,20 @@ server.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+server.geo.continent_code:
+  dashed_name: server-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: server.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 server.geo.continent_name:
   dashed_name: server-geo-continent-name
   description: Name of the continent.
@@ -6272,6 +6442,18 @@ server.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+server.geo.postal_code:
+  dashed_name: server-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: server.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 server.geo.region_iso_code:
   dashed_name: server-geo-region-iso-code
   description: Region ISO code.
@@ -6295,6 +6477,19 @@ server.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+server.geo.time_zone:
+  dashed_name: server-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: server.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 server.ip:
   dashed_name: server-ip
@@ -6727,6 +6922,20 @@ source.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+source.geo.continent_code:
+  dashed_name: source-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: source.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 source.geo.continent_name:
   dashed_name: source-geo-continent-name
   description: Name of the continent.
@@ -6791,6 +7000,18 @@ source.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: wildcard
+source.geo.postal_code:
+  dashed_name: source-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: source.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 source.geo.region_iso_code:
   dashed_name: source-geo-region-iso-code
   description: Region ISO code.
@@ -6814,6 +7035,19 @@ source.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+source.geo.time_zone:
+  dashed_name: source-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: source.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 source.ip:
   dashed_name: source-ip

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -177,9 +177,7 @@ client.geo.city_name:
   type: keyword
 client.geo.continent_code:
   dashed_name: client-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: client.geo.continent_code
   ignore_above: 1024
@@ -187,7 +185,7 @@ client.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 client.geo.continent_name:
   dashed_name: client-geo-continent-name
@@ -255,15 +253,17 @@ client.geo.name:
   type: wildcard
 client.geo.postal_code:
   dashed_name: client-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: client.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 client.geo.region_iso_code:
   dashed_name: client-geo-region-iso-code
@@ -291,8 +291,7 @@ client.geo.region_name:
   type: keyword
 client.geo.time_zone:
   dashed_name: client-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: client.geo.time_zone
   ignore_above: 1024
@@ -866,9 +865,7 @@ destination.geo.city_name:
   type: keyword
 destination.geo.continent_code:
   dashed_name: destination-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: destination.geo.continent_code
   ignore_above: 1024
@@ -876,7 +873,7 @@ destination.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 destination.geo.continent_name:
   dashed_name: destination-geo-continent-name
@@ -944,15 +941,17 @@ destination.geo.name:
   type: wildcard
 destination.geo.postal_code:
   dashed_name: destination-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: destination.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 destination.geo.region_iso_code:
   dashed_name: destination-geo-region-iso-code
@@ -980,8 +979,7 @@ destination.geo.region_name:
   type: keyword
 destination.geo.time_zone:
   dashed_name: destination-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: destination.geo.time_zone
   ignore_above: 1024
@@ -3406,9 +3404,7 @@ host.geo.city_name:
   type: keyword
 host.geo.continent_code:
   dashed_name: host-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: host.geo.continent_code
   ignore_above: 1024
@@ -3416,7 +3412,7 @@ host.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 host.geo.continent_name:
   dashed_name: host-geo-continent-name
@@ -3484,15 +3480,17 @@ host.geo.name:
   type: wildcard
 host.geo.postal_code:
   dashed_name: host-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: host.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 host.geo.region_iso_code:
   dashed_name: host-geo-region-iso-code
@@ -3520,8 +3518,7 @@ host.geo.region_name:
   type: keyword
 host.geo.time_zone:
   dashed_name: host-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: host.geo.time_zone
   ignore_above: 1024
@@ -4581,9 +4578,7 @@ observer.geo.city_name:
   type: keyword
 observer.geo.continent_code:
   dashed_name: observer-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: observer.geo.continent_code
   ignore_above: 1024
@@ -4591,7 +4586,7 @@ observer.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 observer.geo.continent_name:
   dashed_name: observer-geo-continent-name
@@ -4659,15 +4654,17 @@ observer.geo.name:
   type: wildcard
 observer.geo.postal_code:
   dashed_name: observer-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: observer.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 observer.geo.region_iso_code:
   dashed_name: observer-geo-region-iso-code
@@ -4695,8 +4692,7 @@ observer.geo.region_name:
   type: keyword
 observer.geo.time_zone:
   dashed_name: observer-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: observer.geo.time_zone
   ignore_above: 1024
@@ -6366,9 +6362,7 @@ server.geo.city_name:
   type: keyword
 server.geo.continent_code:
   dashed_name: server-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: server.geo.continent_code
   ignore_above: 1024
@@ -6376,7 +6370,7 @@ server.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 server.geo.continent_name:
   dashed_name: server-geo-continent-name
@@ -6444,15 +6438,17 @@ server.geo.name:
   type: wildcard
 server.geo.postal_code:
   dashed_name: server-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: server.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 server.geo.region_iso_code:
   dashed_name: server-geo-region-iso-code
@@ -6480,8 +6476,7 @@ server.geo.region_name:
   type: keyword
 server.geo.time_zone:
   dashed_name: server-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: server.geo.time_zone
   ignore_above: 1024
@@ -6924,9 +6919,7 @@ source.geo.city_name:
   type: keyword
 source.geo.continent_code:
   dashed_name: source-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: source.geo.continent_code
   ignore_above: 1024
@@ -6934,7 +6927,7 @@ source.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 source.geo.continent_name:
   dashed_name: source-geo-continent-name
@@ -7002,15 +6995,17 @@ source.geo.name:
   type: wildcard
 source.geo.postal_code:
   dashed_name: source-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: source.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 source.geo.region_iso_code:
   dashed_name: source-geo-region-iso-code
@@ -7038,8 +7033,7 @@ source.geo.region_name:
   type: keyword
 source.geo.time_zone:
   dashed_name: source-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: source.geo.time_zone
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -255,7 +255,8 @@ client.geo.postal_code:
   dashed_name: client-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: client.geo.postal_code
   ignore_above: 1024
@@ -292,7 +293,7 @@ client.geo.region_name:
 client.geo.timezone:
   dashed_name: client-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: client.geo.timezone
   ignore_above: 1024
   level: core
@@ -943,7 +944,8 @@ destination.geo.postal_code:
   dashed_name: destination-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: destination.geo.postal_code
   ignore_above: 1024
@@ -980,7 +982,7 @@ destination.geo.region_name:
 destination.geo.timezone:
   dashed_name: destination-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: destination.geo.timezone
   ignore_above: 1024
   level: core
@@ -3482,7 +3484,8 @@ host.geo.postal_code:
   dashed_name: host-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: host.geo.postal_code
   ignore_above: 1024
@@ -3519,7 +3522,7 @@ host.geo.region_name:
 host.geo.timezone:
   dashed_name: host-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: host.geo.timezone
   ignore_above: 1024
   level: core
@@ -4656,7 +4659,8 @@ observer.geo.postal_code:
   dashed_name: observer-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: observer.geo.postal_code
   ignore_above: 1024
@@ -4693,7 +4697,7 @@ observer.geo.region_name:
 observer.geo.timezone:
   dashed_name: observer-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: observer.geo.timezone
   ignore_above: 1024
   level: core
@@ -6440,7 +6444,8 @@ server.geo.postal_code:
   dashed_name: server-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: server.geo.postal_code
   ignore_above: 1024
@@ -6477,7 +6482,7 @@ server.geo.region_name:
 server.geo.timezone:
   dashed_name: server-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: server.geo.timezone
   ignore_above: 1024
   level: core
@@ -6997,7 +7002,8 @@ source.geo.postal_code:
   dashed_name: source-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: source.geo.postal_code
   ignore_above: 1024
@@ -7034,7 +7040,7 @@ source.geo.region_name:
 source.geo.timezone:
   dashed_name: source-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: source.geo.timezone
   ignore_above: 1024
   level: core

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -292,7 +292,7 @@ client.geo.region_name:
   type: keyword
 client.geo.timezone:
   dashed_name: client-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: client.geo.timezone
   ignore_above: 1024
@@ -981,7 +981,7 @@ destination.geo.region_name:
   type: keyword
 destination.geo.timezone:
   dashed_name: destination-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: destination.geo.timezone
   ignore_above: 1024
@@ -3521,7 +3521,7 @@ host.geo.region_name:
   type: keyword
 host.geo.timezone:
   dashed_name: host-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: host.geo.timezone
   ignore_above: 1024
@@ -4696,7 +4696,7 @@ observer.geo.region_name:
   type: keyword
 observer.geo.timezone:
   dashed_name: observer-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: observer.geo.timezone
   ignore_above: 1024
@@ -6481,7 +6481,7 @@ server.geo.region_name:
   type: keyword
 server.geo.timezone:
   dashed_name: server-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: server.geo.timezone
   ignore_above: 1024
@@ -7039,7 +7039,7 @@ source.geo.region_name:
   type: keyword
 source.geo.timezone:
   dashed_name: source-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: source.geo.timezone
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -289,14 +289,14 @@ client.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-client.geo.time_zone:
-  dashed_name: client-geo-time-zone
+client.geo.timezone:
+  dashed_name: client-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: client.geo.time_zone
+  flat_name: client.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -977,14 +977,14 @@ destination.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-destination.geo.time_zone:
-  dashed_name: destination-geo-time-zone
+destination.geo.timezone:
+  dashed_name: destination-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: destination.geo.time_zone
+  flat_name: destination.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -3516,14 +3516,14 @@ host.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-host.geo.time_zone:
-  dashed_name: host-geo-time-zone
+host.geo.timezone:
+  dashed_name: host-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: host.geo.time_zone
+  flat_name: host.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -4690,14 +4690,14 @@ observer.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-observer.geo.time_zone:
-  dashed_name: observer-geo-time-zone
+observer.geo.timezone:
+  dashed_name: observer-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: observer.geo.time_zone
+  flat_name: observer.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -6474,14 +6474,14 @@ server.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-server.geo.time_zone:
-  dashed_name: server-geo-time-zone
+server.geo.timezone:
+  dashed_name: server-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: server.geo.time_zone
+  flat_name: server.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -7031,14 +7031,14 @@ source.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-source.geo.time_zone:
-  dashed_name: source-geo-time-zone
+source.geo.timezone:
+  dashed_name: source-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: source.geo.time_zone
+  flat_name: source.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -322,9 +322,7 @@ client:
       type: keyword
     client.geo.continent_code:
       dashed_name: client-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: client.geo.continent_code
       ignore_above: 1024
@@ -332,7 +330,7 @@ client:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     client.geo.continent_name:
       dashed_name: client-geo-continent-name
@@ -400,15 +398,17 @@ client:
       type: wildcard
     client.geo.postal_code:
       dashed_name: client-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: client.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     client.geo.region_iso_code:
       dashed_name: client-geo-region-iso-code
@@ -436,8 +436,7 @@ client:
       type: keyword
     client.geo.time_zone:
       dashed_name: client-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: client.geo.time_zone
       ignore_above: 1024
@@ -1176,9 +1175,7 @@ destination:
       type: keyword
     destination.geo.continent_code:
       dashed_name: destination-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: destination.geo.continent_code
       ignore_above: 1024
@@ -1186,7 +1183,7 @@ destination:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     destination.geo.continent_name:
       dashed_name: destination-geo-continent-name
@@ -1254,15 +1251,17 @@ destination:
       type: wildcard
     destination.geo.postal_code:
       dashed_name: destination-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: destination.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     destination.geo.region_iso_code:
       dashed_name: destination-geo-region-iso-code
@@ -1290,8 +1289,7 @@ destination:
       type: keyword
     destination.geo.time_zone:
       dashed_name: destination-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: destination.geo.time_zone
       ignore_above: 1024
@@ -3791,16 +3789,14 @@ geo:
       type: keyword
     geo.continent_code:
       dashed_name: geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: geo.continent_code
       ignore_above: 1024
       level: core
       name: continent_code
       normalize: []
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     geo.continent_name:
       dashed_name: geo-continent-name
@@ -3863,14 +3859,16 @@ geo:
       type: wildcard
     geo.postal_code:
       dashed_name: geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     geo.region_iso_code:
       dashed_name: geo-region-iso-code
@@ -3896,8 +3894,7 @@ geo:
       type: keyword
     geo.time_zone:
       dashed_name: geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: geo.time_zone
       ignore_above: 1024
@@ -4142,9 +4139,7 @@ host:
       type: keyword
     host.geo.continent_code:
       dashed_name: host-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: host.geo.continent_code
       ignore_above: 1024
@@ -4152,7 +4147,7 @@ host:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     host.geo.continent_name:
       dashed_name: host-geo-continent-name
@@ -4220,15 +4215,17 @@ host:
       type: wildcard
     host.geo.postal_code:
       dashed_name: host-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: host.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     host.geo.region_iso_code:
       dashed_name: host-geo-region-iso-code
@@ -4256,8 +4253,7 @@ host:
       type: keyword
     host.geo.time_zone:
       dashed_name: host-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: host.geo.time_zone
       ignore_above: 1024
@@ -5435,9 +5431,7 @@ observer:
       type: keyword
     observer.geo.continent_code:
       dashed_name: observer-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: observer.geo.continent_code
       ignore_above: 1024
@@ -5445,7 +5439,7 @@ observer:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     observer.geo.continent_name:
       dashed_name: observer-geo-continent-name
@@ -5513,15 +5507,17 @@ observer:
       type: wildcard
     observer.geo.postal_code:
       dashed_name: observer-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: observer.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     observer.geo.region_iso_code:
       dashed_name: observer-geo-region-iso-code
@@ -5549,8 +5545,7 @@ observer:
       type: keyword
     observer.geo.time_zone:
       dashed_name: observer-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: observer.geo.time_zone
       ignore_above: 1024
@@ -7593,9 +7588,7 @@ server:
       type: keyword
     server.geo.continent_code:
       dashed_name: server-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: server.geo.continent_code
       ignore_above: 1024
@@ -7603,7 +7596,7 @@ server:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     server.geo.continent_name:
       dashed_name: server-geo-continent-name
@@ -7671,15 +7664,17 @@ server:
       type: wildcard
     server.geo.postal_code:
       dashed_name: server-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: server.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     server.geo.region_iso_code:
       dashed_name: server-geo-region-iso-code
@@ -7707,8 +7702,7 @@ server:
       type: keyword
     server.geo.time_zone:
       dashed_name: server-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: server.geo.time_zone
       ignore_above: 1024
@@ -8195,9 +8189,7 @@ source:
       type: keyword
     source.geo.continent_code:
       dashed_name: source-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: source.geo.continent_code
       ignore_above: 1024
@@ -8205,7 +8197,7 @@ source:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     source.geo.continent_name:
       dashed_name: source-geo-continent-name
@@ -8273,15 +8265,17 @@ source:
       type: wildcard
     source.geo.postal_code:
       dashed_name: source-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: source.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     source.geo.region_iso_code:
       dashed_name: source-geo-region-iso-code
@@ -8309,8 +8303,7 @@ source:
       type: keyword
     source.geo.time_zone:
       dashed_name: source-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: source.geo.time_zone
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -437,7 +437,7 @@ client:
       type: keyword
     client.geo.timezone:
       dashed_name: client-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: client.geo.timezone
       ignore_above: 1024
@@ -1291,7 +1291,7 @@ destination:
       type: keyword
     destination.geo.timezone:
       dashed_name: destination-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: destination.geo.timezone
       ignore_above: 1024
@@ -3897,7 +3897,7 @@ geo:
       type: keyword
     geo.timezone:
       dashed_name: geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: geo.timezone
       ignore_above: 1024
@@ -4257,7 +4257,7 @@ host:
       type: keyword
     host.geo.timezone:
       dashed_name: host-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: host.geo.timezone
       ignore_above: 1024
@@ -5550,7 +5550,7 @@ observer:
       type: keyword
     observer.geo.timezone:
       dashed_name: observer-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: observer.geo.timezone
       ignore_above: 1024
@@ -7708,7 +7708,7 @@ server:
       type: keyword
     server.geo.timezone:
       dashed_name: server-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: server.geo.timezone
       ignore_above: 1024
@@ -8310,7 +8310,7 @@ source:
       type: keyword
     source.geo.timezone:
       dashed_name: source-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: source.geo.timezone
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -320,6 +320,20 @@ client:
       original_fieldset: geo
       short: City name.
       type: keyword
+    client.geo.continent_code:
+      dashed_name: client-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: client.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     client.geo.continent_name:
       dashed_name: client-geo-continent-name
       description: Name of the continent.
@@ -384,6 +398,18 @@ client:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    client.geo.postal_code:
+      dashed_name: client-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: client.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     client.geo.region_iso_code:
       dashed_name: client-geo-region-iso-code
       description: Region ISO code.
@@ -407,6 +433,19 @@ client:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    client.geo.time_zone:
+      dashed_name: client-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: client.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     client.ip:
       dashed_name: client-ip
@@ -1135,6 +1174,20 @@ destination:
       original_fieldset: geo
       short: City name.
       type: keyword
+    destination.geo.continent_code:
+      dashed_name: destination-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: destination.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     destination.geo.continent_name:
       dashed_name: destination-geo-continent-name
       description: Name of the continent.
@@ -1199,6 +1252,18 @@ destination:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    destination.geo.postal_code:
+      dashed_name: destination-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: destination.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     destination.geo.region_iso_code:
       dashed_name: destination-geo-region-iso-code
       description: Region ISO code.
@@ -1222,6 +1287,19 @@ destination:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    destination.geo.time_zone:
+      dashed_name: destination-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: destination.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     destination.ip:
       dashed_name: destination-ip
@@ -3711,6 +3789,19 @@ geo:
       normalize: []
       short: City name.
       type: keyword
+    geo.continent_code:
+      dashed_name: geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      short: Two-level code representing the continent.
+      type: keyword
     geo.continent_name:
       dashed_name: geo-continent-name
       description: Name of the continent.
@@ -3770,6 +3861,17 @@ geo:
       normalize: []
       short: User-defined description of a location.
       type: wildcard
+    geo.postal_code:
+      dashed_name: geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     geo.region_iso_code:
       dashed_name: geo-region-iso-code
       description: Region ISO code.
@@ -3791,6 +3893,18 @@ geo:
       name: region_name
       normalize: []
       short: Region name.
+      type: keyword
+    geo.time_zone:
+      dashed_name: geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      short: Time zone.
       type: keyword
   group: 2
   name: geo
@@ -4026,6 +4140,20 @@ host:
       original_fieldset: geo
       short: City name.
       type: keyword
+    host.geo.continent_code:
+      dashed_name: host-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: host.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     host.geo.continent_name:
       dashed_name: host-geo-continent-name
       description: Name of the continent.
@@ -4090,6 +4218,18 @@ host:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    host.geo.postal_code:
+      dashed_name: host-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: host.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     host.geo.region_iso_code:
       dashed_name: host-geo-region-iso-code
       description: Region ISO code.
@@ -4113,6 +4253,19 @@ host:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    host.geo.time_zone:
+      dashed_name: host-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: host.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     host.hostname:
       dashed_name: host-hostname
@@ -5280,6 +5433,20 @@ observer:
       original_fieldset: geo
       short: City name.
       type: keyword
+    observer.geo.continent_code:
+      dashed_name: observer-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: observer.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     observer.geo.continent_name:
       dashed_name: observer-geo-continent-name
       description: Name of the continent.
@@ -5344,6 +5511,18 @@ observer:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    observer.geo.postal_code:
+      dashed_name: observer-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: observer.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     observer.geo.region_iso_code:
       dashed_name: observer-geo-region-iso-code
       description: Region ISO code.
@@ -5367,6 +5546,19 @@ observer:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    observer.geo.time_zone:
+      dashed_name: observer-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: observer.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     observer.hostname:
       dashed_name: observer-hostname
@@ -7399,6 +7591,20 @@ server:
       original_fieldset: geo
       short: City name.
       type: keyword
+    server.geo.continent_code:
+      dashed_name: server-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: server.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     server.geo.continent_name:
       dashed_name: server-geo-continent-name
       description: Name of the continent.
@@ -7463,6 +7669,18 @@ server:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    server.geo.postal_code:
+      dashed_name: server-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: server.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     server.geo.region_iso_code:
       dashed_name: server-geo-region-iso-code
       description: Region ISO code.
@@ -7486,6 +7704,19 @@ server:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    server.geo.time_zone:
+      dashed_name: server-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: server.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     server.ip:
       dashed_name: server-ip
@@ -7962,6 +8193,20 @@ source:
       original_fieldset: geo
       short: City name.
       type: keyword
+    source.geo.continent_code:
+      dashed_name: source-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: source.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     source.geo.continent_name:
       dashed_name: source-geo-continent-name
       description: Name of the continent.
@@ -8026,6 +8271,18 @@ source:
       original_fieldset: geo
       short: User-defined description of a location.
       type: wildcard
+    source.geo.postal_code:
+      dashed_name: source-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: source.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     source.geo.region_iso_code:
       dashed_name: source-geo-region-iso-code
       description: Region ISO code.
@@ -8049,6 +8306,19 @@ source:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    source.geo.time_zone:
+      dashed_name: source-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: source.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     source.ip:
       dashed_name: source-ip

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -400,7 +400,8 @@ client:
       dashed_name: client-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: client.geo.postal_code
       ignore_above: 1024
@@ -437,7 +438,7 @@ client:
     client.geo.timezone:
       dashed_name: client-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: client.geo.timezone
       ignore_above: 1024
       level: core
@@ -1253,7 +1254,8 @@ destination:
       dashed_name: destination-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: destination.geo.postal_code
       ignore_above: 1024
@@ -1290,7 +1292,7 @@ destination:
     destination.geo.timezone:
       dashed_name: destination-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: destination.geo.timezone
       ignore_above: 1024
       level: core
@@ -3861,7 +3863,8 @@ geo:
       dashed_name: geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: geo.postal_code
       ignore_above: 1024
@@ -3895,7 +3898,7 @@ geo:
     geo.timezone:
       dashed_name: geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: geo.timezone
       ignore_above: 1024
       level: core
@@ -4217,7 +4220,8 @@ host:
       dashed_name: host-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: host.geo.postal_code
       ignore_above: 1024
@@ -4254,7 +4258,7 @@ host:
     host.geo.timezone:
       dashed_name: host-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: host.geo.timezone
       ignore_above: 1024
       level: core
@@ -5509,7 +5513,8 @@ observer:
       dashed_name: observer-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: observer.geo.postal_code
       ignore_above: 1024
@@ -5546,7 +5551,7 @@ observer:
     observer.geo.timezone:
       dashed_name: observer-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: observer.geo.timezone
       ignore_above: 1024
       level: core
@@ -7666,7 +7671,8 @@ server:
       dashed_name: server-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: server.geo.postal_code
       ignore_above: 1024
@@ -7703,7 +7709,7 @@ server:
     server.geo.timezone:
       dashed_name: server-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: server.geo.timezone
       ignore_above: 1024
       level: core
@@ -8267,7 +8273,8 @@ source:
       dashed_name: source-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: source.geo.postal_code
       ignore_above: 1024
@@ -8304,7 +8311,7 @@ source:
     source.geo.timezone:
       dashed_name: source-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: source.geo.timezone
       ignore_above: 1024
       level: core

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -434,14 +434,14 @@ client:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    client.geo.time_zone:
-      dashed_name: client-geo-time-zone
+    client.geo.timezone:
+      dashed_name: client-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: client.geo.time_zone
+      flat_name: client.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -1287,14 +1287,14 @@ destination:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    destination.geo.time_zone:
-      dashed_name: destination-geo-time-zone
+    destination.geo.timezone:
+      dashed_name: destination-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: destination.geo.time_zone
+      flat_name: destination.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -3892,14 +3892,14 @@ geo:
       normalize: []
       short: Region name.
       type: keyword
-    geo.time_zone:
-      dashed_name: geo-time-zone
+    geo.timezone:
+      dashed_name: geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: geo.time_zone
+      flat_name: geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       short: Time zone.
       type: keyword
@@ -4251,14 +4251,14 @@ host:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    host.geo.time_zone:
-      dashed_name: host-geo-time-zone
+    host.geo.timezone:
+      dashed_name: host-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: host.geo.time_zone
+      flat_name: host.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -5543,14 +5543,14 @@ observer:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    observer.geo.time_zone:
-      dashed_name: observer-geo-time-zone
+    observer.geo.timezone:
+      dashed_name: observer-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: observer.geo.time_zone
+      flat_name: observer.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -7700,14 +7700,14 @@ server:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    server.geo.time_zone:
-      dashed_name: server-geo-time-zone
+    server.geo.timezone:
+      dashed_name: server-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: server.geo.time_zone
+      flat_name: server.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -8301,14 +8301,14 @@ source:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    source.geo.time_zone:
-      dashed_name: source-geo-time-zone
+    source.geo.timezone:
+      dashed_name: source-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: source.geo.time_zone
+      flat_name: source.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -125,7 +125,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -408,7 +408,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1169,7 +1169,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1634,7 +1634,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2323,7 +2323,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2530,7 +2530,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -91,6 +91,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -109,11 +113,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -362,6 +374,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -380,11 +396,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1111,6 +1135,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1129,11 +1157,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1564,6 +1600,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1582,11 +1622,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2241,6 +2289,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2259,11 +2311,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2436,6 +2496,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2454,11 +2518,19 @@
               "name": {
                 "type": "wildcard"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/experimental/generated/elasticsearch/component/client.json
+++ b/experimental/generated/elasticsearch/component/client.json
@@ -44,6 +44,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -62,11 +66,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/client.json
+++ b/experimental/generated/elasticsearch/component/client.json
@@ -78,7 +78,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/destination.json
+++ b/experimental/generated/elasticsearch/component/destination.json
@@ -44,6 +44,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -62,11 +66,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/destination.json
+++ b/experimental/generated/elasticsearch/component/destination.json
@@ -78,7 +78,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/host.json
+++ b/experimental/generated/elasticsearch/component/host.json
@@ -48,6 +48,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -66,11 +70,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/host.json
+++ b/experimental/generated/elasticsearch/component/host.json
@@ -82,7 +82,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/observer.json
+++ b/experimental/generated/elasticsearch/component/observer.json
@@ -51,6 +51,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -69,11 +73,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/observer.json
+++ b/experimental/generated/elasticsearch/component/observer.json
@@ -85,7 +85,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/server.json
+++ b/experimental/generated/elasticsearch/component/server.json
@@ -44,6 +44,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -62,11 +66,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/server.json
+++ b/experimental/generated/elasticsearch/component/server.json
@@ -78,7 +78,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/source.json
+++ b/experimental/generated/elasticsearch/component/source.json
@@ -44,6 +44,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -62,11 +66,19 @@
                 "name": {
                   "type": "wildcard"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/component/source.json
+++ b/experimental/generated/elasticsearch/component/source.json
@@ -78,7 +78,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -209,6 +209,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -244,6 +253,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -256,6 +272,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -642,6 +666,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -677,6 +710,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -689,6 +729,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -1983,6 +2031,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: continent_name
       level: core
       type: keyword
@@ -2018,6 +2075,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: region_iso_code
       level: core
       type: keyword
@@ -2030,6 +2094,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
   - name: group
     title: Group
     group: 2
@@ -2128,6 +2200,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -2163,6 +2244,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -2175,6 +2263,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -2868,6 +2964,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -2903,6 +3008,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -2915,6 +3027,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -4152,6 +4272,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -4187,6 +4316,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -4199,6 +4335,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip
@@ -4488,6 +4632,15 @@
       ignore_above: 1024
       description: City name.
       example: Montreal
+    - name: geo.continent_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      default_field: false
     - name: geo.continent_name
       level: core
       type: keyword
@@ -4523,6 +4676,13 @@
 
         Not typically used in automated geolocation.'
       example: boston-dc
+    - name: geo.postal_code
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      default_field: false
     - name: geo.region_iso_code
       level: core
       type: keyword
@@ -4535,6 +4695,14 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
+    - name: geo.time_zone
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      default_field: false
     - name: ip
       level: core
       type: ip

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -257,7 +257,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -277,7 +278,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -713,7 +714,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -733,7 +735,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -2077,7 +2079,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: region_iso_code
@@ -2097,7 +2100,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
   - name: group
     title: Group
@@ -2245,7 +2248,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -2265,7 +2269,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
       level: core
@@ -3008,7 +3012,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -3028,7 +3033,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
       level: core
@@ -4315,7 +4320,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -4335,7 +4341,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core
@@ -4674,7 +4680,8 @@
       ignore_above: 1024
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       default_field: false
     - name: geo.region_iso_code
@@ -4694,7 +4701,7 @@
       type: keyword
       ignore_above: 1024
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
       level: core

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -277,7 +277,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -734,7 +734,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -2099,7 +2099,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
   - name: group
@@ -2268,7 +2268,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
@@ -3032,7 +3032,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: hostname
@@ -4340,7 +4340,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip
@@ -4700,7 +4700,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
     - name: ip

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -213,9 +213,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -257,8 +255,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -276,8 +276,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -670,9 +669,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -714,8 +711,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -733,8 +732,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -2035,9 +2033,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: continent_name
@@ -2079,8 +2075,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: region_iso_code
       level: core
@@ -2098,8 +2096,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
   - name: group
@@ -2204,9 +2201,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -2248,8 +2243,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -2267,8 +2264,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: hostname
@@ -2968,9 +2964,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -3012,8 +3006,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -3031,8 +3027,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: hostname
@@ -4276,9 +4271,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -4320,8 +4313,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -4339,8 +4334,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip
@@ -4636,9 +4630,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       default_field: false
     - name: geo.continent_name
@@ -4680,8 +4672,10 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       default_field: false
     - name: geo.region_iso_code
       level: core
@@ -4699,8 +4693,7 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       default_field: false
     - name: ip

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -272,7 +272,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -728,7 +728,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -2092,7 +2092,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: time_zone
+    - name: timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -2260,7 +2260,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -3023,7 +3023,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -4330,7 +4330,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024
@@ -4689,7 +4689,7 @@
       ignore_above: 1024
       description: Region name.
       example: Quebec
-    - name: geo.time_zone
+    - name: geo.timezone
       level: core
       type: keyword
       ignore_above: 1024

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -25,7 +25,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,client,client.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,client,client.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -80,7 +80,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,destination,destination.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,destination,destination.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -250,7 +250,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,host,host.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,host,host.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,host,host.hostname,keyword,core,,,Hostname of the host.
 2.0.0-dev,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -340,7 +340,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,observer,observer.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,observer,observer.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -495,7 +495,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,server,server.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,server,server.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -540,7 +540,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,source,source.geo.timezone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,source,source.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 2.0.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -16,13 +16,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 2.0.0-dev,true,client,client.domain,keyword,core,,,Client domain.
 2.0.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,client,client.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,client,client.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,client,client.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,client,client.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -68,13 +71,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 2.0.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
 2.0.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,destination,destination.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,destination,destination.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,destination,destination.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -235,13 +241,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.architecture,keyword,core,,x86_64,Operating system architecture.
 2.0.0-dev,true,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
 2.0.0-dev,true,host,host.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,host,host.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,host,host.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,host,host.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,host,host.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,host,host.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,host,host.hostname,keyword,core,,,Hostname of the host.
 2.0.0-dev,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -322,13 +331,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.egress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 2.0.0-dev,true,observer,observer.egress.zone,keyword,extended,,Public_Internet,Observer Egress zone
 2.0.0-dev,true,observer,observer.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,observer,observer.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,observer,observer.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,observer,observer.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,observer,observer.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -474,13 +486,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 2.0.0-dev,true,server,server.domain,keyword,core,,,Server domain.
 2.0.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,server,server.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,server,server.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,server,server.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,server,server.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -516,13 +531,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 2.0.0-dev,true,source,source.domain,keyword,core,,,Source domain.
 2.0.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
+2.0.0-dev,true,source,source.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
 2.0.0-dev,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,source,source.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,source,source.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,source,source.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
 2.0.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
+2.0.0-dev,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -16,13 +16,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 2.0.0-dev,true,client,client.domain,keyword,core,,,Client domain.
 2.0.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,client,client.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,client,client.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,client,client.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,client,client.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,client,client.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -71,13 +71,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 2.0.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
 2.0.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,destination,destination.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,destination,destination.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,destination,destination.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,destination,destination.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -241,13 +241,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.architecture,keyword,core,,x86_64,Operating system architecture.
 2.0.0-dev,true,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
 2.0.0-dev,true,host,host.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,host,host.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,host,host.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,host,host.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,host,host.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,host,host.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,host,host.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -331,13 +331,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.egress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 2.0.0-dev,true,observer,observer.egress.zone,keyword,extended,,Public_Internet,Observer Egress zone
 2.0.0-dev,true,observer,observer.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,observer,observer.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,observer,observer.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,observer,observer.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,observer,observer.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,observer,observer.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -486,13 +486,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 2.0.0-dev,true,server,server.domain,keyword,core,,,Server domain.
 2.0.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,server,server.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,server,server.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,server,server.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,server,server.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,server,server.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
@@ -531,13 +531,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 2.0.0-dev,true,source,source.domain,keyword,core,,,Source domain.
 2.0.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
-2.0.0-dev,true,source,source.geo.continent_code,keyword,core,,NA,Two-level code representing the continent.
+2.0.0-dev,true,source,source.geo.continent_code,keyword,core,,NA,Continent code.
 2.0.0-dev,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,source,source.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
 2.0.0-dev,true,source,source.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
-2.0.0-dev,true,source,source.geo.postal_code,keyword,core,,0,"Postal code. Also known as postcode, post code, or ZIP code."
+2.0.0-dev,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -25,7 +25,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,client,client.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,client,client.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
 2.0.0-dev,true,client,client.mac,keyword,core,,,MAC address of the client.
 2.0.0-dev,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
@@ -80,7 +80,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,destination,destination.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,destination,destination.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
 2.0.0-dev,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
 2.0.0-dev,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
@@ -250,7 +250,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,host,host.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,host,host.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,host,host.hostname,keyword,core,,,Hostname of the host.
 2.0.0-dev,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev,true,host,host.ip,ip,core,array,,Host ip addresses.
@@ -340,7 +340,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,observer,observer.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,observer,observer.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
 2.0.0-dev,true,observer,observer.ingress,object,extended,,,Object field for ingress information
 2.0.0-dev,true,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
@@ -495,7 +495,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,server,server.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,server,server.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,server,server.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
 2.0.0-dev,true,server,server.mac,keyword,core,,,MAC address of the server.
 2.0.0-dev,true,server,server.nat.ip,ip,extended,,,Server NAT ip
@@ -540,7 +540,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.geo.postal_code,keyword,core,,94040,Postal code.
 2.0.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,source,source.geo.time_zone,keyword,core,,America/Chicago,Time zone.
+2.0.0-dev,true,source,source.geo.timezone,keyword,core,,America/Chicago,Time zone.
 2.0.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
 2.0.0-dev,true,source,source.mac,keyword,core,,,MAC address of the source.
 2.0.0-dev,true,source,source.nat.ip,ip,extended,,,Source NAT ip

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -293,14 +293,14 @@ client.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-client.geo.time_zone:
-  dashed_name: client-geo-time-zone
+client.geo.timezone:
+  dashed_name: client-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: client.geo.time_zone
+  flat_name: client.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -942,14 +942,14 @@ destination.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-destination.geo.time_zone:
-  dashed_name: destination-geo-time-zone
+destination.geo.timezone:
+  dashed_name: destination-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: destination.geo.time_zone
+  flat_name: destination.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -3465,14 +3465,14 @@ host.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-host.geo.time_zone:
-  dashed_name: host-geo-time-zone
+host.geo.timezone:
+  dashed_name: host-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: host.geo.time_zone
+  flat_name: host.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -4611,14 +4611,14 @@ observer.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-observer.geo.time_zone:
-  dashed_name: observer-geo-time-zone
+observer.geo.timezone:
+  dashed_name: observer-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: observer.geo.time_zone
+  flat_name: observer.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -6418,14 +6418,14 @@ server.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-server.geo.time_zone:
-  dashed_name: server-geo-time-zone
+server.geo.timezone:
+  dashed_name: server-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: server.geo.time_zone
+  flat_name: server.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.
@@ -6982,14 +6982,14 @@ source.geo.region_name:
   original_fieldset: geo
   short: Region name.
   type: keyword
-source.geo.time_zone:
-  dashed_name: source-geo-time-zone
+source.geo.timezone:
+  dashed_name: source-geo-timezone
   description: The time zone of the location.
   example: America/Chicago
-  flat_name: source.geo.time_zone
+  flat_name: source.geo.timezone
   ignore_above: 1024
   level: core
-  name: time_zone
+  name: timezone
   normalize: []
   original_fieldset: geo
   short: Time zone.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -178,6 +178,20 @@ client.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+client.geo.continent_code:
+  dashed_name: client-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: client.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 client.geo.continent_name:
   dashed_name: client-geo-continent-name
   description: Name of the continent.
@@ -243,6 +257,18 @@ client.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+client.geo.postal_code:
+  dashed_name: client-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: client.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 client.geo.region_iso_code:
   dashed_name: client-geo-region-iso-code
   description: Region ISO code.
@@ -266,6 +292,19 @@ client.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+client.geo.time_zone:
+  dashed_name: client-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: client.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 client.ip:
   dashed_name: client-ip
@@ -789,6 +828,20 @@ destination.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+destination.geo.continent_code:
+  dashed_name: destination-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: destination.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 destination.geo.continent_name:
   dashed_name: destination-geo-continent-name
   description: Name of the continent.
@@ -854,6 +907,18 @@ destination.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+destination.geo.postal_code:
+  dashed_name: destination-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: destination.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 destination.geo.region_iso_code:
   dashed_name: destination-geo-region-iso-code
   description: Region ISO code.
@@ -877,6 +942,19 @@ destination.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+destination.geo.time_zone:
+  dashed_name: destination-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: destination.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 destination.ip:
   dashed_name: destination-ip
@@ -3274,6 +3352,20 @@ host.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+host.geo.continent_code:
+  dashed_name: host-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: host.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 host.geo.continent_name:
   dashed_name: host-geo-continent-name
   description: Name of the continent.
@@ -3339,6 +3431,18 @@ host.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+host.geo.postal_code:
+  dashed_name: host-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: host.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 host.geo.region_iso_code:
   dashed_name: host-geo-region-iso-code
   description: Region ISO code.
@@ -3362,6 +3466,19 @@ host.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+host.geo.time_zone:
+  dashed_name: host-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: host.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -4382,6 +4499,20 @@ observer.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+observer.geo.continent_code:
+  dashed_name: observer-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: observer.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 observer.geo.continent_name:
   dashed_name: observer-geo-continent-name
   description: Name of the continent.
@@ -4447,6 +4578,18 @@ observer.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+observer.geo.postal_code:
+  dashed_name: observer-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: observer.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 observer.geo.region_iso_code:
   dashed_name: observer-geo-region-iso-code
   description: Region ISO code.
@@ -4470,6 +4613,19 @@ observer.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+observer.geo.time_zone:
+  dashed_name: observer-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: observer.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 observer.hostname:
   dashed_name: observer-hostname
@@ -6151,6 +6307,20 @@ server.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+server.geo.continent_code:
+  dashed_name: server-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: server.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 server.geo.continent_name:
   dashed_name: server-geo-continent-name
   description: Name of the continent.
@@ -6216,6 +6386,18 @@ server.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+server.geo.postal_code:
+  dashed_name: server-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: server.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 server.geo.region_iso_code:
   dashed_name: server-geo-region-iso-code
   description: Region ISO code.
@@ -6239,6 +6421,19 @@ server.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+server.geo.time_zone:
+  dashed_name: server-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: server.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 server.ip:
   dashed_name: server-ip
@@ -6677,6 +6872,20 @@ source.geo.city_name:
   original_fieldset: geo
   short: City name.
   type: keyword
+source.geo.continent_code:
+  dashed_name: source-geo-continent-code
+  description: "Two-letter code representing the continent.\nPossible codes are:\n\
+    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
+    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  example: NA
+  flat_name: source.geo.continent_code
+  ignore_above: 1024
+  level: core
+  name: continent_code
+  normalize: []
+  original_fieldset: geo
+  short: Two-level code representing the continent.
+  type: keyword
 source.geo.continent_name:
   dashed_name: source-geo-continent-name
   description: Name of the continent.
@@ -6742,6 +6951,18 @@ source.geo.name:
   original_fieldset: geo
   short: User-defined description of a location.
   type: keyword
+source.geo.postal_code:
+  dashed_name: source-geo-postal-code
+  description: Postal code. Also known as postcode, post code, or ZIP code.
+  example: 0
+  flat_name: source.geo.postal_code
+  ignore_above: 1024
+  level: core
+  name: postal_code
+  normalize: []
+  original_fieldset: geo
+  short: Postal code. Also known as postcode, post code, or ZIP code.
+  type: keyword
 source.geo.region_iso_code:
   dashed_name: source-geo-region-iso-code
   description: Region ISO code.
@@ -6765,6 +6986,19 @@ source.geo.region_name:
   normalize: []
   original_fieldset: geo
   short: Region name.
+  type: keyword
+source.geo.time_zone:
+  dashed_name: source-geo-time-zone
+  description: The time zone associated with location, as specified by the IANA Time
+    Zone Database.
+  example: America/Chicago
+  flat_name: source.geo.time_zone
+  ignore_above: 1024
+  level: core
+  name: time_zone
+  normalize: []
+  original_fieldset: geo
+  short: Time zone.
   type: keyword
 source.ip:
   dashed_name: source-ip

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -180,9 +180,7 @@ client.geo.city_name:
   type: keyword
 client.geo.continent_code:
   dashed_name: client-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: client.geo.continent_code
   ignore_above: 1024
@@ -190,7 +188,7 @@ client.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 client.geo.continent_name:
   dashed_name: client-geo-continent-name
@@ -259,15 +257,17 @@ client.geo.name:
   type: keyword
 client.geo.postal_code:
   dashed_name: client-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: client.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 client.geo.region_iso_code:
   dashed_name: client-geo-region-iso-code
@@ -295,8 +295,7 @@ client.geo.region_name:
   type: keyword
 client.geo.time_zone:
   dashed_name: client-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: client.geo.time_zone
   ignore_above: 1024
@@ -830,9 +829,7 @@ destination.geo.city_name:
   type: keyword
 destination.geo.continent_code:
   dashed_name: destination-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: destination.geo.continent_code
   ignore_above: 1024
@@ -840,7 +837,7 @@ destination.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 destination.geo.continent_name:
   dashed_name: destination-geo-continent-name
@@ -909,15 +906,17 @@ destination.geo.name:
   type: keyword
 destination.geo.postal_code:
   dashed_name: destination-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: destination.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 destination.geo.region_iso_code:
   dashed_name: destination-geo-region-iso-code
@@ -945,8 +944,7 @@ destination.geo.region_name:
   type: keyword
 destination.geo.time_zone:
   dashed_name: destination-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: destination.geo.time_zone
   ignore_above: 1024
@@ -3354,9 +3352,7 @@ host.geo.city_name:
   type: keyword
 host.geo.continent_code:
   dashed_name: host-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: host.geo.continent_code
   ignore_above: 1024
@@ -3364,7 +3360,7 @@ host.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 host.geo.continent_name:
   dashed_name: host-geo-continent-name
@@ -3433,15 +3429,17 @@ host.geo.name:
   type: keyword
 host.geo.postal_code:
   dashed_name: host-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: host.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 host.geo.region_iso_code:
   dashed_name: host-geo-region-iso-code
@@ -3469,8 +3467,7 @@ host.geo.region_name:
   type: keyword
 host.geo.time_zone:
   dashed_name: host-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: host.geo.time_zone
   ignore_above: 1024
@@ -4501,9 +4498,7 @@ observer.geo.city_name:
   type: keyword
 observer.geo.continent_code:
   dashed_name: observer-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: observer.geo.continent_code
   ignore_above: 1024
@@ -4511,7 +4506,7 @@ observer.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 observer.geo.continent_name:
   dashed_name: observer-geo-continent-name
@@ -4580,15 +4575,17 @@ observer.geo.name:
   type: keyword
 observer.geo.postal_code:
   dashed_name: observer-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: observer.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 observer.geo.region_iso_code:
   dashed_name: observer-geo-region-iso-code
@@ -4616,8 +4613,7 @@ observer.geo.region_name:
   type: keyword
 observer.geo.time_zone:
   dashed_name: observer-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: observer.geo.time_zone
   ignore_above: 1024
@@ -6309,9 +6305,7 @@ server.geo.city_name:
   type: keyword
 server.geo.continent_code:
   dashed_name: server-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: server.geo.continent_code
   ignore_above: 1024
@@ -6319,7 +6313,7 @@ server.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 server.geo.continent_name:
   dashed_name: server-geo-continent-name
@@ -6388,15 +6382,17 @@ server.geo.name:
   type: keyword
 server.geo.postal_code:
   dashed_name: server-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: server.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 server.geo.region_iso_code:
   dashed_name: server-geo-region-iso-code
@@ -6424,8 +6420,7 @@ server.geo.region_name:
   type: keyword
 server.geo.time_zone:
   dashed_name: server-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: server.geo.time_zone
   ignore_above: 1024
@@ -6874,9 +6869,7 @@ source.geo.city_name:
   type: keyword
 source.geo.continent_code:
   dashed_name: source-geo-continent-code
-  description: "Two-letter code representing the continent.\nPossible codes are:\n\
-    \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  * NA\
-    \ - North America\n  * OC - Oceania\n  * SA - South America"
+  description: Two-letter code representing continent's name.
   example: NA
   flat_name: source.geo.continent_code
   ignore_above: 1024
@@ -6884,7 +6877,7 @@ source.geo.continent_code:
   name: continent_code
   normalize: []
   original_fieldset: geo
-  short: Two-level code representing the continent.
+  short: Continent code.
   type: keyword
 source.geo.continent_name:
   dashed_name: source-geo-continent-name
@@ -6953,15 +6946,17 @@ source.geo.name:
   type: keyword
 source.geo.postal_code:
   dashed_name: source-geo-postal-code
-  description: Postal code. Also known as postcode, post code, or ZIP code.
-  example: 0
+  description: 'Postal code associated with the location.
+
+    Values appropriate for this field may also be known as a postcode or ZIP code.'
+  example: 94040
   flat_name: source.geo.postal_code
   ignore_above: 1024
   level: core
   name: postal_code
   normalize: []
   original_fieldset: geo
-  short: Postal code. Also known as postcode, post code, or ZIP code.
+  short: Postal code.
   type: keyword
 source.geo.region_iso_code:
   dashed_name: source-geo-region-iso-code
@@ -6989,8 +6984,7 @@ source.geo.region_name:
   type: keyword
 source.geo.time_zone:
   dashed_name: source-geo-time-zone
-  description: The time zone associated with location, as specified by the IANA Time
-    Zone Database.
+  description: The time zone of the location.
   example: America/Chicago
   flat_name: source.geo.time_zone
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -259,7 +259,8 @@ client.geo.postal_code:
   dashed_name: client-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: client.geo.postal_code
   ignore_above: 1024
@@ -296,7 +297,7 @@ client.geo.region_name:
 client.geo.timezone:
   dashed_name: client-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: client.geo.timezone
   ignore_above: 1024
   level: core
@@ -908,7 +909,8 @@ destination.geo.postal_code:
   dashed_name: destination-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: destination.geo.postal_code
   ignore_above: 1024
@@ -945,7 +947,7 @@ destination.geo.region_name:
 destination.geo.timezone:
   dashed_name: destination-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: destination.geo.timezone
   ignore_above: 1024
   level: core
@@ -3431,7 +3433,8 @@ host.geo.postal_code:
   dashed_name: host-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: host.geo.postal_code
   ignore_above: 1024
@@ -3468,7 +3471,7 @@ host.geo.region_name:
 host.geo.timezone:
   dashed_name: host-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: host.geo.timezone
   ignore_above: 1024
   level: core
@@ -4577,7 +4580,8 @@ observer.geo.postal_code:
   dashed_name: observer-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: observer.geo.postal_code
   ignore_above: 1024
@@ -4614,7 +4618,7 @@ observer.geo.region_name:
 observer.geo.timezone:
   dashed_name: observer-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: observer.geo.timezone
   ignore_above: 1024
   level: core
@@ -6384,7 +6388,8 @@ server.geo.postal_code:
   dashed_name: server-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: server.geo.postal_code
   ignore_above: 1024
@@ -6421,7 +6426,7 @@ server.geo.region_name:
 server.geo.timezone:
   dashed_name: server-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: server.geo.timezone
   ignore_above: 1024
   level: core
@@ -6948,7 +6953,8 @@ source.geo.postal_code:
   dashed_name: source-geo-postal-code
   description: 'Postal code associated with the location.
 
-    Values appropriate for this field may also be known as a postcode or ZIP code.'
+    Values appropriate for this field may also be known as a postcode or ZIP code
+    and will vary widely from country to country.'
   example: 94040
   flat_name: source.geo.postal_code
   ignore_above: 1024
@@ -6985,7 +6991,7 @@ source.geo.region_name:
 source.geo.timezone:
   dashed_name: source-geo-timezone
   description: The time zone of the location.
-  example: America/Chicago
+  example: America/Argentina/Buenos_Aires
   flat_name: source.geo.timezone
   ignore_above: 1024
   level: core

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -296,7 +296,7 @@ client.geo.region_name:
   type: keyword
 client.geo.timezone:
   dashed_name: client-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: client.geo.timezone
   ignore_above: 1024
@@ -946,7 +946,7 @@ destination.geo.region_name:
   type: keyword
 destination.geo.timezone:
   dashed_name: destination-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: destination.geo.timezone
   ignore_above: 1024
@@ -3470,7 +3470,7 @@ host.geo.region_name:
   type: keyword
 host.geo.timezone:
   dashed_name: host-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: host.geo.timezone
   ignore_above: 1024
@@ -4617,7 +4617,7 @@ observer.geo.region_name:
   type: keyword
 observer.geo.timezone:
   dashed_name: observer-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: observer.geo.timezone
   ignore_above: 1024
@@ -6425,7 +6425,7 @@ server.geo.region_name:
   type: keyword
 server.geo.timezone:
   dashed_name: server-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: server.geo.timezone
   ignore_above: 1024
@@ -6990,7 +6990,7 @@ source.geo.region_name:
   type: keyword
 source.geo.timezone:
   dashed_name: source-geo-timezone
-  description: The time zone of the location.
+  description: The time zone of the location, such as IANA time zone name.
   example: America/Argentina/Buenos_Aires
   flat_name: source.geo.timezone
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -442,7 +442,7 @@ client:
       type: keyword
     client.geo.timezone:
       dashed_name: client-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: client.geo.timezone
       ignore_above: 1024
@@ -1234,7 +1234,7 @@ destination:
       type: keyword
     destination.geo.timezone:
       dashed_name: destination-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: destination.geo.timezone
       ignore_above: 1024
@@ -3858,7 +3858,7 @@ geo:
       type: keyword
     geo.timezone:
       dashed_name: geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: geo.timezone
       ignore_above: 1024
@@ -4185,7 +4185,7 @@ host:
       type: keyword
     host.geo.timezone:
       dashed_name: host-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: host.geo.timezone
       ignore_above: 1024
@@ -5450,7 +5450,7 @@ observer:
       type: keyword
     observer.geo.timezone:
       dashed_name: observer-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: observer.geo.timezone
       ignore_above: 1024
@@ -7634,7 +7634,7 @@ server:
       type: keyword
     server.geo.timezone:
       dashed_name: server-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: server.geo.timezone
       ignore_above: 1024
@@ -8243,7 +8243,7 @@ source:
       type: keyword
     source.geo.timezone:
       dashed_name: source-geo-timezone
-      description: The time zone of the location.
+      description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       flat_name: source.geo.timezone
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -439,14 +439,14 @@ client:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    client.geo.time_zone:
-      dashed_name: client-geo-time-zone
+    client.geo.timezone:
+      dashed_name: client-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: client.geo.time_zone
+      flat_name: client.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -1230,14 +1230,14 @@ destination:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    destination.geo.time_zone:
-      dashed_name: destination-geo-time-zone
+    destination.geo.timezone:
+      dashed_name: destination-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: destination.geo.time_zone
+      flat_name: destination.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -3853,14 +3853,14 @@ geo:
       normalize: []
       short: Region name.
       type: keyword
-    geo.time_zone:
-      dashed_name: geo-time-zone
+    geo.timezone:
+      dashed_name: geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: geo.time_zone
+      flat_name: geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       short: Time zone.
       type: keyword
@@ -4179,14 +4179,14 @@ host:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    host.geo.time_zone:
-      dashed_name: host-geo-time-zone
+    host.geo.timezone:
+      dashed_name: host-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: host.geo.time_zone
+      flat_name: host.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -5443,14 +5443,14 @@ observer:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    observer.geo.time_zone:
-      dashed_name: observer-geo-time-zone
+    observer.geo.timezone:
+      dashed_name: observer-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: observer.geo.time_zone
+      flat_name: observer.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -7626,14 +7626,14 @@ server:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    server.geo.time_zone:
-      dashed_name: server-geo-time-zone
+    server.geo.timezone:
+      dashed_name: server-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: server.geo.time_zone
+      flat_name: server.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.
@@ -8234,14 +8234,14 @@ source:
       original_fieldset: geo
       short: Region name.
       type: keyword
-    source.geo.time_zone:
-      dashed_name: source-geo-time-zone
+    source.geo.timezone:
+      dashed_name: source-geo-timezone
       description: The time zone of the location.
       example: America/Chicago
-      flat_name: source.geo.time_zone
+      flat_name: source.geo.timezone
       ignore_above: 1024
       level: core
-      name: time_zone
+      name: timezone
       normalize: []
       original_fieldset: geo
       short: Time zone.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -326,9 +326,7 @@ client:
       type: keyword
     client.geo.continent_code:
       dashed_name: client-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: client.geo.continent_code
       ignore_above: 1024
@@ -336,7 +334,7 @@ client:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     client.geo.continent_name:
       dashed_name: client-geo-continent-name
@@ -405,15 +403,17 @@ client:
       type: keyword
     client.geo.postal_code:
       dashed_name: client-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: client.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     client.geo.region_iso_code:
       dashed_name: client-geo-region-iso-code
@@ -441,8 +441,7 @@ client:
       type: keyword
     client.geo.time_zone:
       dashed_name: client-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: client.geo.time_zone
       ignore_above: 1024
@@ -1118,9 +1117,7 @@ destination:
       type: keyword
     destination.geo.continent_code:
       dashed_name: destination-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: destination.geo.continent_code
       ignore_above: 1024
@@ -1128,7 +1125,7 @@ destination:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     destination.geo.continent_name:
       dashed_name: destination-geo-continent-name
@@ -1197,15 +1194,17 @@ destination:
       type: keyword
     destination.geo.postal_code:
       dashed_name: destination-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: destination.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     destination.geo.region_iso_code:
       dashed_name: destination-geo-region-iso-code
@@ -1233,8 +1232,7 @@ destination:
       type: keyword
     destination.geo.time_zone:
       dashed_name: destination-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: destination.geo.time_zone
       ignore_above: 1024
@@ -3751,16 +3749,14 @@ geo:
       type: keyword
     geo.continent_code:
       dashed_name: geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: geo.continent_code
       ignore_above: 1024
       level: core
       name: continent_code
       normalize: []
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     geo.continent_name:
       dashed_name: geo-continent-name
@@ -3824,14 +3820,16 @@ geo:
       type: keyword
     geo.postal_code:
       dashed_name: geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     geo.region_iso_code:
       dashed_name: geo-region-iso-code
@@ -3857,8 +3855,7 @@ geo:
       type: keyword
     geo.time_zone:
       dashed_name: geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: geo.time_zone
       ignore_above: 1024
@@ -4069,9 +4066,7 @@ host:
       type: keyword
     host.geo.continent_code:
       dashed_name: host-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: host.geo.continent_code
       ignore_above: 1024
@@ -4079,7 +4074,7 @@ host:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     host.geo.continent_name:
       dashed_name: host-geo-continent-name
@@ -4148,15 +4143,17 @@ host:
       type: keyword
     host.geo.postal_code:
       dashed_name: host-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: host.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     host.geo.region_iso_code:
       dashed_name: host-geo-region-iso-code
@@ -4184,8 +4181,7 @@ host:
       type: keyword
     host.geo.time_zone:
       dashed_name: host-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: host.geo.time_zone
       ignore_above: 1024
@@ -5334,9 +5330,7 @@ observer:
       type: keyword
     observer.geo.continent_code:
       dashed_name: observer-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: observer.geo.continent_code
       ignore_above: 1024
@@ -5344,7 +5338,7 @@ observer:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     observer.geo.continent_name:
       dashed_name: observer-geo-continent-name
@@ -5413,15 +5407,17 @@ observer:
       type: keyword
     observer.geo.postal_code:
       dashed_name: observer-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: observer.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     observer.geo.region_iso_code:
       dashed_name: observer-geo-region-iso-code
@@ -5449,8 +5445,7 @@ observer:
       type: keyword
     observer.geo.time_zone:
       dashed_name: observer-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: observer.geo.time_zone
       ignore_above: 1024
@@ -7518,9 +7513,7 @@ server:
       type: keyword
     server.geo.continent_code:
       dashed_name: server-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: server.geo.continent_code
       ignore_above: 1024
@@ -7528,7 +7521,7 @@ server:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     server.geo.continent_name:
       dashed_name: server-geo-continent-name
@@ -7597,15 +7590,17 @@ server:
       type: keyword
     server.geo.postal_code:
       dashed_name: server-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: server.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     server.geo.region_iso_code:
       dashed_name: server-geo-region-iso-code
@@ -7633,8 +7628,7 @@ server:
       type: keyword
     server.geo.time_zone:
       dashed_name: server-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: server.geo.time_zone
       ignore_above: 1024
@@ -8127,9 +8121,7 @@ source:
       type: keyword
     source.geo.continent_code:
       dashed_name: source-geo-continent-code
-      description: "Two-letter code representing the continent.\nPossible codes are:\n\
-        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
-        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      description: Two-letter code representing continent's name.
       example: NA
       flat_name: source.geo.continent_code
       ignore_above: 1024
@@ -8137,7 +8129,7 @@ source:
       name: continent_code
       normalize: []
       original_fieldset: geo
-      short: Two-level code representing the continent.
+      short: Continent code.
       type: keyword
     source.geo.continent_name:
       dashed_name: source-geo-continent-name
@@ -8206,15 +8198,17 @@ source:
       type: keyword
     source.geo.postal_code:
       dashed_name: source-geo-postal-code
-      description: Postal code. Also known as postcode, post code, or ZIP code.
-      example: 0
+      description: 'Postal code associated with the location.
+
+        Values appropriate for this field may also be known as a postcode or ZIP code.'
+      example: 94040
       flat_name: source.geo.postal_code
       ignore_above: 1024
       level: core
       name: postal_code
       normalize: []
       original_fieldset: geo
-      short: Postal code. Also known as postcode, post code, or ZIP code.
+      short: Postal code.
       type: keyword
     source.geo.region_iso_code:
       dashed_name: source-geo-region-iso-code
@@ -8242,8 +8236,7 @@ source:
       type: keyword
     source.geo.time_zone:
       dashed_name: source-geo-time-zone
-      description: The time zone associated with location, as specified by the IANA
-        Time Zone Database.
+      description: The time zone of the location.
       example: America/Chicago
       flat_name: source.geo.time_zone
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -324,6 +324,20 @@ client:
       original_fieldset: geo
       short: City name.
       type: keyword
+    client.geo.continent_code:
+      dashed_name: client-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: client.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     client.geo.continent_name:
       dashed_name: client-geo-continent-name
       description: Name of the continent.
@@ -389,6 +403,18 @@ client:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    client.geo.postal_code:
+      dashed_name: client-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: client.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     client.geo.region_iso_code:
       dashed_name: client-geo-region-iso-code
       description: Region ISO code.
@@ -412,6 +438,19 @@ client:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    client.geo.time_zone:
+      dashed_name: client-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: client.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     client.ip:
       dashed_name: client-ip
@@ -1077,6 +1116,20 @@ destination:
       original_fieldset: geo
       short: City name.
       type: keyword
+    destination.geo.continent_code:
+      dashed_name: destination-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: destination.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     destination.geo.continent_name:
       dashed_name: destination-geo-continent-name
       description: Name of the continent.
@@ -1142,6 +1195,18 @@ destination:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    destination.geo.postal_code:
+      dashed_name: destination-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: destination.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     destination.geo.region_iso_code:
       dashed_name: destination-geo-region-iso-code
       description: Region ISO code.
@@ -1165,6 +1230,19 @@ destination:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    destination.geo.time_zone:
+      dashed_name: destination-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: destination.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     destination.ip:
       dashed_name: destination-ip
@@ -3671,6 +3749,19 @@ geo:
       normalize: []
       short: City name.
       type: keyword
+    geo.continent_code:
+      dashed_name: geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      short: Two-level code representing the continent.
+      type: keyword
     geo.continent_name:
       dashed_name: geo-continent-name
       description: Name of the continent.
@@ -3731,6 +3822,17 @@ geo:
       normalize: []
       short: User-defined description of a location.
       type: keyword
+    geo.postal_code:
+      dashed_name: geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     geo.region_iso_code:
       dashed_name: geo-region-iso-code
       description: Region ISO code.
@@ -3752,6 +3854,18 @@ geo:
       name: region_name
       normalize: []
       short: Region name.
+      type: keyword
+    geo.time_zone:
+      dashed_name: geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      short: Time zone.
       type: keyword
   group: 2
   name: geo
@@ -3953,6 +4067,20 @@ host:
       original_fieldset: geo
       short: City name.
       type: keyword
+    host.geo.continent_code:
+      dashed_name: host-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: host.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     host.geo.continent_name:
       dashed_name: host-geo-continent-name
       description: Name of the continent.
@@ -4018,6 +4146,18 @@ host:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    host.geo.postal_code:
+      dashed_name: host-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: host.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     host.geo.region_iso_code:
       dashed_name: host-geo-region-iso-code
       description: Region ISO code.
@@ -4041,6 +4181,19 @@ host:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    host.geo.time_zone:
+      dashed_name: host-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: host.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     host.hostname:
       dashed_name: host-hostname
@@ -5179,6 +5332,20 @@ observer:
       original_fieldset: geo
       short: City name.
       type: keyword
+    observer.geo.continent_code:
+      dashed_name: observer-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: observer.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     observer.geo.continent_name:
       dashed_name: observer-geo-continent-name
       description: Name of the continent.
@@ -5244,6 +5411,18 @@ observer:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    observer.geo.postal_code:
+      dashed_name: observer-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: observer.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     observer.geo.region_iso_code:
       dashed_name: observer-geo-region-iso-code
       description: Region ISO code.
@@ -5267,6 +5446,19 @@ observer:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    observer.geo.time_zone:
+      dashed_name: observer-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: observer.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     observer.hostname:
       dashed_name: observer-hostname
@@ -7324,6 +7516,20 @@ server:
       original_fieldset: geo
       short: City name.
       type: keyword
+    server.geo.continent_code:
+      dashed_name: server-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: server.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     server.geo.continent_name:
       dashed_name: server-geo-continent-name
       description: Name of the continent.
@@ -7389,6 +7595,18 @@ server:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    server.geo.postal_code:
+      dashed_name: server-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: server.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     server.geo.region_iso_code:
       dashed_name: server-geo-region-iso-code
       description: Region ISO code.
@@ -7412,6 +7630,19 @@ server:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    server.geo.time_zone:
+      dashed_name: server-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: server.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     server.ip:
       dashed_name: server-ip
@@ -7894,6 +8125,20 @@ source:
       original_fieldset: geo
       short: City name.
       type: keyword
+    source.geo.continent_code:
+      dashed_name: source-geo-continent-code
+      description: "Two-letter code representing the continent.\nPossible codes are:\n\
+        \  * AF - Africa\n  * AN - Antarctica\n  * AS - Asia\n  * EU - Europe\n  *\
+        \ NA - North America\n  * OC - Oceania\n  * SA - South America"
+      example: NA
+      flat_name: source.geo.continent_code
+      ignore_above: 1024
+      level: core
+      name: continent_code
+      normalize: []
+      original_fieldset: geo
+      short: Two-level code representing the continent.
+      type: keyword
     source.geo.continent_name:
       dashed_name: source-geo-continent-name
       description: Name of the continent.
@@ -7959,6 +8204,18 @@ source:
       original_fieldset: geo
       short: User-defined description of a location.
       type: keyword
+    source.geo.postal_code:
+      dashed_name: source-geo-postal-code
+      description: Postal code. Also known as postcode, post code, or ZIP code.
+      example: 0
+      flat_name: source.geo.postal_code
+      ignore_above: 1024
+      level: core
+      name: postal_code
+      normalize: []
+      original_fieldset: geo
+      short: Postal code. Also known as postcode, post code, or ZIP code.
+      type: keyword
     source.geo.region_iso_code:
       dashed_name: source-geo-region-iso-code
       description: Region ISO code.
@@ -7982,6 +8239,19 @@ source:
       normalize: []
       original_fieldset: geo
       short: Region name.
+      type: keyword
+    source.geo.time_zone:
+      dashed_name: source-geo-time-zone
+      description: The time zone associated with location, as specified by the IANA
+        Time Zone Database.
+      example: America/Chicago
+      flat_name: source.geo.time_zone
+      ignore_above: 1024
+      level: core
+      name: time_zone
+      normalize: []
+      original_fieldset: geo
+      short: Time zone.
       type: keyword
     source.ip:
       dashed_name: source-ip

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -405,7 +405,8 @@ client:
       dashed_name: client-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: client.geo.postal_code
       ignore_above: 1024
@@ -442,7 +443,7 @@ client:
     client.geo.timezone:
       dashed_name: client-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: client.geo.timezone
       ignore_above: 1024
       level: core
@@ -1196,7 +1197,8 @@ destination:
       dashed_name: destination-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: destination.geo.postal_code
       ignore_above: 1024
@@ -1233,7 +1235,7 @@ destination:
     destination.geo.timezone:
       dashed_name: destination-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: destination.geo.timezone
       ignore_above: 1024
       level: core
@@ -3822,7 +3824,8 @@ geo:
       dashed_name: geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: geo.postal_code
       ignore_above: 1024
@@ -3856,7 +3859,7 @@ geo:
     geo.timezone:
       dashed_name: geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: geo.timezone
       ignore_above: 1024
       level: core
@@ -4145,7 +4148,8 @@ host:
       dashed_name: host-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: host.geo.postal_code
       ignore_above: 1024
@@ -4182,7 +4186,7 @@ host:
     host.geo.timezone:
       dashed_name: host-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: host.geo.timezone
       ignore_above: 1024
       level: core
@@ -5409,7 +5413,8 @@ observer:
       dashed_name: observer-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: observer.geo.postal_code
       ignore_above: 1024
@@ -5446,7 +5451,7 @@ observer:
     observer.geo.timezone:
       dashed_name: observer-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: observer.geo.timezone
       ignore_above: 1024
       level: core
@@ -7592,7 +7597,8 @@ server:
       dashed_name: server-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: server.geo.postal_code
       ignore_above: 1024
@@ -7629,7 +7635,7 @@ server:
     server.geo.timezone:
       dashed_name: server-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: server.geo.timezone
       ignore_above: 1024
       level: core
@@ -8200,7 +8206,8 @@ source:
       dashed_name: source-geo-postal-code
       description: 'Postal code associated with the location.
 
-        Values appropriate for this field may also be known as a postcode or ZIP code.'
+        Values appropriate for this field may also be known as a postcode or ZIP code
+        and will vary widely from country to country.'
       example: 94040
       flat_name: source.geo.postal_code
       ignore_above: 1024
@@ -8237,7 +8244,7 @@ source:
     source.geo.timezone:
       dashed_name: source-geo-timezone
       description: The time zone of the location.
-      example: America/Chicago
+      example: America/Argentina/Buenos_Aires
       flat_name: source.geo.timezone
       ignore_above: 1024
       level: core

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -95,6 +95,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -114,11 +118,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -360,6 +372,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -379,11 +395,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1101,6 +1125,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -1120,11 +1148,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1542,6 +1578,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -1561,11 +1601,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -2242,6 +2290,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -2261,11 +2313,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -2444,6 +2504,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -2463,11 +2527,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -130,7 +130,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -407,7 +407,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1160,7 +1160,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -1613,7 +1613,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -2325,7 +2325,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }
@@ -2539,7 +2539,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -129,7 +129,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -406,7 +406,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1159,7 +1159,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1612,7 +1612,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2324,7 +2324,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2538,7 +2538,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "time_zone": {
+              "timezone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -94,6 +94,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -113,11 +117,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -359,6 +371,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -378,11 +394,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1100,6 +1124,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1119,11 +1147,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -1541,6 +1577,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1560,11 +1600,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2241,6 +2289,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2260,11 +2312,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -2443,6 +2503,10 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "continent_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "continent_name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2462,11 +2526,19 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "postal_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "region_iso_code": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "time_zone": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -81,7 +81,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -46,6 +46,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -65,11 +69,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -81,7 +81,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -46,6 +46,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -65,11 +69,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -22,6 +22,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -41,11 +45,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -57,7 +57,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -51,6 +51,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -70,11 +74,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -86,7 +86,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -81,7 +81,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -46,6 +46,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -65,11 +69,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -81,7 +81,7 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "time_zone": {
+                "timezone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -46,6 +46,10 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "continent_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "continent_name": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -65,11 +69,19 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "postal_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "region_iso_code": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "time_zone": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -94,7 +94,7 @@
       type: keyword
       short: Time zone.
       description: >
-        The time zone of the location.
+        The time zone of the location, such as IANA time zone name.
       example: "America/Argentina/Buenos_Aires"
 
     - name: name

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -27,6 +27,23 @@
         Longitude and latitude.
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
 
+    - name: continent_code
+      level: core
+      type: keyword
+      short: Two-level code representing the continent.
+      description: >
+        Two-letter code representing the continent.
+
+        Possible codes are:
+          * AF - Africa
+          * AN - Antarctica
+          * AS - Asia
+          * EU - Europe
+          * NA - North America
+          * OC - Oceania
+          * SA - South America
+      example: NA
+
     - name: continent_name
       level: core
       type: keyword
@@ -62,12 +79,29 @@
         Country ISO code.
       example: CA
 
+    - name: postal_code
+      level: core
+      type: keyword
+      example: Postal code.
+      description: >
+         Postal code. Also known as postcode, post code, or ZIP code.
+      example: 00000
+
     - name: region_iso_code
       level: core
       type: keyword
       description: >
         Region ISO code.
       example: CA-QC
+
+    - name: time_zone
+      level: core
+      type: keyword
+      short: Time zone.
+      description: >
+        The time zone associated with location, as specified by the
+        IANA Time Zone Database.
+      example: "America/Chicago"
 
     - name: name
       level: extended

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -78,7 +78,8 @@
          Postal code associated with the location.
 
          Values appropriate for this field may also be known
-         as a postcode or ZIP code.
+         as a postcode or ZIP code and will vary widely from
+         country to country.
       example: 94040
 
     - name: region_iso_code
@@ -94,7 +95,7 @@
       short: Time zone.
       description: >
         The time zone of the location.
-      example: "America/Chicago"
+      example: "America/Argentina/Buenos_Aires"
 
     - name: name
       level: extended

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -88,7 +88,7 @@
         Region ISO code.
       example: CA-QC
 
-    - name: time_zone
+    - name: timezone
       level: core
       type: keyword
       short: Time zone.

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -30,18 +30,9 @@
     - name: continent_code
       level: core
       type: keyword
-      short: Two-level code representing the continent.
+      short: Continent code.
       description: >
-        Two-letter code representing the continent.
-
-        Possible codes are:
-          * AF - Africa
-          * AN - Antarctica
-          * AS - Asia
-          * EU - Europe
-          * NA - North America
-          * OC - Oceania
-          * SA - South America
+        Two-letter code representing continent's name.
       example: NA
 
     - name: continent_name
@@ -82,10 +73,13 @@
     - name: postal_code
       level: core
       type: keyword
-      example: Postal code.
+      short: Postal code.
       description: >
-         Postal code. Also known as postcode, post code, or ZIP code.
-      example: 00000
+         Postal code associated with the location.
+
+         Values appropriate for this field may also be known
+         as a postcode or ZIP code.
+      example: 94040
 
     - name: region_iso_code
       level: core
@@ -99,8 +93,7 @@
       type: keyword
       short: Time zone.
       description: >
-        The time zone associated with location, as specified by the
-        IANA Time Zone Database.
+        The time zone of the location.
       example: "America/Chicago"
 
     - name: name


### PR DESCRIPTION
### Summary

Add three new fields to the ECS `geo.*` fieldset:

* `geo.timezone`
* `geo.postal_code`
* `geo.continent_code`

### Motivation

These fields will allow for additional geolocation context on events. Like the other `geo.*` fields, these values can be populated by automatically by GeoIP enrichment or manually by the user.

### Other Considerations

* I originally chose `time_zone` over `timezone`. However, reviewing existing geoip implementations ([[0](https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html)], [[1](https://github.com/logstash-plugins/logstash-filter-geoip/blob/master/src/main/java/org/logstash/filters/Fields.java)]), opted for `timezone`.

* Considered explicitly listing the seven two-letter continent codes in the description as used by other sources. However, despite other sources referencing [ISO-3166-1](https://en.wikipedia.org/wiki/ISO_3166-1) or [UN M.49](https://unstats.un.org/unsd/methodology/m49/), I couldn't find a definitive, available standard confirming the seven two-letter continent codes as an official standard. Any opinions or feedback one way or the other?

Closes #1217 