### PR TITLE
[1.x] Add scaled_float type to go generator (#1250)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -33,6 +33,7 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 * Clean up `event.reference` description. #1181
+* Go code generator fails if `scaled_float` type is used. #1250
 
 #### Added
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -280,7 +280,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 		return "int64"
 	case "integer":
 		return "int32"
-	case "float":
+	case "float", "scaled_float":
 		return "float64"
 	case "date":
 		return "time.Time"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add scaled_float type to go generator (#1250)