### PR TITLE
[1.x] Specify MAC address format (#456)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Include formatting guidance and examples for MAC address fields. #456
+
 #### Deprecated
 
 

--- a/code/go/ecs/client.go
+++ b/code/go/ecs/client.go
@@ -47,6 +47,10 @@ type Client struct {
 	Port int64 `ecs:"port"`
 
 	// MAC address of the client.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// Client domain.

--- a/code/go/ecs/destination.go
+++ b/code/go/ecs/destination.go
@@ -43,6 +43,10 @@ type Destination struct {
 	Port int64 `ecs:"port"`
 
 	// MAC address of the destination.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// Destination domain.

--- a/code/go/ecs/host.go
+++ b/code/go/ecs/host.go
@@ -44,7 +44,11 @@ type Host struct {
 	// Host ip addresses.
 	IP string `ecs:"ip"`
 
-	// Host mac addresses.
+	// Host MAC addresses.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// Type of host.

--- a/code/go/ecs/observer.go
+++ b/code/go/ecs/observer.go
@@ -32,7 +32,11 @@ package ecs
 // and ETL components used in processing events or metrics are not considered
 // observers in ECS.
 type Observer struct {
-	// MAC addresses of the observer
+	// MAC addresses of the observer.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// IP addresses of the observer.
@@ -67,24 +71,24 @@ type Observer struct {
 	Type string `ecs:"type"`
 
 	// Observer.ingress holds information like interface number and name, vlan,
-	// and zone information to  classify ingress traffic.  Single armed
-	// monitoring such as a network sensor on a span port should  only use
+	// and zone information to classify ingress traffic.  Single armed
+	// monitoring such as a network sensor on a span port should only use
 	// observer.ingress to categorize traffic.
 	Ingress map[string]interface{} `ecs:"ingress"`
 
 	// Network zone of incoming traffic as reported by the observer to
-	// categorize the source area of ingress  traffic. e.g. internal, External,
+	// categorize the source area of ingress traffic. e.g. internal, External,
 	// DMZ, HR, Legal, etc.
 	IngressZone string `ecs:"ingress.zone"`
 
 	// Observer.egress holds information like interface number and name, vlan,
-	// and zone information to  classify egress traffic.  Single armed
-	// monitoring such as a network sensor on a span port should  only use
+	// and zone information to classify egress traffic.  Single armed
+	// monitoring such as a network sensor on a span port should only use
 	// observer.ingress to categorize traffic.
 	Egress map[string]interface{} `ecs:"egress"`
 
 	// Network zone of outbound traffic as reported by the observer to
-	// categorize the destination area of egress  traffic, e.g. Internal,
+	// categorize the destination area of egress traffic, e.g. Internal,
 	// External, DMZ, HR, Legal, etc.
 	EgressZone string `ecs:"egress.zone"`
 }

--- a/code/go/ecs/server.go
+++ b/code/go/ecs/server.go
@@ -47,6 +47,10 @@ type Server struct {
 	Port int64 `ecs:"port"`
 
 	// MAC address of the server.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// Server domain.

--- a/code/go/ecs/source.go
+++ b/code/go/ecs/source.go
@@ -43,6 +43,10 @@ type Source struct {
 	Port int64 `ecs:"port"`
 
 	// MAC address of the source.
+	// The notation format from RFC 7042 is suggested: Each octet (that is,
+	// 8-bit byte) is represented by two [uppercase] hexadecimal digits giving
+	// the value of the octet as an unsigned integer. Successive octets are
+	// separated by a hyphen.
 	MAC string `ecs:"mac"`
 
 	// Source domain.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -375,11 +375,13 @@ type: ip
 
 | MAC address of the client.
 
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
+
 type: keyword
 
 
 
-
+example: `00-00-5E-00-53-23`
 
 | core
 
@@ -1067,11 +1069,13 @@ type: ip
 
 | MAC address of the destination.
 
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
+
 type: keyword
 
 
 
-
+example: `00-00-5E-00-53-23`
 
 | core
 
@@ -3263,7 +3267,9 @@ Note: this field should contain an array of values.
 [[field-host-mac]]
 <<field-host-mac, host.mac>>
 
-| Host mac addresses.
+| Host MAC addresses.
+
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
 
 type: keyword
 
@@ -3272,7 +3278,7 @@ Note: this field should contain an array of values.
 
 
 
-
+example: `["00-00-5E-00-53-23", "00-00-5E-00-53-24"]`
 
 | core
 
@@ -4238,7 +4244,7 @@ This could be a custom hardware appliance or a server that has been configured t
 [[field-observer-egress]]
 <<field-observer-egress, observer.egress>>
 
-| Observer.egress holds information like interface number and name, vlan, and zone information to  classify egress traffic.  Single armed monitoring such as a network sensor on a span port should  only use observer.ingress to categorize traffic.
+| Observer.egress holds information like interface number and name, vlan, and zone information to classify egress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.
 
 type: object
 
@@ -4254,7 +4260,7 @@ type: object
 [[field-observer-egress-zone]]
 <<field-observer-egress-zone, observer.egress.zone>>
 
-| Network zone of outbound traffic as reported by the observer to categorize the destination area of egress  traffic, e.g. Internal, External, DMZ, HR, Legal, etc.
+| Network zone of outbound traffic as reported by the observer to categorize the destination area of egress traffic, e.g. Internal, External, DMZ, HR, Legal, etc.
 
 type: keyword
 
@@ -4286,7 +4292,7 @@ type: keyword
 [[field-observer-ingress]]
 <<field-observer-ingress, observer.ingress>>
 
-| Observer.ingress holds information like interface number and name, vlan, and zone information to  classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should  only use observer.ingress to categorize traffic.
+| Observer.ingress holds information like interface number and name, vlan, and zone information to classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should only use observer.ingress to categorize traffic.
 
 type: object
 
@@ -4302,7 +4308,7 @@ type: object
 [[field-observer-ingress-zone]]
 <<field-observer-ingress-zone, observer.ingress.zone>>
 
-| Network zone of incoming traffic as reported by the observer to categorize the source area of ingress  traffic. e.g. internal, External, DMZ, HR, Legal, etc.
+| Network zone of incoming traffic as reported by the observer to categorize the source area of ingress traffic. e.g. internal, External, DMZ, HR, Legal, etc.
 
 type: keyword
 
@@ -4337,7 +4343,9 @@ Note: this field should contain an array of values.
 [[field-observer-mac]]
 <<field-observer-mac, observer.mac>>
 
-| MAC addresses of the observer
+| MAC addresses of the observer.
+
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
 
 type: keyword
 
@@ -4346,7 +4354,7 @@ Note: this field should contain an array of values.
 
 
 
-
+example: `["00-00-5E-00-53-23", "00-00-5E-00-53-24"]`
 
 | core
 
@@ -5965,11 +5973,13 @@ type: ip
 
 | MAC address of the server.
 
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
+
 type: keyword
 
 
 
-
+example: `00-00-5E-00-53-23`
 
 | core
 
@@ -6376,11 +6386,13 @@ type: ip
 
 | MAC address of the source.
 
+The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen.
+
 type: keyword
 
 
 
-
+example: `00-00-5E-00-53-23`
 
 | core
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -283,7 +283,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the client.
+      description: 'MAC address of the client.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -785,7 +791,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the destination.
+      description: 'MAC address of the destination.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -2338,7 +2350,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Host mac addresses.
+      description: 'Host MAC addresses.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
     - name: name
       level: core
       type: keyword
@@ -2965,9 +2983,9 @@
       level: extended
       type: object
       description: Observer.egress holds information like interface number and name,
-        vlan, and zone information to  classify egress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify egress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       default_field: false
     - name: egress.interface.alias
       level: extended
@@ -3011,7 +3029,7 @@
       type: keyword
       ignore_above: 1024
       description: Network zone of outbound traffic as reported by the observer to
-        categorize the destination area of egress  traffic, e.g. Internal, External,
+        categorize the destination area of egress traffic, e.g. Internal, External,
         DMZ, HR, Legal, etc.
       example: Public_Internet
       default_field: false
@@ -3100,9 +3118,9 @@
       level: extended
       type: object
       description: Observer.ingress holds information like interface number and name,
-        vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify ingress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       default_field: false
     - name: ingress.interface.alias
       level: extended
@@ -3146,7 +3164,7 @@
       type: keyword
       ignore_above: 1024
       description: Network zone of incoming traffic as reported by the observer to
-        categorize the source area of ingress  traffic. e.g. internal, External, DMZ,
+        categorize the source area of ingress traffic. e.g. internal, External, DMZ,
         HR, Legal, etc.
       example: DMZ
       default_field: false
@@ -3158,7 +3176,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC addresses of the observer
+      description: 'MAC addresses of the observer.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
     - name: name
       level: extended
       type: keyword
@@ -4381,7 +4405,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the server.
+      description: 'MAC address of the server.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -4734,7 +4764,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the source.
+      description: 'MAC address of the source.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -27,7 +27,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev+exp,true,client,client.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev+exp,true,client,client.ip,ip,core,,,IP address of the client.
-1.9.0-dev+exp,true,client,client.mac,keyword,core,,,MAC address of the client.
+1.9.0-dev+exp,true,client,client.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the client.
 1.9.0-dev+exp,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
 1.9.0-dev+exp,true,client,client.nat.port,long,extended,,,Client NAT port
 1.9.0-dev+exp,true,client,client.packets,long,core,,12,Packets sent from the client to the server.
@@ -85,7 +85,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev+exp,true,destination,destination.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev+exp,true,destination,destination.ip,ip,core,,,IP address of the destination.
-1.9.0-dev+exp,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
+1.9.0-dev+exp,true,destination,destination.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the destination.
 1.9.0-dev+exp,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
 1.9.0-dev+exp,true,destination,destination.nat.port,long,extended,,,Destination NAT Port
 1.9.0-dev+exp,true,destination,destination.packets,long,core,,12,Packets sent from the destination to the source.
@@ -260,7 +260,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,host,host.hostname,wildcard,core,,,Hostname of the host.
 1.9.0-dev+exp,true,host,host.id,keyword,core,,,Unique host id.
 1.9.0-dev+exp,true,host,host.ip,ip,core,array,,Host ip addresses.
-1.9.0-dev+exp,true,host,host.mac,keyword,core,array,,Host mac addresses.
+1.9.0-dev+exp,true,host,host.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",Host MAC addresses.
 1.9.0-dev+exp,true,host,host.name,keyword,core,,,Name of the host.
 1.9.0-dev+exp,true,host,host.network.egress.bytes,long,extended,,,The number of bytes sent on all network interfaces.
 1.9.0-dev+exp,true,host,host.network.egress.packets,long,extended,,,The number of packets sent on all network interfaces.
@@ -360,7 +360,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,observer,observer.ingress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 1.9.0-dev+exp,true,observer,observer.ingress.zone,keyword,extended,,DMZ,Observer ingress zone
 1.9.0-dev+exp,true,observer,observer.ip,ip,core,array,,IP addresses of the observer.
-1.9.0-dev+exp,true,observer,observer.mac,keyword,core,array,,MAC addresses of the observer
+1.9.0-dev+exp,true,observer,observer.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",MAC addresses of the observer.
 1.9.0-dev+exp,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 1.9.0-dev+exp,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.9.0-dev+exp,true,observer,observer.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -507,7 +507,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev+exp,true,server,server.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev+exp,true,server,server.ip,ip,core,,,IP address of the server.
-1.9.0-dev+exp,true,server,server.mac,keyword,core,,,MAC address of the server.
+1.9.0-dev+exp,true,server,server.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the server.
 1.9.0-dev+exp,true,server,server.nat.ip,ip,extended,,,Server NAT ip
 1.9.0-dev+exp,true,server,server.nat.port,long,extended,,,Server NAT port
 1.9.0-dev+exp,true,server,server.packets,long,core,,12,Packets sent from the server to the client.
@@ -552,7 +552,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev+exp,true,source,source.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev+exp,true,source,source.ip,ip,core,,,IP address of the source.
-1.9.0-dev+exp,true,source,source.mac,keyword,core,,,MAC address of the source.
+1.9.0-dev+exp,true,source,source.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the source.
 1.9.0-dev+exp,true,source,source.nat.ip,ip,extended,,,Source NAT ip
 1.9.0-dev+exp,true,source,source.nat.port,long,extended,,,Source NAT port
 1.9.0-dev+exp,true,source,source.packets,long,core,,12,Packets sent from the source to the destination.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -313,7 +313,12 @@ client.ip:
   type: ip
 client.mac:
   dashed_name: client-mac
-  description: MAC address of the client.
+  description: 'MAC address of the client.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: client.mac
   ignore_above: 1024
   level: core
@@ -1002,7 +1007,12 @@ destination.ip:
   type: ip
 destination.mac:
   dashed_name: destination-mac
-  description: MAC address of the destination.
+  description: 'MAC address of the destination.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: destination.mac
   ignore_above: 1024
   level: core
@@ -3568,14 +3578,19 @@ host.ip:
   type: ip
 host.mac:
   dashed_name: host-mac
-  description: Host mac addresses.
+  description: 'Host MAC addresses.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
   flat_name: host.mac
   ignore_above: 1024
   level: core
   name: mac
   normalize:
   - array
-  short: Host mac addresses.
+  short: Host MAC addresses.
   type: keyword
 host.name:
   dashed_name: host-name
@@ -4484,8 +4499,8 @@ network.vlan.name:
 observer.egress:
   dashed_name: observer-egress
   description: Observer.egress holds information like interface number and name, vlan,
-    and zone information to  classify egress traffic.  Single armed monitoring such
-    as a network sensor on a span port should  only use observer.ingress to categorize
+    and zone information to classify egress traffic.  Single armed monitoring such
+    as a network sensor on a span port should only use observer.ingress to categorize
     traffic.
   flat_name: observer.egress
   level: extended
@@ -4557,7 +4572,7 @@ observer.egress.vlan.name:
 observer.egress.zone:
   dashed_name: observer-egress-zone
   description: Network zone of outbound traffic as reported by the observer to categorize
-    the destination area of egress  traffic, e.g. Internal, External, DMZ, HR, Legal,
+    the destination area of egress traffic, e.g. Internal, External, DMZ, HR, Legal,
     etc.
   example: Public_Internet
   flat_name: observer.egress.zone
@@ -4719,8 +4734,8 @@ observer.hostname:
 observer.ingress:
   dashed_name: observer-ingress
   description: Observer.ingress holds information like interface number and name,
-    vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-    such as a network sensor on a span port should  only use observer.ingress to categorize
+    vlan, and zone information to classify ingress traffic.  Single armed monitoring
+    such as a network sensor on a span port should only use observer.ingress to categorize
     traffic.
   flat_name: observer.ingress
   level: extended
@@ -4792,8 +4807,7 @@ observer.ingress.vlan.name:
 observer.ingress.zone:
   dashed_name: observer-ingress-zone
   description: Network zone of incoming traffic as reported by the observer to categorize
-    the source area of ingress  traffic. e.g. internal, External, DMZ, HR, Legal,
-    etc.
+    the source area of ingress traffic. e.g. internal, External, DMZ, HR, Legal, etc.
   example: DMZ
   flat_name: observer.ingress.zone
   ignore_above: 1024
@@ -4814,14 +4828,19 @@ observer.ip:
   type: ip
 observer.mac:
   dashed_name: observer-mac
-  description: MAC addresses of the observer
+  description: 'MAC addresses of the observer.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
   flat_name: observer.mac
   ignore_above: 1024
   level: core
   name: mac
   normalize:
   - array
-  short: MAC addresses of the observer
+  short: MAC addresses of the observer.
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -6502,7 +6521,12 @@ server.ip:
   type: ip
 server.mac:
   dashed_name: server-mac
-  description: MAC address of the server.
+  description: 'MAC address of the server.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: server.mac
   ignore_above: 1024
   level: core
@@ -7060,7 +7084,12 @@ source.ip:
   type: ip
 source.mac:
   dashed_name: source-mac
-  description: MAC address of the source.
+  description: 'MAC address of the source.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: source.mac
   ignore_above: 1024
   level: core

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -458,7 +458,13 @@ client:
       type: ip
     client.mac:
       dashed_name: client-mac
-      description: MAC address of the client.
+      description: 'MAC address of the client.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: client.mac
       ignore_above: 1024
       level: core
@@ -1312,7 +1318,13 @@ destination:
       type: ip
     destination.mac:
       dashed_name: destination-mac
-      description: MAC address of the destination.
+      description: 'MAC address of the destination.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: destination.mac
       ignore_above: 1024
       level: core
@@ -4304,14 +4316,20 @@ host:
       type: ip
     host.mac:
       dashed_name: host-mac
-      description: Host mac addresses.
+      description: 'Host MAC addresses.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       flat_name: host.mac
       ignore_above: 1024
       level: core
       name: mac
       normalize:
       - array
-      short: Host mac addresses.
+      short: Host MAC addresses.
       type: keyword
     host.name:
       dashed_name: host-name
@@ -5337,9 +5355,9 @@ observer:
     observer.egress:
       dashed_name: observer-egress
       description: Observer.egress holds information like interface number and name,
-        vlan, and zone information to  classify egress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify egress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       flat_name: observer.egress
       level: extended
       name: egress
@@ -5411,7 +5429,7 @@ observer:
     observer.egress.zone:
       dashed_name: observer-egress-zone
       description: Network zone of outbound traffic as reported by the observer to
-        categorize the destination area of egress  traffic, e.g. Internal, External,
+        categorize the destination area of egress traffic, e.g. Internal, External,
         DMZ, HR, Legal, etc.
       example: Public_Internet
       flat_name: observer.egress.zone
@@ -5573,9 +5591,9 @@ observer:
     observer.ingress:
       dashed_name: observer-ingress
       description: Observer.ingress holds information like interface number and name,
-        vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify ingress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       flat_name: observer.ingress
       level: extended
       name: ingress
@@ -5647,7 +5665,7 @@ observer:
     observer.ingress.zone:
       dashed_name: observer-ingress-zone
       description: Network zone of incoming traffic as reported by the observer to
-        categorize the source area of ingress  traffic. e.g. internal, External, DMZ,
+        categorize the source area of ingress traffic. e.g. internal, External, DMZ,
         HR, Legal, etc.
       example: DMZ
       flat_name: observer.ingress.zone
@@ -5669,14 +5687,20 @@ observer:
       type: ip
     observer.mac:
       dashed_name: observer-mac
-      description: MAC addresses of the observer
+      description: 'MAC addresses of the observer.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       flat_name: observer.mac
       ignore_above: 1024
       level: core
       name: mac
       normalize:
       - array
-      short: MAC addresses of the observer
+      short: MAC addresses of the observer.
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -7729,7 +7753,13 @@ server:
       type: ip
     server.mac:
       dashed_name: server-mac
-      description: MAC address of the server.
+      description: 'MAC address of the server.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: server.mac
       ignore_above: 1024
       level: core
@@ -8331,7 +8361,13 @@ source:
       type: ip
     source.mac:
       dashed_name: source-mac
-      description: MAC address of the source.
+      description: 'MAC address of the source.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: source.mac
       ignore_above: 1024
       level: core

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -288,7 +288,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the client.
+      description: 'MAC address of the client.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -745,7 +751,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the destination.
+      description: 'MAC address of the destination.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -2295,7 +2307,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Host mac addresses.
+      description: 'Host MAC addresses.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
     - name: name
       level: core
       type: keyword
@@ -2908,9 +2926,9 @@
       level: extended
       type: object
       description: Observer.egress holds information like interface number and name,
-        vlan, and zone information to  classify egress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify egress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       default_field: false
     - name: egress.interface.alias
       level: extended
@@ -2954,7 +2972,7 @@
       type: keyword
       ignore_above: 1024
       description: Network zone of outbound traffic as reported by the observer to
-        categorize the destination area of egress  traffic, e.g. Internal, External,
+        categorize the destination area of egress traffic, e.g. Internal, External,
         DMZ, HR, Legal, etc.
       example: Public_Internet
       default_field: false
@@ -3044,9 +3062,9 @@
       level: extended
       type: object
       description: Observer.ingress holds information like interface number and name,
-        vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify ingress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       default_field: false
     - name: ingress.interface.alias
       level: extended
@@ -3090,7 +3108,7 @@
       type: keyword
       ignore_above: 1024
       description: Network zone of incoming traffic as reported by the observer to
-        categorize the source area of ingress  traffic. e.g. internal, External, DMZ,
+        categorize the source area of ingress traffic. e.g. internal, External, DMZ,
         HR, Legal, etc.
       example: DMZ
       default_field: false
@@ -3102,7 +3120,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC addresses of the observer
+      description: 'MAC addresses of the observer.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
     - name: name
       level: extended
       type: keyword
@@ -4351,7 +4375,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the server.
+      description: 'MAC address of the server.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip
@@ -4711,7 +4741,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: MAC address of the source.
+      description: 'MAC address of the source.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
     - name: nat.ip
       level: extended
       type: ip

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -27,7 +27,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,client,client.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev,true,client,client.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev,true,client,client.ip,ip,core,,,IP address of the client.
-1.9.0-dev,true,client,client.mac,keyword,core,,,MAC address of the client.
+1.9.0-dev,true,client,client.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the client.
 1.9.0-dev,true,client,client.nat.ip,ip,extended,,,Client NAT ip address
 1.9.0-dev,true,client,client.nat.port,long,extended,,,Client NAT port
 1.9.0-dev,true,client,client.packets,long,core,,12,Packets sent from the client to the server.
@@ -82,7 +82,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev,true,destination,destination.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev,true,destination,destination.ip,ip,core,,,IP address of the destination.
-1.9.0-dev,true,destination,destination.mac,keyword,core,,,MAC address of the destination.
+1.9.0-dev,true,destination,destination.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the destination.
 1.9.0-dev,true,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
 1.9.0-dev,true,destination,destination.nat.port,long,extended,,,Destination NAT Port
 1.9.0-dev,true,destination,destination.packets,long,core,,12,Packets sent from the destination to the source.
@@ -254,7 +254,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,host,host.hostname,keyword,core,,,Hostname of the host.
 1.9.0-dev,true,host,host.id,keyword,core,,,Unique host id.
 1.9.0-dev,true,host,host.ip,ip,core,array,,Host ip addresses.
-1.9.0-dev,true,host,host.mac,keyword,core,array,,Host mac addresses.
+1.9.0-dev,true,host,host.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",Host MAC addresses.
 1.9.0-dev,true,host,host.name,keyword,core,,,Name of the host.
 1.9.0-dev,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.9.0-dev,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -350,7 +350,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,observer,observer.ingress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
 1.9.0-dev,true,observer,observer.ingress.zone,keyword,extended,,DMZ,Observer ingress zone
 1.9.0-dev,true,observer,observer.ip,ip,core,array,,IP addresses of the observer.
-1.9.0-dev,true,observer,observer.mac,keyword,core,array,,MAC addresses of the observer
+1.9.0-dev,true,observer,observer.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",MAC addresses of the observer.
 1.9.0-dev,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 1.9.0-dev,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.9.0-dev,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -497,7 +497,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,server,server.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev,true,server,server.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev,true,server,server.ip,ip,core,,,IP address of the server.
-1.9.0-dev,true,server,server.mac,keyword,core,,,MAC address of the server.
+1.9.0-dev,true,server,server.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the server.
 1.9.0-dev,true,server,server.nat.ip,ip,extended,,,Server NAT ip
 1.9.0-dev,true,server,server.nat.port,long,extended,,,Server NAT port
 1.9.0-dev,true,server,server.packets,long,core,,12,Packets sent from the server to the client.
@@ -542,7 +542,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,source,source.geo.region_name,keyword,core,,Quebec,Region name.
 1.9.0-dev,true,source,source.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 1.9.0-dev,true,source,source.ip,ip,core,,,IP address of the source.
-1.9.0-dev,true,source,source.mac,keyword,core,,,MAC address of the source.
+1.9.0-dev,true,source,source.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the source.
 1.9.0-dev,true,source,source.nat.ip,ip,extended,,,Source NAT ip
 1.9.0-dev,true,source,source.nat.port,long,extended,,,Source NAT port
 1.9.0-dev,true,source,source.packets,long,core,,12,Packets sent from the source to the destination.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -317,7 +317,12 @@ client.ip:
   type: ip
 client.mac:
   dashed_name: client-mac
-  description: MAC address of the client.
+  description: 'MAC address of the client.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: client.mac
   ignore_above: 1024
   level: core
@@ -967,7 +972,12 @@ destination.ip:
   type: ip
 destination.mac:
   dashed_name: destination-mac
-  description: MAC address of the destination.
+  description: 'MAC address of the destination.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: destination.mac
   ignore_above: 1024
   level: core
@@ -3518,14 +3528,19 @@ host.ip:
   type: ip
 host.mac:
   dashed_name: host-mac
-  description: Host mac addresses.
+  description: 'Host MAC addresses.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
   flat_name: host.mac
   ignore_above: 1024
   level: core
   name: mac
   normalize:
   - array
-  short: Host mac addresses.
+  short: Host MAC addresses.
   type: keyword
 host.name:
   dashed_name: host-name
@@ -4404,8 +4419,8 @@ network.vlan.name:
 observer.egress:
   dashed_name: observer-egress
   description: Observer.egress holds information like interface number and name, vlan,
-    and zone information to  classify egress traffic.  Single armed monitoring such
-    as a network sensor on a span port should  only use observer.ingress to categorize
+    and zone information to classify egress traffic.  Single armed monitoring such
+    as a network sensor on a span port should only use observer.ingress to categorize
     traffic.
   flat_name: observer.egress
   level: extended
@@ -4477,7 +4492,7 @@ observer.egress.vlan.name:
 observer.egress.zone:
   dashed_name: observer-egress-zone
   description: Network zone of outbound traffic as reported by the observer to categorize
-    the destination area of egress  traffic, e.g. Internal, External, DMZ, HR, Legal,
+    the destination area of egress traffic, e.g. Internal, External, DMZ, HR, Legal,
     etc.
   example: Public_Internet
   flat_name: observer.egress.zone
@@ -4640,8 +4655,8 @@ observer.hostname:
 observer.ingress:
   dashed_name: observer-ingress
   description: Observer.ingress holds information like interface number and name,
-    vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-    such as a network sensor on a span port should  only use observer.ingress to categorize
+    vlan, and zone information to classify ingress traffic.  Single armed monitoring
+    such as a network sensor on a span port should only use observer.ingress to categorize
     traffic.
   flat_name: observer.ingress
   level: extended
@@ -4713,8 +4728,7 @@ observer.ingress.vlan.name:
 observer.ingress.zone:
   dashed_name: observer-ingress-zone
   description: Network zone of incoming traffic as reported by the observer to categorize
-    the source area of ingress  traffic. e.g. internal, External, DMZ, HR, Legal,
-    etc.
+    the source area of ingress traffic. e.g. internal, External, DMZ, HR, Legal, etc.
   example: DMZ
   flat_name: observer.ingress.zone
   ignore_above: 1024
@@ -4735,14 +4749,19 @@ observer.ip:
   type: ip
 observer.mac:
   dashed_name: observer-mac
-  description: MAC addresses of the observer
+  description: 'MAC addresses of the observer.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
   flat_name: observer.mac
   ignore_above: 1024
   level: core
   name: mac
   normalize:
   - array
-  short: MAC addresses of the observer
+  short: MAC addresses of the observer.
   type: keyword
 observer.name:
   dashed_name: observer-name
@@ -6446,7 +6465,12 @@ server.ip:
   type: ip
 server.mac:
   dashed_name: server-mac
-  description: MAC address of the server.
+  description: 'MAC address of the server.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: server.mac
   ignore_above: 1024
   level: core
@@ -7011,7 +7035,12 @@ source.ip:
   type: ip
 source.mac:
   dashed_name: source-mac
-  description: MAC address of the source.
+  description: 'MAC address of the source.
+
+    The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte)
+    is represented by two [uppercase] hexadecimal digits giving the value of the octet
+    as an unsigned integer. Successive octets are separated by a hyphen.'
+  example: 00-00-5E-00-53-23
   flat_name: source.mac
   ignore_above: 1024
   level: core

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -463,7 +463,13 @@ client:
       type: ip
     client.mac:
       dashed_name: client-mac
-      description: MAC address of the client.
+      description: 'MAC address of the client.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: client.mac
       ignore_above: 1024
       level: core
@@ -1255,7 +1261,13 @@ destination:
       type: ip
     destination.mac:
       dashed_name: destination-mac
-      description: MAC address of the destination.
+      description: 'MAC address of the destination.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: destination.mac
       ignore_above: 1024
       level: core
@@ -4233,14 +4245,20 @@ host:
       type: ip
     host.mac:
       dashed_name: host-mac
-      description: Host mac addresses.
+      description: 'Host MAC addresses.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       flat_name: host.mac
       ignore_above: 1024
       level: core
       name: mac
       normalize:
       - array
-      short: Host mac addresses.
+      short: Host MAC addresses.
       type: keyword
     host.name:
       dashed_name: host-name
@@ -5236,9 +5254,9 @@ observer:
     observer.egress:
       dashed_name: observer-egress
       description: Observer.egress holds information like interface number and name,
-        vlan, and zone information to  classify egress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify egress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       flat_name: observer.egress
       level: extended
       name: egress
@@ -5310,7 +5328,7 @@ observer:
     observer.egress.zone:
       dashed_name: observer-egress-zone
       description: Network zone of outbound traffic as reported by the observer to
-        categorize the destination area of egress  traffic, e.g. Internal, External,
+        categorize the destination area of egress traffic, e.g. Internal, External,
         DMZ, HR, Legal, etc.
       example: Public_Internet
       flat_name: observer.egress.zone
@@ -5473,9 +5491,9 @@ observer:
     observer.ingress:
       dashed_name: observer-ingress
       description: Observer.ingress holds information like interface number and name,
-        vlan, and zone information to  classify ingress traffic.  Single armed monitoring
-        such as a network sensor on a span port should  only use observer.ingress
-        to categorize traffic.
+        vlan, and zone information to classify ingress traffic.  Single armed monitoring
+        such as a network sensor on a span port should only use observer.ingress to
+        categorize traffic.
       flat_name: observer.ingress
       level: extended
       name: ingress
@@ -5547,7 +5565,7 @@ observer:
     observer.ingress.zone:
       dashed_name: observer-ingress-zone
       description: Network zone of incoming traffic as reported by the observer to
-        categorize the source area of ingress  traffic. e.g. internal, External, DMZ,
+        categorize the source area of ingress traffic. e.g. internal, External, DMZ,
         HR, Legal, etc.
       example: DMZ
       flat_name: observer.ingress.zone
@@ -5569,14 +5587,20 @@ observer:
       type: ip
     observer.mac:
       dashed_name: observer-mac
-      description: MAC addresses of the observer
+      description: 'MAC addresses of the observer.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       flat_name: observer.mac
       ignore_above: 1024
       level: core
       name: mac
       normalize:
       - array
-      short: MAC addresses of the observer
+      short: MAC addresses of the observer.
       type: keyword
     observer.name:
       dashed_name: observer-name
@@ -7655,7 +7679,13 @@ server:
       type: ip
     server.mac:
       dashed_name: server-mac
-      description: MAC address of the server.
+      description: 'MAC address of the server.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: server.mac
       ignore_above: 1024
       level: core
@@ -8264,7 +8294,13 @@ source:
       type: ip
     source.mac:
       dashed_name: source-mac
-      description: MAC address of the source.
+      description: 'MAC address of the source.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit
+        byte) is represented by two [uppercase] hexadecimal digits giving the value
+        of the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.'
+      example: 00-00-5E-00-53-23
       flat_name: source.mac
       ignore_above: 1024
       level: core

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -48,8 +48,15 @@
     - name: mac
       level: core
       type: keyword
+      short: MAC address of the client.
+      example: 00-00-5E-00-53-23
       description: >
         MAC address of the client.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
 
     - name: domain
       level: core

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -43,8 +43,15 @@
     - name: mac
       level: core
       type: keyword
+      short: MAC address of the destination.
+      example: 00-00-5E-00-53-23
       description: >
         MAC address of the destination.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
 
     - name: domain
       level: core

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -55,8 +55,15 @@
     - name: mac
       level: core
       type: keyword
+      short: Host MAC addresses.
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       description: >
-        Host mac addresses.
+        Host MAC addresses.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
       normalize:
         - array
 

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -20,8 +20,15 @@
     - name: mac
       level: core
       type: keyword
+      example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+      short: MAC addresses of the observer.
       description: >
-        MAC addresses of the observer
+        MAC addresses of the observer.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
       normalize:
         - array
 
@@ -96,8 +103,8 @@
       type: object
       short: Object field for ingress information
       description: >
-        Observer.ingress holds information like interface number and name, vlan, and zone information to 
-        classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should 
+        Observer.ingress holds information like interface number and name, vlan, and zone information to
+        classify ingress traffic.  Single armed monitoring such as a network sensor on a span port should
         only use observer.ingress to categorize traffic.
 
     - name: ingress.zone
@@ -106,16 +113,16 @@
       short: Observer ingress zone
       example: DMZ
       description: >
-        Network zone of incoming traffic as reported by the observer to categorize the source area of ingress 
+        Network zone of incoming traffic as reported by the observer to categorize the source area of ingress
         traffic. e.g. internal, External, DMZ, HR, Legal, etc.
-      
+
     - name: egress
       level: extended
       type: object
       short: Object field for egress information
       description: >
-        Observer.egress holds information like interface number and name, vlan, and zone information to 
-        classify egress traffic.  Single armed monitoring such as a network sensor on a span port should 
+        Observer.egress holds information like interface number and name, vlan, and zone information to
+        classify egress traffic.  Single armed monitoring such as a network sensor on a span port should
         only use observer.ingress to categorize traffic.
 
     - name: egress.zone
@@ -124,5 +131,5 @@
       short: Observer Egress zone
       example: Public_Internet
       description: >
-        Network zone of outbound traffic as reported by the observer to categorize the destination area of egress 
+        Network zone of outbound traffic as reported by the observer to categorize the destination area of egress
         traffic, e.g. Internal, External, DMZ, HR, Legal, etc.

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -48,8 +48,15 @@
     - name: mac
       level: core
       type: keyword
+      short: MAC address of the server.
+      example: 00-00-5E-00-53-23
       description: >
         MAC address of the server.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
 
     - name: domain
       level: core

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -43,8 +43,15 @@
     - name: mac
       level: core
       type: keyword
+      short: MAC address of the source.
+      example: 00-00-5E-00-53-23
       description: >
         MAC address of the source.
+
+        The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is
+        represented by two [uppercase] hexadecimal digits giving the value of
+        the octet as an unsigned integer. Successive octets are separated by a
+        hyphen.
 
     - name: domain
       level: core


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Specify MAC address format (#456)