### PR TITLE
Revert wildcard adoption back to experimental stage

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -45,7 +45,6 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Event categorization fields GA. #1067
-* `wildcard` field type adoption. #1098
 * Note `[` and `]` bracket characters may enclose a literal IPv6 address when populating `url.domain`. #1131
 * Reinforce the exclusion of the leading dot from `url.extension`. #1151
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5100,13 +5100,11 @@ example: `4`
 [[field-process-command-line]]
 <<field-process-command-line, process.command_line>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Full command line that started the process, including the absolute path to the executable, and all arguments.
+| Full command line that started the process, including the absolute path to the executable, and all arguments.
 
 Some arguments may be filtered to protect sensitive information.
 
-type: wildcard
+type: keyword
 
 Multi-fields:
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -115,13 +115,11 @@ Examples include Beats. Agents may also run on observers. ECS agent.* fields sha
 [[field-agent-build-original]]
 <<field-agent-build-original, agent.build.original>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Extended build information for the agent.
+| Extended build information for the agent.
 
 This field is intended to contain any build information that a data source may provide, no specific formatting is required.
 
-type: wildcard
+type: keyword
 
 
 
@@ -257,11 +255,9 @@ example: `15169`
 [[field-as-organization-name]]
 <<field-as-organization-name, as.organization.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Organization name.
 
-Organization name.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -345,11 +341,9 @@ example: `184`
 [[field-client-domain]]
 <<field-client-domain, client.domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Client domain.
 
-Client domain.
-
-type: wildcard
+type: keyword
 
 
 
@@ -463,15 +457,13 @@ type: long
 [[field-client-registered-domain]]
 <<field-client-registered-domain, client.registered_domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The highest registered client domain, stripped of the subdomain.
+| The highest registered client domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
-type: wildcard
+type: keyword
 
 
 
@@ -1041,11 +1033,9 @@ example: `184`
 [[field-destination-domain]]
 <<field-destination-domain, destination.domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Destination domain.
 
-Destination domain.
-
-type: wildcard
+type: keyword
 
 
 
@@ -1159,15 +1149,13 @@ type: long
 [[field-destination-registered-domain]]
 <<field-destination-registered-domain, destination.registered_domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The highest registered destination domain, stripped of the subdomain.
+| The highest registered destination domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
-type: wildcard
+type: keyword
 
 
 
@@ -1408,13 +1396,11 @@ example: `IN`
 [[field-dns-answers-data]]
 <<field-dns-answers-data, dns.answers.data>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The data describing the resource.
+| The data describing the resource.
 
 The meaning of this data depends on the type and class of the resource record.
 
-type: wildcard
+type: keyword
 
 
 
@@ -1547,13 +1533,11 @@ example: `IN`
 [[field-dns-question-name]]
 <<field-dns-question-name, dns.question.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The name being queried.
+| The name being queried.
 
 If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively.
 
-type: wildcard
+type: keyword
 
 
 
@@ -1796,11 +1780,9 @@ type: text
 [[field-error-stack-trace]]
 <<field-error-stack-trace, error.stack_trace>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The stack trace of this error in plain text.
 
-The stack trace of this error in plain text.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -1820,11 +1802,9 @@ Multi-fields:
 [[field-error-type]]
 <<field-error-type, error.type>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The type of the error, for example the class name of the exception.
 
-The type of the error, for example the class name of the exception.
-
-type: wildcard
+type: keyword
 
 
 
@@ -2461,11 +2441,9 @@ example: `sda`
 [[field-file-directory]]
 <<field-file-directory, file.directory>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Directory where the file is located. It should include the drive letter, when appropriate.
 
-Directory where the file is located. It should include the drive letter, when appropriate.
-
-type: wildcard
+type: keyword
 
 
 
@@ -2643,11 +2621,9 @@ example: `alice`
 [[field-file-path]]
 <<field-file-path, file.path>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Full path to the file, including the file name. It should include the drive letter, when appropriate.
 
-Full path to the file, including the file name. It should include the drive letter, when appropriate.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -2685,11 +2661,9 @@ example: `16384`
 [[field-file-target-path]]
 <<field-file-target-path, file.target_path>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Target path for symlinks.
 
-Target path for symlinks.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -2882,15 +2856,13 @@ example: `{ "lon": -73.614830, "lat": 45.505918 }`
 [[field-geo-name]]
 <<field-geo-name, geo.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-User-defined description of a location, at the level of granularity they care about.
+| User-defined description of a location, at the level of granularity they care about.
 
 Could be the name of their data centers, the floor number, if this describes a local physical entity, city names.
 
 Not typically used in automated geolocation.
 
-type: wildcard
+type: keyword
 
 
 
@@ -3184,13 +3156,11 @@ example: `CONTOSO`
 [[field-host-hostname]]
 <<field-host-hostname, host.hostname>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Hostname of the host.
+| Hostname of the host.
 
 It normally contains what the `hostname` command returns on the host machine.
 
-type: wildcard
+type: keyword
 
 
 
@@ -3383,11 +3353,9 @@ example: `887`
 [[field-http-request-body-content]]
 <<field-http-request-body-content, http.request.body.content>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The full HTTP request body.
 
-The full HTTP request body.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -3481,11 +3449,9 @@ example: `image/gif`
 [[field-http-request-referrer]]
 <<field-http-request-referrer, http.request.referrer>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Referrer for this HTTP request.
 
-Referrer for this HTTP request.
-
-type: wildcard
+type: keyword
 
 
 
@@ -3515,11 +3481,9 @@ example: `887`
 [[field-http-response-body-content]]
 <<field-http-response-body-content, http.response.body.content>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The full HTTP response body.
 
-The full HTTP response body.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -3699,13 +3663,11 @@ The details specific to your event source are typically not logged under `log.*`
 [[field-log-file-path]]
 <<field-log-file-path, log.file.path>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.
+| Full path to the log file this event came from, including the file name. It should include the drive letter, when appropriate.
 
 If the event wasn't read from a log file, do not populate this field.
 
-type: wildcard
+type: keyword
 
 
 
@@ -3739,11 +3701,9 @@ example: `error`
 [[field-log-logger]]
 <<field-log-logger, log.logger>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.
 
-The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.
-
-type: wildcard
+type: keyword
 
 
 
@@ -4537,11 +4497,9 @@ type: keyword
 [[field-organization-name]]
 <<field-organization-name, organization.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Organization name.
 
-Organization name.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -4593,11 +4551,9 @@ example: `debian`
 [[field-os-full]]
 <<field-os-full, os.full>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Operating system name, including the version or code name.
 
-Operating system name, including the version or code name.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -4633,11 +4589,9 @@ example: `4.4.0-112-generic`
 [[field-os-name]]
 <<field-os-name, os.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Operating system name, without the version.
 
-Operating system name, without the version.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -5047,11 +5001,9 @@ example: `0c6803c4e922103c4dca5963aad36ddf`
 [[field-pe-original-file-name]]
 <<field-pe-original-file-name, pe.original_file_name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Internal name of the file, provided at compile-time.
 
-Internal name of the file, provided at compile-time.
-
-type: wildcard
+type: keyword
 
 
 
@@ -5194,11 +5146,9 @@ example: `c2c455d9f99375d`
 [[field-process-executable]]
 <<field-process-executable, process.executable>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Absolute path to the process executable.
 
-Absolute path to the process executable.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -5236,13 +5186,11 @@ example: `137`
 [[field-process-name]]
 <<field-process-name, process.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Process name.
+| Process name.
 
 Sometimes called program name or similar.
 
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -5342,11 +5290,9 @@ example: `4242`
 [[field-process-thread-name]]
 <<field-process-thread-name, process.thread.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Thread name.
 
-Thread name.
-
-type: wildcard
+type: keyword
 
 
 
@@ -5360,13 +5306,11 @@ example: `thread-0`
 [[field-process-title]]
 <<field-process-title, process.title>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Process title.
+| Process title.
 
 The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
 
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -5402,11 +5346,9 @@ example: `1325`
 [[field-process-working-directory]]
 <<field-process-working-directory, process.working_directory>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| The working directory of the process.
 
-The working directory of the process.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -5507,13 +5449,11 @@ example: `ZQBuAC0AVQBTAAAAZQBuAAAAAAA=`
 [[field-registry-data-strings]]
 <<field-registry-data-strings, registry.data.strings>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Content when writing string types.
+| Content when writing string types.
 
 Populated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `"1"`).
 
-type: wildcard
+type: keyword
 
 
 Note: this field should contain an array of values.
@@ -5562,11 +5502,9 @@ example: `HKLM`
 [[field-registry-key]]
 <<field-registry-key, registry.key>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Hive-relative path of keys.
 
-Hive-relative path of keys.
-
-type: wildcard
+type: keyword
 
 
 
@@ -5580,11 +5518,9 @@ example: `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Opti
 [[field-registry-path]]
 <<field-registry-path, registry.path>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Full path, including hive, key and value
 
-Full path, including hive, key and value
-
-type: wildcard
+type: keyword
 
 
 
@@ -5947,11 +5883,9 @@ example: `184`
 [[field-server-domain]]
 <<field-server-domain, server.domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Server domain.
 
-Server domain.
-
-type: wildcard
+type: keyword
 
 
 
@@ -6065,15 +5999,13 @@ type: long
 [[field-server-registered-domain]]
 <<field-server-registered-domain, server.registered_domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The highest registered server domain, stripped of the subdomain.
+| The highest registered server domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
-type: wildcard
+type: keyword
 
 
 
@@ -6362,11 +6294,9 @@ example: `184`
 [[field-source-domain]]
 <<field-source-domain, source.domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Source domain.
 
-Source domain.
-
-type: wildcard
+type: keyword
 
 
 
@@ -6480,15 +6410,13 @@ type: long
 [[field-source-registered-domain]]
 <<field-source-registered-domain, source.registered_domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The highest registered source domain, stripped of the subdomain.
+| The highest registered source domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
-type: wildcard
+type: keyword
 
 
 
@@ -6907,11 +6835,9 @@ example: `0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0`
 [[field-tls-client-issuer]]
 <<field-tls-client-issuer, tls.client.issuer>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
 
-Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
-
-type: wildcard
+type: keyword
 
 
 
@@ -6989,11 +6915,9 @@ example: `www.elastic.co`
 [[field-tls-client-subject]]
 <<field-tls-client-subject, tls.client.subject>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Distinguished name of subject of the x.509 certificate presented by the client.
 
-Distinguished name of subject of the x.509 certificate presented by the client.
-
-type: wildcard
+type: keyword
 
 
 
@@ -7173,11 +7097,9 @@ example: `0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0`
 [[field-tls-server-issuer]]
 <<field-tls-server-issuer, tls.server.issuer>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Subject of the issuer of the x.509 certificate presented by the server.
 
-Subject of the issuer of the x.509 certificate presented by the server.
-
-type: wildcard
+type: keyword
 
 
 
@@ -7239,11 +7161,9 @@ example: `1970-01-01T00:00:00.000Z`
 [[field-tls-server-subject]]
 <<field-tls-server-subject, tls.server.subject>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Subject of the x.509 certificate presented by the server.
 
-Subject of the x.509 certificate presented by the server.
-
-type: wildcard
+type: keyword
 
 
 
@@ -7408,15 +7328,13 @@ URL fields provide support for complete or partial URLs, and supports the breaki
 [[field-url-domain]]
 <<field-url-domain, url.domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Domain of the url, such as "www.elastic.co".
+| Domain of the url, such as "www.elastic.co".
 
 In some cases a URL may refer to an IP and/or port directly, without a domain name. In this case, the IP address would go to the `domain` field.
 
 If the URL contains a literal IPv6 address enclosed by `[` and `]` (IETF RFC 2732), the `[` and `]` characters should also be captured in the `domain` field.
 
-type: wildcard
+type: keyword
 
 
 
@@ -7470,11 +7388,9 @@ type: keyword
 [[field-url-full]]
 <<field-url-full, url.full>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
 
-If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -7494,15 +7410,13 @@ example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 [[field-url-original]]
 <<field-url-original, url.original>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-Unmodified original url as seen in the event source.
+| Unmodified original url as seen in the event source.
 
 Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.
 
 This field is meant to represent the URL as it was observed, complete or not.
 
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -7538,11 +7452,9 @@ type: keyword
 [[field-url-path]]
 <<field-url-path, url.path>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Path of the request, such as "/search".
 
-Path of the request, such as "/search".
-
-type: wildcard
+type: keyword
 
 
 
@@ -7590,15 +7502,13 @@ type: keyword
 [[field-url-registered-domain]]
 <<field-url-registered-domain, url.registered_domain>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
-
-The highest registered url domain, stripped of the subdomain.
+| The highest registered url domain, stripped of the subdomain.
 
 For example, the registered domain for "foo.example.com" is "example.com".
 
 This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk".
 
-type: wildcard
+type: keyword
 
 
 
@@ -7722,11 +7632,9 @@ type: keyword
 [[field-user-email]]
 <<field-user-email, user.email>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| User email address.
 
-User email address.
-
-type: wildcard
+type: keyword
 
 
 
@@ -7740,11 +7648,9 @@ type: wildcard
 [[field-user-full-name]]
 <<field-user-full-name, user.full_name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| User's full name, if available.
 
-User's full name, if available.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -7798,11 +7704,9 @@ type: keyword
 [[field-user-name]]
 <<field-user-name, user.name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Short name or login of the user.
 
-Short name or login of the user.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -7945,11 +7849,9 @@ example: `Safari`
 [[field-user-agent-original]]
 <<field-user-agent-original, user_agent.original>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Unparsed user_agent string.
 
-Unparsed user_agent string.
-
-type: wildcard
+type: keyword
 
 Multi-fields:
 
@@ -8394,11 +8296,9 @@ example: `US`
 [[field-x509-issuer-distinguished-name]]
 <<field-x509-issuer-distinguished-name, x509.issuer.distinguished_name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Distinguished name (DN) of issuing certificate authority.
 
-Distinguished name (DN) of issuing certificate authority.
-
-type: wildcard
+type: keyword
 
 
 
@@ -8654,11 +8554,9 @@ example: `US`
 [[field-x509-subject-distinguished-name]]
 <<field-x509-subject-distinguished-name, x509.subject.distinguished_name>>
 
-| beta:[ Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`. ]
+| Distinguished name (DN) of the certificate subject entity.
 
-Distinguished name (DN) of the certificate subject entity.
-
-type: wildcard
+type: keyword
 
 
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -18,8 +18,6 @@
   short: Date/time when the event originated.
   type: date
 agent.build.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: agent-build-original
   description: 'Extended build information for the agent.
 
@@ -130,8 +128,6 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -159,8 +155,6 @@ client.bytes:
   short: Bytes sent from the client to the server.
   type: long
 client.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-domain
   description: Client domain.
   flat_name: client.domain
@@ -229,8 +223,6 @@ client.geo.location:
   short: Longitude and latitude.
   type: geo_point
 client.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -336,8 +328,6 @@ client.port:
   short: Port of the client.
   type: long
 client.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-registered-domain
   description: 'The highest registered client domain, stripped of the subdomain.
 
@@ -402,8 +392,6 @@ client.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 client.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-email
   description: User email address.
   flat_name: client.user.email
@@ -414,8 +402,6 @@ client.user.email:
   short: User email address.
   type: wildcard
 client.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -493,8 +479,6 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
@@ -794,8 +778,6 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -823,8 +805,6 @@ destination.bytes:
   short: Bytes sent from the destination to the source.
   type: long
 destination.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-domain
   description: Destination domain.
   flat_name: destination.domain
@@ -893,8 +873,6 @@ destination.geo.location:
   short: Longitude and latitude.
   type: geo_point
 destination.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -999,8 +977,6 @@ destination.port:
   short: Port of the destination.
   type: long
 destination.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
@@ -1065,8 +1041,6 @@ destination.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 destination.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-email
   description: User email address.
   flat_name: destination.user.email
@@ -1077,8 +1051,6 @@ destination.user.email:
   short: User email address.
   type: wildcard
 destination.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1156,8 +1128,6 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
@@ -1398,8 +1368,6 @@ dll.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 dll.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dll-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
@@ -1453,8 +1421,6 @@ dns.answers.class:
   short: The class of DNS data contained in this resource record.
   type: keyword
 dns.answers.data:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dns-answers-data
   description: 'The data describing the resource.
 
@@ -1555,8 +1521,6 @@ dns.question.class:
   short: The class of records being queried.
   type: keyword
 dns.question.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dns-question-name
   description: 'The name being queried.
 
@@ -1723,8 +1687,6 @@ error.message:
   short: Error message.
   type: text
 error.stack_trace:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -1739,8 +1701,6 @@ error.stack_trace:
   short: The stack trace of this error in plain text.
   type: wildcard
 error.type:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
   example: java.lang.NullPointerException
@@ -2627,8 +2587,6 @@ file.device:
   short: Device that is the source of the file.
   type: keyword
 file.directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-directory
   description: Directory where the file is located. It should include the drive letter,
     when appropriate.
@@ -2811,8 +2769,6 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -2893,8 +2849,6 @@ file.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 file.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
@@ -2930,8 +2884,6 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -3009,8 +2961,6 @@ file.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 file.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -3200,8 +3150,6 @@ file.x509.subject.country:
   short: List of country (C) code
   type: keyword
 file.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -3426,8 +3374,6 @@ host.geo.location:
   short: Longitude and latitude.
   type: geo_point
 host.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -3469,8 +3415,6 @@ host.geo.region_name:
   short: Region name.
   type: keyword
 host.hostname:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-hostname
   description: 'Hostname of the host.
 
@@ -3582,8 +3526,6 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -3612,8 +3554,6 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -3709,8 +3649,6 @@ host.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 host.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-email
   description: User email address.
   flat_name: host.user.email
@@ -3721,8 +3659,6 @@ host.user.email:
   short: User email address.
   type: wildcard
 host.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -3800,8 +3736,6 @@ host.user.id:
   short: Unique identifier of the user.
   type: keyword
 host.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-name
   description: Short name or login of the user.
   example: albert
@@ -3842,8 +3776,6 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -3918,8 +3850,6 @@ http.request.mime_type:
   short: Mime type of the body of the request.
   type: keyword
 http.request.referrer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-request-referrer
   description: Referrer for this HTTP request.
   example: https://blog.example.com/
@@ -3941,8 +3871,6 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -4022,8 +3950,6 @@ labels:
   short: Custom key/value pairs.
   type: object
 log.file.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: log-file-path
   description: 'Full path to the log file this event came from, including the file
     name. It should include the drive letter, when appropriate.
@@ -4054,8 +3980,6 @@ log.level:
   short: Log level of the log event.
   type: keyword
 log.logger:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: log-logger
   description: The name of the logger inside an application. This is usually the name
     of the class which initialized the logger, or can be a custom name.
@@ -4586,8 +4510,6 @@ observer.geo.location:
   short: Longitude and latitude.
   type: geo_point
 observer.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -4774,8 +4696,6 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4804,8 +4724,6 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4931,8 +4849,6 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -5232,8 +5148,6 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -5317,8 +5231,6 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-name
   description: 'Process name.
 
@@ -5476,8 +5388,6 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -5563,8 +5473,6 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -5647,8 +5555,6 @@ process.parent.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 process.parent.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
@@ -5730,8 +5636,6 @@ process.parent.thread.id:
   short: Thread ID.
   type: long
 process.parent.thread.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-thread-name
   description: Thread name.
   example: thread-0
@@ -5743,8 +5647,6 @@ process.parent.thread.name:
   short: Thread name.
   type: wildcard
 process.parent.title:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -5774,8 +5676,6 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -5856,8 +5756,6 @@ process.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 process.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
@@ -5934,8 +5832,6 @@ process.thread.id:
   short: Thread ID.
   type: long
 process.thread.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-thread-name
   description: Thread name.
   example: thread-0
@@ -5946,8 +5842,6 @@ process.thread.name:
   short: Thread name.
   type: wildcard
 process.title:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-title
   description: 'Process title.
 
@@ -5975,8 +5869,6 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -6007,8 +5899,6 @@ registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 registry.data.strings:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-data-strings
   description: 'Content when writing string types.
 
@@ -6048,8 +5938,6 @@ registry.hive:
   short: Abbreviated name for the hive.
   type: keyword
 registry.key:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-key
   description: Hive-relative path of keys.
   example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
@@ -6060,8 +5948,6 @@ registry.key:
   short: Hive-relative path of keys.
   type: wildcard
 registry.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-path
   description: Full path, including hive, key and value
   example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
@@ -6279,8 +6165,6 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -6308,8 +6192,6 @@ server.bytes:
   short: Bytes sent from the server to the client.
   type: long
 server.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-domain
   description: Server domain.
   flat_name: server.domain
@@ -6378,8 +6260,6 @@ server.geo.location:
   short: Longitude and latitude.
   type: geo_point
 server.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -6485,8 +6365,6 @@ server.port:
   short: Port of the server.
   type: long
 server.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-registered-domain
   description: 'The highest registered server domain, stripped of the subdomain.
 
@@ -6551,8 +6429,6 @@ server.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 server.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-email
   description: User email address.
   flat_name: server.user.email
@@ -6563,8 +6439,6 @@ server.user.email:
   short: User email address.
   type: wildcard
 server.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -6642,8 +6516,6 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
@@ -6812,8 +6684,6 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -6841,8 +6711,6 @@ source.bytes:
   short: Bytes sent from the source to the destination.
   type: long
 source.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-domain
   description: Source domain.
   flat_name: source.domain
@@ -6911,8 +6779,6 @@ source.geo.location:
   short: Longitude and latitude.
   type: geo_point
 source.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -7018,8 +6884,6 @@ source.port:
   short: Port of the source.
   type: long
 source.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
@@ -7084,8 +6948,6 @@ source.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 source.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-email
   description: User email address.
   flat_name: source.user.email
@@ -7096,8 +6958,6 @@ source.user.email:
   short: User email address.
   type: wildcard
 source.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -7175,8 +7035,6 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
@@ -7455,8 +7313,6 @@ tls.client.hash.sha256:
     certificate offered by the client.
   type: keyword
 tls.client.issuer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-issuer
   description: Distinguished name of subject of the issuer of the x.509 certificate
     presented by the client.
@@ -7515,8 +7371,6 @@ tls.client.server_name:
   short: Hostname the client is trying to connect to. Also called the SNI.
   type: keyword
 tls.client.subject:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-subject
   description: Distinguished name of subject of the x.509 certificate presented by
     the client.
@@ -7582,8 +7436,6 @@ tls.client.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 tls.client.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -7773,8 +7625,6 @@ tls.client.x509.subject.country:
   short: List of country (C) code
   type: keyword
 tls.client.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -7965,8 +7815,6 @@ tls.server.hash.sha256:
     certificate offered by the server.
   type: keyword
 tls.server.issuer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-issuer
   description: Subject of the issuer of the x.509 certificate presented by the server.
   example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
@@ -8010,8 +7858,6 @@ tls.server.not_before:
   short: Timestamp indicating when server certificate is first considered valid.
   type: date
 tls.server.subject:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-subject
   description: Subject of the x.509 certificate presented by the server.
   example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
@@ -8063,8 +7909,6 @@ tls.server.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 tls.server.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -8254,8 +8098,6 @@ tls.server.x509.subject.country:
   short: List of country (C) code
   type: keyword
 tls.server.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -8380,8 +8222,6 @@ transaction.id:
   short: Unique identifier of the transaction within the scope of its trace.
   type: keyword
 url.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-domain
   description: 'Domain of the url, such as "www.elastic.co".
 
@@ -8430,8 +8270,6 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -8448,8 +8286,6 @@ url.full:
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -8480,8 +8316,6 @@ url.password:
   short: Password of the request.
   type: keyword
 url.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path
@@ -8518,8 +8352,6 @@ url.query:
   short: Query string of the request.
   type: keyword
 url.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-registered-domain
   description: 'The highest registered url domain, stripped of the subdomain.
 
@@ -8607,8 +8439,6 @@ user.changes.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.changes.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-email
   description: User email address.
   flat_name: user.changes.email
@@ -8619,8 +8449,6 @@ user.changes.email:
   short: User email address.
   type: wildcard
 user.changes.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8698,8 +8526,6 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
@@ -8754,8 +8580,6 @@ user.effective.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.effective.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-email
   description: User email address.
   flat_name: user.effective.email
@@ -8766,8 +8590,6 @@ user.effective.email:
   short: User email address.
   type: wildcard
 user.effective.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8845,8 +8667,6 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
@@ -8876,8 +8696,6 @@ user.effective.roles:
   short: Array of user roles at the time of the event.
   type: keyword
 user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-email
   description: User email address.
   flat_name: user.email
@@ -8887,8 +8705,6 @@ user.email:
   short: User email address.
   type: wildcard
 user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8963,8 +8779,6 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
@@ -9005,8 +8819,6 @@ user.target.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.target.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-email
   description: User email address.
   flat_name: user.target.email
@@ -9017,8 +8829,6 @@ user.target.email:
   short: User email address.
   type: wildcard
 user.target.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -9096,8 +8906,6 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
@@ -9149,8 +8957,6 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -9179,8 +8985,6 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -9209,8 +9013,6 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5109,8 +5109,6 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -5347,8 +5345,6 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6210,8 +6210,6 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -6448,8 +6446,6 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -8,8 +8,6 @@ agent:
     event happened or the measurement was taken.'
   fields:
     agent.build.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: agent-build-original
       description: 'Extended build information for the agent.
 
@@ -120,8 +118,6 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -277,8 +273,6 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -306,8 +300,6 @@ client:
       short: Bytes sent from the client to the server.
       type: long
     client.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-domain
       description: Client domain.
       flat_name: client.domain
@@ -376,8 +368,6 @@ client:
       short: Longitude and latitude.
       type: geo_point
     client.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -483,8 +473,6 @@ client:
       short: Port of the client.
       type: long
     client.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-registered-domain
       description: 'The highest registered client domain, stripped of the subdomain.
 
@@ -549,8 +537,6 @@ client:
       short: Name of the directory the user is a member of.
       type: keyword
     client.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-email
       description: User email address.
       flat_name: client.user.email
@@ -561,8 +547,6 @@ client:
       short: User email address.
       type: wildcard
     client.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -640,8 +624,6 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
@@ -1106,8 +1088,6 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1135,8 +1115,6 @@ destination:
       short: Bytes sent from the destination to the source.
       type: long
     destination.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-domain
       description: Destination domain.
       flat_name: destination.domain
@@ -1205,8 +1183,6 @@ destination:
       short: Longitude and latitude.
       type: geo_point
     destination.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -1311,8 +1287,6 @@ destination:
       short: Port of the destination.
       type: long
     destination.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-registered-domain
       description: 'The highest registered destination domain, stripped of the subdomain.
 
@@ -1377,8 +1351,6 @@ destination:
       short: Name of the directory the user is a member of.
       type: keyword
     destination.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-email
       description: User email address.
       flat_name: destination.user.email
@@ -1389,8 +1361,6 @@ destination:
       short: User email address.
       type: wildcard
     destination.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1468,8 +1438,6 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
@@ -1744,8 +1712,6 @@ dll:
       short: A hash of the imports in a PE file.
       type: keyword
     dll.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dll-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
@@ -1827,8 +1793,6 @@ dns:
       short: The class of DNS data contained in this resource record.
       type: keyword
     dns.answers.data:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dns-answers-data
       description: 'The data describing the resource.
 
@@ -1931,8 +1895,6 @@ dns:
       short: The class of records being queried.
       type: keyword
     dns.question.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dns-question-name
       description: 'The name being queried.
 
@@ -2120,8 +2082,6 @@ error:
       short: Error message.
       type: text
     error.stack_trace:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -2136,8 +2096,6 @@ error:
       short: The stack trace of this error in plain text.
       type: wildcard
     error.type:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: error-type
       description: The type of the error, for example the class name of the exception.
       example: java.lang.NullPointerException
@@ -3075,8 +3033,6 @@ file:
       short: Device that is the source of the file.
       type: keyword
     file.directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-directory
       description: Directory where the file is located. It should include the drive
         letter, when appropriate.
@@ -3259,8 +3215,6 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -3341,8 +3295,6 @@ file:
       short: A hash of the imports in a PE file.
       type: keyword
     file.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
@@ -3378,8 +3330,6 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -3457,8 +3407,6 @@ file:
       short: List of country (C) codes
       type: keyword
     file.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -3648,8 +3596,6 @@ file:
       short: List of country (C) code
       type: keyword
     file.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -3809,8 +3755,6 @@ geo:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -4130,8 +4074,6 @@ host:
       short: Longitude and latitude.
       type: geo_point
     host.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -4173,8 +4115,6 @@ host:
       short: Region name.
       type: keyword
     host.hostname:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-hostname
       description: 'Hostname of the host.
 
@@ -4287,8 +4227,6 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -4317,8 +4255,6 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4416,8 +4352,6 @@ host:
       short: Name of the directory the user is a member of.
       type: keyword
     host.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-email
       description: User email address.
       flat_name: host.user.email
@@ -4428,8 +4362,6 @@ host:
       short: User email address.
       type: wildcard
     host.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -4507,8 +4439,6 @@ host:
       short: Unique identifier of the user.
       type: keyword
     host.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-name
       description: Short name or login of the user.
       example: albert
@@ -4573,8 +4503,6 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -4651,8 +4579,6 @@ http:
       short: Mime type of the body of the request.
       type: keyword
     http.request.referrer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-request-referrer
       description: Referrer for this HTTP request.
       example: https://blog.example.com/
@@ -4674,8 +4600,6 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -4813,8 +4737,6 @@ log:
     but rather in `event.*` or in other ECS fields.'
   fields:
     log.file.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: log-file-path
       description: 'Full path to the log file this event came from, including the
         file name. It should include the drive letter, when appropriate.
@@ -4845,8 +4767,6 @@ log:
       short: Log level of the log event.
       type: keyword
     log.logger:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: log-logger
       description: The name of the logger inside an application. This is usually the
         name of the class which initialized the logger, or can be a custom name.
@@ -5408,8 +5328,6 @@ observer:
       short: Longitude and latitude.
       type: geo_point
     observer.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -5597,8 +5515,6 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -5627,8 +5543,6 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -5794,8 +5708,6 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -5830,8 +5742,6 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -5858,8 +5768,6 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6159,8 +6067,6 @@ pe:
       short: A hash of the imports in a PE file.
       type: keyword
     pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
@@ -6343,8 +6249,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -6428,8 +6332,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-name
       description: 'Process name.
 
@@ -6587,8 +6489,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -6674,8 +6574,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -6758,8 +6656,6 @@ process:
       short: A hash of the imports in a PE file.
       type: keyword
     process.parent.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
@@ -6841,8 +6737,6 @@ process:
       short: Thread ID.
       type: long
     process.parent.thread.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-thread-name
       description: Thread name.
       example: thread-0
@@ -6854,8 +6748,6 @@ process:
       short: Thread name.
       type: wildcard
     process.parent.title:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -6885,8 +6777,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -6967,8 +6857,6 @@ process:
       short: A hash of the imports in a PE file.
       type: keyword
     process.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
@@ -7045,8 +6933,6 @@ process:
       short: Thread ID.
       type: long
     process.thread.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-thread-name
       description: Thread name.
       example: thread-0
@@ -7057,8 +6943,6 @@ process:
       short: Thread name.
       type: wildcard
     process.title:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-title
       description: 'Process title.
 
@@ -7086,8 +6970,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -7151,8 +7033,6 @@ registry:
       short: Original bytes written with base64 encoding.
       type: keyword
     registry.data.strings:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-data-strings
       description: 'Content when writing string types.
 
@@ -7192,8 +7072,6 @@ registry:
       short: Abbreviated name for the hive.
       type: keyword
     registry.key:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-key
       description: Hive-relative path of keys.
       example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
@@ -7204,8 +7082,6 @@ registry:
       short: Hive-relative path of keys.
       type: wildcard
     registry.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-path
       description: Full path, including hive, key and value
       example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
@@ -7480,8 +7356,6 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -7509,8 +7383,6 @@ server:
       short: Bytes sent from the server to the client.
       type: long
     server.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-domain
       description: Server domain.
       flat_name: server.domain
@@ -7579,8 +7451,6 @@ server:
       short: Longitude and latitude.
       type: geo_point
     server.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -7686,8 +7556,6 @@ server:
       short: Port of the server.
       type: long
     server.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-registered-domain
       description: 'The highest registered server domain, stripped of the subdomain.
 
@@ -7752,8 +7620,6 @@ server:
       short: Name of the directory the user is a member of.
       type: keyword
     server.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-email
       description: User email address.
       flat_name: server.user.email
@@ -7764,8 +7630,6 @@ server:
       short: User email address.
       type: wildcard
     server.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -7843,8 +7707,6 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
@@ -8057,8 +7919,6 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -8086,8 +7946,6 @@ source:
       short: Bytes sent from the source to the destination.
       type: long
     source.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-domain
       description: Source domain.
       flat_name: source.domain
@@ -8156,8 +8014,6 @@ source:
       short: Longitude and latitude.
       type: geo_point
     source.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -8263,8 +8119,6 @@ source:
       short: Port of the source.
       type: long
     source.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-registered-domain
       description: 'The highest registered source domain, stripped of the subdomain.
 
@@ -8329,8 +8183,6 @@ source:
       short: Name of the directory the user is a member of.
       type: keyword
     source.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-email
       description: User email address.
       flat_name: source.user.email
@@ -8341,8 +8193,6 @@ source:
       short: User email address.
       type: wildcard
     source.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -8420,8 +8270,6 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
@@ -8714,8 +8562,6 @@ tls:
         of certificate offered by the client.
       type: keyword
     tls.client.issuer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-issuer
       description: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
@@ -8776,8 +8622,6 @@ tls:
       short: Hostname the client is trying to connect to. Also called the SNI.
       type: keyword
     tls.client.subject:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-subject
       description: Distinguished name of subject of the x.509 certificate presented
         by the client.
@@ -8844,8 +8688,6 @@ tls:
       short: List of country (C) codes
       type: keyword
     tls.client.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -9035,8 +8877,6 @@ tls:
       short: List of country (C) code
       type: keyword
     tls.client.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -9227,8 +9067,6 @@ tls:
         of certificate offered by the server.
       type: keyword
     tls.server.issuer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-issuer
       description: Subject of the issuer of the x.509 certificate presented by the
         server.
@@ -9275,8 +9113,6 @@ tls:
       short: Timestamp indicating when server certificate is first considered valid.
       type: date
     tls.server.subject:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-subject
       description: Subject of the x.509 certificate presented by the server.
       example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
@@ -9328,8 +9164,6 @@ tls:
       short: List of country (C) codes
       type: keyword
     tls.server.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -9519,8 +9353,6 @@ tls:
       short: List of country (C) code
       type: keyword
     tls.server.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
@@ -9696,8 +9528,6 @@ url:
     the breaking down into scheme, domain, path, and so on.
   fields:
     url.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-domain
       description: 'Domain of the url, such as "www.elastic.co".
 
@@ -9747,8 +9577,6 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -9766,8 +9594,6 @@ url:
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -9798,8 +9624,6 @@ url:
       short: Password of the request.
       type: keyword
     url.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-path
       description: Path of the request, such as "/search".
       flat_name: url.path
@@ -9836,8 +9660,6 @@ url:
       short: Query string of the request.
       type: keyword
     url.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-registered-domain
       description: 'The highest registered url domain, stripped of the subdomain.
 
@@ -9938,8 +9760,6 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.changes.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-email
       description: User email address.
       flat_name: user.changes.email
@@ -9950,8 +9770,6 @@ user:
       short: User email address.
       type: wildcard
     user.changes.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10029,8 +9847,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
@@ -10085,8 +9901,6 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.effective.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-email
       description: User email address.
       flat_name: user.effective.email
@@ -10097,8 +9911,6 @@ user:
       short: User email address.
       type: wildcard
     user.effective.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10176,8 +9988,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
@@ -10207,8 +10017,6 @@ user:
       short: Array of user roles at the time of the event.
       type: keyword
     user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-email
       description: User email address.
       flat_name: user.email
@@ -10218,8 +10026,6 @@ user:
       short: User email address.
       type: wildcard
     user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10294,8 +10100,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
@@ -10336,8 +10140,6 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.target.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-email
       description: User email address.
       flat_name: user.target.email
@@ -10348,8 +10150,6 @@ user:
       short: User email address.
       type: wildcard
     user.target.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10427,8 +10227,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
@@ -10542,8 +10340,6 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -10572,8 +10368,6 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -10602,8 +10396,6 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -10984,8 +10776,6 @@ x509:
       short: List of country (C) codes
       type: keyword
     x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
@@ -11160,8 +10950,6 @@ x509:
       short: List of country (C) code
       type: keyword
     x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net

--- a/experimental/schemas/agent.yml
+++ b/experimental/schemas/agent.yml
@@ -1,0 +1,5 @@
+---
+- name: agent
+  fields:
+    - name: build.original
+      type: wildcard

--- a/experimental/schemas/as.yml
+++ b/experimental/schemas/as.yml
@@ -1,0 +1,5 @@
+---
+- name: as
+  fields:
+    - name: organization.name
+      type: wildcard

--- a/experimental/schemas/client.yml
+++ b/experimental/schemas/client.yml
@@ -1,0 +1,7 @@
+---
+  - name: client
+    fields:
+      - name: domain
+        type: wildcard
+      - name: registered_domain
+        type: wildcard

--- a/experimental/schemas/destination.yml
+++ b/experimental/schemas/destination.yml
@@ -1,0 +1,7 @@
+---
+  - name: destination
+    fields:
+      - name: domain
+        type: wildcard
+      - name: registered_domain
+        type: wildcard

--- a/experimental/schemas/dns.yml
+++ b/experimental/schemas/dns.yml
@@ -1,0 +1,9 @@
+---
+- name: dns
+  fields:
+    - name: question.name
+      type: wildcard
+    - name: answers
+      type: object
+    - name: answers.data
+      type: wildcard

--- a/experimental/schemas/error.yml
+++ b/experimental/schemas/error.yml
@@ -1,0 +1,9 @@
+---
+- name: error
+  fields:
+    - name: stack_trace
+      index: true
+      type: wildcard
+
+    - name: type
+      type: wildcard

--- a/experimental/schemas/file.yml
+++ b/experimental/schemas/file.yml
@@ -1,0 +1,9 @@
+---
+- name: file
+  fields:
+    - name: directory
+      type: wildcard
+    - name: path
+      type: wildcard
+    - name: target_path
+      type: wildcard

--- a/experimental/schemas/geo.yml
+++ b/experimental/schemas/geo.yml
@@ -1,0 +1,5 @@
+---
+  - name: geo
+    fields:
+      - name: name
+        type: wildcard

--- a/experimental/schemas/host.yml
+++ b/experimental/schemas/host.yml
@@ -60,3 +60,6 @@
       description: >
         The total number of bytes (gauge) written successfully (aggregated from
         all disks) since the last metric collection.
+
+    - name: hostname
+      type: wildcard

--- a/experimental/schemas/http.yml
+++ b/experimental/schemas/http.yml
@@ -1,0 +1,9 @@
+---
+- name: http
+  fields:
+    - name: request.body.content
+      type: wildcard
+    - name: request.referrer
+      type: wildcard
+    - name: response.body.content
+      type: wildcard

--- a/experimental/schemas/log.yml
+++ b/experimental/schemas/log.yml
@@ -1,0 +1,7 @@
+---
+- name: log
+  fields:
+    - name: file.path
+      type: wildcard
+    - name: logger
+      type: wildcard

--- a/experimental/schemas/organization.yml
+++ b/experimental/schemas/organization.yml
@@ -1,0 +1,5 @@
+---
+- name: organization
+  fields:
+    - name: name
+      type: wildcard

--- a/experimental/schemas/os.yml
+++ b/experimental/schemas/os.yml
@@ -1,0 +1,7 @@
+---
+- name: os
+  fields:
+    - name: name
+      type: wildcard
+    - name: full
+      type: wildcard

--- a/experimental/schemas/pe.yml
+++ b/experimental/schemas/pe.yml
@@ -1,0 +1,5 @@
+---
+- name: pe
+  fields:
+    - name: original_file_name
+      type: wildcard

--- a/experimental/schemas/process.yml
+++ b/experimental/schemas/process.yml
@@ -1,0 +1,15 @@
+---
+- name: process
+  fields:
+    - name: command_line
+      type: wildcard
+    - name: executable
+      type: wildcard
+    - name: name
+      type: wildcard
+    - name: thread.name
+      type: wildcard
+    - name: title
+      type: wildcard
+    - name: working_directory
+      type: wildcard

--- a/experimental/schemas/registry.yml
+++ b/experimental/schemas/registry.yml
@@ -1,0 +1,9 @@
+---
+- name: registry
+  fields:
+    - name: key
+      type: wildcard
+    - name: path
+      type: wildcard
+    - name: data.strings
+      type: wildcard

--- a/experimental/schemas/server.yml
+++ b/experimental/schemas/server.yml
@@ -1,0 +1,9 @@
+---
+- name: registry
+  fields:
+    - name: key
+      type: wildcard
+    - name: path
+      type: wildcard
+    - name: data.strings
+      type: wildcard

--- a/experimental/schemas/server.yml
+++ b/experimental/schemas/server.yml
@@ -1,9 +1,7 @@
 ---
-- name: registry
-  fields:
-    - name: key
-      type: wildcard
-    - name: path
-      type: wildcard
-    - name: data.strings
-      type: wildcard
+  - name: server
+    fields:
+      - name: domain
+        type: wildcard
+      - name: registered_domain
+        type: wildcard

--- a/experimental/schemas/source.yml
+++ b/experimental/schemas/source.yml
@@ -1,0 +1,7 @@
+---
+- name: source
+  fields:
+    - name: domain
+      type: wildcard
+    - name: registered_domain
+      type: wildcard

--- a/experimental/schemas/tls.yml
+++ b/experimental/schemas/tls.yml
@@ -1,0 +1,11 @@
+---
+- name: tls
+  fields:
+    - name: client.issuer
+      type: wildcard
+    - name: client.subject
+      type: wildcard
+    - name: server.issuer
+      type: wildcard
+    - name: server.subject
+      type: wildcard

--- a/experimental/schemas/url.yml
+++ b/experimental/schemas/url.yml
@@ -1,0 +1,13 @@
+---
+- name: url
+  fields:
+    - name: original
+      type: wildcard
+    - name: full
+      type: wildcard
+    - name: path
+      type: wildcard
+    - name: domain
+      type: wildcard
+    - name: registered_domain
+      type: wildcard

--- a/experimental/schemas/user.yml
+++ b/experimental/schemas/user.yml
@@ -1,0 +1,9 @@
+---
+- name: user
+  fields:
+    - name: name
+      type: wildcard
+    - name: full_name
+      type: wildcard
+    - name: email
+      type: wildcard

--- a/experimental/schemas/user_agent.yml
+++ b/experimental/schemas/user_agent.yml
@@ -1,0 +1,5 @@
+---
+- name: user_agent
+  fields:
+    - name: original
+      type: wildcard

--- a/experimental/schemas/x509.yml
+++ b/experimental/schemas/x509.yml
@@ -1,0 +1,7 @@
+---
+- name: x509
+  fields:
+    - name: issuer.distinguished_name
+      type: wildcard
+    - name: subject.distinguished_name
+      type: wildcard

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -66,7 +66,8 @@
     fields:
     - name: build.original
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Extended build information for the agent.
 
         This field is intended to contain any build information that a data source
@@ -135,7 +136,8 @@
       example: 15169
     - name: organization.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -181,7 +183,8 @@
       example: 15169
     - name: as.organization.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -197,7 +200,8 @@
       example: 184
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Client domain.
     - name: geo.city_name
       level: core
@@ -230,7 +234,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -287,7 +292,8 @@
       description: Port of the client.
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The highest registered client domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
@@ -331,11 +337,13 @@
         For example, an LDAP or Active Directory domain name.'
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: user.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -376,7 +384,8 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -607,7 +616,8 @@
       example: 15169
     - name: as.organization.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -623,7 +633,8 @@
       example: 184
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Destination domain.
     - name: geo.city_name
       level: core
@@ -656,7 +667,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -712,7 +724,8 @@
       description: Port of the destination.
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The highest registered destination domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
@@ -756,11 +769,13 @@
         For example, an LDAP or Active Directory domain name.'
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: user.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -801,7 +816,8 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -962,7 +978,8 @@
       default_field: false
     - name: pe.original_file_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
@@ -1005,7 +1022,8 @@
       example: IN
     - name: answers.data
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The data describing the resource.
 
         The meaning of this data depends on the type and class of the resource record.'
@@ -1064,7 +1082,8 @@
       example: IN
     - name: question.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The name being queried.
 
         If the name field contains non-printable characters (below 32 or above 126),
@@ -1183,16 +1202,19 @@
       description: Error message.
     - name: stack_trace
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
         norms: false
         default_field: false
       description: The stack trace of this error in plain text.
+      index: false
     - name: type
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: The type of the error, for example the class name of the exception.
       example: java.lang.NullPointerException
   - name: event
@@ -1581,7 +1603,8 @@
       example: sda
     - name: directory
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Directory where the file is located. It should include the drive
         letter, when appropriate.
       example: /home/alice
@@ -1681,7 +1704,8 @@
       example: alice
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -1731,7 +1755,8 @@
       default_field: false
     - name: pe.original_file_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
@@ -1751,7 +1776,8 @@
       example: 16384
     - name: target_path
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -1795,7 +1821,8 @@
       default_field: false
     - name: x509.issuer.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
@@ -1901,7 +1928,8 @@
       default_field: false
     - name: x509.subject.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
@@ -1980,7 +2008,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -2124,7 +2153,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -2147,7 +2177,8 @@
       example: Quebec
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Hostname of the host.
 
         It normally contains what the `hostname` command returns on the host machine.'
@@ -2186,7 +2217,8 @@
       example: debian
     - name: os.full
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2202,7 +2234,8 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2260,11 +2293,13 @@
         For example, an LDAP or Active Directory domain name.'
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: user.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2305,7 +2340,8 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2335,7 +2371,8 @@
       example: 887
     - name: request.body.content
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2388,7 +2425,8 @@
       default_field: false
     - name: request.referrer
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Referrer for this HTTP request.
       example: https://blog.example.com/
     - name: response.body.bytes
@@ -2399,7 +2437,8 @@
       example: 887
     - name: response.body.content
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2485,7 +2524,8 @@
     fields:
     - name: file.path
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Full path to the log file this event came from, including the
         file name. It should include the drive letter, when appropriate.
 
@@ -2506,7 +2546,8 @@
       example: error
     - name: logger
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: The name of the logger inside an application. This is usually the
         name of the class which initialized the logger, or can be a custom name.
       example: org.elasticsearch.bootstrap.Bootstrap
@@ -2852,7 +2893,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -2960,7 +3002,8 @@
       example: debian
     - name: os.full
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -2976,7 +3019,8 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3059,7 +3103,8 @@
       description: Unique identifier for the organization.
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3080,7 +3125,8 @@
       example: debian
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3096,7 +3142,8 @@
       example: 4.4.0-112-generic
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3276,7 +3323,8 @@
       default_field: false
     - name: original_file_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
@@ -3388,7 +3436,8 @@
       default_field: false
     - name: executable
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3433,7 +3482,8 @@
       default_field: false
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3535,7 +3585,8 @@
       default_field: false
     - name: parent.executable
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3584,7 +3635,8 @@
       default_field: false
     - name: parent.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3635,7 +3687,8 @@
       default_field: false
     - name: parent.pe.original_file_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
@@ -3681,13 +3734,15 @@
       default_field: false
     - name: parent.thread.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Thread name.
       example: thread-0
       default_field: false
     - name: parent.title
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3705,7 +3760,8 @@
       default_field: false
     - name: parent.working_directory
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3754,7 +3810,8 @@
       default_field: false
     - name: pe.original_file_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
@@ -3795,12 +3852,14 @@
       example: 4242
     - name: thread.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Thread name.
       example: thread-0
     - name: title
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3817,7 +3876,8 @@
       example: 1325
     - name: working_directory
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3844,7 +3904,8 @@
       default_field: false
     - name: data.strings
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Content when writing string types.
 
         Populated as an array when writing string data to the registry. For single
@@ -3870,13 +3931,15 @@
       default_field: false
     - name: key
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Hive-relative path of keys.
       example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
       default_field: false
     - name: path
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Full path, including hive, key and value
       example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
         Options\winword.exe\Debugger
@@ -4061,7 +4124,8 @@
       example: 15169
     - name: as.organization.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4077,7 +4141,8 @@
       example: 184
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Server domain.
     - name: geo.city_name
       level: core
@@ -4110,7 +4175,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -4167,7 +4233,8 @@
       description: Port of the server.
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The highest registered server domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
@@ -4211,11 +4278,13 @@
         For example, an LDAP or Active Directory domain name.'
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: user.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4256,7 +4325,8 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4390,7 +4460,8 @@
       example: 15169
     - name: as.organization.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4406,7 +4477,8 @@
       example: 184
     - name: domain
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Source domain.
     - name: geo.city_name
       level: core
@@ -4439,7 +4511,8 @@
       example: '{ "lon": -73.614830, "lat": 45.505918 }'
     - name: geo.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'User-defined description of a location, at the level of granularity
         they care about.
 
@@ -4496,7 +4569,8 @@
       description: Port of the source.
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The highest registered source domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
@@ -4540,11 +4614,13 @@
         For example, an LDAP or Active Directory domain name.'
     - name: user.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: user.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4585,7 +4661,8 @@
       description: Unique identifier of the user.
     - name: user.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -4759,7 +4836,8 @@
       default_field: false
     - name: client.issuer
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
       example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
@@ -4797,7 +4875,8 @@
       default_field: false
     - name: client.subject
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name of subject of the x.509 certificate presented
         by the client.
       example: CN=myclient, OU=Documentation Team, DC=example, DC=com
@@ -4835,7 +4914,8 @@
       default_field: false
     - name: client.x509.issuer.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
@@ -4941,7 +5021,8 @@
       default_field: false
     - name: client.x509.subject.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
@@ -5054,7 +5135,8 @@
       default_field: false
     - name: server.issuer
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Subject of the issuer of the x.509 certificate presented by the
         server.
       example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
@@ -5083,7 +5165,8 @@
       default_field: false
     - name: server.subject
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Subject of the x.509 certificate presented by the server.
       example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
       default_field: false
@@ -5112,7 +5195,8 @@
       default_field: false
     - name: server.x509.issuer.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
@@ -5218,7 +5302,8 @@
       default_field: false
     - name: server.x509.subject.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false
@@ -5307,7 +5392,8 @@
     fields:
     - name: domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'Domain of the url, such as "www.elastic.co".
 
         In some cases a URL may refer to an IP and/or port directly, without a domain
@@ -5341,7 +5427,8 @@
         The `#` is not part of the fragment.'
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5353,7 +5440,8 @@
       example: https://www.elastic.co:443/search?q=elasticsearch#top
     - name: original
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5373,7 +5461,8 @@
       description: Password of the request.
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Path of the request, such as "/search".
     - name: port
       level: extended
@@ -5394,7 +5483,8 @@
         the two cases.'
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: 'The highest registered url domain, stripped of the subdomain.
 
         For example, the registered domain for "foo.example.com" is "example.com".
@@ -5462,12 +5552,14 @@
       default_field: false
     - name: changes.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
       default_field: false
     - name: changes.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5513,7 +5605,8 @@
       default_field: false
     - name: changes.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5545,12 +5638,14 @@
       default_field: false
     - name: effective.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
       default_field: false
     - name: effective.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5596,7 +5691,8 @@
       default_field: false
     - name: effective.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5613,11 +5709,13 @@
       default_field: false
     - name: email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
     - name: full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5658,7 +5756,8 @@
       description: Unique identifier of the user.
     - name: name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5683,12 +5782,14 @@
       default_field: false
     - name: target.email
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: User email address.
       default_field: false
     - name: target.full_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5734,7 +5835,8 @@
       default_field: false
     - name: target.name
       level: core
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5771,7 +5873,8 @@
       example: Safari
     - name: original
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5787,7 +5890,8 @@
       example: debian
     - name: os.full
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -5803,7 +5907,8 @@
       example: 4.4.0-112-generic
     - name: os.name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -6050,7 +6155,8 @@
       default_field: false
     - name: issuer.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
@@ -6156,7 +6262,8 @@
       default_field: false
     - name: subject.distinguished_name
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       default_field: false

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3408,7 +3408,8 @@
       default_field: false
     - name: command_line
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text
@@ -3557,7 +3558,8 @@
       default_field: false
     - name: parent.command_line
       level: extended
-      type: wildcard
+      type: keyword
+      ignore_above: 1024
       multi_fields:
       - name: text
         type: text

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -377,7 +377,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 2.0.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 2.0.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-2.0.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 2.0.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
@@ -397,7 +397,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 2.0.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 2.0.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
-2.0.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 2.0.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -3,7 +3,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
 2.0.0-dev,true,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
 2.0.0-dev,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
-2.0.0-dev,true,agent,agent.build.original,wildcard,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
+2.0.0-dev,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 2.0.0-dev,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
 2.0.0-dev,true,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
 2.0.0-dev,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
@@ -11,16 +11,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
 2.0.0-dev,true,client,client.address,keyword,extended,,,Client network address.
 2.0.0-dev,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
-2.0.0-dev,true,client,client.as.organization.name,wildcard,extended,,Google LLC,Organization name.
+2.0.0-dev,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
 2.0.0-dev,true,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
 2.0.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
-2.0.0-dev,true,client,client.domain,wildcard,core,,,Client domain.
+2.0.0-dev,true,client,client.domain,keyword,core,,,Client domain.
 2.0.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
 2.0.0-dev,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,client,client.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,client,client.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,client,client.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
@@ -29,19 +29,19 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.nat.port,long,extended,,,Client NAT port
 2.0.0-dev,true,client,client.packets,long,core,,12,Packets sent from the client to the server.
 2.0.0-dev,true,client,client.port,long,core,,,Port of the client.
-2.0.0-dev,true,client,client.registered_domain,wildcard,extended,,example.com,"The highest registered client domain, stripped of the subdomain."
+2.0.0-dev,true,client,client.registered_domain,keyword,extended,,example.com,"The highest registered client domain, stripped of the subdomain."
 2.0.0-dev,true,client,client.subdomain,keyword,extended,,east,The subdomain of the domain.
 2.0.0-dev,true,client,client.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 2.0.0-dev,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,client,client.user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,client,client.user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,client,client.user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,client,client.user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
@@ -63,16 +63,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,container,container.runtime,keyword,extended,,docker,Runtime managing this container.
 2.0.0-dev,true,destination,destination.address,keyword,extended,,,Destination network address.
 2.0.0-dev,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
-2.0.0-dev,true,destination,destination.as.organization.name,wildcard,extended,,Google LLC,Organization name.
+2.0.0-dev,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
 2.0.0-dev,true,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
 2.0.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
-2.0.0-dev,true,destination,destination.domain,wildcard,core,,,Destination domain.
+2.0.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
 2.0.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
 2.0.0-dev,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,destination,destination.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,destination,destination.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
@@ -81,19 +81,19 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,destination,destination.nat.port,long,extended,,,Destination NAT Port
 2.0.0-dev,true,destination,destination.packets,long,core,,12,Packets sent from the destination to the source.
 2.0.0-dev,true,destination,destination.port,long,core,,,Port of the destination.
-2.0.0-dev,true,destination,destination.registered_domain,wildcard,extended,,example.com,"The highest registered destination domain, stripped of the subdomain."
+2.0.0-dev,true,destination,destination.registered_domain,keyword,extended,,example.com,"The highest registered destination domain, stripped of the subdomain."
 2.0.0-dev,true,destination,destination.subdomain,keyword,extended,,east,The subdomain of the domain.
 2.0.0-dev,true,destination,destination.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 2.0.0-dev,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,destination,destination.user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,destination,destination.user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,destination,destination.user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,destination,destination.user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -113,11 +113,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,dll,dll.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 2.0.0-dev,true,dll,dll.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
 2.0.0-dev,true,dll,dll.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
-2.0.0-dev,true,dll,dll.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev,true,dll,dll.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 2.0.0-dev,true,dll,dll.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 2.0.0-dev,true,dns,dns.answers,object,extended,array,,Array of DNS answers.
 2.0.0-dev,true,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
-2.0.0-dev,true,dns,dns.answers.data,wildcard,extended,,10.10.10.10,The data describing the resource.
+2.0.0-dev,true,dns,dns.answers.data,keyword,extended,,10.10.10.10,The data describing the resource.
 2.0.0-dev,true,dns,dns.answers.name,keyword,extended,,www.example.com,The domain name to which this resource record pertains.
 2.0.0-dev,true,dns,dns.answers.ttl,long,extended,,180,The time interval in seconds that this resource record may be cached before it should be discarded.
 2.0.0-dev,true,dns,dns.answers.type,keyword,extended,,CNAME,The type of data contained in this resource record.
@@ -125,7 +125,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,dns,dns.id,keyword,extended,,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
 2.0.0-dev,true,dns,dns.op_code,keyword,extended,,QUERY,The DNS operation code that specifies the kind of query in the message.
 2.0.0-dev,true,dns,dns.question.class,keyword,extended,,IN,The class of records being queried.
-2.0.0-dev,true,dns,dns.question.name,wildcard,extended,,www.example.com,The name being queried.
+2.0.0-dev,true,dns,dns.question.name,keyword,extended,,www.example.com,The name being queried.
 2.0.0-dev,true,dns,dns.question.registered_domain,keyword,extended,,example.com,"The highest registered domain, stripped of the subdomain."
 2.0.0-dev,true,dns,dns.question.subdomain,keyword,extended,,www,The subdomain of the domain.
 2.0.0-dev,true,dns,dns.question.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
@@ -137,9 +137,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,error,error.code,keyword,core,,,Error code describing the error.
 2.0.0-dev,true,error,error.id,keyword,core,,,Unique identifier for the error.
 2.0.0-dev,true,error,error.message,text,core,,,Error message.
-2.0.0-dev,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
-2.0.0-dev,true,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
-2.0.0-dev,true,error,error.type,wildcard,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
+2.0.0-dev,false,error,error.stack_trace,keyword,extended,,,The stack trace of this error in plain text.
+2.0.0-dev,false,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+2.0.0-dev,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 2.0.0-dev,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 2.0.0-dev,true,event,event.category,keyword,core,array,authentication,Event category. The second categorization field in the hierarchy.
 2.0.0-dev,true,event,event.code,keyword,extended,,4648,Identification code for this event.
@@ -175,7 +175,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,file,file.created,date,extended,,,File creation time.
 2.0.0-dev,true,file,file.ctime,date,extended,,,Last time the file attributes or metadata changed.
 2.0.0-dev,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
-2.0.0-dev,true,file,file.directory,wildcard,extended,,/home/alice,Directory where the file is located.
+2.0.0-dev,true,file,file.directory,keyword,extended,,/home/alice,Directory where the file is located.
 2.0.0-dev,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
 2.0.0-dev,true,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
 2.0.0-dev,true,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
@@ -191,24 +191,24 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,file,file.mtime,date,extended,,,Last time the file content was modified.
 2.0.0-dev,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 2.0.0-dev,true,file,file.owner,keyword,extended,,alice,File owner's username.
-2.0.0-dev,true,file,file.path,wildcard,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+2.0.0-dev,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 2.0.0-dev,true,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 2.0.0-dev,true,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 2.0.0-dev,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 2.0.0-dev,true,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 2.0.0-dev,true,file,file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
 2.0.0-dev,true,file,file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
-2.0.0-dev,true,file,file.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev,true,file,file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 2.0.0-dev,true,file,file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 2.0.0-dev,true,file,file.size,long,extended,,16384,File size in bytes.
-2.0.0-dev,true,file,file.target_path,wildcard,extended,,,Target path for symlinks.
+2.0.0-dev,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
 2.0.0-dev,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
 2.0.0-dev,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 2.0.0-dev,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 2.0.0-dev,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
 2.0.0-dev,true,file,file.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 2.0.0-dev,true,file,file.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-2.0.0-dev,true,file,file.x509.issuer.distinguished_name,wildcard,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+2.0.0-dev,true,file,file.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 2.0.0-dev,true,file,file.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
 2.0.0-dev,true,file,file.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
 2.0.0-dev,true,file,file.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
@@ -223,7 +223,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,file,file.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
 2.0.0-dev,true,file,file.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 2.0.0-dev,true,file,file.x509.subject.country,keyword,extended,array,US,List of country (C) code
-2.0.0-dev,true,file,file.x509.subject.distinguished_name,wildcard,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+2.0.0-dev,true,file,file.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 2.0.0-dev,true,file,file.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
 2.0.0-dev,true,file,file.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 2.0.0-dev,true,file,file.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
@@ -239,19 +239,19 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,host,host.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,host,host.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,host,host.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,host,host.geo.region_name,keyword,core,,Quebec,Region name.
-2.0.0-dev,true,host,host.hostname,wildcard,core,,,Hostname of the host.
+2.0.0-dev,true,host,host.hostname,keyword,core,,,Hostname of the host.
 2.0.0-dev,true,host,host.id,keyword,core,,,Unique host id.
 2.0.0-dev,true,host,host.ip,ip,core,array,,Host ip addresses.
 2.0.0-dev,true,host,host.mac,keyword,core,array,,Host mac addresses.
 2.0.0-dev,true,host,host.name,keyword,core,,,Name of the host.
 2.0.0-dev,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
-2.0.0-dev,true,host,host.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+2.0.0-dev,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
-2.0.0-dev,true,host,host.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
+2.0.0-dev,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 2.0.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
@@ -259,35 +259,35 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.type,keyword,core,,,Type of host.
 2.0.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 2.0.0-dev,true,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,host,host.user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,host,host.user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,host,host.user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,host,host.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,host,host.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,host,host.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,host,host.user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,host,host.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,host,host.user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,host,host.user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,host,host.user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,host,host.user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
-2.0.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
+2.0.0-dev,true,http,http.request.body.content,keyword,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 2.0.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 2.0.0-dev,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
 2.0.0-dev,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
-2.0.0-dev,true,http,http.request.referrer,wildcard,extended,,https://blog.example.com/,Referrer for this HTTP request.
+2.0.0-dev,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 2.0.0-dev,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
-2.0.0-dev,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
+2.0.0-dev,true,http,http.response.body.content,keyword,extended,,Hello world,The full HTTP response body.
 2.0.0-dev,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
 2.0.0-dev,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 2.0.0-dev,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 2.0.0-dev,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
 2.0.0-dev,true,http,http.version,keyword,extended,,1.1,HTTP version.
-2.0.0-dev,true,log,log.file.path,wildcard,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
+2.0.0-dev,true,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 2.0.0-dev,true,log,log.level,keyword,core,,error,Log level of the log event.
-2.0.0-dev,true,log,log.logger,wildcard,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
+2.0.0-dev,true,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
 2.0.0-dev,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
 2.0.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 2.0.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
@@ -326,7 +326,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,observer,observer.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,observer,observer.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,observer,observer.hostname,keyword,core,,,Hostname of the observer.
@@ -341,10 +341,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.mac,keyword,core,array,,MAC addresses of the observer
 2.0.0-dev,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 2.0.0-dev,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
-2.0.0-dev,true,observer,observer.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+2.0.0-dev,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
-2.0.0-dev,true,observer,observer.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
+2.0.0-dev,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 2.0.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
@@ -355,7 +355,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.vendor,keyword,core,,Symantec,Vendor name of the observer.
 2.0.0-dev,true,observer,observer.version,keyword,core,,,Observer version.
 2.0.0-dev,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
-2.0.0-dev,true,organization,organization.name,wildcard,extended,,,Organization name.
+2.0.0-dev,true,organization,organization.name,keyword,extended,,,Organization name.
 2.0.0-dev,true,organization,organization.name.text,text,extended,,,Organization name.
 2.0.0-dev,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 2.0.0-dev,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
@@ -380,7 +380,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
-2.0.0-dev,true,process,process.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 2.0.0-dev,true,process,process.hash.md5,keyword,extended,,,MD5 hash.
@@ -388,7 +388,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.hash.sha256,keyword,extended,,,SHA256 hash.
 2.0.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 2.0.0-dev,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
-2.0.0-dev,true,process,process.name,wildcard,extended,,ssh,Process name.
+2.0.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
 2.0.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
 2.0.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 2.0.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
@@ -400,7 +400,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
-2.0.0-dev,true,process,process.parent.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 2.0.0-dev,true,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
@@ -408,50 +408,50 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,process,process.parent.hash.sha256,keyword,extended,,,SHA256 hash.
 2.0.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 2.0.0-dev,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
-2.0.0-dev,true,process,process.parent.name,wildcard,extended,,ssh,Process name.
+2.0.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
 2.0.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
 2.0.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 2.0.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 2.0.0-dev,true,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
 2.0.0-dev,true,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
-2.0.0-dev,true,process,process.parent.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev,true,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 2.0.0-dev,true,process,process.parent.pid,long,core,,4242,Process id.
 2.0.0-dev,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.
 2.0.0-dev,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 2.0.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
-2.0.0-dev,true,process,process.parent.thread.name,wildcard,extended,,thread-0,Thread name.
-2.0.0-dev,true,process,process.parent.title,wildcard,extended,,,Process title.
+2.0.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
+2.0.0-dev,true,process,process.parent.title,keyword,extended,,,Process title.
 2.0.0-dev,true,process,process.parent.title.text,text,extended,,,Process title.
 2.0.0-dev,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
-2.0.0-dev,true,process,process.parent.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
+2.0.0-dev,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 2.0.0-dev,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 2.0.0-dev,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 2.0.0-dev,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 2.0.0-dev,true,process,process.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
 2.0.0-dev,true,process,process.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
-2.0.0-dev,true,process,process.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev,true,process,process.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 2.0.0-dev,true,process,process.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 2.0.0-dev,true,process,process.pid,long,core,,4242,Process id.
 2.0.0-dev,true,process,process.ppid,long,extended,,4241,Parent process' pid.
 2.0.0-dev,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 2.0.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
-2.0.0-dev,true,process,process.thread.name,wildcard,extended,,thread-0,Thread name.
-2.0.0-dev,true,process,process.title,wildcard,extended,,,Process title.
+2.0.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
+2.0.0-dev,true,process,process.title,keyword,extended,,,Process title.
 2.0.0-dev,true,process,process.title.text,text,extended,,,Process title.
 2.0.0-dev,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
-2.0.0-dev,true,process,process.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
+2.0.0-dev,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 2.0.0-dev,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 2.0.0-dev,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
-2.0.0-dev,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+2.0.0-dev,true,registry,registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 2.0.0-dev,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
 2.0.0-dev,true,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
-2.0.0-dev,true,registry,registry.key,wildcard,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
-2.0.0-dev,true,registry,registry.path,wildcard,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
+2.0.0-dev,true,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
+2.0.0-dev,true,registry,registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
 2.0.0-dev,true,registry,registry.value,keyword,core,,Debugger,Name of the value written.
 2.0.0-dev,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
 2.0.0-dev,true,related,related.hosts,keyword,extended,array,,All the host identifiers seen on your event.
@@ -469,16 +469,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,rule,rule.version,keyword,extended,,1.1,Rule version
 2.0.0-dev,true,server,server.address,keyword,extended,,,Server network address.
 2.0.0-dev,true,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
-2.0.0-dev,true,server,server.as.organization.name,wildcard,extended,,Google LLC,Organization name.
+2.0.0-dev,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
 2.0.0-dev,true,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
 2.0.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
-2.0.0-dev,true,server,server.domain,wildcard,core,,,Server domain.
+2.0.0-dev,true,server,server.domain,keyword,core,,,Server domain.
 2.0.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
 2.0.0-dev,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,server,server.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,server,server.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,server,server.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
@@ -487,19 +487,19 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,server,server.nat.port,long,extended,,,Server NAT port
 2.0.0-dev,true,server,server.packets,long,core,,12,Packets sent from the server to the client.
 2.0.0-dev,true,server,server.port,long,core,,,Port of the server.
-2.0.0-dev,true,server,server.registered_domain,wildcard,extended,,example.com,"The highest registered server domain, stripped of the subdomain."
+2.0.0-dev,true,server,server.registered_domain,keyword,extended,,example.com,"The highest registered server domain, stripped of the subdomain."
 2.0.0-dev,true,server,server.subdomain,keyword,extended,,east,The subdomain of the domain.
 2.0.0-dev,true,server,server.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 2.0.0-dev,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,server,server.user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,server,server.user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,server,server.user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,server,server.user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -511,16 +511,16 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,service,service.version,keyword,core,,3.2.4,Version of the service.
 2.0.0-dev,true,source,source.address,keyword,extended,,,Source network address.
 2.0.0-dev,true,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
-2.0.0-dev,true,source,source.as.organization.name,wildcard,extended,,Google LLC,Organization name.
+2.0.0-dev,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
 2.0.0-dev,true,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
 2.0.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
-2.0.0-dev,true,source,source.domain,wildcard,core,,,Source domain.
+2.0.0-dev,true,source,source.domain,keyword,core,,,Source domain.
 2.0.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
 2.0.0-dev,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
 2.0.0-dev,true,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
 2.0.0-dev,true,source,source.geo.country_name,keyword,core,,Canada,Country name.
 2.0.0-dev,true,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
-2.0.0-dev,true,source,source.geo.name,wildcard,extended,,boston-dc,User-defined description of a location.
+2.0.0-dev,true,source,source.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
 2.0.0-dev,true,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 2.0.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
 2.0.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
@@ -529,19 +529,19 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,source,source.nat.port,long,extended,,,Source NAT port
 2.0.0-dev,true,source,source.packets,long,core,,12,Packets sent from the source to the destination.
 2.0.0-dev,true,source,source.port,long,core,,,Port of the source.
-2.0.0-dev,true,source,source.registered_domain,wildcard,extended,,example.com,"The highest registered source domain, stripped of the subdomain."
+2.0.0-dev,true,source,source.registered_domain,keyword,extended,,example.com,"The highest registered source domain, stripped of the subdomain."
 2.0.0-dev,true,source,source.subdomain,keyword,extended,,east,The subdomain of the domain.
 2.0.0-dev,true,source,source.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 2.0.0-dev,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,source,source.user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,source,source.user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,source,source.user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,source,source.user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
@@ -563,17 +563,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,tls,tls.client.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client.
 2.0.0-dev,true,tls,tls.client.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client.
 2.0.0-dev,true,tls,tls.client.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client.
-2.0.0-dev,true,tls,tls.client.issuer,wildcard,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+2.0.0-dev,true,tls,tls.client.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
 2.0.0-dev,true,tls,tls.client.ja3,keyword,extended,,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
 2.0.0-dev,true,tls,tls.client.not_after,date,extended,,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
 2.0.0-dev,true,tls,tls.client.not_before,date,extended,,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
 2.0.0-dev,true,tls,tls.client.server_name,keyword,extended,,www.elastic.co,Hostname the client is trying to connect to. Also called the SNI.
-2.0.0-dev,true,tls,tls.client.subject,wildcard,extended,,"CN=myclient, OU=Documentation Team, DC=example, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
+2.0.0-dev,true,tls,tls.client.subject,keyword,extended,,"CN=myclient, OU=Documentation Team, DC=example, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
 2.0.0-dev,true,tls,tls.client.supported_ciphers,keyword,extended,array,"[""TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"", ""TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"", ""...""]",Array of ciphers offered by the client during the client hello.
 2.0.0-dev,true,tls,tls.client.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
 2.0.0-dev,true,tls,tls.client.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.client.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-2.0.0-dev,true,tls,tls.client.x509.issuer.distinguished_name,wildcard,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+2.0.0-dev,true,tls,tls.client.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.client.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
 2.0.0-dev,true,tls,tls.client.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.client.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
@@ -588,7 +588,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,tls,tls.client.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
 2.0.0-dev,true,tls,tls.client.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 2.0.0-dev,true,tls,tls.client.x509.subject.country,keyword,extended,array,US,List of country (C) code
-2.0.0-dev,true,tls,tls.client.x509.subject.distinguished_name,wildcard,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+2.0.0-dev,true,tls,tls.client.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 2.0.0-dev,true,tls,tls.client.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
 2.0.0-dev,true,tls,tls.client.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 2.0.0-dev,true,tls,tls.client.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
@@ -603,15 +603,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,tls,tls.server.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server.
 2.0.0-dev,true,tls,tls.server.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server.
 2.0.0-dev,true,tls,tls.server.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server.
-2.0.0-dev,true,tls,tls.server.issuer,wildcard,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
+2.0.0-dev,true,tls,tls.server.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
 2.0.0-dev,true,tls,tls.server.ja3s,keyword,extended,,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
 2.0.0-dev,true,tls,tls.server.not_after,date,extended,,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
 2.0.0-dev,true,tls,tls.server.not_before,date,extended,,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
-2.0.0-dev,true,tls,tls.server.subject,wildcard,extended,,"CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com",Subject of the x.509 certificate presented by the server.
+2.0.0-dev,true,tls,tls.server.subject,keyword,extended,,"CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com",Subject of the x.509 certificate presented by the server.
 2.0.0-dev,true,tls,tls.server.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
 2.0.0-dev,true,tls,tls.server.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.server.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
-2.0.0-dev,true,tls,tls.server.x509.issuer.distinguished_name,wildcard,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+2.0.0-dev,true,tls,tls.server.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.server.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
 2.0.0-dev,true,tls,tls.server.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
 2.0.0-dev,true,tls,tls.server.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
@@ -626,7 +626,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,tls,tls.server.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
 2.0.0-dev,true,tls,tls.server.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
 2.0.0-dev,true,tls,tls.server.x509.subject.country,keyword,extended,array,US,List of country (C) code
-2.0.0-dev,true,tls,tls.server.x509.subject.distinguished_name,wildcard,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+2.0.0-dev,true,tls,tls.server.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
 2.0.0-dev,true,tls,tls.server.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
 2.0.0-dev,true,tls,tls.server.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
 2.0.0-dev,true,tls,tls.server.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
@@ -636,79 +636,79 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,tls,tls.version_protocol,keyword,extended,,tls,Normalized lowercase protocol name parsed from original string.
 2.0.0-dev,true,trace,trace.id,keyword,extended,,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
 2.0.0-dev,true,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction within the scope of its trace.
-2.0.0-dev,true,url,url.domain,wildcard,extended,,www.elastic.co,Domain of the url.
+2.0.0-dev,true,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
 2.0.0-dev,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 2.0.0-dev,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
-2.0.0-dev,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+2.0.0-dev,true,url,url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 2.0.0-dev,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-2.0.0-dev,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+2.0.0-dev,true,url,url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 2.0.0-dev,true,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 2.0.0-dev,true,url,url.password,keyword,extended,,,Password of the request.
-2.0.0-dev,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
+2.0.0-dev,true,url,url.path,keyword,extended,,,"Path of the request, such as ""/search""."
 2.0.0-dev,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
 2.0.0-dev,true,url,url.query,keyword,extended,,,Query string of the request.
-2.0.0-dev,true,url,url.registered_domain,wildcard,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
+2.0.0-dev,true,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
 2.0.0-dev,true,url,url.scheme,keyword,extended,,https,Scheme of the url.
 2.0.0-dev,true,url,url.subdomain,keyword,extended,,east,The subdomain of the domain.
 2.0.0-dev,true,url,url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
 2.0.0-dev,true,url,url.username,keyword,extended,,,Username of the request.
 2.0.0-dev,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,user,user.changes.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,user,user.changes.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,user,user.changes.email,keyword,extended,,,User email address.
+2.0.0-dev,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,user,user.changes.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 2.0.0-dev,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,user,user.effective.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,user,user.effective.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,user,user.effective.email,keyword,extended,,,User email address.
+2.0.0-dev,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,user,user.effective.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
-2.0.0-dev,true,user,user.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,user,user.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,user,user.email,keyword,extended,,,User email address.
+2.0.0-dev,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,user,user.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,user,user.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,user,user.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
-2.0.0-dev,true,user,user.target.email,wildcard,extended,,,User email address.
-2.0.0-dev,true,user,user.target.full_name,wildcard,extended,,Albert Einstein,"User's full name, if available."
+2.0.0-dev,true,user,user.target.email,keyword,extended,,,User email address.
+2.0.0-dev,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
 2.0.0-dev,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 2.0.0-dev,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 2.0.0-dev,true,user,user.target.group.name,keyword,extended,,,Name of the group.
 2.0.0-dev,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 2.0.0-dev,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
-2.0.0-dev,true,user,user.target.name,wildcard,core,,albert,Short name or login of the user.
+2.0.0-dev,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
 2.0.0-dev,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 2.0.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
-2.0.0-dev,true,user_agent,user_agent.original,wildcard,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+2.0.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 2.0.0-dev,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 2.0.0-dev,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
-2.0.0-dev,true,user_agent,user_agent.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+2.0.0-dev,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
-2.0.0-dev,true,user_agent,user_agent.os.name,wildcard,extended,,Mac OS X,"Operating system name, without the version."
+2.0.0-dev,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
 2.0.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 2.0.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -18,8 +18,6 @@
   short: Date/time when the event originated.
   type: date
 agent.build.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: agent-build-original
   description: 'Extended build information for the agent.
 
@@ -28,11 +26,12 @@ agent.build.original:
   example: metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c
     built 2020-02-05 23:10:10 +0000 UTC]
   flat_name: agent.build.original
+  ignore_above: 1024
   level: core
   name: build.original
   normalize: []
   short: Extended build information for the agent.
-  type: wildcard
+  type: keyword
 agent.ephemeral_id:
   dashed_name: agent-ephemeral-id
   description: 'Ephemeral identifier of this agent (if one exists).
@@ -130,12 +129,11 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: client.as.organization.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: client.as.organization.name.text
@@ -146,7 +144,7 @@ client.as.organization.name:
   normalize: []
   original_fieldset: as
   short: Organization name.
-  type: wildcard
+  type: keyword
 client.bytes:
   dashed_name: client-bytes
   description: Bytes sent from the client to the server.
@@ -159,16 +157,15 @@ client.bytes:
   short: Bytes sent from the client to the server.
   type: long
 client.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-domain
   description: Client domain.
   flat_name: client.domain
+  ignore_above: 1024
   level: core
   name: domain
   normalize: []
   short: Client domain.
-  type: wildcard
+  type: keyword
 client.geo.city_name:
   dashed_name: client-geo-city-name
   description: City name.
@@ -229,8 +226,6 @@ client.geo.location:
   short: Longitude and latitude.
   type: geo_point
 client.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -241,12 +236,13 @@ client.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: client.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 client.geo.region_iso_code:
   dashed_name: client-geo-region-iso-code
   description: Region ISO code.
@@ -336,8 +332,6 @@ client.port:
   short: Port of the client.
   type: long
 client.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-registered-domain
   description: 'The highest registered client domain, stripped of the subdomain.
 
@@ -348,11 +342,12 @@ client.registered_domain:
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: client.registered_domain
+  ignore_above: 1024
   level: extended
   name: registered_domain
   normalize: []
   short: The highest registered client domain, stripped of the subdomain.
-  type: wildcard
+  type: keyword
 client.subdomain:
   dashed_name: client-subdomain
   description: 'The subdomain portion of a fully qualified domain name includes all
@@ -402,24 +397,22 @@ client.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 client.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-email
   description: User email address.
   flat_name: client.user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 client.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: client.user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: client.user.full_name.text
@@ -430,7 +423,7 @@ client.user.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 client.user.group.domain:
   dashed_name: client-user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -493,12 +486,11 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: client.user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: client.user.name.text
@@ -509,7 +501,7 @@ client.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 client.user.roles:
   dashed_name: client-user-roles
   description: Array of user roles at the time of the event.
@@ -748,12 +740,11 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: destination.as.organization.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: destination.as.organization.name.text
@@ -764,7 +755,7 @@ destination.as.organization.name:
   normalize: []
   original_fieldset: as
   short: Organization name.
-  type: wildcard
+  type: keyword
 destination.bytes:
   dashed_name: destination-bytes
   description: Bytes sent from the destination to the source.
@@ -777,16 +768,15 @@ destination.bytes:
   short: Bytes sent from the destination to the source.
   type: long
 destination.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-domain
   description: Destination domain.
   flat_name: destination.domain
+  ignore_above: 1024
   level: core
   name: domain
   normalize: []
   short: Destination domain.
-  type: wildcard
+  type: keyword
 destination.geo.city_name:
   dashed_name: destination-geo-city-name
   description: City name.
@@ -847,8 +837,6 @@ destination.geo.location:
   short: Longitude and latitude.
   type: geo_point
 destination.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -859,12 +847,13 @@ destination.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: destination.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 destination.geo.region_iso_code:
   dashed_name: destination-geo-region-iso-code
   description: Region ISO code.
@@ -953,8 +942,6 @@ destination.port:
   short: Port of the destination.
   type: long
 destination.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
@@ -965,11 +952,12 @@ destination.registered_domain:
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: destination.registered_domain
+  ignore_above: 1024
   level: extended
   name: registered_domain
   normalize: []
   short: The highest registered destination domain, stripped of the subdomain.
-  type: wildcard
+  type: keyword
 destination.subdomain:
   dashed_name: destination-subdomain
   description: 'The subdomain portion of a fully qualified domain name includes all
@@ -1019,24 +1007,22 @@ destination.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 destination.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-email
   description: User email address.
   flat_name: destination.user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 destination.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: destination.user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: destination.user.full_name.text
@@ -1047,7 +1033,7 @@ destination.user.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 destination.user.group.domain:
   dashed_name: destination-user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -1110,12 +1096,11 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: destination.user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: destination.user.name.text
@@ -1126,7 +1111,7 @@ destination.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 destination.user.roles:
   dashed_name: destination-user-roles
   description: Array of user roles at the time of the event.
@@ -1352,18 +1337,17 @@ dll.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 dll.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dll-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
   flat_name: dll.pe.original_file_name
+  ignore_above: 1024
   level: extended
   name: original_file_name
   normalize: []
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
-  type: wildcard
+  type: keyword
 dll.pe.product:
   dashed_name: dll-pe-product
   description: Internal product name of the file, provided at compile-time.
@@ -1407,19 +1391,18 @@ dns.answers.class:
   short: The class of DNS data contained in this resource record.
   type: keyword
 dns.answers.data:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dns-answers-data
   description: 'The data describing the resource.
 
     The meaning of this data depends on the type and class of the resource record.'
   example: 10.10.10.10
   flat_name: dns.answers.data
+  ignore_above: 1024
   level: extended
   name: answers.data
   normalize: []
   short: The data describing the resource.
-  type: wildcard
+  type: keyword
 dns.answers.name:
   dashed_name: dns-answers-name
   description: 'The domain name to which this resource record pertains.
@@ -1509,8 +1492,6 @@ dns.question.class:
   short: The class of records being queried.
   type: keyword
 dns.question.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: dns-question-name
   description: 'The name being queried.
 
@@ -1520,11 +1501,12 @@ dns.question.name:
     converted to \t, \r, and \n respectively.'
   example: www.example.com
   flat_name: dns.question.name
+  ignore_above: 1024
   level: extended
   name: question.name
   normalize: []
   short: The name being queried.
-  type: wildcard
+  type: keyword
 dns.question.registered_domain:
   dashed_name: dns-question-registered-domain
   description: 'The highest registered domain, stripped of the subdomain.
@@ -1677,11 +1659,12 @@ error.message:
   short: Error message.
   type: text
 error.stack_trace:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
+  doc_values: false
   flat_name: error.stack_trace
+  ignore_above: 1024
+  index: false
   level: extended
   multi_fields:
   - flat_name: error.stack_trace.text
@@ -1691,19 +1674,18 @@ error.stack_trace:
   name: stack_trace
   normalize: []
   short: The stack trace of this error in plain text.
-  type: wildcard
+  type: keyword
 error.type:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: error-type
   description: The type of the error, for example the class name of the exception.
   example: java.lang.NullPointerException
   flat_name: error.type
+  ignore_above: 1024
   level: extended
   name: type
   normalize: []
   short: The type of the error, for example the class name of the exception.
-  type: wildcard
+  type: keyword
 event.action:
   dashed_name: event-action
   description: 'The action captured by the event.
@@ -2581,18 +2563,17 @@ file.device:
   short: Device that is the source of the file.
   type: keyword
 file.directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-directory
   description: Directory where the file is located. It should include the drive letter,
     when appropriate.
   example: /home/alice
   flat_name: file.directory
+  ignore_above: 1024
   level: extended
   name: directory
   normalize: []
   short: Directory where the file is located.
-  type: wildcard
+  type: keyword
 file.drive_letter:
   dashed_name: file-drive-letter
   description: 'Drive letter where the file is located. This field is only relevant
@@ -2765,13 +2746,12 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
   example: /home/alice/example.png
   flat_name: file.path
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: file.path.text
@@ -2781,7 +2761,7 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
-  type: wildcard
+  type: keyword
 file.pe.architecture:
   dashed_name: file-pe-architecture
   description: CPU architecture target for the file.
@@ -2847,18 +2827,17 @@ file.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 file.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
   flat_name: file.pe.original_file_name
+  ignore_above: 1024
   level: extended
   name: original_file_name
   normalize: []
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
-  type: wildcard
+  type: keyword
 file.pe.product:
   dashed_name: file-pe-product
   description: Internal product name of the file, provided at compile-time.
@@ -2884,11 +2863,10 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: file.target_path.text
@@ -2898,7 +2876,7 @@ file.target_path:
   name: target_path
   normalize: []
   short: Target path for symlinks.
-  type: wildcard
+  type: keyword
 file.type:
   dashed_name: file-type
   description: File type (file, dir, or symlink).
@@ -2963,19 +2941,18 @@ file.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 file.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: file.x509.issuer.distinguished_name
+  ignore_above: 1024
   level: extended
   name: issuer.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of issuing certificate authority.
-  type: wildcard
+  type: keyword
 file.x509.issuer.locality:
   dashed_name: file-x509-issuer-locality
   description: List of locality names (L)
@@ -3154,18 +3131,17 @@ file.x509.subject.country:
   short: List of country (C) code
   type: keyword
 file.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: file-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: file.x509.subject.distinguished_name
+  ignore_above: 1024
   level: extended
   name: subject.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of the certificate subject entity.
-  type: wildcard
+  type: keyword
 file.x509.subject.locality:
   dashed_name: file-x509-subject-locality
   description: List of locality names (L)
@@ -3346,8 +3322,6 @@ host.geo.location:
   short: Longitude and latitude.
   type: geo_point
 host.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -3358,12 +3332,13 @@ host.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: host.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 host.geo.region_iso_code:
   dashed_name: host-geo-region-iso-code
   description: Region ISO code.
@@ -3389,18 +3364,17 @@ host.geo.region_name:
   short: Region name.
   type: keyword
 host.hostname:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-hostname
   description: 'Hostname of the host.
 
     It normally contains what the `hostname` command returns on the host machine.'
   flat_name: host.hostname
+  ignore_above: 1024
   level: core
   name: hostname
   normalize: []
   short: Hostname of the host.
-  type: wildcard
+  type: keyword
 host.id:
   dashed_name: host-id
   description: 'Unique host id.
@@ -3462,12 +3436,11 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: host.os.full
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: host.os.full.text
@@ -3478,7 +3451,7 @@ host.os.full:
   normalize: []
   original_fieldset: os
   short: Operating system name, including the version or code name.
-  type: wildcard
+  type: keyword
 host.os.kernel:
   dashed_name: host-os-kernel
   description: Operating system kernel version as a raw string.
@@ -3492,12 +3465,11 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: host.os.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: host.os.name.text
@@ -3508,7 +3480,7 @@ host.os.name:
   normalize: []
   original_fieldset: os
   short: Operating system name, without the version.
-  type: wildcard
+  type: keyword
 host.os.platform:
   dashed_name: host-os-platform
   description: Operating system platform (such centos, ubuntu, windows).
@@ -3589,24 +3561,22 @@ host.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 host.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-email
   description: User email address.
   flat_name: host.user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 host.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: host.user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: host.user.full_name.text
@@ -3617,7 +3587,7 @@ host.user.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 host.user.group.domain:
   dashed_name: host-user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -3680,12 +3650,11 @@ host.user.id:
   short: Unique identifier of the user.
   type: keyword
 host.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: host-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: host.user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: host.user.name.text
@@ -3696,7 +3665,7 @@ host.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 host.user.roles:
   dashed_name: host-user-roles
   description: Array of user roles at the time of the event.
@@ -3722,12 +3691,11 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
   flat_name: http.request.body.content
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: http.request.body.content.text
@@ -3737,7 +3705,7 @@ http.request.body.content:
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
-  type: wildcard
+  type: keyword
 http.request.bytes:
   dashed_name: http-request-bytes
   description: Total size in bytes of the request (body and headers).
@@ -3798,17 +3766,16 @@ http.request.mime_type:
   short: Mime type of the body of the request.
   type: keyword
 http.request.referrer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-request-referrer
   description: Referrer for this HTTP request.
   example: https://blog.example.com/
   flat_name: http.request.referrer
+  ignore_above: 1024
   level: extended
   name: request.referrer
   normalize: []
   short: Referrer for this HTTP request.
-  type: wildcard
+  type: keyword
 http.response.body.bytes:
   dashed_name: http-response-body-bytes
   description: Size in bytes of the response body.
@@ -3821,12 +3788,11 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
   flat_name: http.response.body.content
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: http.response.body.content.text
@@ -3836,7 +3802,7 @@ http.response.body.content:
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
-  type: wildcard
+  type: keyword
 http.response.bytes:
   dashed_name: http-response-bytes
   description: Total size in bytes of the response (body and headers).
@@ -3902,8 +3868,6 @@ labels:
   short: Custom key/value pairs.
   type: object
 log.file.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: log-file-path
   description: 'Full path to the log file this event came from, including the file
     name. It should include the drive letter, when appropriate.
@@ -3911,11 +3875,12 @@ log.file.path:
     If the event wasn''t read from a log file, do not populate this field.'
   example: /var/log/fun-times.log
   flat_name: log.file.path
+  ignore_above: 1024
   level: extended
   name: file.path
   normalize: []
   short: Full path to the log file this event came from.
-  type: wildcard
+  type: keyword
 log.level:
   dashed_name: log-level
   description: 'Original log level of the log event.
@@ -3934,18 +3899,17 @@ log.level:
   short: Log level of the log event.
   type: keyword
 log.logger:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: log-logger
   description: The name of the logger inside an application. This is usually the name
     of the class which initialized the logger, or can be a custom name.
   example: org.elasticsearch.bootstrap.Bootstrap
   flat_name: log.logger
+  ignore_above: 1024
   level: core
   name: logger
   normalize: []
   short: Name of the logger.
-  type: wildcard
+  type: keyword
 log.origin.file.line:
   dashed_name: log-origin-file-line
   description: The line number of the file containing the source code which originated
@@ -4466,8 +4430,6 @@ observer.geo.location:
   short: Longitude and latitude.
   type: geo_point
 observer.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -4478,12 +4440,13 @@ observer.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: observer.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 observer.geo.region_iso_code:
   dashed_name: observer-geo-region-iso-code
   description: Region ISO code.
@@ -4654,12 +4617,11 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: observer.os.full
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: observer.os.full.text
@@ -4670,7 +4632,7 @@ observer.os.full:
   normalize: []
   original_fieldset: os
   short: Operating system name, including the version or code name.
-  type: wildcard
+  type: keyword
 observer.os.kernel:
   dashed_name: observer-os-kernel
   description: Operating system kernel version as a raw string.
@@ -4684,12 +4646,11 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: observer.os.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: observer.os.name.text
@@ -4700,7 +4661,7 @@ observer.os.name:
   normalize: []
   original_fieldset: os
   short: Operating system name, without the version.
-  type: wildcard
+  type: keyword
 observer.os.platform:
   dashed_name: observer-os-platform
   description: Operating system platform (such centos, ubuntu, windows).
@@ -4811,11 +4772,10 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: organization.name.text
@@ -4825,7 +4785,7 @@ organization.name:
   name: name
   normalize: []
   short: Organization name.
-  type: wildcard
+  type: keyword
 package.architecture:
   dashed_name: package-architecture
   description: Package architecture.
@@ -5112,12 +5072,11 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
   flat_name: process.executable
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.executable.text
@@ -5127,7 +5086,7 @@ process.executable:
   name: executable
   normalize: []
   short: Absolute path to the process executable.
-  type: wildcard
+  type: keyword
 process.exit_code:
   dashed_name: process-exit-code
   description: 'The exit code of the process, if this is a termination event.
@@ -5197,14 +5156,13 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-name
   description: 'Process name.
 
     Sometimes called program name or similar.'
   example: ssh
   flat_name: process.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.name.text
@@ -5214,7 +5172,7 @@ process.name:
   name: name
   normalize: []
   short: Process name.
-  type: wildcard
+  type: keyword
 process.parent.args:
   dashed_name: process-parent-args
   description: 'Array of process arguments, starting with the absolute path to the
@@ -5356,12 +5314,11 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
   flat_name: process.parent.executable
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.parent.executable.text
@@ -5372,7 +5329,7 @@ process.parent.executable:
   normalize: []
   original_fieldset: process
   short: Absolute path to the process executable.
-  type: wildcard
+  type: keyword
 process.parent.exit_code:
   dashed_name: process-parent-exit-code
   description: 'The exit code of the process, if this is a termination event.
@@ -5443,14 +5400,13 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-name
   description: 'Process name.
 
     Sometimes called program name or similar.'
   example: ssh
   flat_name: process.parent.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.parent.name.text
@@ -5461,7 +5417,7 @@ process.parent.name:
   normalize: []
   original_fieldset: process
   short: Process name.
-  type: wildcard
+  type: keyword
 process.parent.pe.architecture:
   dashed_name: process-parent-pe-architecture
   description: CPU architecture target for the file.
@@ -5527,18 +5483,17 @@ process.parent.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 process.parent.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
   flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
   level: extended
   name: original_file_name
   normalize: []
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
-  type: wildcard
+  type: keyword
 process.parent.pe.product:
   dashed_name: process-parent-pe-product
   description: Internal product name of the file, provided at compile-time.
@@ -5610,27 +5565,25 @@ process.parent.thread.id:
   short: Thread ID.
   type: long
 process.parent.thread.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-thread-name
   description: Thread name.
   example: thread-0
   flat_name: process.parent.thread.name
+  ignore_above: 1024
   level: extended
   name: thread.name
   normalize: []
   original_fieldset: process
   short: Thread name.
-  type: wildcard
+  type: keyword
 process.parent.title:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-title
   description: 'Process title.
 
     The proctitle, some times the same as process name. Can also be different: for
     example a browser setting its title to the web page currently opened.'
   flat_name: process.parent.title
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.parent.title.text
@@ -5641,7 +5594,7 @@ process.parent.title:
   normalize: []
   original_fieldset: process
   short: Process title.
-  type: wildcard
+  type: keyword
 process.parent.uptime:
   dashed_name: process-parent-uptime
   description: Seconds the process has been up.
@@ -5654,12 +5607,11 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
   flat_name: process.parent.working_directory
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.parent.working_directory.text
@@ -5670,7 +5622,7 @@ process.parent.working_directory:
   normalize: []
   original_fieldset: process
   short: The working directory of the process.
-  type: wildcard
+  type: keyword
 process.pe.architecture:
   dashed_name: process-pe-architecture
   description: CPU architecture target for the file.
@@ -5736,18 +5688,17 @@ process.pe.imphash:
   short: A hash of the imports in a PE file.
   type: keyword
 process.pe.original_file_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
   example: MSPAINT.EXE
   flat_name: process.pe.original_file_name
+  ignore_above: 1024
   level: extended
   name: original_file_name
   normalize: []
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
-  type: wildcard
+  type: keyword
 process.pe.product:
   dashed_name: process-pe-product
   description: Internal product name of the file, provided at compile-time.
@@ -5814,26 +5765,24 @@ process.thread.id:
   short: Thread ID.
   type: long
 process.thread.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-thread-name
   description: Thread name.
   example: thread-0
   flat_name: process.thread.name
+  ignore_above: 1024
   level: extended
   name: thread.name
   normalize: []
   short: Thread name.
-  type: wildcard
+  type: keyword
 process.title:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-title
   description: 'Process title.
 
     The proctitle, some times the same as process name. Can also be different: for
     example a browser setting its title to the web page currently opened.'
   flat_name: process.title
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.title.text
@@ -5843,7 +5792,7 @@ process.title:
   name: title
   normalize: []
   short: Process title.
-  type: wildcard
+  type: keyword
 process.uptime:
   dashed_name: process-uptime
   description: Seconds the process has been up.
@@ -5855,12 +5804,11 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
   flat_name: process.working_directory
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.working_directory.text
@@ -5870,7 +5818,7 @@ process.working_directory:
   name: working_directory
   normalize: []
   short: The working directory of the process.
-  type: wildcard
+  type: keyword
 registry.data.bytes:
   dashed_name: registry-data-bytes
   description: 'Original bytes written with base64 encoding.
@@ -5887,8 +5835,6 @@ registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 registry.data.strings:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-data-strings
   description: 'Content when writing string types.
 
@@ -5899,12 +5845,13 @@ registry.data.strings:
     the decimal representation (e.g `"1"`).'
   example: '["C:\rta\red_ttp\bin\myapp.exe"]'
   flat_name: registry.data.strings
+  ignore_above: 1024
   level: core
   name: data.strings
   normalize:
   - array
   short: List of strings representing what was written to the registry.
-  type: wildcard
+  type: keyword
 registry.data.type:
   dashed_name: registry-data-type
   description: Standard registry type for encoding contents
@@ -5928,30 +5875,28 @@ registry.hive:
   short: Abbreviated name for the hive.
   type: keyword
 registry.key:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-key
   description: Hive-relative path of keys.
   example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
   flat_name: registry.key
+  ignore_above: 1024
   level: core
   name: key
   normalize: []
   short: Hive-relative path of keys.
-  type: wildcard
+  type: keyword
 registry.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: registry-path
   description: Full path, including hive, key and value
   example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
     Options\winword.exe\Debugger
   flat_name: registry.path
+  ignore_above: 1024
   level: core
   name: path
   normalize: []
   short: Full path, including hive, key and value
-  type: wildcard
+  type: keyword
 registry.value:
   dashed_name: registry-value
   description: Name of the value written.
@@ -6159,12 +6104,11 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: server.as.organization.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: server.as.organization.name.text
@@ -6175,7 +6119,7 @@ server.as.organization.name:
   normalize: []
   original_fieldset: as
   short: Organization name.
-  type: wildcard
+  type: keyword
 server.bytes:
   dashed_name: server-bytes
   description: Bytes sent from the server to the client.
@@ -6188,16 +6132,15 @@ server.bytes:
   short: Bytes sent from the server to the client.
   type: long
 server.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-domain
   description: Server domain.
   flat_name: server.domain
+  ignore_above: 1024
   level: core
   name: domain
   normalize: []
   short: Server domain.
-  type: wildcard
+  type: keyword
 server.geo.city_name:
   dashed_name: server-geo-city-name
   description: City name.
@@ -6258,8 +6201,6 @@ server.geo.location:
   short: Longitude and latitude.
   type: geo_point
 server.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -6270,12 +6211,13 @@ server.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: server.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 server.geo.region_iso_code:
   dashed_name: server-geo-region-iso-code
   description: Region ISO code.
@@ -6365,8 +6307,6 @@ server.port:
   short: Port of the server.
   type: long
 server.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-registered-domain
   description: 'The highest registered server domain, stripped of the subdomain.
 
@@ -6377,11 +6317,12 @@ server.registered_domain:
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: server.registered_domain
+  ignore_above: 1024
   level: extended
   name: registered_domain
   normalize: []
   short: The highest registered server domain, stripped of the subdomain.
-  type: wildcard
+  type: keyword
 server.subdomain:
   dashed_name: server-subdomain
   description: 'The subdomain portion of a fully qualified domain name includes all
@@ -6431,24 +6372,22 @@ server.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 server.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-email
   description: User email address.
   flat_name: server.user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 server.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: server.user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: server.user.full_name.text
@@ -6459,7 +6398,7 @@ server.user.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 server.user.group.domain:
   dashed_name: server-user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -6522,12 +6461,11 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: server.user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: server.user.name.text
@@ -6538,7 +6476,7 @@ server.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 server.user.roles:
   dashed_name: server-user-roles
   description: Array of user roles at the time of the event.
@@ -6692,12 +6630,11 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
   flat_name: source.as.organization.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: source.as.organization.name.text
@@ -6708,7 +6645,7 @@ source.as.organization.name:
   normalize: []
   original_fieldset: as
   short: Organization name.
-  type: wildcard
+  type: keyword
 source.bytes:
   dashed_name: source-bytes
   description: Bytes sent from the source to the destination.
@@ -6721,16 +6658,15 @@ source.bytes:
   short: Bytes sent from the source to the destination.
   type: long
 source.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-domain
   description: Source domain.
   flat_name: source.domain
+  ignore_above: 1024
   level: core
   name: domain
   normalize: []
   short: Source domain.
-  type: wildcard
+  type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name
   description: City name.
@@ -6791,8 +6727,6 @@ source.geo.location:
   short: Longitude and latitude.
   type: geo_point
 source.geo.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-geo-name
   description: 'User-defined description of a location, at the level of granularity
     they care about.
@@ -6803,12 +6737,13 @@ source.geo.name:
     Not typically used in automated geolocation.'
   example: boston-dc
   flat_name: source.geo.name
+  ignore_above: 1024
   level: extended
   name: name
   normalize: []
   original_fieldset: geo
   short: User-defined description of a location.
-  type: wildcard
+  type: keyword
 source.geo.region_iso_code:
   dashed_name: source-geo-region-iso-code
   description: Region ISO code.
@@ -6898,8 +6833,6 @@ source.port:
   short: Port of the source.
   type: long
 source.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
@@ -6910,11 +6843,12 @@ source.registered_domain:
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: source.registered_domain
+  ignore_above: 1024
   level: extended
   name: registered_domain
   normalize: []
   short: The highest registered source domain, stripped of the subdomain.
-  type: wildcard
+  type: keyword
 source.subdomain:
   dashed_name: source-subdomain
   description: 'The subdomain portion of a fully qualified domain name includes all
@@ -6964,24 +6898,22 @@ source.user.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 source.user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-email
   description: User email address.
   flat_name: source.user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 source.user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: source.user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: source.user.full_name.text
@@ -6992,7 +6924,7 @@ source.user.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 source.user.group.domain:
   dashed_name: source-user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -7055,12 +6987,11 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
   flat_name: source.user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: source.user.name.text
@@ -7071,7 +7002,7 @@ source.user.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 source.user.roles:
   dashed_name: source-user-roles
   description: Array of user roles at the time of the event.
@@ -7335,19 +7266,18 @@ tls.client.hash.sha256:
     certificate offered by the client.
   type: keyword
 tls.client.issuer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-issuer
   description: Distinguished name of subject of the issuer of the x.509 certificate
     presented by the client.
   example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.client.issuer
+  ignore_above: 1024
   level: extended
   name: client.issuer
   normalize: []
   short: Distinguished name of subject of the issuer of the x.509 certificate presented
     by the client.
-  type: wildcard
+  type: keyword
 tls.client.ja3:
   dashed_name: tls-client-ja3
   description: A hash that identifies clients based on how they perform an SSL/TLS
@@ -7395,18 +7325,17 @@ tls.client.server_name:
   short: Hostname the client is trying to connect to. Also called the SNI.
   type: keyword
 tls.client.subject:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-subject
   description: Distinguished name of subject of the x.509 certificate presented by
     the client.
   example: CN=myclient, OU=Documentation Team, DC=example, DC=com
   flat_name: tls.client.subject
+  ignore_above: 1024
   level: extended
   name: client.subject
   normalize: []
   short: Distinguished name of subject of the x.509 certificate presented by the client.
-  type: wildcard
+  type: keyword
 tls.client.supported_ciphers:
   dashed_name: tls-client-supported-ciphers
   description: Array of ciphers offered by the client during the client hello.
@@ -7462,19 +7391,18 @@ tls.client.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 tls.client.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: tls.client.x509.issuer.distinguished_name
+  ignore_above: 1024
   level: extended
   name: issuer.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of issuing certificate authority.
-  type: wildcard
+  type: keyword
 tls.client.x509.issuer.locality:
   dashed_name: tls-client-x509-issuer-locality
   description: List of locality names (L)
@@ -7653,18 +7581,17 @@ tls.client.x509.subject.country:
   short: List of country (C) code
   type: keyword
 tls.client.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-client-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: tls.client.x509.subject.distinguished_name
+  ignore_above: 1024
   level: extended
   name: subject.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of the certificate subject entity.
-  type: wildcard
+  type: keyword
 tls.client.x509.subject.locality:
   dashed_name: tls-client-x509-subject-locality
   description: List of locality names (L)
@@ -7845,17 +7772,16 @@ tls.server.hash.sha256:
     certificate offered by the server.
   type: keyword
 tls.server.issuer:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-issuer
   description: Subject of the issuer of the x.509 certificate presented by the server.
   example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.server.issuer
+  ignore_above: 1024
   level: extended
   name: server.issuer
   normalize: []
   short: Subject of the issuer of the x.509 certificate presented by the server.
-  type: wildcard
+  type: keyword
 tls.server.ja3s:
   dashed_name: tls-server-ja3s
   description: A hash that identifies servers based on how they perform an SSL/TLS
@@ -7890,17 +7816,16 @@ tls.server.not_before:
   short: Timestamp indicating when server certificate is first considered valid.
   type: date
 tls.server.subject:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-subject
   description: Subject of the x.509 certificate presented by the server.
   example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
   flat_name: tls.server.subject
+  ignore_above: 1024
   level: extended
   name: server.subject
   normalize: []
   short: Subject of the x.509 certificate presented by the server.
-  type: wildcard
+  type: keyword
 tls.server.x509.alternative_names:
   dashed_name: tls-server-x509-alternative-names
   description: List of subject alternative names (SAN). Name types vary by certificate
@@ -7943,19 +7868,18 @@ tls.server.x509.issuer.country:
   short: List of country (C) codes
   type: keyword
 tls.server.x509.issuer.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-x509-issuer-distinguished-name
   description: Distinguished name (DN) of issuing certificate authority.
   example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
     Server CA
   flat_name: tls.server.x509.issuer.distinguished_name
+  ignore_above: 1024
   level: extended
   name: issuer.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of issuing certificate authority.
-  type: wildcard
+  type: keyword
 tls.server.x509.issuer.locality:
   dashed_name: tls-server-x509-issuer-locality
   description: List of locality names (L)
@@ -8134,18 +8058,17 @@ tls.server.x509.subject.country:
   short: List of country (C) code
   type: keyword
 tls.server.x509.subject.distinguished_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: tls-server-x509-subject-distinguished-name
   description: Distinguished name (DN) of the certificate subject entity.
   example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
   flat_name: tls.server.x509.subject.distinguished_name
+  ignore_above: 1024
   level: extended
   name: subject.distinguished_name
   normalize: []
   original_fieldset: x509
   short: Distinguished name (DN) of the certificate subject entity.
-  type: wildcard
+  type: keyword
 tls.server.x509.subject.locality:
   dashed_name: tls-server-x509-subject-locality
   description: List of locality names (L)
@@ -8260,8 +8183,6 @@ transaction.id:
   short: Unique identifier of the transaction within the scope of its trace.
   type: keyword
 url.domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-domain
   description: 'Domain of the url, such as "www.elastic.co".
 
@@ -8272,11 +8193,12 @@ url.domain:
     the `[` and `]` characters should also be captured in the `domain` field.'
   example: www.elastic.co
   flat_name: url.domain
+  ignore_above: 1024
   level: extended
   name: domain
   normalize: []
   short: Domain of the url.
-  type: wildcard
+  type: keyword
 url.extension:
   dashed_name: url-extension
   description: 'The field contains the file extension from the original request url,
@@ -8310,13 +8232,12 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
   example: https://www.elastic.co:443/search?q=elasticsearch#top
   flat_name: url.full
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: url.full.text
@@ -8326,10 +8247,8 @@ url.full:
   name: full
   normalize: []
   short: Full unparsed URL.
-  type: wildcard
+  type: keyword
 url.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -8339,6 +8258,7 @@ url.original:
     This field is meant to represent the URL as it was observed, complete or not.'
   example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
   flat_name: url.original
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: url.original.text
@@ -8348,7 +8268,7 @@ url.original:
   name: original
   normalize: []
   short: Unmodified original url as seen in the event source.
-  type: wildcard
+  type: keyword
 url.password:
   dashed_name: url-password
   description: Password of the request.
@@ -8360,16 +8280,15 @@ url.password:
   short: Password of the request.
   type: keyword
 url.path:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path
+  ignore_above: 1024
   level: extended
   name: path
   normalize: []
   short: Path of the request, such as "/search".
-  type: wildcard
+  type: keyword
 url.port:
   dashed_name: url-port
   description: Port of the request, such as 443.
@@ -8398,8 +8317,6 @@ url.query:
   short: Query string of the request.
   type: keyword
 url.registered_domain:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: url-registered-domain
   description: 'The highest registered url domain, stripped of the subdomain.
 
@@ -8410,11 +8327,12 @@ url.registered_domain:
     two labels will not work well for TLDs such as "co.uk".'
   example: example.com
   flat_name: url.registered_domain
+  ignore_above: 1024
   level: extended
   name: registered_domain
   normalize: []
   short: The highest registered url domain, stripped of the subdomain.
-  type: wildcard
+  type: keyword
 url.scheme:
   dashed_name: url-scheme
   description: 'Scheme of the request, such as "https".
@@ -8487,24 +8405,22 @@ user.changes.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.changes.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-email
   description: User email address.
   flat_name: user.changes.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 user.changes.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: user.changes.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user.changes.full_name.text
@@ -8515,7 +8431,7 @@ user.changes.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 user.changes.group.domain:
   dashed_name: user-changes-group-domain
   description: 'Name of the directory the group is a member of.
@@ -8578,12 +8494,11 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
   flat_name: user.changes.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: user.changes.name.text
@@ -8594,7 +8509,7 @@ user.changes.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 user.changes.roles:
   dashed_name: user-changes-roles
   description: Array of user roles at the time of the event.
@@ -8634,24 +8549,22 @@ user.effective.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.effective.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-email
   description: User email address.
   flat_name: user.effective.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 user.effective.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: user.effective.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user.effective.full_name.text
@@ -8662,7 +8575,7 @@ user.effective.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 user.effective.group.domain:
   dashed_name: user-effective-group-domain
   description: 'Name of the directory the group is a member of.
@@ -8725,12 +8638,11 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
   flat_name: user.effective.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: user.effective.name.text
@@ -8741,7 +8653,7 @@ user.effective.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 user.effective.roles:
   dashed_name: user-effective-roles
   description: Array of user roles at the time of the event.
@@ -8756,23 +8668,21 @@ user.effective.roles:
   short: Array of user roles at the time of the event.
   type: keyword
 user.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-email
   description: User email address.
   flat_name: user.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   short: User email address.
-  type: wildcard
+  type: keyword
 user.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: user.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user.full_name.text
@@ -8782,7 +8692,7 @@ user.full_name:
   name: full_name
   normalize: []
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 user.group.domain:
   dashed_name: user-group-domain
   description: 'Name of the directory the group is a member of.
@@ -8843,12 +8753,11 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
   flat_name: user.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: user.name.text
@@ -8858,7 +8767,7 @@ user.name:
   name: name
   normalize: []
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 user.roles:
   dashed_name: user-roles
   description: Array of user roles at the time of the event.
@@ -8885,24 +8794,22 @@ user.target.domain:
   short: Name of the directory the user is a member of.
   type: keyword
 user.target.email:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-email
   description: User email address.
   flat_name: user.target.email
+  ignore_above: 1024
   level: extended
   name: email
   normalize: []
   original_fieldset: user
   short: User email address.
-  type: wildcard
+  type: keyword
 user.target.full_name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
   flat_name: user.target.full_name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user.target.full_name.text
@@ -8913,7 +8820,7 @@ user.target.full_name:
   normalize: []
   original_fieldset: user
   short: User's full name, if available.
-  type: wildcard
+  type: keyword
 user.target.group.domain:
   dashed_name: user-target-group-domain
   description: 'Name of the directory the group is a member of.
@@ -8976,12 +8883,11 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
   flat_name: user.target.name
+  ignore_above: 1024
   level: core
   multi_fields:
   - flat_name: user.target.name.text
@@ -8992,7 +8898,7 @@ user.target.name:
   normalize: []
   original_fieldset: user
   short: Short name or login of the user.
-  type: wildcard
+  type: keyword
 user.target.roles:
   dashed_name: user-target-roles
   description: Array of user roles at the time of the event.
@@ -9029,13 +8935,12 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
     (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
   flat_name: user_agent.original
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user_agent.original.text
@@ -9045,7 +8950,7 @@ user_agent.original:
   name: original
   normalize: []
   short: Unparsed user_agent string.
-  type: wildcard
+  type: keyword
 user_agent.os.family:
   dashed_name: user-agent-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
@@ -9059,12 +8964,11 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
   flat_name: user_agent.os.full
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user_agent.os.full.text
@@ -9075,7 +8979,7 @@ user_agent.os.full:
   normalize: []
   original_fieldset: os
   short: Operating system name, including the version or code name.
-  type: wildcard
+  type: keyword
 user_agent.os.kernel:
   dashed_name: user-agent-os-kernel
   description: Operating system kernel version as a raw string.
@@ -9089,12 +8993,11 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
   flat_name: user_agent.os.name
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: user_agent.os.name.text
@@ -9105,7 +9008,7 @@ user_agent.os.name:
   normalize: []
   original_fieldset: os
   short: Operating system name, without the version.
-  type: wildcard
+  type: keyword
 user_agent.os.platform:
   dashed_name: user-agent-os-platform
   description: Operating system platform (such centos, ubuntu, windows).

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5033,8 +5033,6 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -5042,6 +5040,7 @@ process.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.command_line
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.command_line.text
@@ -5051,7 +5050,7 @@ process.command_line:
   name: command_line
   normalize: []
   short: Full command line that started the process.
-  type: wildcard
+  type: keyword
 process.entity_id:
   dashed_name: process-entity-id
   description: 'Unique identifier for the process.
@@ -5273,8 +5272,6 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Note the usage of `wildcard` type is considered beta. This field used to be
-    type `keyword`.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -5282,6 +5279,7 @@ process.parent.command_line:
     Some arguments may be filtered to protect sensitive information.'
   example: /usr/bin/ssh -l user 10.0.0.16
   flat_name: process.parent.command_line
+  ignore_above: 1024
   level: extended
   multi_fields:
   - flat_name: process.parent.command_line.text
@@ -5292,7 +5290,7 @@ process.parent.command_line:
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
-  type: wildcard
+  type: keyword
 process.parent.entity_id:
   dashed_name: process-parent-entity-id
   description: 'Unique identifier for the process.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8,8 +8,6 @@ agent:
     event happened or the measurement was taken.'
   fields:
     agent.build.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: agent-build-original
       description: 'Extended build information for the agent.
 
@@ -18,11 +16,12 @@ agent:
       example: metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c
         built 2020-02-05 23:10:10 +0000 UTC]
       flat_name: agent.build.original
+      ignore_above: 1024
       level: core
       name: build.original
       normalize: []
       short: Extended build information for the agent.
-      type: wildcard
+      type: keyword
     agent.ephemeral_id:
       dashed_name: agent-ephemeral-id
       description: 'Ephemeral identifier of this agent (if one exists).
@@ -120,12 +119,11 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: as.organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: as.organization.name.text
@@ -135,7 +133,7 @@ as:
       name: organization.name
       normalize: []
       short: Organization name.
-      type: wildcard
+      type: keyword
   group: 2
   name: as
   prefix: as.
@@ -277,12 +275,11 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: client.as.organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: client.as.organization.name.text
@@ -293,7 +290,7 @@ client:
       normalize: []
       original_fieldset: as
       short: Organization name.
-      type: wildcard
+      type: keyword
     client.bytes:
       dashed_name: client-bytes
       description: Bytes sent from the client to the server.
@@ -306,16 +303,15 @@ client:
       short: Bytes sent from the client to the server.
       type: long
     client.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-domain
       description: Client domain.
       flat_name: client.domain
+      ignore_above: 1024
       level: core
       name: domain
       normalize: []
       short: Client domain.
-      type: wildcard
+      type: keyword
     client.geo.city_name:
       dashed_name: client-geo-city-name
       description: City name.
@@ -376,8 +372,6 @@ client:
       short: Longitude and latitude.
       type: geo_point
     client.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -388,12 +382,13 @@ client:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: client.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     client.geo.region_iso_code:
       dashed_name: client-geo-region-iso-code
       description: Region ISO code.
@@ -483,8 +478,6 @@ client:
       short: Port of the client.
       type: long
     client.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-registered-domain
       description: 'The highest registered client domain, stripped of the subdomain.
 
@@ -495,11 +488,12 @@ client:
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: client.registered_domain
+      ignore_above: 1024
       level: extended
       name: registered_domain
       normalize: []
       short: The highest registered client domain, stripped of the subdomain.
-      type: wildcard
+      type: keyword
     client.subdomain:
       dashed_name: client-subdomain
       description: 'The subdomain portion of a fully qualified domain name includes
@@ -549,24 +543,22 @@ client:
       short: Name of the directory the user is a member of.
       type: keyword
     client.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-email
       description: User email address.
       flat_name: client.user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     client.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: client.user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: client.user.full_name.text
@@ -577,7 +569,7 @@ client:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     client.user.group.domain:
       dashed_name: client-user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -640,12 +632,11 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: client.user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: client.user.name.text
@@ -656,7 +647,7 @@ client:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     client.user.roles:
       dashed_name: client-user-roles
       description: Array of user roles at the time of the event.
@@ -1037,12 +1028,11 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: destination.as.organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: destination.as.organization.name.text
@@ -1053,7 +1043,7 @@ destination:
       normalize: []
       original_fieldset: as
       short: Organization name.
-      type: wildcard
+      type: keyword
     destination.bytes:
       dashed_name: destination-bytes
       description: Bytes sent from the destination to the source.
@@ -1066,16 +1056,15 @@ destination:
       short: Bytes sent from the destination to the source.
       type: long
     destination.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-domain
       description: Destination domain.
       flat_name: destination.domain
+      ignore_above: 1024
       level: core
       name: domain
       normalize: []
       short: Destination domain.
-      type: wildcard
+      type: keyword
     destination.geo.city_name:
       dashed_name: destination-geo-city-name
       description: City name.
@@ -1136,8 +1125,6 @@ destination:
       short: Longitude and latitude.
       type: geo_point
     destination.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -1148,12 +1135,13 @@ destination:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: destination.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     destination.geo.region_iso_code:
       dashed_name: destination-geo-region-iso-code
       description: Region ISO code.
@@ -1242,8 +1230,6 @@ destination:
       short: Port of the destination.
       type: long
     destination.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-registered-domain
       description: 'The highest registered destination domain, stripped of the subdomain.
 
@@ -1254,11 +1240,12 @@ destination:
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: destination.registered_domain
+      ignore_above: 1024
       level: extended
       name: registered_domain
       normalize: []
       short: The highest registered destination domain, stripped of the subdomain.
-      type: wildcard
+      type: keyword
     destination.subdomain:
       dashed_name: destination-subdomain
       description: 'The subdomain portion of a fully qualified domain name includes
@@ -1308,24 +1295,22 @@ destination:
       short: Name of the directory the user is a member of.
       type: keyword
     destination.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-email
       description: User email address.
       flat_name: destination.user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     destination.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: destination.user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: destination.user.full_name.text
@@ -1336,7 +1321,7 @@ destination:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     destination.user.group.domain:
       dashed_name: destination-user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -1399,12 +1384,11 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: destination.user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: destination.user.name.text
@@ -1415,7 +1399,7 @@ destination:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     destination.user.roles:
       dashed_name: destination-user-roles
       description: Array of user roles at the time of the event.
@@ -1675,18 +1659,17 @@ dll:
       short: A hash of the imports in a PE file.
       type: keyword
     dll.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dll-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       flat_name: dll.pe.original_file_name
+      ignore_above: 1024
       level: extended
       name: original_file_name
       normalize: []
       original_fieldset: pe
       short: Internal name of the file, provided at compile-time.
-      type: wildcard
+      type: keyword
     dll.pe.product:
       dashed_name: dll-pe-product
       description: Internal product name of the file, provided at compile-time.
@@ -1758,19 +1741,18 @@ dns:
       short: The class of DNS data contained in this resource record.
       type: keyword
     dns.answers.data:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dns-answers-data
       description: 'The data describing the resource.
 
         The meaning of this data depends on the type and class of the resource record.'
       example: 10.10.10.10
       flat_name: dns.answers.data
+      ignore_above: 1024
       level: extended
       name: answers.data
       normalize: []
       short: The data describing the resource.
-      type: wildcard
+      type: keyword
     dns.answers.name:
       dashed_name: dns-answers-name
       description: 'The domain name to which this resource record pertains.
@@ -1862,8 +1844,6 @@ dns:
       short: The class of records being queried.
       type: keyword
     dns.question.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: dns-question-name
       description: 'The name being queried.
 
@@ -1873,11 +1853,12 @@ dns:
         feeds should be converted to \t, \r, and \n respectively.'
       example: www.example.com
       flat_name: dns.question.name
+      ignore_above: 1024
       level: extended
       name: question.name
       normalize: []
       short: The name being queried.
-      type: wildcard
+      type: keyword
     dns.question.registered_domain:
       dashed_name: dns-question-registered-domain
       description: 'The highest registered domain, stripped of the subdomain.
@@ -2051,11 +2032,12 @@ error:
       short: Error message.
       type: text
     error.stack_trace:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
+      doc_values: false
       flat_name: error.stack_trace
+      ignore_above: 1024
+      index: false
       level: extended
       multi_fields:
       - flat_name: error.stack_trace.text
@@ -2065,19 +2047,18 @@ error:
       name: stack_trace
       normalize: []
       short: The stack trace of this error in plain text.
-      type: wildcard
+      type: keyword
     error.type:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: error-type
       description: The type of the error, for example the class name of the exception.
       example: java.lang.NullPointerException
       flat_name: error.type
+      ignore_above: 1024
       level: extended
       name: type
       normalize: []
       short: The type of the error, for example the class name of the exception.
-      type: wildcard
+      type: keyword
   group: 2
   name: error
   prefix: error.
@@ -3006,18 +2987,17 @@ file:
       short: Device that is the source of the file.
       type: keyword
     file.directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-directory
       description: Directory where the file is located. It should include the drive
         letter, when appropriate.
       example: /home/alice
       flat_name: file.directory
+      ignore_above: 1024
       level: extended
       name: directory
       normalize: []
       short: Directory where the file is located.
-      type: wildcard
+      type: keyword
     file.drive_letter:
       dashed_name: file-drive-letter
       description: 'Drive letter where the file is located. This field is only relevant
@@ -3190,13 +3170,12 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
       flat_name: file.path
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: file.path.text
@@ -3206,7 +3185,7 @@ file:
       name: path
       normalize: []
       short: Full path to the file, including the file name.
-      type: wildcard
+      type: keyword
     file.pe.architecture:
       dashed_name: file-pe-architecture
       description: CPU architecture target for the file.
@@ -3272,18 +3251,17 @@ file:
       short: A hash of the imports in a PE file.
       type: keyword
     file.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       flat_name: file.pe.original_file_name
+      ignore_above: 1024
       level: extended
       name: original_file_name
       normalize: []
       original_fieldset: pe
       short: Internal name of the file, provided at compile-time.
-      type: wildcard
+      type: keyword
     file.pe.product:
       dashed_name: file-pe-product
       description: Internal product name of the file, provided at compile-time.
@@ -3309,11 +3287,10 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: file.target_path.text
@@ -3323,7 +3300,7 @@ file:
       name: target_path
       normalize: []
       short: Target path for symlinks.
-      type: wildcard
+      type: keyword
     file.type:
       dashed_name: file-type
       description: File type (file, dir, or symlink).
@@ -3388,19 +3365,18 @@ file:
       short: List of country (C) codes
       type: keyword
     file.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: file.x509.issuer.distinguished_name
+      ignore_above: 1024
       level: extended
       name: issuer.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of issuing certificate authority.
-      type: wildcard
+      type: keyword
     file.x509.issuer.locality:
       dashed_name: file-x509-issuer-locality
       description: List of locality names (L)
@@ -3579,18 +3555,17 @@ file:
       short: List of country (C) code
       type: keyword
     file.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: file-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: file.x509.subject.distinguished_name
+      ignore_above: 1024
       level: extended
       name: subject.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of the certificate subject entity.
-      type: wildcard
+      type: keyword
     file.x509.subject.locality:
       dashed_name: file-x509-subject-locality
       description: List of locality names (L)
@@ -3740,8 +3715,6 @@ geo:
       short: Longitude and latitude.
       type: geo_point
     geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -3752,11 +3725,12 @@ geo:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     geo.region_iso_code:
       dashed_name: geo-region-iso-code
       description: Region ISO code.
@@ -4027,8 +4001,6 @@ host:
       short: Longitude and latitude.
       type: geo_point
     host.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -4039,12 +4011,13 @@ host:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: host.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     host.geo.region_iso_code:
       dashed_name: host-geo-region-iso-code
       description: Region ISO code.
@@ -4070,18 +4043,17 @@ host:
       short: Region name.
       type: keyword
     host.hostname:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-hostname
       description: 'Hostname of the host.
 
         It normally contains what the `hostname` command returns on the host machine.'
       flat_name: host.hostname
+      ignore_above: 1024
       level: core
       name: hostname
       normalize: []
       short: Hostname of the host.
-      type: wildcard
+      type: keyword
     host.id:
       dashed_name: host-id
       description: 'Unique host id.
@@ -4144,12 +4116,11 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: host.os.full
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: host.os.full.text
@@ -4160,7 +4131,7 @@ host:
       normalize: []
       original_fieldset: os
       short: Operating system name, including the version or code name.
-      type: wildcard
+      type: keyword
     host.os.kernel:
       dashed_name: host-os-kernel
       description: Operating system kernel version as a raw string.
@@ -4174,12 +4145,11 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: host.os.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: host.os.name.text
@@ -4190,7 +4160,7 @@ host:
       normalize: []
       original_fieldset: os
       short: Operating system name, without the version.
-      type: wildcard
+      type: keyword
     host.os.platform:
       dashed_name: host-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
@@ -4273,24 +4243,22 @@ host:
       short: Name of the directory the user is a member of.
       type: keyword
     host.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-email
       description: User email address.
       flat_name: host.user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     host.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: host.user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: host.user.full_name.text
@@ -4301,7 +4269,7 @@ host:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     host.user.group.domain:
       dashed_name: host-user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -4364,12 +4332,11 @@ host:
       short: Unique identifier of the user.
       type: keyword
     host.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: host-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: host.user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: host.user.name.text
@@ -4380,7 +4347,7 @@ host:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     host.user.roles:
       dashed_name: host-user-roles
       description: Array of user roles at the time of the event.
@@ -4430,12 +4397,11 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
       flat_name: http.request.body.content
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: http.request.body.content.text
@@ -4445,7 +4411,7 @@ http:
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
-      type: wildcard
+      type: keyword
     http.request.bytes:
       dashed_name: http-request-bytes
       description: Total size in bytes of the request (body and headers).
@@ -4508,17 +4474,16 @@ http:
       short: Mime type of the body of the request.
       type: keyword
     http.request.referrer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-request-referrer
       description: Referrer for this HTTP request.
       example: https://blog.example.com/
       flat_name: http.request.referrer
+      ignore_above: 1024
       level: extended
       name: request.referrer
       normalize: []
       short: Referrer for this HTTP request.
-      type: wildcard
+      type: keyword
     http.response.body.bytes:
       dashed_name: http-response-body-bytes
       description: Size in bytes of the response body.
@@ -4531,12 +4496,11 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
       flat_name: http.response.body.content
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: http.response.body.content.text
@@ -4546,7 +4510,7 @@ http:
       name: response.body.content
       normalize: []
       short: The full HTTP response body.
-      type: wildcard
+      type: keyword
     http.response.bytes:
       dashed_name: http-response-bytes
       description: Total size in bytes of the response (body and headers).
@@ -4670,8 +4634,6 @@ log:
     but rather in `event.*` or in other ECS fields.'
   fields:
     log.file.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: log-file-path
       description: 'Full path to the log file this event came from, including the
         file name. It should include the drive letter, when appropriate.
@@ -4679,11 +4641,12 @@ log:
         If the event wasn''t read from a log file, do not populate this field.'
       example: /var/log/fun-times.log
       flat_name: log.file.path
+      ignore_above: 1024
       level: extended
       name: file.path
       normalize: []
       short: Full path to the log file this event came from.
-      type: wildcard
+      type: keyword
     log.level:
       dashed_name: log-level
       description: 'Original log level of the log event.
@@ -4702,18 +4665,17 @@ log:
       short: Log level of the log event.
       type: keyword
     log.logger:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: log-logger
       description: The name of the logger inside an application. This is usually the
         name of the class which initialized the logger, or can be a custom name.
       example: org.elasticsearch.bootstrap.Bootstrap
       flat_name: log.logger
+      ignore_above: 1024
       level: core
       name: logger
       normalize: []
       short: Name of the logger.
-      type: wildcard
+      type: keyword
     log.origin.file.line:
       dashed_name: log-origin-file-line
       description: The line number of the file containing the source code which originated
@@ -5265,8 +5227,6 @@ observer:
       short: Longitude and latitude.
       type: geo_point
     observer.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -5277,12 +5237,13 @@ observer:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: observer.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     observer.geo.region_iso_code:
       dashed_name: observer-geo-region-iso-code
       description: Region ISO code.
@@ -5454,12 +5415,11 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: observer.os.full
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: observer.os.full.text
@@ -5470,7 +5430,7 @@ observer:
       normalize: []
       original_fieldset: os
       short: Operating system name, including the version or code name.
-      type: wildcard
+      type: keyword
     observer.os.kernel:
       dashed_name: observer-os-kernel
       description: Operating system kernel version as a raw string.
@@ -5484,12 +5444,11 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: observer.os.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: observer.os.name.text
@@ -5500,7 +5459,7 @@ observer:
       normalize: []
       original_fieldset: os
       short: Operating system name, without the version.
-      type: wildcard
+      type: keyword
     observer.os.platform:
       dashed_name: observer-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
@@ -5651,11 +5610,10 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: organization.name.text
@@ -5665,7 +5623,7 @@ organization:
       name: name
       normalize: []
       short: Organization name.
-      type: wildcard
+      type: keyword
   group: 2
   name: organization
   prefix: organization.
@@ -5687,12 +5645,11 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: os.full
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: os.full.text
@@ -5702,7 +5659,7 @@ os:
       name: full
       normalize: []
       short: Operating system name, including the version or code name.
-      type: wildcard
+      type: keyword
     os.kernel:
       dashed_name: os-kernel
       description: Operating system kernel version as a raw string.
@@ -5715,12 +5672,11 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: os.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: os.name.text
@@ -5730,7 +5686,7 @@ os:
       name: name
       normalize: []
       short: Operating system name, without the version.
-      type: wildcard
+      type: keyword
     os.platform:
       dashed_name: os-platform
       description: Operating system platform (such centos, ubuntu, windows).
@@ -6016,17 +5972,16 @@ pe:
       short: A hash of the imports in a PE file.
       type: keyword
     pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       flat_name: pe.original_file_name
+      ignore_above: 1024
       level: extended
       name: original_file_name
       normalize: []
       short: Internal name of the file, provided at compile-time.
-      type: wildcard
+      type: keyword
     pe.product:
       dashed_name: pe-product
       description: Internal product name of the file, provided at compile-time.
@@ -6200,12 +6155,11 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       flat_name: process.executable
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.executable.text
@@ -6215,7 +6169,7 @@ process:
       name: executable
       normalize: []
       short: Absolute path to the process executable.
-      type: wildcard
+      type: keyword
     process.exit_code:
       dashed_name: process-exit-code
       description: 'The exit code of the process, if this is a termination event.
@@ -6285,14 +6239,13 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-name
       description: 'Process name.
 
         Sometimes called program name or similar.'
       example: ssh
       flat_name: process.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.name.text
@@ -6302,7 +6255,7 @@ process:
       name: name
       normalize: []
       short: Process name.
-      type: wildcard
+      type: keyword
     process.parent.args:
       dashed_name: process-parent-args
       description: 'Array of process arguments, starting with the absolute path to
@@ -6444,12 +6397,11 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       flat_name: process.parent.executable
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.parent.executable.text
@@ -6460,7 +6412,7 @@ process:
       normalize: []
       original_fieldset: process
       short: Absolute path to the process executable.
-      type: wildcard
+      type: keyword
     process.parent.exit_code:
       dashed_name: process-parent-exit-code
       description: 'The exit code of the process, if this is a termination event.
@@ -6531,14 +6483,13 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-name
       description: 'Process name.
 
         Sometimes called program name or similar.'
       example: ssh
       flat_name: process.parent.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.parent.name.text
@@ -6549,7 +6500,7 @@ process:
       normalize: []
       original_fieldset: process
       short: Process name.
-      type: wildcard
+      type: keyword
     process.parent.pe.architecture:
       dashed_name: process-parent-pe-architecture
       description: CPU architecture target for the file.
@@ -6615,18 +6566,17 @@ process:
       short: A hash of the imports in a PE file.
       type: keyword
     process.parent.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       flat_name: process.parent.pe.original_file_name
+      ignore_above: 1024
       level: extended
       name: original_file_name
       normalize: []
       original_fieldset: pe
       short: Internal name of the file, provided at compile-time.
-      type: wildcard
+      type: keyword
     process.parent.pe.product:
       dashed_name: process-parent-pe-product
       description: Internal product name of the file, provided at compile-time.
@@ -6698,27 +6648,25 @@ process:
       short: Thread ID.
       type: long
     process.parent.thread.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-thread-name
       description: Thread name.
       example: thread-0
       flat_name: process.parent.thread.name
+      ignore_above: 1024
       level: extended
       name: thread.name
       normalize: []
       original_fieldset: process
       short: Thread name.
-      type: wildcard
+      type: keyword
     process.parent.title:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-title
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.'
       flat_name: process.parent.title
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.parent.title.text
@@ -6729,7 +6677,7 @@ process:
       normalize: []
       original_fieldset: process
       short: Process title.
-      type: wildcard
+      type: keyword
     process.parent.uptime:
       dashed_name: process-parent-uptime
       description: Seconds the process has been up.
@@ -6742,12 +6690,11 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
       flat_name: process.parent.working_directory
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.parent.working_directory.text
@@ -6758,7 +6705,7 @@ process:
       normalize: []
       original_fieldset: process
       short: The working directory of the process.
-      type: wildcard
+      type: keyword
     process.pe.architecture:
       dashed_name: process-pe-architecture
       description: CPU architecture target for the file.
@@ -6824,18 +6771,17 @@ process:
       short: A hash of the imports in a PE file.
       type: keyword
     process.pe.original_file_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       flat_name: process.pe.original_file_name
+      ignore_above: 1024
       level: extended
       name: original_file_name
       normalize: []
       original_fieldset: pe
       short: Internal name of the file, provided at compile-time.
-      type: wildcard
+      type: keyword
     process.pe.product:
       dashed_name: process-pe-product
       description: Internal product name of the file, provided at compile-time.
@@ -6902,26 +6848,24 @@ process:
       short: Thread ID.
       type: long
     process.thread.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-thread-name
       description: Thread name.
       example: thread-0
       flat_name: process.thread.name
+      ignore_above: 1024
       level: extended
       name: thread.name
       normalize: []
       short: Thread name.
-      type: wildcard
+      type: keyword
     process.title:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-title
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.'
       flat_name: process.title
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.title.text
@@ -6931,7 +6875,7 @@ process:
       name: title
       normalize: []
       short: Process title.
-      type: wildcard
+      type: keyword
     process.uptime:
       dashed_name: process-uptime
       description: Seconds the process has been up.
@@ -6943,12 +6887,11 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
       flat_name: process.working_directory
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.working_directory.text
@@ -6958,7 +6901,7 @@ process:
       name: working_directory
       normalize: []
       short: The working directory of the process.
-      type: wildcard
+      type: keyword
   group: 2
   name: process
   nestings:
@@ -7008,8 +6951,6 @@ registry:
       short: Original bytes written with base64 encoding.
       type: keyword
     registry.data.strings:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-data-strings
       description: 'Content when writing string types.
 
@@ -7020,12 +6961,13 @@ registry:
         be populated with the decimal representation (e.g `"1"`).'
       example: '["C:\rta\red_ttp\bin\myapp.exe"]'
       flat_name: registry.data.strings
+      ignore_above: 1024
       level: core
       name: data.strings
       normalize:
       - array
       short: List of strings representing what was written to the registry.
-      type: wildcard
+      type: keyword
     registry.data.type:
       dashed_name: registry-data-type
       description: Standard registry type for encoding contents
@@ -7049,30 +6991,28 @@ registry:
       short: Abbreviated name for the hive.
       type: keyword
     registry.key:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-key
       description: Hive-relative path of keys.
       example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
       flat_name: registry.key
+      ignore_above: 1024
       level: core
       name: key
       normalize: []
       short: Hive-relative path of keys.
-      type: wildcard
+      type: keyword
     registry.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: registry-path
       description: Full path, including hive, key and value
       example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution
         Options\winword.exe\Debugger
       flat_name: registry.path
+      ignore_above: 1024
       level: core
       name: path
       normalize: []
       short: Full path, including hive, key and value
-      type: wildcard
+      type: keyword
     registry.value:
       dashed_name: registry-value
       description: Name of the value written.
@@ -7337,12 +7277,11 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: server.as.organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: server.as.organization.name.text
@@ -7353,7 +7292,7 @@ server:
       normalize: []
       original_fieldset: as
       short: Organization name.
-      type: wildcard
+      type: keyword
     server.bytes:
       dashed_name: server-bytes
       description: Bytes sent from the server to the client.
@@ -7366,16 +7305,15 @@ server:
       short: Bytes sent from the server to the client.
       type: long
     server.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-domain
       description: Server domain.
       flat_name: server.domain
+      ignore_above: 1024
       level: core
       name: domain
       normalize: []
       short: Server domain.
-      type: wildcard
+      type: keyword
     server.geo.city_name:
       dashed_name: server-geo-city-name
       description: City name.
@@ -7436,8 +7374,6 @@ server:
       short: Longitude and latitude.
       type: geo_point
     server.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -7448,12 +7384,13 @@ server:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: server.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     server.geo.region_iso_code:
       dashed_name: server-geo-region-iso-code
       description: Region ISO code.
@@ -7543,8 +7480,6 @@ server:
       short: Port of the server.
       type: long
     server.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-registered-domain
       description: 'The highest registered server domain, stripped of the subdomain.
 
@@ -7555,11 +7490,12 @@ server:
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: server.registered_domain
+      ignore_above: 1024
       level: extended
       name: registered_domain
       normalize: []
       short: The highest registered server domain, stripped of the subdomain.
-      type: wildcard
+      type: keyword
     server.subdomain:
       dashed_name: server-subdomain
       description: 'The subdomain portion of a fully qualified domain name includes
@@ -7609,24 +7545,22 @@ server:
       short: Name of the directory the user is a member of.
       type: keyword
     server.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-email
       description: User email address.
       flat_name: server.user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     server.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: server.user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: server.user.full_name.text
@@ -7637,7 +7571,7 @@ server:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     server.user.group.domain:
       dashed_name: server-user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -7700,12 +7634,11 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: server.user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: server.user.name.text
@@ -7716,7 +7649,7 @@ server:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     server.user.roles:
       dashed_name: server-user-roles
       description: Array of user roles at the time of the event.
@@ -7914,12 +7847,11 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
       flat_name: source.as.organization.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: source.as.organization.name.text
@@ -7930,7 +7862,7 @@ source:
       normalize: []
       original_fieldset: as
       short: Organization name.
-      type: wildcard
+      type: keyword
     source.bytes:
       dashed_name: source-bytes
       description: Bytes sent from the source to the destination.
@@ -7943,16 +7875,15 @@ source:
       short: Bytes sent from the source to the destination.
       type: long
     source.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-domain
       description: Source domain.
       flat_name: source.domain
+      ignore_above: 1024
       level: core
       name: domain
       normalize: []
       short: Source domain.
-      type: wildcard
+      type: keyword
     source.geo.city_name:
       dashed_name: source-geo-city-name
       description: City name.
@@ -8013,8 +7944,6 @@ source:
       short: Longitude and latitude.
       type: geo_point
     source.geo.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-geo-name
       description: 'User-defined description of a location, at the level of granularity
         they care about.
@@ -8025,12 +7954,13 @@ source:
         Not typically used in automated geolocation.'
       example: boston-dc
       flat_name: source.geo.name
+      ignore_above: 1024
       level: extended
       name: name
       normalize: []
       original_fieldset: geo
       short: User-defined description of a location.
-      type: wildcard
+      type: keyword
     source.geo.region_iso_code:
       dashed_name: source-geo-region-iso-code
       description: Region ISO code.
@@ -8120,8 +8050,6 @@ source:
       short: Port of the source.
       type: long
     source.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-registered-domain
       description: 'The highest registered source domain, stripped of the subdomain.
 
@@ -8132,11 +8060,12 @@ source:
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: source.registered_domain
+      ignore_above: 1024
       level: extended
       name: registered_domain
       normalize: []
       short: The highest registered source domain, stripped of the subdomain.
-      type: wildcard
+      type: keyword
     source.subdomain:
       dashed_name: source-subdomain
       description: 'The subdomain portion of a fully qualified domain name includes
@@ -8186,24 +8115,22 @@ source:
       short: Name of the directory the user is a member of.
       type: keyword
     source.user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-email
       description: User email address.
       flat_name: source.user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     source.user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: source.user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: source.user.full_name.text
@@ -8214,7 +8141,7 @@ source:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     source.user.group.domain:
       dashed_name: source-user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -8277,12 +8204,11 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
       flat_name: source.user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: source.user.name.text
@@ -8293,7 +8219,7 @@ source:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     source.user.roles:
       dashed_name: source-user-roles
       description: Array of user roles at the time of the event.
@@ -8571,19 +8497,18 @@ tls:
         of certificate offered by the client.
       type: keyword
     tls.client.issuer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-issuer
       description: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
       example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.client.issuer
+      ignore_above: 1024
       level: extended
       name: client.issuer
       normalize: []
       short: Distinguished name of subject of the issuer of the x.509 certificate
         presented by the client.
-      type: wildcard
+      type: keyword
     tls.client.ja3:
       dashed_name: tls-client-ja3
       description: A hash that identifies clients based on how they perform an SSL/TLS
@@ -8633,19 +8558,18 @@ tls:
       short: Hostname the client is trying to connect to. Also called the SNI.
       type: keyword
     tls.client.subject:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-subject
       description: Distinguished name of subject of the x.509 certificate presented
         by the client.
       example: CN=myclient, OU=Documentation Team, DC=example, DC=com
       flat_name: tls.client.subject
+      ignore_above: 1024
       level: extended
       name: client.subject
       normalize: []
       short: Distinguished name of subject of the x.509 certificate presented by the
         client.
-      type: wildcard
+      type: keyword
     tls.client.supported_ciphers:
       dashed_name: tls-client-supported-ciphers
       description: Array of ciphers offered by the client during the client hello.
@@ -8701,19 +8625,18 @@ tls:
       short: List of country (C) codes
       type: keyword
     tls.client.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: tls.client.x509.issuer.distinguished_name
+      ignore_above: 1024
       level: extended
       name: issuer.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of issuing certificate authority.
-      type: wildcard
+      type: keyword
     tls.client.x509.issuer.locality:
       dashed_name: tls-client-x509-issuer-locality
       description: List of locality names (L)
@@ -8892,18 +8815,17 @@ tls:
       short: List of country (C) code
       type: keyword
     tls.client.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-client-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: tls.client.x509.subject.distinguished_name
+      ignore_above: 1024
       level: extended
       name: subject.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of the certificate subject entity.
-      type: wildcard
+      type: keyword
     tls.client.x509.subject.locality:
       dashed_name: tls-client-x509-subject-locality
       description: List of locality names (L)
@@ -9084,18 +9006,17 @@ tls:
         of certificate offered by the server.
       type: keyword
     tls.server.issuer:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-issuer
       description: Subject of the issuer of the x.509 certificate presented by the
         server.
       example: CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.server.issuer
+      ignore_above: 1024
       level: extended
       name: server.issuer
       normalize: []
       short: Subject of the issuer of the x.509 certificate presented by the server.
-      type: wildcard
+      type: keyword
     tls.server.ja3s:
       dashed_name: tls-server-ja3s
       description: A hash that identifies servers based on how they perform an SSL/TLS
@@ -9132,17 +9053,16 @@ tls:
       short: Timestamp indicating when server certificate is first considered valid.
       type: date
     tls.server.subject:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-subject
       description: Subject of the x.509 certificate presented by the server.
       example: CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com
       flat_name: tls.server.subject
+      ignore_above: 1024
       level: extended
       name: server.subject
       normalize: []
       short: Subject of the x.509 certificate presented by the server.
-      type: wildcard
+      type: keyword
     tls.server.x509.alternative_names:
       dashed_name: tls-server-x509-alternative-names
       description: List of subject alternative names (SAN). Name types vary by certificate
@@ -9185,19 +9105,18 @@ tls:
       short: List of country (C) codes
       type: keyword
     tls.server.x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: tls.server.x509.issuer.distinguished_name
+      ignore_above: 1024
       level: extended
       name: issuer.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of issuing certificate authority.
-      type: wildcard
+      type: keyword
     tls.server.x509.issuer.locality:
       dashed_name: tls-server-x509-issuer-locality
       description: List of locality names (L)
@@ -9376,18 +9295,17 @@ tls:
       short: List of country (C) code
       type: keyword
     tls.server.x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: tls-server-x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: tls.server.x509.subject.distinguished_name
+      ignore_above: 1024
       level: extended
       name: subject.distinguished_name
       normalize: []
       original_fieldset: x509
       short: Distinguished name (DN) of the certificate subject entity.
-      type: wildcard
+      type: keyword
     tls.server.x509.subject.locality:
       dashed_name: tls-server-x509-subject-locality
       description: List of locality names (L)
@@ -9553,8 +9471,6 @@ url:
     the breaking down into scheme, domain, path, and so on.
   fields:
     url.domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-domain
       description: 'Domain of the url, such as "www.elastic.co".
 
@@ -9566,11 +9482,12 @@ url:
         field.'
       example: www.elastic.co
       flat_name: url.domain
+      ignore_above: 1024
       level: extended
       name: domain
       normalize: []
       short: Domain of the url.
-      type: wildcard
+      type: keyword
     url.extension:
       dashed_name: url-extension
       description: 'The field contains the file extension from the original request
@@ -9604,14 +9521,13 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
       flat_name: url.full
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: url.full.text
@@ -9621,10 +9537,8 @@ url:
       name: full
       normalize: []
       short: Full unparsed URL.
-      type: wildcard
+      type: keyword
     url.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -9634,6 +9548,7 @@ url:
         This field is meant to represent the URL as it was observed, complete or not.'
       example: https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
       flat_name: url.original
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: url.original.text
@@ -9643,7 +9558,7 @@ url:
       name: original
       normalize: []
       short: Unmodified original url as seen in the event source.
-      type: wildcard
+      type: keyword
     url.password:
       dashed_name: url-password
       description: Password of the request.
@@ -9655,16 +9570,15 @@ url:
       short: Password of the request.
       type: keyword
     url.path:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-path
       description: Path of the request, such as "/search".
       flat_name: url.path
+      ignore_above: 1024
       level: extended
       name: path
       normalize: []
       short: Path of the request, such as "/search".
-      type: wildcard
+      type: keyword
     url.port:
       dashed_name: url-port
       description: Port of the request, such as 443.
@@ -9693,8 +9607,6 @@ url:
       short: Query string of the request.
       type: keyword
     url.registered_domain:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: url-registered-domain
       description: 'The highest registered url domain, stripped of the subdomain.
 
@@ -9705,11 +9617,12 @@ url:
         the last two labels will not work well for TLDs such as "co.uk".'
       example: example.com
       flat_name: url.registered_domain
+      ignore_above: 1024
       level: extended
       name: registered_domain
       normalize: []
       short: The highest registered url domain, stripped of the subdomain.
-      type: wildcard
+      type: keyword
     url.scheme:
       dashed_name: url-scheme
       description: 'Scheme of the request, such as "https".
@@ -9795,24 +9708,22 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.changes.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-email
       description: User email address.
       flat_name: user.changes.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     user.changes.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: user.changes.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user.changes.full_name.text
@@ -9823,7 +9734,7 @@ user:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     user.changes.group.domain:
       dashed_name: user-changes-group-domain
       description: 'Name of the directory the group is a member of.
@@ -9886,12 +9797,11 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
       flat_name: user.changes.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: user.changes.name.text
@@ -9902,7 +9812,7 @@ user:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     user.changes.roles:
       dashed_name: user-changes-roles
       description: Array of user roles at the time of the event.
@@ -9942,24 +9852,22 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.effective.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-email
       description: User email address.
       flat_name: user.effective.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     user.effective.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: user.effective.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user.effective.full_name.text
@@ -9970,7 +9878,7 @@ user:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     user.effective.group.domain:
       dashed_name: user-effective-group-domain
       description: 'Name of the directory the group is a member of.
@@ -10033,12 +9941,11 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
       flat_name: user.effective.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: user.effective.name.text
@@ -10049,7 +9956,7 @@ user:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     user.effective.roles:
       dashed_name: user-effective-roles
       description: Array of user roles at the time of the event.
@@ -10064,23 +9971,21 @@ user:
       short: Array of user roles at the time of the event.
       type: keyword
     user.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-email
       description: User email address.
       flat_name: user.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       short: User email address.
-      type: wildcard
+      type: keyword
     user.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: user.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user.full_name.text
@@ -10090,7 +9995,7 @@ user:
       name: full_name
       normalize: []
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     user.group.domain:
       dashed_name: user-group-domain
       description: 'Name of the directory the group is a member of.
@@ -10151,12 +10056,11 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
       flat_name: user.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: user.name.text
@@ -10166,7 +10070,7 @@ user:
       name: name
       normalize: []
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     user.roles:
       dashed_name: user-roles
       description: Array of user roles at the time of the event.
@@ -10193,24 +10097,22 @@ user:
       short: Name of the directory the user is a member of.
       type: keyword
     user.target.email:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-email
       description: User email address.
       flat_name: user.target.email
+      ignore_above: 1024
       level: extended
       name: email
       normalize: []
       original_fieldset: user
       short: User email address.
-      type: wildcard
+      type: keyword
     user.target.full_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
       flat_name: user.target.full_name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user.target.full_name.text
@@ -10221,7 +10123,7 @@ user:
       normalize: []
       original_fieldset: user
       short: User's full name, if available.
-      type: wildcard
+      type: keyword
     user.target.group.domain:
       dashed_name: user-target-group-domain
       description: 'Name of the directory the group is a member of.
@@ -10284,12 +10186,11 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
       flat_name: user.target.name
+      ignore_above: 1024
       level: core
       multi_fields:
       - flat_name: user.target.name.text
@@ -10300,7 +10201,7 @@ user:
       normalize: []
       original_fieldset: user
       short: Short name or login of the user.
-      type: wildcard
+      type: keyword
     user.target.roles:
       dashed_name: user-target-roles
       description: Array of user roles at the time of the event.
@@ -10399,13 +10300,12 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
       flat_name: user_agent.original
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user_agent.original.text
@@ -10415,7 +10315,7 @@ user_agent:
       name: original
       normalize: []
       short: Unparsed user_agent string.
-      type: wildcard
+      type: keyword
     user_agent.os.family:
       dashed_name: user-agent-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -10429,12 +10329,11 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
       flat_name: user_agent.os.full
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user_agent.os.full.text
@@ -10445,7 +10344,7 @@ user_agent:
       normalize: []
       original_fieldset: os
       short: Operating system name, including the version or code name.
-      type: wildcard
+      type: keyword
     user_agent.os.kernel:
       dashed_name: user-agent-os-kernel
       description: Operating system kernel version as a raw string.
@@ -10459,12 +10358,11 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
       flat_name: user_agent.os.name
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: user_agent.os.name.text
@@ -10475,7 +10373,7 @@ user_agent:
       normalize: []
       original_fieldset: os
       short: Operating system name, without the version.
-      type: wildcard
+      type: keyword
     user_agent.os.platform:
       dashed_name: user-agent-os-platform
       description: Operating system platform (such centos, ubuntu, windows).
@@ -10841,18 +10739,17 @@ x509:
       short: List of country (C) codes
       type: keyword
     x509.issuer.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: x509-issuer-distinguished-name
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance
         Server CA
       flat_name: x509.issuer.distinguished_name
+      ignore_above: 1024
       level: extended
       name: issuer.distinguished_name
       normalize: []
       short: Distinguished name (DN) of issuing certificate authority.
-      type: wildcard
+      type: keyword
     x509.issuer.locality:
       dashed_name: x509-issuer-locality
       description: List of locality names (L)
@@ -11017,17 +10914,16 @@ x509:
       short: List of country (C) code
       type: keyword
     x509.subject.distinguished_name:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: x509-subject-distinguished-name
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
       flat_name: x509.subject.distinguished_name
+      ignore_above: 1024
       level: extended
       name: subject.distinguished_name
       normalize: []
       short: Distinguished name (DN) of the certificate subject entity.
-      type: wildcard
+      type: keyword
     x509.subject.locality:
       dashed_name: x509-subject-locality
       description: List of locality names (L)

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6116,8 +6116,6 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -6125,6 +6123,7 @@ process:
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
       flat_name: process.command_line
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.command_line.text
@@ -6134,7 +6133,7 @@ process:
       name: command_line
       normalize: []
       short: Full command line that started the process.
-      type: wildcard
+      type: keyword
     process.entity_id:
       dashed_name: process-entity-id
       description: 'Unique identifier for the process.
@@ -6356,8 +6355,6 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Note the usage of `wildcard` type is considered beta. This field used
-        to be type `keyword`.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -6365,6 +6362,7 @@ process:
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
       flat_name: process.parent.command_line
+      ignore_above: 1024
       level: extended
       multi_fields:
       - flat_name: process.parent.command_line.text
@@ -6375,7 +6373,7 @@ process:
       normalize: []
       original_fieldset: process
       short: Full command line that started the process.
-      type: wildcard
+      type: keyword
     process.parent.entity_id:
       dashed_name: process-parent-entity-id
       description: 'Unique identifier for the process.

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -27,7 +27,8 @@
           "build": {
             "properties": {
               "original": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -73,7 +74,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               }
@@ -83,7 +85,8 @@
             "type": "long"
           },
           "domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "geo": {
             "properties": {
@@ -107,7 +110,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -143,7 +147,8 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "subdomain": {
             "ignore_above": 1024,
@@ -160,7 +165,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -169,7 +175,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -202,7 +209,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -331,7 +339,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               }
@@ -341,7 +350,8 @@
             "type": "long"
           },
           "domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "geo": {
             "properties": {
@@ -365,7 +375,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -401,7 +412,8 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "subdomain": {
             "ignore_above": 1024,
@@ -418,7 +430,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -427,7 +440,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -460,7 +474,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -548,7 +563,8 @@
                 "type": "keyword"
               },
               "original_file_name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "product": {
                 "ignore_above": 1024,
@@ -567,7 +583,8 @@
                 "type": "keyword"
               },
               "data": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "name": {
                 "ignore_above": 1024,
@@ -602,7 +619,8 @@
                 "type": "keyword"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "registered_domain": {
                 "ignore_above": 1024,
@@ -658,16 +676,20 @@
             "type": "text"
           },
           "stack_trace": {
+            "doc_values": false,
             "fields": {
               "text": {
                 "norms": false,
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "index": false,
+            "type": "keyword"
           },
           "type": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -809,7 +831,8 @@
             "type": "keyword"
           },
           "directory": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "drive_letter": {
             "ignore_above": 1,
@@ -881,7 +904,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "pe": {
             "properties": {
@@ -906,7 +930,8 @@
                 "type": "keyword"
               },
               "original_file_name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "product": {
                 "ignore_above": 1024,
@@ -924,7 +949,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "type": {
             "ignore_above": 1024,
@@ -951,7 +977,8 @@
                     "type": "keyword"
                   },
                   "distinguished_name": {
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "locality": {
                     "ignore_above": 1024,
@@ -1012,7 +1039,8 @@
                     "type": "keyword"
                   },
                   "distinguished_name": {
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "locality": {
                     "ignore_above": 1024,
@@ -1088,7 +1116,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -1101,7 +1130,8 @@
             }
           },
           "hostname": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "id": {
             "ignore_above": 1024,
@@ -1131,7 +1161,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "kernel": {
                 "ignore_above": 1024,
@@ -1144,7 +1175,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "platform": {
                 "ignore_above": 1024,
@@ -1174,7 +1206,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -1183,7 +1216,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -1216,7 +1250,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -1242,7 +1277,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               },
@@ -1262,7 +1298,8 @@
                 "type": "keyword"
               },
               "referrer": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -1280,7 +1317,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               },
@@ -1310,7 +1348,8 @@
           "file": {
             "properties": {
               "path": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -1319,7 +1358,8 @@
             "type": "keyword"
           },
           "logger": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "origin": {
             "properties": {
@@ -1517,7 +1557,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -1594,7 +1635,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "kernel": {
                 "ignore_above": 1024,
@@ -1607,7 +1649,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "platform": {
                 "ignore_above": 1024,
@@ -1658,7 +1701,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -1766,7 +1810,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "exit_code": {
             "type": "long"
@@ -1802,7 +1847,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "parent": {
             "properties": {
@@ -1854,7 +1900,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "exit_code": {
                 "type": "long"
@@ -1890,7 +1937,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "pe": {
                 "properties": {
@@ -1915,7 +1963,8 @@
                     "type": "keyword"
                   },
                   "original_file_name": {
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "product": {
                     "ignore_above": 1024,
@@ -1941,7 +1990,8 @@
                     "type": "long"
                   },
                   "name": {
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               },
@@ -1952,7 +2002,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "uptime": {
                 "type": "long"
@@ -1964,7 +2015,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -1991,7 +2043,8 @@
                 "type": "keyword"
               },
               "original_file_name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "product": {
                 "ignore_above": 1024,
@@ -2017,7 +2070,8 @@
                 "type": "long"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -2028,7 +2082,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "uptime": {
             "type": "long"
@@ -2040,7 +2095,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -2053,7 +2109,8 @@
                 "type": "keyword"
               },
               "strings": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "type": {
                 "ignore_above": 1024,
@@ -2066,10 +2123,12 @@
             "type": "keyword"
           },
           "key": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "path": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "value": {
             "ignore_above": 1024,
@@ -2160,7 +2219,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               }
@@ -2170,7 +2230,8 @@
             "type": "long"
           },
           "domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "geo": {
             "properties": {
@@ -2194,7 +2255,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -2230,7 +2292,8 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "subdomain": {
             "ignore_above": 1024,
@@ -2247,7 +2310,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -2256,7 +2320,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -2289,7 +2354,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -2355,7 +2421,8 @@
                         "type": "text"
                       }
                     },
-                    "type": "wildcard"
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               }
@@ -2365,7 +2432,8 @@
             "type": "long"
           },
           "domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "geo": {
             "properties": {
@@ -2389,7 +2457,8 @@
                 "type": "geo_point"
               },
               "name": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "region_iso_code": {
                 "ignore_above": 1024,
@@ -2425,7 +2494,8 @@
             "type": "long"
           },
           "registered_domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "subdomain": {
             "ignore_above": 1024,
@@ -2442,7 +2512,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -2451,7 +2522,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -2484,7 +2556,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -2607,7 +2680,8 @@
                 }
               },
               "issuer": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "ja3": {
                 "ignore_above": 1024,
@@ -2624,7 +2698,8 @@
                 "type": "keyword"
               },
               "subject": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "supported_ciphers": {
                 "ignore_above": 1024,
@@ -2647,7 +2722,8 @@
                         "type": "keyword"
                       },
                       "distinguished_name": {
-                        "type": "wildcard"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "locality": {
                         "ignore_above": 1024,
@@ -2708,7 +2784,8 @@
                         "type": "keyword"
                       },
                       "distinguished_name": {
-                        "type": "wildcard"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "locality": {
                         "ignore_above": 1024,
@@ -2777,7 +2854,8 @@
                 }
               },
               "issuer": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "ja3s": {
                 "ignore_above": 1024,
@@ -2790,7 +2868,8 @@
                 "type": "date"
               },
               "subject": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "x509": {
                 "properties": {
@@ -2809,7 +2888,8 @@
                         "type": "keyword"
                       },
                       "distinguished_name": {
-                        "type": "wildcard"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "locality": {
                         "ignore_above": 1024,
@@ -2870,7 +2950,8 @@
                         "type": "keyword"
                       },
                       "distinguished_name": {
-                        "type": "wildcard"
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "locality": {
                         "ignore_above": 1024,
@@ -2927,7 +3008,8 @@
       "url": {
         "properties": {
           "domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "extension": {
             "ignore_above": 1024,
@@ -2944,7 +3026,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "original": {
             "fields": {
@@ -2953,14 +3036,16 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "password": {
             "ignore_above": 1024,
             "type": "keyword"
           },
           "path": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "port": {
             "type": "long"
@@ -2970,7 +3055,8 @@
             "type": "keyword"
           },
           "registered_domain": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "scheme": {
             "ignore_above": 1024,
@@ -2999,7 +3085,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -3008,7 +3095,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -3041,7 +3129,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -3060,7 +3149,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -3069,7 +3159,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -3102,7 +3193,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -3111,7 +3203,8 @@
             }
           },
           "email": {
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "full_name": {
             "fields": {
@@ -3120,7 +3213,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "group": {
             "properties": {
@@ -3153,7 +3247,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "roles": {
             "ignore_above": 1024,
@@ -3166,7 +3261,8 @@
                 "type": "keyword"
               },
               "email": {
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "full_name": {
                 "fields": {
@@ -3175,7 +3271,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "group": {
                 "properties": {
@@ -3208,7 +3305,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "roles": {
                 "ignore_above": 1024,
@@ -3239,7 +3337,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "os": {
             "properties": {
@@ -3254,7 +3353,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "kernel": {
                 "ignore_above": 1024,
@@ -3267,7 +3367,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "platform": {
                 "ignore_above": 1024,

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1797,7 +1797,8 @@
                 "type": "text"
               }
             },
-            "type": "wildcard"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "entity_id": {
             "ignore_above": 1024,
@@ -1887,7 +1888,8 @@
                     "type": "text"
                   }
                 },
-                "type": "wildcard"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "entity_id": {
                 "ignore_above": 1024,

--- a/generated/elasticsearch/component/agent.json
+++ b/generated/elasticsearch/component/agent.json
@@ -11,7 +11,8 @@
             "build": {
               "properties": {
                 "original": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -26,7 +26,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
@@ -36,7 +37,8 @@
               "type": "long"
             },
             "domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "geo": {
               "properties": {
@@ -60,7 +62,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -96,7 +99,8 @@
               "type": "long"
             },
             "registered_domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -113,7 +117,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -122,7 +127,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -155,7 +161,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -26,7 +26,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
@@ -36,7 +37,8 @@
               "type": "long"
             },
             "domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "geo": {
               "properties": {
@@ -60,7 +62,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -96,7 +99,8 @@
               "type": "long"
             },
             "registered_domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -113,7 +117,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -122,7 +127,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -155,7 +161,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -84,7 +84,8 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "product": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/dns.json
+++ b/generated/elasticsearch/component/dns.json
@@ -15,7 +15,8 @@
                   "type": "keyword"
                 },
                 "data": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "name": {
                   "ignore_above": 1024,
@@ -50,7 +51,8 @@
                   "type": "keyword"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "registered_domain": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/error.json
+++ b/generated/elasticsearch/component/error.json
@@ -21,16 +21,20 @@
               "type": "text"
             },
             "stack_trace": {
+              "doc_values": false,
               "fields": {
                 "text": {
                   "norms": false,
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "index": false,
+              "type": "keyword"
             },
             "type": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         }

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -47,7 +47,8 @@
               "type": "keyword"
             },
             "directory": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "drive_letter": {
               "ignore_above": 1,
@@ -119,7 +120,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "pe": {
               "properties": {
@@ -144,7 +146,8 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "product": {
                   "ignore_above": 1024,
@@ -162,7 +165,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "type": {
               "ignore_above": 1024,
@@ -189,7 +193,8 @@
                       "type": "keyword"
                     },
                     "distinguished_name": {
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "locality": {
                       "ignore_above": 1024,
@@ -250,7 +255,8 @@
                       "type": "keyword"
                     },
                     "distinguished_name": {
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "locality": {
                       "ignore_above": 1024,

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -38,7 +38,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -51,7 +52,8 @@
               }
             },
             "hostname": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "id": {
               "ignore_above": 1024,
@@ -81,7 +83,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -94,7 +97,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "platform": {
                   "ignore_above": 1024,
@@ -124,7 +128,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -133,7 +138,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -166,7 +172,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -22,7 +22,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
@@ -42,7 +43,8 @@
                   "type": "keyword"
                 },
                 "referrer": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -60,7 +62,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },

--- a/generated/elasticsearch/component/log.json
+++ b/generated/elasticsearch/component/log.json
@@ -11,7 +11,8 @@
             "file": {
               "properties": {
                 "path": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -20,7 +21,8 @@
               "type": "keyword"
             },
             "logger": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "origin": {
               "properties": {

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -67,7 +67,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -144,7 +145,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -157,7 +159,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "platform": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/organization.json
+++ b/generated/elasticsearch/component/organization.json
@@ -19,7 +19,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         }

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -43,7 +43,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "entity_id": {
               "ignore_above": 1024,
@@ -133,7 +134,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "entity_id": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -56,7 +56,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "exit_code": {
               "type": "long"
@@ -92,7 +93,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "parent": {
               "properties": {
@@ -144,7 +146,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "exit_code": {
                   "type": "long"
@@ -180,7 +183,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "pe": {
                   "properties": {
@@ -205,7 +209,8 @@
                       "type": "keyword"
                     },
                     "original_file_name": {
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     },
                     "product": {
                       "ignore_above": 1024,
@@ -231,7 +236,8 @@
                       "type": "long"
                     },
                     "name": {
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
@@ -242,7 +248,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "uptime": {
                   "type": "long"
@@ -254,7 +261,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -281,7 +289,8 @@
                   "type": "keyword"
                 },
                 "original_file_name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "product": {
                   "ignore_above": 1024,
@@ -307,7 +316,8 @@
                   "type": "long"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -318,7 +328,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "uptime": {
               "type": "long"
@@ -330,7 +341,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         }

--- a/generated/elasticsearch/component/registry.json
+++ b/generated/elasticsearch/component/registry.json
@@ -15,7 +15,8 @@
                   "type": "keyword"
                 },
                 "strings": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "type": {
                   "ignore_above": 1024,
@@ -28,10 +29,12 @@
               "type": "keyword"
             },
             "key": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "path": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "value": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -26,7 +26,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
@@ -36,7 +37,8 @@
               "type": "long"
             },
             "domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "geo": {
               "properties": {
@@ -60,7 +62,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -96,7 +99,8 @@
               "type": "long"
             },
             "registered_domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -113,7 +117,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -122,7 +127,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -155,7 +161,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -26,7 +26,8 @@
                           "type": "text"
                         }
                       },
-                      "type": "wildcard"
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 }
@@ -36,7 +37,8 @@
               "type": "long"
             },
             "domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "geo": {
               "properties": {
@@ -60,7 +62,8 @@
                   "type": "geo_point"
                 },
                 "name": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "region_iso_code": {
                   "ignore_above": 1024,
@@ -96,7 +99,8 @@
               "type": "long"
             },
             "registered_domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "subdomain": {
               "ignore_above": 1024,
@@ -113,7 +117,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -122,7 +127,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -155,7 +161,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/tls.json
+++ b/generated/elasticsearch/component/tls.json
@@ -39,7 +39,8 @@
                   }
                 },
                 "issuer": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "ja3": {
                   "ignore_above": 1024,
@@ -56,7 +57,8 @@
                   "type": "keyword"
                 },
                 "subject": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "supported_ciphers": {
                   "ignore_above": 1024,
@@ -79,7 +81,8 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "type": "wildcard"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -140,7 +143,8 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "type": "wildcard"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -209,7 +213,8 @@
                   }
                 },
                 "issuer": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "ja3s": {
                   "ignore_above": 1024,
@@ -222,7 +227,8 @@
                   "type": "date"
                 },
                 "subject": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "x509": {
                   "properties": {
@@ -241,7 +247,8 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "type": "wildcard"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "locality": {
                           "ignore_above": 1024,
@@ -302,7 +309,8 @@
                           "type": "keyword"
                         },
                         "distinguished_name": {
-                          "type": "wildcard"
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         },
                         "locality": {
                           "ignore_above": 1024,

--- a/generated/elasticsearch/component/url.json
+++ b/generated/elasticsearch/component/url.json
@@ -9,7 +9,8 @@
         "url": {
           "properties": {
             "domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "extension": {
               "ignore_above": 1024,
@@ -26,7 +27,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "original": {
               "fields": {
@@ -35,14 +37,16 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "password": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "path": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "port": {
               "type": "long"
@@ -52,7 +56,8 @@
               "type": "keyword"
             },
             "registered_domain": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "scheme": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/user.json
+++ b/generated/elasticsearch/component/user.json
@@ -15,7 +15,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -24,7 +25,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -57,7 +59,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,
@@ -76,7 +79,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -85,7 +89,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -118,7 +123,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,
@@ -127,7 +133,8 @@
               }
             },
             "email": {
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "full_name": {
               "fields": {
@@ -136,7 +143,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "group": {
               "properties": {
@@ -169,7 +177,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "roles": {
               "ignore_above": 1024,
@@ -182,7 +191,8 @@
                   "type": "keyword"
                 },
                 "email": {
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "full_name": {
                   "fields": {
@@ -191,7 +201,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "group": {
                   "properties": {
@@ -224,7 +235,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/user_agent.json
+++ b/generated/elasticsearch/component/user_agent.json
@@ -27,7 +27,8 @@
                   "type": "text"
                 }
               },
-              "type": "wildcard"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "os": {
               "properties": {
@@ -42,7 +43,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "kernel": {
                   "ignore_above": 1024,
@@ -55,7 +57,8 @@
                       "type": "text"
                     }
                   },
-                  "type": "wildcard"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "platform": {
                   "ignore_above": 1024,

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -24,9 +24,8 @@
 
     - name: build.original
       level: core
-      type: wildcard
+      type: keyword
       short: Extended build information for the agent.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Extended build information for the agent.
 

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -29,8 +29,7 @@
 
     - name: organization.name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Organization name.
       example: Google LLC

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -53,16 +53,14 @@
 
     - name: domain
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Client domain.
 
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
       short: The highest registered client domain, stripped of the subdomain.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The highest registered client domain, stripped of the subdomain.
 

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -48,15 +48,13 @@
 
     - name: domain
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Destination domain.
 
     - name: registered_domain
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       short: The highest registered destination domain, stripped of the subdomain.
       description: >
         The highest registered destination domain, stripped of the subdomain.

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -66,9 +66,8 @@
 
     - name: question.name
       level: extended
-      type: wildcard
+      type: keyword
       short: The name being queried.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The name being queried.
 
@@ -186,9 +185,8 @@
 
     - name: answers.data
       level: extended
-      type: wildcard
+      type: keyword
       short: The data describing the resource.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The data describing the resource.
 

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -31,16 +31,15 @@
 
     - name: type
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       example: java.lang.NullPointerException
       description: >
         The type of the error, for example the class name of the exception.
 
     - name: stack_trace
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
+      index: false
       description: >
         The stack trace of this error in plain text.
       multi_fields:

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -33,9 +33,8 @@
 
     - name: directory
       level: extended
-      type: wildcard
+      type: keyword
       short: Directory where the file is located.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Directory where the file is located. It should include the drive letter,
         when appropriate.
@@ -54,9 +53,8 @@
 
     - name: path
       level: extended
-      type: wildcard
+      type: keyword
       short: Full path to the file, including the file name.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Full path to the file, including the file name. It should include the
         drive letter, when appropriate.
@@ -67,8 +65,7 @@
 
     - name: target_path
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Target path for symlinks.
       multi_fields:
         - type: text

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -71,9 +71,8 @@
 
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
       short: User-defined description of a location.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         User-defined description of a location, at the level of granularity they care about.
 

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -14,9 +14,8 @@
 
     - name: hostname
       level: core
-      type: wildcard
+      type: keyword
       short: Hostname of the host.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Hostname of the host.
 

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -15,9 +15,9 @@
       description: >
         A unique identifier for each HTTP request to correlate logs between clients
         and servers in transactions.
-        
+
         The id may be contained in a non-standard HTTP header, such as `X-Request-ID`
-        or `X-Correlation-ID`. 
+        or `X-Correlation-ID`.
 
       example: 123e4567-e89b-12d3-a456-426614174000
 
@@ -55,8 +55,7 @@
 
     - name: request.body.content
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         The full HTTP request body.
       example: Hello world
@@ -66,8 +65,7 @@
 
     - name: request.referrer
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Referrer for this HTTP request.
       example: https://blog.example.com/
@@ -96,8 +94,7 @@
 
     - name: response.body.content
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         The full HTTP response body.
       example: Hello world

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -31,9 +31,8 @@
 
     - name: file.path
       level: extended
-      type: wildcard
+      type: keyword
       short: Full path to the log file this event came from.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Full path to the log file this event came from, including the file name.
         It should include the drive letter, when appropriate.
@@ -64,10 +63,9 @@
 
     - name: logger
       level: core
-      type: wildcard
+      type: keyword
       example: org.elasticsearch.bootstrap.Bootstrap
       short: Name of the logger.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The name of the logger inside an application. This is usually the name of the class which initialized the logger, or can be a custom name.
 

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -14,8 +14,7 @@
 
     - name: name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Organization name.
       multi_fields:

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -36,9 +36,8 @@
 
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
       example: "Mac OS X"
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Operating system name, without the version.
       multi_fields:
@@ -47,9 +46,8 @@
 
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
       example: "Mac OS Mojave"
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Operating system name, including the version or code name.
       multi_fields:

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -13,8 +13,7 @@
   fields:
     - name: original_file_name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
 

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -72,9 +72,8 @@
 
     - name: command_line
       level: extended
-      type: wildcard
+      type: keyword
       short: Full command line that started the process.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Full command line that started the process, including the absolute path
         to the executable, and all arguments.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -44,9 +44,8 @@
 
     - name: name
       level: extended
-      type: wildcard
+      type: keyword
       short: Process name.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Process name.
 
@@ -112,8 +111,7 @@
 
     - name: executable
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -123,9 +121,8 @@
 
     - name: title
       level: extended
-      type: wildcard
+      type: keyword
       short: Process title.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Process title.
 
@@ -145,8 +142,7 @@
 
     - name: thread.name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       example: 'thread-0'
       description: >
         Thread name.
@@ -167,9 +163,8 @@
 
     - name: working_directory
       level: extended
-      type: wildcard
+      type: keyword
       example: /home/alice
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The working directory of the process.
       multi_fields:

--- a/schemas/registry.yml
+++ b/schemas/registry.yml
@@ -14,8 +14,7 @@
 
     - name: key
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Hive-relative path of keys.
       example: SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe
 
@@ -27,8 +26,7 @@
 
     - name: path
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Full path, including hive, key and value
       example: HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger
 
@@ -40,9 +38,8 @@
 
     - name: data.strings
       level: core
-      type: wildcard
+      type: keyword
       short: List of strings representing what was written to the registry.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       example: '["C:\rta\red_ttp\bin\myapp.exe"]'
       description: >
         Content when writing string types.

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -53,15 +53,13 @@
 
     - name: domain
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Server domain.
 
     - name: registered_domain
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       short: The highest registered server domain, stripped of the subdomain.
       description: >
         The highest registered server domain, stripped of the subdomain.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -48,16 +48,14 @@
 
     - name: domain
       level: core
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Source domain.
 
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
       short: The highest registered source domain, stripped of the subdomain.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The highest registered source domain, stripped of the subdomain.
 

--- a/schemas/tls.yml
+++ b/schemas/tls.yml
@@ -78,16 +78,14 @@
         - array
 
     - name: client.subject
-      type: wildcard
+      type: keyword
       level: extended
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: Distinguished name of subject of the x.509 certificate presented by the client.
       example: "CN=myclient, OU=Documentation Team, DC=example, DC=com"
 
     - name: client.issuer
-      type: wildcard
+      type: keyword
       level: extended
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
       example: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
 
@@ -159,16 +157,14 @@
       example: 394441ab65754e2207b1e1b457b3641d
 
     - name: server.subject
-      type: wildcard
+      type: keyword
       level: extended
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: Subject of the x.509 certificate presented by the server.
       example: "CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com"
 
     - name: server.issuer
-      type: wildcard
+      type: keyword
       level: extended
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: Subject of the issuer of the x.509 certificate presented by the server.
       example: "CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com"
 

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -10,8 +10,7 @@
 
     - name: original
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
@@ -29,9 +28,8 @@
 
     - name: full
       level: extended
-      type: wildcard
+      type: keyword
       short: Full unparsed URL.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         If full URLs are important to your use case, they should be stored in
         `url.full`, whether this field is reconstructed or present in the
@@ -53,9 +51,8 @@
 
     - name: domain
       level: extended
-      type: wildcard
+      type: keyword
       short: Domain of the url.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Domain of the url, such as "www.elastic.co".
 
@@ -68,9 +65,8 @@
 
     - name: registered_domain
       level: extended
-      type: wildcard
+      type: keyword
       short: The highest registered url domain, stripped of the subdomain.
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         The highest registered url domain, stripped of the subdomain.
 
@@ -120,8 +116,7 @@
 
     - name: path
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         Path of the request, such as "/search".
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -39,9 +39,8 @@
 
     - name: name
       level: core
-      type: wildcard
+      type: keyword
       example: albert
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
       description: >
         Short name or login of the user.
       multi_fields:
@@ -50,8 +49,7 @@
 
     - name: full_name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       example: Albert Einstein
       description: >
         User's full name, if available.
@@ -61,8 +59,7 @@
 
     - name: email
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: >
         User email address.
 

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -12,8 +12,7 @@
 
     - name: original
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       multi_fields:
       - type: text
         name: text

--- a/schemas/x509.yml
+++ b/schemas/x509.yml
@@ -37,8 +37,7 @@
 
     - name: issuer.distinguished_name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Distinguished name (DN) of issuing certificate authority.
       example: C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA
 
@@ -114,8 +113,7 @@
 
     - name: subject.distinguished_name
       level: extended
-      type: wildcard
-      beta: Note the usage of `wildcard` type is considered beta. This field used to be type `keyword`.
+      type: keyword
       description: Distinguished name (DN) of the certificate subject entity.
       example: C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net
 

--- a/use-cases/auditbeat.md
+++ b/use-cases/auditbeat.md
@@ -9,8 +9,8 @@ ECS usage in Auditbeat.
 |---|---|---|---|---|
 | [event.module](../README.md#event.module)  | Auditbeat module name. | core | keyword | `apache` |
 | <a name="file.&ast;"></a>*file.&ast;* | *File attributes.<br/>* |  |  |  |
-| [file.path](../README.md#file.path)  | The path to the file. | extended | wildcard | `/home/alice/example.png` |
-| [file.target_path](../README.md#file.target_path)  | The target path for symlinks. | extended | wildcard |  |
+| [file.path](../README.md#file.path)  | The path to the file. | extended | keyword | `/home/alice/example.png` |
+| [file.target_path](../README.md#file.target_path)  | The target path for symlinks. | extended | keyword |  |
 | [file.type](../README.md#file.type)  | The file type (file, dir, or symlink). | extended | keyword | `file` |
 | [file.device](../README.md#file.device)  | The device. | extended | keyword | `sda` |
 | [file.inode](../README.md#file.inode)  | The inode representing the file in the filesystem. | extended | keyword | `256383` |

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -13,7 +13,7 @@ ECS fields used in Filebeat for the apache module.
 | [event.module](../README.md#event.module)  | Currently fileset.module | core | keyword | `apache` |
 | [event.dataset](../README.md#event.dataset)  | Currenly fileset.name | core | keyword | `access` |
 | [source.ip](../README.md#source.ip)  | Source ip of the request. Currently apache.access.remote_ip | core | ip | `192.168.1.1` |
-| [user.name](../README.md#user.name)  | User name in the request. Currently apache.access.user_name | core | wildcard | `ruflin` |
+| [user.name](../README.md#user.name)  | User name in the request. Currently apache.access.user_name | core | keyword | `ruflin` |
 | <a name="http.method"></a>*http.method* | *Http method, currently apache.access.method* | (use case) | keyword | `GET` |
 | <a name="http.url"></a>*http.url* | *Http url, currently apache.access.url* | (use case) | keyword | `http://elastic.co/` |
 | [http.version](../README.md#http.version)  | Http version, currently apache.access.http_version | extended | keyword | `1.1` |
@@ -21,7 +21,7 @@ ECS fields used in Filebeat for the apache module.
 | <a name="http.response.body_sent.bytes"></a>*http.response.body_sent.bytes* | *Http response body bytes sent, currently apache.access.body_sent.bytes* | (use case) | long | `117` |
 | <a name="http.referer"></a>*http.referer* | *Http referrer code, currently apache.access.referrer<br/>NOTE: In the RFC its misspell as referer and has become accepted standard* | (use case) | keyword | `http://elastic.co/` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *User agent fields as in schema. Currently under apache.access.user_agent.*<br/>* |  |  |  |
-| [user_agent.original](../README.md#user_agent.original)  | Original user agent. Currently apache.access.agent | extended | wildcard | `http://elastic.co/` |
+| [user_agent.original](../README.md#user_agent.original)  | Original user agent. Currently apache.access.agent | extended | keyword | `http://elastic.co/` |
 | <a name="geoip.&ast;"></a>*geoip.&ast;* | *User agent fields as in schema. Currently under apache.access.geoip.*<br/>These are extracted from source.ip<br/>Should they be under source.geoip?<br/>* |  |  |  |
 | <a name="geoip...."></a>*geoip....* | *All geoip fields.* | (use case) | keyword |  |
 

--- a/use-cases/kubernetes.md
+++ b/use-cases/kubernetes.md
@@ -10,7 +10,7 @@ You can monitor containers running in a Kubernetes cluster by adding Kubernetes-
 |---|---|---|---|---|
 | [container.id](../README.md#container.id)  | Unique container id. | core | keyword | `fdbef803fa2b` |
 | [container.name](../README.md#container.name)  | Container name. | extended | keyword |  |
-| [host.hostname](../README.md#host.hostname)  | Hostname of the host.<br/>It normally contains what the `hostname` command returns on the host machine. | core | wildcard | `kube-high-cpu-42` |
+| [host.hostname](../README.md#host.hostname)  | Hostname of the host.<br/>It normally contains what the `hostname` command returns on the host machine. | core | keyword | `kube-high-cpu-42` |
 | <a name="kubernetes.pod.name"></a>*kubernetes.pod.name* | *Kubernetes pod name* | (use case) | keyword | `foo-webserver` |
 | <a name="kubernetes.namespace"></a>*kubernetes.namespace* | *Kubernetes namespace* | (use case) | keyword | `foo-team` |
 | <a name="kubernetes.labels"></a>*kubernetes.labels* | *Kubernetes labels map* | (use case) | object |  |

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -21,7 +21,7 @@ ECS fields used Metricbeat.
 | <a name="error.&ast;"></a>*error.&ast;* | *Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>* |  |  |  |
 | [error.message](../README.md#error.message)  | Error message returned by the service during fetching metrics. | core | text |  |
 | [error.code](../README.md#error.code)  | Error code returned by the service during fetching metrics. | core | keyword |  |
-| [host.hostname](../README.md#host.hostname)  | Hostname of the system metricbeat is running on or user defined name. | core | wildcard |  |
+| [host.hostname](../README.md#host.hostname)  | Hostname of the system metricbeat is running on or user defined name. | core | keyword |  |
 | <a name="host.timezone.offset.sec"></a>*host.timezone.offset.sec* | *Timezone offset of the host in seconds.* | (use case) | long |  |
 | [host.id](../README.md#host.id)  | Unique host id. | core | keyword |  |
 | [event.module](../README.md#event.module)  | Name of the module this data is coming from. | core | keyword | `mysql` |

--- a/use-cases/web-logs.md
+++ b/use-cases/web-logs.md
@@ -12,12 +12,12 @@ Using the fields as represented here is not expected to conflict with ECS, but m
 | [@timestamp](../README.md#@timestamp)  | Time at which the response was sent, and the web server log created. | core | date | `2016-05-23T08:05:34.853Z` |
 | <a name="http.&ast;"></a>*http.&ast;* | *Fields related to HTTP requests and responses.<br/>* |  |  |  |
 | [http.request.method](../README.md#http.request.method)  | Http request method. | extended | keyword | `GET, POST, PUT` |
-| [http.request.referrer](../README.md#http.request.referrer)  | Referrer for this HTTP request. | extended | wildcard | `https://blog.example.com/` |
+| [http.request.referrer](../README.md#http.request.referrer)  | Referrer for this HTTP request. | extended | keyword | `https://blog.example.com/` |
 | [http.response.status_code](../README.md#http.response.status_code)  | Http response status code. | extended | long | `404` |
-| [http.response.body.content](../README.md#http.response.body.content)  | The full http response body. | extended | wildcard | `Hello world` |
+| [http.response.body.content](../README.md#http.response.body.content)  | The full http response body. | extended | keyword | `Hello world` |
 | [http.version](../README.md#http.version)  | Http version. | extended | keyword | `1.1` |
 | <a name="user_agent.&ast;"></a>*user_agent.&ast;* | *The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.<br/>* |  |  |  |
-| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | wildcard | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
+| [user_agent.original](../README.md#user_agent.original)  | Unparsed version of the user_agent. | extended | keyword | `Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1` |
 | <a name="user_agent.device"></a>*user_agent.device* | *Name of the physical device.* | (use case) | keyword |  |
 | [user_agent.version](../README.md#user_agent.version)  | Version of the physical device. | extended | keyword | `12.0` |
 | <a name="user_agent.major"></a>*user_agent.major* | *Major version of the user agent.* | (use case) | long |  |


### PR DESCRIPTION
### Summary

Revert fields identified for the `wildcard` type migration back to `keyword` due to the identified performance and storage regressions (#1233)

### Changes

* Revert `wildcard` fields back to `keyword`
* Remove `beta` attribute from `wildcard`-candidate fields
* Add `wildcard` fields back into experimental schema: `experimental/schemas`
* Update all associated artifacts and docs

[Generated Fields CSV](https://github.com/elastic/ecs/blob/ab85c967f11d0535c18256f7b816e1eefdfaeb13/generated/csv/fields.csv)
[Docs Preview](https://ecs_1235.docs-preview.app.elstc.co/diff)