### PR TITLE
Add categorization fields usage docs

### DIFF
--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -1,14 +1,23 @@
-[[ecs-categorization-values-usage]]
-=== Categorization Usage
+[[ecs-using-the-categorization-fields]]
+=== Using the Categorization Fields
 
-The following are usage examples of populating the categorization fields. Using the categorization fields together helps identify and group common subsets of events.
+The event categorization fields work together to identify and group similar events from multiple data sources.
 
-Each categorization example is based on an event from real-world data sources. Categorization fields should be populated using knowledge of each type of event a data source emits.
+These general principles can help guide the categorization process:
+
+* Events from multiple data sources that are similar enough to be viewed or analyzed together, should fall into the same `event.category` field.
+* Both `event.category` and `event.type` may be populated with multiple allowed values, if the event can be reasonably classified into more than one category and/or subcategory.
+* Values of `event.outcome` are a very limited set to indicate success or failure. Domain-specific actions, such as deny and allow, that could be considered outcomes are not
+  captured in the `event.outcome` field, but rather in the `event.type` and/or `event.action` fields.
+* Values of `event.category`, `event.type`, and `event.outcome` are consistent across all values of `event.kind`.
+* When a specific event doesn't fit into any of the defined allowed categorization values, the field should be left empty.
+
+The following examples detail populating the categorization fields and provides some context for the classification decisions.
 
 [float]
-==== Firewall blocked a network connection
+==== Firewall blocking a network connection
 
-Network firewalls generate events based on which network flows were allowed or denied based on the firewall's configuration.
+This event from a firewall describes a successfully blocked network connection:
 
 [source,json]
 ----
@@ -45,15 +54,15 @@ Network firewalls generate events based on which network flows were allowed or d
 ...
 ----
 
-<1> The `event` value will be the most common and most general event `kind`.
-<2> Event relates to network activity.
-<3> The firewall blocked, dropped, or someway `denied` the attempted network `connection`.
-<4> A blocked connection is expected based on the configuration of this firewall. The outcome is a `success` from the perspective of the firewall emitting the event.
-<5> The data source describes this `denied` connection as `dropped`, which is best captured in `event.action`.
+<1> Classifying as an `event`.
+<2> `event.category` categorizes this event as `network` activity.
+<3> The event was both an attempted network `connection` which was `denied`.
+<4> The blocking of this connection is expected. The outcome is a `success` from the perspective of the firewall emitting the event.
+<5> The firewall classifies this denied connection as `dropped`, and this value is captured in `event.action`.
 
-A "denied" network connection falls under different actions: "blocked", "dropped", "quarantined". The `event.action` can capture the action taken by the source, and populating `event.type:denied` provides a normalized category which is independent of the source.
+A "denied" network connection could fall under different action values: "blocked", "dropped", "quarantined", etc. The `event.action` field captures the action taken as described by the source, and populating `event.type:denied` provides an independent, normalized value.
 
-Any network flows or connections that are "denied" can be searched with a single query:
+A single query will return all denied network connections which have been normalized with the same categorization values:
 
 [source,sh]
 ----
@@ -63,7 +72,7 @@ event.category:network AND event.type:denied
 [float]
 ==== Failed attempt to create a user account
 
-User `alice` attempts to add a user account, `bob`, into a directory service, but the action fails.
+User `alice` attempts to add a user account, `bob`, into a directory service, but the action fails:
 
 [source,json]
 ----
@@ -75,27 +84,28 @@ User `alice` attempts to add a user account, `bob`, into a directory service, bu
     }
   },
   "event": {
-    "kind": "event",
-    "category": [ <1>
+    "kind": "event", <1>
+    "category": [ <2>
       "iam"
     ],
-    "type": [ <2>
+    "type": [ <3>
       "user",
       "creation"
     ],
-    "outcome": "failure" <3>
+    "outcome": "failure" <4>
   }
 }
 ----
 
-<1> Categorized using `iam` for an event user account activity.
-<2> Both `user` and `creation`
-<3> The creation of a user account was attempted, but it was not successful.
+<1> Again classifying as an `event`.
+<2> Categorized using `iam` for an event user account activity.
+<3> Both `user` and `creation`
+<4> The creation of a user account was attempted, but it was not successful.
 
 [float]
 ==== Informational listing of a file
 
-A utility, such as a file integrity monitoring (FIM) application, takes inventory of a file but does not access or modify the file.
+A utility, such as a file integrity monitoring (FIM) application, takes inventory of a file but does not access or modify the file:
 
 [source,json]
 ----
@@ -118,17 +128,28 @@ A utility, such as a file integrity monitoring (FIM) application, takes inventor
 }
 ----
 
-<1> A file was reported on
-<2> The "info" type categorizes purely informational events. A file was listed but not accessed or modified.
+<1> The event is reporting on a `file`.
+<2> The `info` type categorizes purely informational events. The target file here was not accessed or modified.
 
 [float]
 === Security application failed to block a network connection
 
-An intrusion detection system (IDS) performing analysis on network connections and protocols attempts to block a connection but fails.
+An intrusion detection system (IDS) attempts to block a connection but fails. The event emitted by the IDS is considered an alert:
 
 [source,json]
 ----
 {
+  "source": {
+      "address": "10.42.42.42",
+      "ip": "10.42.42.42",
+      "port": 38842
+    },
+  "destination": {
+      "address": "10.42.42.1",
+      "ip": "10.42.42.1",
+      "port": 443
+  },
+  ...
   "event": {
     "kind": "alert", <1>
     "category": [ <2>
@@ -144,7 +165,7 @@ An intrusion detection system (IDS) performing analysis on network connections a
 }
 ----
 
-<1> The event was associated with a detection alert from an intrusion detection application.
-<2> The data source is a network-based intrusion detection application.
-<3> A network connection is associated with the event, and the IDS attempted action to deny the connection from continuing.
-<4> The IDS application failed to deny the connection for some reason, resulting in `outcome: failure`
+<1> The IDS emitted this event when a detection rule generated an alert. The `event.type` is set to `alert`.
+<2> With the event emitted from a network IDS device, the event is categorized both as `network` and `intrusion_detection`.
+<3> The alert event is a `connection` that was `denied` by the IDS' configuration.
+<4> The IDS experience an issue when attempting to deny the connection. Since the action taken by the IDS failed, the outcome is set as `failure`.

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -1,69 +1,150 @@
 [[ecs-categorization-values-usage]]
-=== Event Categorization Examples
+=== Categorization Usage
 
-The following are examples use the four events categorization fields together.
+The following are usage examples of populating the categorization fields. Using the categorization fields together helps identify and group common subsets of events.
+
+Each categorization example is based on an event from real-world data sources. Categorization fields should be populated using knowledge of each type of event a data source emits.
 
 [float]
 ==== Firewall blocked a network connection
 
-[source,yaml]
+Network firewalls generate events based on which network flows were allowed or denied based on the firewall's configuration.
+
+[source,json]
 ----
-event:
-  kind: event
-  category:
-    - network
-  type:
-    - connection
-    - denied
-  outcome:
-    - success
+...
+  {
+    "source": {
+      "address": "10.42.42.42",
+      "ip": "10.42.42.42",
+      "port": 38842
+    },
+    "destination": {
+      "address": "10.42.42.1",
+      "ip": "10.42.42.1",
+      "port": 443
+    },
+    "rule": {
+      "name": "wan-lan",
+      "id": "default"
+    },
+    ...
+    "event": {
+      "kind": "event", <1>
+      "category": [ <2>
+        "network"
+      ],
+      "type": [ <3>
+        "connection",
+        "denied"
+      ],
+      "outcome": "success", <4>
+      "action": "dropped" <5>
+    }
+  }
+...
+----
+
+<1> The `event` value will be the most common and most general event `kind`.
+<2> Event relates to network activity.
+<3> The firewall blocked, dropped, or someway `denied` the attempted network `connection`.
+<4> A blocked connection is expected based on the configuration of this firewall. The outcome is a `success` from the perspective of the firewall emitting the event.
+<5> The data source describes this `denied` connection as `dropped`, which is best captured in `event.action`.
+
+A "denied" network connection falls under different actions: "blocked", "dropped", "quarantined". The `event.action` can capture the action taken by the source, and populating `event.type:denied` provides a normalized category which is independent of the source.
+
+Any network flows or connections that are "denied" can be searched with a single query:
+
+[source,sh]
+----
+event.category:network AND event.type:denied
 ----
 
 [float]
-==== Failed attempt to add user account
+==== Failed attempt to create a user account
 
-[source,yaml]
+User `alice` attempts to add a user account, `bob`, into a directory service, but the action fails.
+
+[source,json]
 ----
-event:
-  kind: event
-  category:
-    - iam
-  type:
-    - user
-    - creation
-  outcome:
-    - failure
+{
+  "user": {
+    "name": "alice",
+    "target": {
+      "name": "bob"
+    }
+  },
+  "event": {
+    "kind": "event",
+    "category": [ <1>
+      "iam"
+    ],
+    "type": [ <2>
+      "user",
+      "creation"
+    ],
+    "outcome": "failure" <3>
+  }
+}
 ----
+
+<1> Categorized using `iam` for an event user account activity.
+<2> Both `user` and `creation`
+<3> The creation of a user account was attempted, but it was not successful.
 
 [float]
-==== Gathering information about a file
+==== Informational listing of a file
 
-[source,yaml]
+A utility, such as a file integrity monitoring (FIM) application, takes inventory of a file but does not access or modify the file.
+
+[source,json]
 ----
-event:
-  kind: event
-  category:
-    - iam
-  type:
-    - user
-    - creation
-  outcome:
-    - failure
+{
+  "file": {
+    "name": "example.png",
+    "owner": "alice",
+    "path": "/home/alice/example.png",
+    "type": "file"
+  },
+  "event": {
+    "kind": "event",
+    "category": [ <1>
+      "file"
+    ],
+    "type": [ <2>
+      "info"
+    ]
+  }
+}
 ----
+
+<1> A file was reported on
+<2> The "info" type categorizes purely informational events. A file was listed but not accessed or modified.
 
 [float]
 === Security application failed to block a network connection
 
-[source,yaml]
+An intrusion detection system (IDS) performing analysis on network connections and protocols attempts to block a connection but fails.
+
+[source,json]
 ----
-event:
-  kind: alert
-  category:
-    - intrustion_detection
-    - network
-  type:
-    - connection
-    - denied
-  outcome: failure
+{
+  "event": {
+    "kind": "alert", <1>
+    "category": [ <2>
+      "intrusion_detection",
+      "network"
+    ],
+    "type": [ <3>
+      "connection",
+      "denied"
+    ],
+    "outcome": "failure" <4>
+  }
+}
 ----
 
+<1> The event was associated with a detection alert from an intrusion detection application.
+<2> The data source is a network-based intrusion detection application.
+<3> A network connection is associated with the event, and the IDS attempted action to deny the connection from continuing.
+<4> The IDS application failed to deny the connection for some reason, resulting in `outcome: failure`

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -165,7 +165,7 @@ An intrusion detection system (IDS) attempts to block a connection but fails. Th
 }
 ----
 
-<1> The IDS emitted this event when a detection rule generated an alert. The `event.type` is set to `alert`.
+<1> The IDS emitted this event when a detection rule generated an alert. The `event.kind` is set to `alert`.
 <2> With the event emitted from a network IDS device, the event is categorized both as `network` and `intrusion_detection`.
 <3> The alert event is a `connection` that was `denied` by the IDS' configuration.
 <4> The IDS experience an issue when attempting to deny the connection. Since the action taken by the IDS failed, the outcome is set as `failure`.

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -57,7 +57,7 @@ This event from a firewall describes a successfully blocked network connection:
 
 <1> Classifying as an `event`.
 <2> `event.category` categorizes this event as `network` activity.
-<3> The event was both an attempted network `connection` which was `denied`.
+<3> The event was both an attempted network `connection` and was `denied`.
 <4> The blocking of this connection is expected. The outcome is a `success` from the perspective of the firewall emitting the event.
 <5> The firewall classifies this denied connection as `dropped`, and this value is captured in `event.action`.
 
@@ -172,4 +172,4 @@ An intrusion detection system (IDS) attempts to block a connection but fails. Th
 <1> The IDS emitted this event when a detection rule generated an alert. The `event.kind` is set to `alert`.
 <2> With the event emitted from a network IDS device, the event is categorized both as `network` and `intrusion_detection`.
 <3> The alert event is a `connection` that was `denied` by the IDS' configuration.
-<4> The IDS experience an issue when attempting to deny the connection. Since the action taken by the IDS failed, the outcome is set as `failure`.
+<4> The IDS experienced an issue when attempting to deny the connection. Since the action taken by the IDS failed, the outcome is set as `failure`.

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -6,7 +6,8 @@ The event categorization fields work together to identify and group similar even
 These general principles can help guide the categorization process:
 
 * Events from multiple data sources that are similar enough to be viewed or analyzed together, should fall into the same `event.category` field.
-* Both `event.category` and `event.type` may be populated with multiple allowed values, if the event can be reasonably classified into more than one category and/or subcategory.
+* Both `event.category` and `event.type` are arrays and may be populated with multiple allowed values, if the event can be reasonably classified into more than one category and/or type.
+* `event.kind`, `event.category`, `event.type` and `event.outcome` all have allowed values. This is to normalize these fields. Values that aren't in the list of allowed values should not be used.
 * Values of `event.outcome` are a very limited set to indicate success or failure. Domain-specific actions, such as deny and allow, that could be considered outcomes are not
   captured in the `event.outcome` field, but rather in the `event.type` and/or `event.action` fields.
 * Values of `event.category`, `event.type`, and `event.outcome` are consistent across all values of `event.kind`.

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -118,19 +118,22 @@ A utility, such as a file integrity monitoring (FIM) application, takes inventor
     "type": "file"
   },
   "event": {
-    "kind": "event",
-    "category": [ <1>
+    "kind": "event", <1>
+    "category": [ <2>
       "file"
     ],
-    "type": [ <2>
+    "type": [ <3>
       "info"
     ]
   }
 }
 ----
 
-<1> The event is reporting on a `file`.
-<2> The `info` type categorizes purely informational events. The target file here was not accessed or modified.
+<1> Classifying as `event`.
+<2> The event is reporting on a `file`.
+<3> The `info` type categorizes purely informational events. The target file here was not accessed or modified.
+
+The source data didn't include any context around the event's outcome, so `event.outcome` should not be populated.
 
 [float]
 === Security application failed to block a network connection

--- a/docs/field-values-usage.asciidoc
+++ b/docs/field-values-usage.asciidoc
@@ -1,0 +1,69 @@
+[[ecs-categorization-values-usage]]
+=== Event Categorization Examples
+
+The following are examples use the four events categorization fields together.
+
+[float]
+==== Firewall blocked a network connection
+
+[source,yaml]
+----
+event:
+  kind: event
+  category:
+    - network
+  type:
+    - connection
+    - denied
+  outcome:
+    - success
+----
+
+[float]
+==== Failed attempt to add user account
+
+[source,yaml]
+----
+event:
+  kind: event
+  category:
+    - iam
+  type:
+    - user
+    - creation
+  outcome:
+    - failure
+----
+
+[float]
+==== Gathering information about a file
+
+[source,yaml]
+----
+event:
+  kind: event
+  category:
+    - iam
+  type:
+    - user
+    - creation
+  outcome:
+    - failure
+----
+
+[float]
+=== Security application failed to block a network connection
+
+[source,yaml]
+----
+event:
+  kind: alert
+  category:
+    - intrustion_detection
+    - network
+  type:
+    - connection
+    - denied
+  outcome: failure
+----
+

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -26,7 +26,7 @@ once the appropriate categorization values are published, in a later release.
 [[ecs-category-usage]]
 === Categorization Usage
 
-<<ecs-categorization-values-usage,Categorization usage>> contains examples combining the categorization fields to classify different types of events.
+<<ecs-using-the-categorization-fields,Using the categorization fields>> contains examples combining the categorization fields to classify different types of events.
 
 
 [[ecs-allowed-values-event-kind]]

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -22,6 +22,13 @@ NOTE: If your events don't match any of these categorization values, you should
 leave the fields empty. This will ensure you can start populating the fields
 once the appropriate categorization values are published, in a later release.
 
+[float]
+[[ecs-category-usage]]
+=== Categorization Usage
+
+<<ecs-categorization-values-usage,Categorization usage>> contains examples combining the categorization fields to classify different types of events.
+
+
 [[ecs-allowed-values-event-kind]]
 === ECS Categorization Field: event.kind
 
@@ -515,6 +522,8 @@ Indicates that this event describes a successful result. A common example is `ev
 ==== unknown
 
 Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about the request side of a transaction that results in a response, populating `event.outcome:unknown` in the request event is appropriate. The unknown value should not be used when an outcome doesn't make logical sense for the event. In such cases `event.outcome` should not be populated.
+
+
 
 
 include::field-values-usage.asciidoc[]

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -517,3 +517,4 @@ Indicates that this event describes a successful result. A common example is `ev
 Indicates that this event describes only an attempt for which the result is unknown from the perspective of the event producer. For example, if the event contains information only about the request side of a transaction that results in a response, populating `event.outcome:unknown` in the request event is appropriate. The unknown value should not be used when an outcome doesn't make logical sense for the event. In such cases `event.outcome` should not be populated.
 
 
+include::field-values-usage.asciidoc[]

--- a/rfcs/text/0012-orchestrator-field-set.md
+++ b/rfcs/text/0012-orchestrator-field-set.md
@@ -1,0 +1,111 @@
+# 0012: Orchestrator field set creation
+
+- Stage: **0 (strawperson)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
+- Date: **2021-01-11** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
+
+There is currently no ECS field set for container orchestration engines. There is an example of an ECS
+[use-case][0] for Kubernetes, but it largely relies on other ECS field sets, and doesn't cover all of the
+potential fields relevant to typical orchestrators. The purpose of this RFC is to propose some improvements to
+the existing use-case and then turn it into a full-featured ECS field set, with a larger number of
+fields that describe orchestrator-specific primitives which are currently missing (such as cluster names or
+resource types, for example).
+
+One use case for this is to allow easier work with [Kubernetes audit logs][1]. Consistent
+field definitions will allow teams working with Kubernetes audit logs to share and correlate
+data/alerts/visualisations far more easily than currently possible.
+
+There should not be any breaking impact as a result of this change, due to the fact that it should solely
+add a new schema rather than change existing material.
+
+## Fields
+
+<!--
+Stage 1: Describe at a high level how this change affects fields. Which fieldsets will be impacted? How many fields overall? Are we primarily adding fields, removing fields, or changing existing fields? The goal here is to understand the fundamental technical implications and likely extent of these changes. ~2-5 sentences.
+-->
+
+<!--
+Stage 2: Include new or updated yml field definitions for all of the essential fields in this draft. While not exhaustive, the fields documented here should be comprehensive enough to deeply evaluate the technical considerations of this change. The goal here is to validate the technical details for all essential fields and to provide a basis for adding experimental field definitions to the schema. Use GitHub code blocks with yml syntax formatting.
+-->
+
+<!--
+Stage 3: Add or update all remaining field definitions. The list should now be exhaustive. The goal here is to validate the technical details of all remaining fields and to provide a basis for releasing these field definitions as beta in the schema. Use GitHub code blocks with yml syntax formatting.
+-->
+
+## Usage
+
+<!--
+Stage 1: Describe at a high-level how these field changes will be used in practice. Real world examples are encouraged. The goal here is to understand how people would leverage these fields to gain insights or solve problems. ~1-3 paragraphs.
+-->
+
+## Source data
+
+<!--
+Stage 1: Provide a high-level description of example sources of data. This does not yet need to be a concrete example of a source document, but instead can simply describe a potential source (e.g. nginx access log). This will ultimately be fleshed out to include literal source examples in a future stage. The goal here is to identify practical sources for these fields in the real world. ~1-3 sentences or unordered list.
+-->
+
+<!--
+Stage 2: Included a real world example source document. Ideally this example comes from the source(s) identified in stage 1. If not, it should replace them. The goal here is to validate the utility of these field changes in the context of a real world example. Format with the source name as a ### header and the example document in a GitHub code block with json formatting.
+-->
+
+<!--
+Stage 3: Add more real world example source documents so we have at least 2 total, but ideally 3. Format as described in stage 2.
+-->
+
+## Scope of impact
+
+<!--
+Stage 2: Identifies scope of impact of changes. Are breaking changes required? Should deprecation strategies be adopted? Will significant refactoring be involved? Break the impact down into:
+ * Ingestion mechanisms (e.g. beats/logstash)
+ * Usage mechanisms (e.g. Kibana applications, detections)
+ * ECS project (e.g. docs, tooling)
+The goal here is to research and understand the impact of these changes on users in the community and development teams across Elastic. 2-5 sentences each.
+-->
+
+## Concerns
+
+<!--
+Stage 1: Identify potential concerns, implementation challenges, or complexity. Spend some time on this. Play devil's advocate. Try to identify the sort of non-obvious challenges that tend to surface later. The goal here is to surface risks early, allow everyone the time to work through them, and ultimately document resolution for posterity's sake.
+-->
+
+<!--
+Stage 2: Document new concerns or resolutions to previously listed concerns. It's not critical that all concerns have resolutions at this point, but it would be helpful if resolutions were taking shape for the most significant concerns.
+-->
+
+<!--
+Stage 3: Document resolutions for all existing concerns. Any new concerns should be documented along with their resolution. The goal here is to eliminate the risk of churn and instability by resolving outstanding concerns.
+-->
+
+<!--
+Stage 4: Document any new concerns and their resolution. The goal here is to eliminate risk of churn and instability by ensuring all concerns have been addressed.
+-->
+
+## Real-world implementations
+
+<!--
+Stage 4: Identify at least one real-world, production-ready implementation that uses these updated field definitions. An example of this might be a GA feature in an Elastic application in Kibana.
+-->
+
+## People
+
+The following are the people that consulted on the contents of this RFC.
+
+* @ferozsalam | author
+
+## References
+
+* [Kubernetes ECS use case][0]
+* [Kubernetes audit log documentation][1]
+
+### RFC Pull Requests
+
+<!-- An RFC should link to the PRs for each of it stage advancements. -->
+
+* Stage 0: https://github.com/elastic/ecs/pull/1209
+
+<!--
+* Stage 1: https://github.com/elastic/ecs/pull/NNN
+...
+-->
+
+[0]: https://github.com/elastic/ecs/blob/master/use-cases/kubernetes.yml
+[1]: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/

--- a/scripts/templates/field_values.j2
+++ b/scripts/templates/field_values.j2
@@ -21,6 +21,13 @@ ECS defines four categorization fields for this purpose, each of which falls und
 NOTE: If your events don't match any of these categorization values, you should
 leave the fields empty. This will ensure you can start populating the fields
 once the appropriate categorization values are published, in a later release.
+
+[float]
+[[ecs-category-usage]]
+=== Categorization Usage
+
+<<ecs-categorization-values-usage,Categorization usage>> contains examples combining the categorization fields to classify different types of events.
+
 {% for field in fields %}
 [[ecs-allowed-values-{{ field['dashed_name'] }}]]
 === ECS Categorization Field: {{ field['flat_name'] }}
@@ -45,3 +52,5 @@ once the appropriate categorization values are published, in a later release.
 {% endif %}
 {% endfor %}
 {%- endfor %}
+
+include::field-values-usage.asciidoc[]

--- a/scripts/templates/field_values.j2
+++ b/scripts/templates/field_values.j2
@@ -26,7 +26,7 @@ once the appropriate categorization values are published, in a later release.
 [[ecs-category-usage]]
 === Categorization Usage
 
-<<ecs-categorization-values-usage,Categorization usage>> contains examples combining the categorization fields to classify different types of events.
+<<ecs-using-the-categorization-fields,Using the categorization fields>> contains examples combining the categorization fields to classify different types of events.
 
 {% for field in fields %}
 [[ecs-allowed-values-{{ field['dashed_name'] }}]]


### PR DESCRIPTION
### Summary

Adds a new documentation section, `Using the Categorization Fields`, that contains guidance for using the four ECS categorization fields together to classify real-world example events.

### Motivation

Help those implementing ECS to use the event categorization fields more consistently.

### Design

While originally considered adding fields into the field definitions to provide examples, the approach felt too restrictive to capture more subtle or nuanced context. I instead opted for a new page, `docs/field-values-usage.asciidoc`, with an `include` directive to add the new content to the existing `ECS Categorization Fields` section.

After the section introduction, I captured some of the categorization usage principles from the public [ECS categorization doc](https://docs.google.com/document/d/1TxpruDWAfd_5JavWyjpPEia4nMqt0YIIo1zRxAeu05g/edit). This general guidance seemed like a good addition alongside the following examples.

Next are the actual examples. Each example follows this structure:

* Intro
* Code block with callouts
* Callout explanations
* Optionally, additional description or usage guidance relating to the example.

[Docs Preview](https://ecs_1242.docs-preview.app.elstc.co/guide/en/ecs/master/ecs-using-the-categorization-fields.html)

Closes #860 