### PR TITLE
Add binary file content fields

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2406,6 +2406,28 @@ example: `["readonly", "system"]`
 // ===============================================================
 
 |
+[[field-file-content]]
+<<field-file-content, file.content>>
+
+| Content of the file, base64 encoded
+
+type: binary
+
+Multi-fields:
+
+* file.content.text (type: text)
+
+
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-file-created]]
 <<field-file-created, file.created>>
 
@@ -3394,6 +3416,9 @@ Multi-fields:
 * http.request.body.content.text (type: text)
 
 
+* http.request.body.content.raw (type: binary)
+
+
 
 
 
@@ -3524,6 +3549,9 @@ type: wildcard
 Multi-fields:
 
 * http.response.body.content.text (type: text)
+
+
+* http.response.body.content.raw (type: binary)
 
 
 

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1560,6 +1560,15 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: content
+      level: extended
+      type: binary
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Content of the file, base64 encoded
+      default_field: false
     - name: created
       level: extended
       type: date
@@ -2341,6 +2350,9 @@
         type: text
         norms: false
         default_field: false
+      - name: raw
+        type: binary
+        default_field: false
       description: The full HTTP request body.
       example: Hello world
     - name: request.bytes
@@ -2404,6 +2416,9 @@
       - name: text
         type: text
         norms: false
+        default_field: false
+      - name: raw
+        type: binary
         default_field: false
       description: The full HTTP response body.
       example: Hello world

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -172,6 +172,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 2.0.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 2.0.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+2.0.0-dev,true,file,file.content,binary,extended,,,"Content of the file, base64 encoded"
+2.0.0-dev,true,file,file.content.text,text,extended,,,"Content of the file, base64 encoded"
 2.0.0-dev,true,file,file.created,date,extended,,,File creation time.
 2.0.0-dev,true,file,file.ctime,date,extended,,,Last time the file attributes or metadata changed.
 2.0.0-dev,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
@@ -273,6 +275,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 2.0.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+2.0.0-dev,true,http,http.request.body.content.raw,binary,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 2.0.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 2.0.0-dev,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
@@ -281,6 +284,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
 2.0.0-dev,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
 2.0.0-dev,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+2.0.0-dev,true,http,http.response.body.content.raw,binary,extended,,Hello world,The full HTTP response body.
 2.0.0-dev,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 2.0.0-dev,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 2.0.0-dev,true,http,http.response.status_code,long,extended,,404,HTTP response status code.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2546,6 +2546,27 @@ file.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+file.content:
+  dashed_name: file-content
+  description: Content of the file, base64 encoded
+  flat_name: file.content
+  level: extended
+  multi_fields:
+  - description: 'Content of the file, unencoded.
+
+      This field should only be used when the content of the file represent human-readable
+      data. Binary encoded formats should use `content` instead.
+
+      '
+    flat_name: file.content.text
+    name: text
+    norms: false
+    short: Content of the file, unencoded.
+    type: text
+  name: content
+  normalize: []
+  short: Content of the file, base64 encoded
+  type: binary
 file.created:
   dashed_name: file-created
   description: 'File creation time.
@@ -3734,6 +3755,9 @@ http.request.body.content:
     name: text
     norms: false
     type: text
+  - flat_name: http.request.body.content.raw
+    name: raw
+    type: binary
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
@@ -3833,6 +3857,9 @@ http.response.body.content:
     name: text
     norms: false
     type: text
+  - flat_name: http.response.body.content.raw
+    name: raw
+    type: binary
   name: response.body.content
   normalize: []
   short: The full HTTP response body.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2971,6 +2971,27 @@ file:
       short: Boolean to capture if the digital signature is verified against the binary
         content.
       type: boolean
+    file.content:
+      dashed_name: file-content
+      description: Content of the file, base64 encoded
+      flat_name: file.content
+      level: extended
+      multi_fields:
+      - description: 'Content of the file, unencoded.
+
+          This field should only be used when the content of the file represent human-readable
+          data. Binary encoded formats should use `content` instead.
+
+          '
+        flat_name: file.content.text
+        name: text
+        norms: false
+        short: Content of the file, unencoded.
+        type: text
+      name: content
+      normalize: []
+      short: Content of the file, base64 encoded
+      type: binary
     file.created:
       dashed_name: file-created
       description: 'File creation time.
@@ -4442,6 +4463,9 @@ http:
         name: text
         norms: false
         type: text
+      - flat_name: http.request.body.content.raw
+        name: raw
+        type: binary
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
@@ -4543,6 +4567,9 @@ http:
         name: text
         norms: false
         type: text
+      - flat_name: http.response.body.content.raw
+        name: raw
+        type: binary
       name: response.body.content
       normalize: []
       short: The full HTTP response body.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -821,6 +821,15 @@
                 }
               }
             },
+            "content": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "type": "binary"
+            },
             "created": {
               "type": "date"
             },
@@ -1273,6 +1282,9 @@
                     },
                     "content": {
                       "fields": {
+                        "raw": {
+                          "type": "binary"
+                        },
                         "text": {
                           "norms": false,
                           "type": "text"
@@ -1313,6 +1325,9 @@
                     },
                     "content": {
                       "fields": {
+                        "raw": {
+                          "type": "binary"
+                        },
                         "text": {
                           "norms": false,
                           "type": "text"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -798,6 +798,15 @@
               }
             }
           },
+          "content": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "type": "binary"
+          },
           "created": {
             "type": "date"
           },
@@ -1237,6 +1246,9 @@
                   },
                   "content": {
                     "fields": {
+                      "raw": {
+                        "type": "binary"
+                      },
                       "text": {
                         "norms": false,
                         "type": "text"
@@ -1275,6 +1287,9 @@
                   },
                   "content": {
                     "fields": {
+                      "raw": {
+                        "type": "binary"
+                      },
                       "text": {
                         "norms": false,
                         "type": "text"

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -36,6 +36,15 @@
                 }
               }
             },
+            "content": {
+              "fields": {
+                "text": {
+                  "norms": false,
+                  "type": "text"
+                }
+              },
+              "type": "binary"
+            },
             "created": {
               "type": "date"
             },

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -17,6 +17,9 @@
                     },
                     "content": {
                       "fields": {
+                        "raw": {
+                          "type": "binary"
+                        },
                         "text": {
                           "norms": false,
                           "type": "text"
@@ -55,6 +58,9 @@
                     },
                     "content": {
                       "fields": {
+                        "raw": {
+                          "type": "binary"
+                        },
                         "text": {
                           "norms": false,
                           "type": "text"

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -187,3 +187,17 @@
         https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types],
         where possible. When more than one type is applicable, the most specific
         type should be used.
+
+    - name: content
+      level: extended
+      type: binary
+      description: Content of the file, base64 encoded
+      multi_fields:
+      - type: text
+        name: text
+        short: Content of the file, unencoded.
+        description: >
+          Content of the file, unencoded.
+
+          This field should only be used when the content of the file represent human-readable
+          data. Binary encoded formats should use `content` instead.

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -63,6 +63,8 @@
       multi_fields:
       - type: text
         name: text
+      - type: binary
+        name: raw
 
     - name: request.referrer
       level: extended
@@ -104,7 +106,9 @@
       multi_fields:
       - type: text
         name: text
-
+      - type: binary
+        name: raw
+        
     - name: version
       level: extended
       type: keyword


### PR DESCRIPTION
This PR aims to fill in a couple of gaps in ECS around binary file content.

1. Currently the `http.*.body.content` fields are `keyword` with a `text` multi-field. Neither makes sense if you have a binary chunk of data that you want to include in a document. To address this I'm proposing adding a `binary`-type multi-field called `raw` to the `content` fields.
2. Ideally we'd have the same sort of ability to return file samples in a `content` field. In the Endgame product for example, you had the ability to download and analyze malware samples that might have triggered an alert on a monitored system. Having a `file.content` field to contain such information would standardize this.

The only somewhat different thing between the added fields is that for the `http` fields, the `binary` field is added as a multi-field, presumably because you're often going to have response bodys that you may be interested in sending generally in html format or something of the sort. In the case of `file` content, you could really be working with pretty much anything, so rather than add a `binary` multi-field, the `binary` field is primary and there's an additional `text` field that can be used for non-binary data added as a multi-field.