### PR TITLE
Add scaled_float type to go generator

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -33,6 +33,7 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 * Clean up `event.reference` description. #1181
+* Go code generator fails if `scaled_float` type is used. #1250
 
 #### Added
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -280,7 +280,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 		return "int64"
 	case "integer":
 		return "int32"
-	case "float":
+	case "float", "scaled_float":
 		return "float64"
 	case "date":
 		return "time.Time"


### PR DESCRIPTION
When a field uses `type: scaled_float` in the field definitions, `make` fails due to `scaled_float` not being a defined data type in `go` generator:

```
$ make
build/ve/bin/python scripts/generator.py --strict --include ""
Loading schemas from local files
Running generator. ECS version 2.0.0-dev
build/ve/bin/python scripts/use-cases.py --stdout=true >> /dev/null
find code/go/ecs -name '*.go' -not -name 'doc.go' | xargs rm
cd scripts \
          && GO111MODULE=on go run cmd/gocodegen/gocodegen.go \
                -version=2.0.0-dev \
                -schema=../schemas \
                -out=../code/go/ecs
no translation for scaled_float (field cpu.usage)
exit status 1
make: *** [gocodegen] Error 1
```

This fix adds a type mapping for `scaled_float`.

I'll plan on backporting to 1.8 as well.