### PR TITLE
Stage 1 changes for RFC 0015 - add elf fieldset

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -29,6 +29,7 @@ Thanks, you're awesome :-) -->
 * Extended `pe` fields added to experimental schema. #1256
 * Added `code_signature.team_id`, `code_signature.signing_id`. #1249
 * Add `threat.indicator` fields to experimental schema. #1268
+* Add `elf` fieldset to experimental schema. #1261
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1531,7 +1531,7 @@
       type: keyword
       ignore_above: 1024
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       default_field: false
     - name: byte_order
       level: extended
@@ -1545,7 +1545,7 @@
       type: keyword
       ignore_above: 1024
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       default_field: false
     - name: creation_date
       level: extended
@@ -2162,7 +2162,7 @@
       type: keyword
       ignore_above: 1024
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       default_field: false
     - name: elf.byte_order
       level: extended
@@ -2176,7 +2176,7 @@
       type: keyword
       ignore_above: 1024
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       default_field: false
     - name: elf.creation_date
       level: extended
@@ -4684,7 +4684,7 @@
       type: keyword
       ignore_above: 1024
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       default_field: false
     - name: elf.byte_order
       level: extended
@@ -4698,7 +4698,7 @@
       type: keyword
       ignore_above: 1024
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       default_field: false
     - name: elf.creation_date
       level: extended
@@ -5025,7 +5025,7 @@
       type: keyword
       ignore_above: 1024
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       default_field: false
     - name: parent.elf.byte_order
       level: extended
@@ -5039,7 +5039,7 @@
       type: keyword
       ignore_above: 1024
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       default_field: false
     - name: parent.elf.creation_date
       level: extended

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1520,6 +1520,186 @@
         ECS versions -- this field lets integrations adjust to the schema version
         of the events.'
       example: 1.0.0
+  - name: elf
+    title: ELF Header
+    group: 2
+    description: These fields contain Linux Executable Linkable Format (ELF) metadata.
+    type: group
+    fields:
+    - name: architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      default_field: false
+    - name: byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      default_field: false
+    - name: cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      default_field: false
+    - name: creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: sections
+      level: extended
+      type: nested
+      description: Section information of the ELF file.
+      default_field: false
+    - name: sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: segments
+      level: extended
+      type: nested
+      description: ELF object segment list.
+      default_field: false
+    - name: segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object
+      default_field: false
+    - name: telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      default_field: false
   - name: error
     title: Error
     group: 2
@@ -1976,6 +2156,180 @@
 
         The value should be uppercase, and not include the colon.'
       example: C
+      default_field: false
+    - name: elf.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      default_field: false
+    - name: elf.byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      default_field: false
+    - name: elf.cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      default_field: false
+    - name: elf.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: elf.exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: elf.header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: elf.header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: elf.header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: elf.header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: elf.header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: elf.header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: elf.header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: elf.header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: elf.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: elf.sections
+      level: extended
+      type: nested
+      description: Section information of the ELF file.
+      default_field: false
+    - name: elf.sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: elf.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: elf.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: elf.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: elf.sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: elf.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: elf.sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: elf.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: elf.segments
+      level: extended
+      type: nested
+      description: ELF object segment list.
+      default_field: false
+    - name: elf.segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: elf.segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: elf.shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object
+      default_field: false
+    - name: elf.telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
       default_field: false
     - name: extension
       level: extended
@@ -4325,6 +4679,180 @@
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
       default_field: false
+    - name: elf.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      default_field: false
+    - name: elf.byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      default_field: false
+    - name: elf.cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      default_field: false
+    - name: elf.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: elf.exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: elf.header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: elf.header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: elf.header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: elf.header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: elf.header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: elf.header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: elf.header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: elf.header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: elf.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: elf.sections
+      level: extended
+      type: nested
+      description: Section information of the ELF file.
+      default_field: false
+    - name: elf.sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: elf.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: elf.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: elf.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: elf.sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: elf.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: elf.sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: elf.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: elf.segments
+      level: extended
+      type: nested
+      description: ELF object segment list.
+      default_field: false
+    - name: elf.segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: elf.segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: elf.shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object
+      default_field: false
+    - name: elf.telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      default_field: false
     - name: entity_id
       level: extended
       type: keyword
@@ -4491,6 +5019,180 @@
 
         Some arguments may be filtered to protect sensitive information.'
       example: /usr/bin/ssh -l user 10.0.0.16
+      default_field: false
+    - name: parent.elf.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      default_field: false
+    - name: parent.elf.byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      default_field: false
+    - name: parent.elf.cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      default_field: false
+    - name: parent.elf.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: parent.elf.exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: parent.elf.header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: parent.elf.header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: parent.elf.header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: parent.elf.header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: parent.elf.header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: parent.elf.header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: parent.elf.header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: parent.elf.header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: parent.elf.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: parent.elf.sections
+      level: extended
+      type: nested
+      description: Section information of the ELF file.
+      default_field: false
+    - name: parent.elf.sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: parent.elf.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.elf.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: parent.elf.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: parent.elf.sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: parent.elf.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: parent.elf.sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: parent.elf.sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: parent.elf.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: parent.elf.segments
+      level: extended
+      type: nested
+      description: ELF object segment list.
+      default_field: false
+    - name: parent.elf.segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: parent.elf.segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: parent.elf.shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object
+      default_field: false
+    - name: parent.elf.telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
       default_field: false
     - name: parent.entity_id
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -221,9 +221,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
 2.0.0-dev+exp,true,file,file.directory,wildcard,extended,,/home/alice,Directory where the file is located.
 2.0.0-dev+exp,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
-2.0.0-dev+exp,true,file,file.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 2.0.0-dev+exp,true,file,file.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
-2.0.0-dev+exp,true,file,file.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 2.0.0-dev+exp,true,file,file.elf.creation_date,date,extended,,,Build or compile date.
 2.0.0-dev+exp,true,file,file.elf.exports,flattened,extended,,,List of exported element names and types.
 2.0.0-dev+exp,true,file,file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
@@ -498,9 +498,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 2.0.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev+exp,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-2.0.0-dev+exp,true,process,process.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 2.0.0-dev+exp,true,process,process.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
-2.0.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 2.0.0-dev+exp,true,process,process.elf.creation_date,date,extended,,,Build or compile date.
 2.0.0-dev+exp,true,process,process.elf.exports,flattened,extended,,,List of exported element names and types.
 2.0.0-dev+exp,true,process,process.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
@@ -549,9 +549,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 2.0.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev+exp,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-2.0.0-dev+exp,true,process,process.parent.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 2.0.0-dev+exp,true,process,process.parent.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
-2.0.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 2.0.0-dev+exp,true,process,process.parent.elf.creation_date,date,extended,,,Build or compile date.
 2.0.0-dev+exp,true,process,process.parent.elf.exports,flattened,extended,,,List of exported element names and types.
 2.0.0-dev+exp,true,process,process.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -221,6 +221,35 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,file,file.device,keyword,extended,,sda,Device that is the source of the file.
 2.0.0-dev+exp,true,file,file.directory,wildcard,extended,,/home/alice,Directory where the file is located.
 2.0.0-dev+exp,true,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
+2.0.0-dev+exp,true,file,file.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
+2.0.0-dev+exp,true,file,file.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.creation_date,date,extended,,,Build or compile date.
+2.0.0-dev+exp,true,file,file.elf.exports,flattened,extended,,,List of exported element names and types.
+2.0.0-dev+exp,true,file,file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+2.0.0-dev+exp,true,file,file.elf.header.class,keyword,extended,,,Header class of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.header.data,keyword,extended,,,Data table of the ELF header.
+2.0.0-dev+exp,true,file,file.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+2.0.0-dev+exp,true,file,file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+2.0.0-dev+exp,true,file,file.elf.header.type,keyword,extended,,,Header type of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.header.version,keyword,extended,,,Version of the ELF header.
+2.0.0-dev+exp,true,file,file.elf.imports,flattened,extended,,,List of imported element names and types.
+2.0.0-dev+exp,true,file,file.elf.sections,nested,extended,,,Section information of the ELF file.
+2.0.0-dev+exp,true,file,file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+2.0.0-dev+exp,true,file,file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+2.0.0-dev+exp,true,file,file.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+2.0.0-dev+exp,true,file,file.elf.sections.name,keyword,extended,,,ELF Section List name.
+2.0.0-dev+exp,true,file,file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+2.0.0-dev+exp,true,file,file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+2.0.0-dev+exp,true,file,file.elf.sections.type,keyword,extended,,,ELF Section List type.
+2.0.0-dev+exp,true,file,file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+2.0.0-dev+exp,true,file,file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+2.0.0-dev+exp,true,file,file.elf.segments,nested,extended,,,ELF object segment list.
+2.0.0-dev+exp,true,file,file.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+2.0.0-dev+exp,true,file,file.elf.segments.type,keyword,extended,,,ELF object segment type.
+2.0.0-dev+exp,true,file,file.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object
+2.0.0-dev+exp,true,file,file.elf.telfhash,keyword,extended,,,telfhash hash for ELF files
 2.0.0-dev+exp,true,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
 2.0.0-dev+exp,true,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 2.0.0-dev+exp,true,file,file.group,keyword,extended,,alice,Primary group name of the file.
@@ -469,6 +498,35 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 2.0.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev+exp,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
+2.0.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.creation_date,date,extended,,,Build or compile date.
+2.0.0-dev+exp,true,process,process.elf.exports,flattened,extended,,,List of exported element names and types.
+2.0.0-dev+exp,true,process,process.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+2.0.0-dev+exp,true,process,process.elf.header.class,keyword,extended,,,Header class of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.header.data,keyword,extended,,,Data table of the ELF header.
+2.0.0-dev+exp,true,process,process.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+2.0.0-dev+exp,true,process,process.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+2.0.0-dev+exp,true,process,process.elf.header.type,keyword,extended,,,Header type of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.header.version,keyword,extended,,,Version of the ELF header.
+2.0.0-dev+exp,true,process,process.elf.imports,flattened,extended,,,List of imported element names and types.
+2.0.0-dev+exp,true,process,process.elf.sections,nested,extended,,,Section information of the ELF file.
+2.0.0-dev+exp,true,process,process.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+2.0.0-dev+exp,true,process,process.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+2.0.0-dev+exp,true,process,process.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+2.0.0-dev+exp,true,process,process.elf.sections.name,keyword,extended,,,ELF Section List name.
+2.0.0-dev+exp,true,process,process.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+2.0.0-dev+exp,true,process,process.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+2.0.0-dev+exp,true,process,process.elf.sections.type,keyword,extended,,,ELF Section List type.
+2.0.0-dev+exp,true,process,process.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+2.0.0-dev+exp,true,process,process.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+2.0.0-dev+exp,true,process,process.elf.segments,nested,extended,,,ELF object segment list.
+2.0.0-dev+exp,true,process,process.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+2.0.0-dev+exp,true,process,process.elf.segments.type,keyword,extended,,,ELF object segment type.
+2.0.0-dev+exp,true,process,process.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object
+2.0.0-dev+exp,true,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF files
 2.0.0-dev+exp,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 2.0.0-dev+exp,true,process,process.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev+exp,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
@@ -491,6 +549,35 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 2.0.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 2.0.0-dev+exp,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.parent.elf.architecture,keyword,extended,,"ARM, x86-64, etc",Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.byte_order,keyword,extended,,"Little Endian, Big Endian",Byte sequence of ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,"Intel, PowerPC, RISC, etc.",CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.creation_date,date,extended,,,Build or compile date.
+2.0.0-dev+exp,true,process,process.parent.elf.exports,flattened,extended,,,List of exported element names and types.
+2.0.0-dev+exp,true,process,process.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+2.0.0-dev+exp,true,process,process.parent.elf.header.class,keyword,extended,,,Header class of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.header.data,keyword,extended,,,Data table of the ELF header.
+2.0.0-dev+exp,true,process,process.parent.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+2.0.0-dev+exp,true,process,process.parent.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+2.0.0-dev+exp,true,process,process.parent.elf.header.type,keyword,extended,,,Header type of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.header.version,keyword,extended,,,Version of the ELF header.
+2.0.0-dev+exp,true,process,process.parent.elf.imports,flattened,extended,,,List of imported element names and types.
+2.0.0-dev+exp,true,process,process.parent.elf.sections,nested,extended,,,Section information of the ELF file.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.name,keyword,extended,,,ELF Section List name.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.type,keyword,extended,,,ELF Section List type.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+2.0.0-dev+exp,true,process,process.parent.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+2.0.0-dev+exp,true,process,process.parent.elf.segments,nested,extended,,,ELF object segment list.
+2.0.0-dev+exp,true,process,process.parent.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+2.0.0-dev+exp,true,process,process.parent.elf.segments.type,keyword,extended,,,ELF object segment type.
+2.0.0-dev+exp,true,process,process.parent.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object
+2.0.0-dev+exp,true,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF files
 2.0.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 2.0.0-dev+exp,true,process,process.parent.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
 2.0.0-dev+exp,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3133,7 +3133,7 @@ file.drive_letter:
 file.elf.architecture:
   dashed_name: file-elf-architecture
   description: Machine architecture of the ELF file.
-  example: ARM, x86-64, etc
+  example: x86-64
   flat_name: file.elf.architecture
   ignore_above: 1024
   level: extended
@@ -3157,7 +3157,7 @@ file.elf.byte_order:
 file.elf.cpu_type:
   dashed_name: file-elf-cpu-type
   description: CPU type of the ELF file.
-  example: Intel, PowerPC, RISC, etc.
+  example: Intel
   flat_name: file.elf.cpu_type
   ignore_above: 1024
   level: extended
@@ -6465,7 +6465,7 @@ process.command_line:
 process.elf.architecture:
   dashed_name: process-elf-architecture
   description: Machine architecture of the ELF file.
-  example: ARM, x86-64, etc
+  example: x86-64
   flat_name: process.elf.architecture
   ignore_above: 1024
   level: extended
@@ -6489,7 +6489,7 @@ process.elf.byte_order:
 process.elf.cpu_type:
   dashed_name: process-elf-cpu-type
   description: CPU type of the ELF file.
-  example: Intel, PowerPC, RISC, etc.
+  example: Intel
   flat_name: process.elf.cpu_type
   ignore_above: 1024
   level: extended
@@ -7052,7 +7052,7 @@ process.parent.command_line:
 process.parent.elf.architecture:
   dashed_name: process-parent-elf-architecture
   description: Machine architecture of the ELF file.
-  example: ARM, x86-64, etc
+  example: x86-64
   flat_name: process.parent.elf.architecture
   ignore_above: 1024
   level: extended
@@ -7076,7 +7076,7 @@ process.parent.elf.byte_order:
 process.parent.elf.cpu_type:
   dashed_name: process-parent-elf-cpu-type
   description: CPU type of the ELF file.
-  example: Intel, PowerPC, RISC, etc.
+  example: Intel
   flat_name: process.parent.elf.cpu_type
   ignore_above: 1024
   level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3130,6 +3130,326 @@ file.drive_letter:
   normalize: []
   short: Drive letter where the file is located.
   type: keyword
+file.elf.architecture:
+  dashed_name: file-elf-architecture
+  description: Machine architecture of the ELF file.
+  example: ARM, x86-64, etc
+  flat_name: file.elf.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: elf
+  short: Machine architecture of the ELF file.
+  type: keyword
+file.elf.byte_order:
+  dashed_name: file-elf-byte-order
+  description: Byte sequence of ELF file.
+  example: Little Endian, Big Endian
+  flat_name: file.elf.byte_order
+  ignore_above: 1024
+  level: extended
+  name: byte_order
+  normalize: []
+  original_fieldset: elf
+  short: Byte sequence of ELF file.
+  type: keyword
+file.elf.cpu_type:
+  dashed_name: file-elf-cpu-type
+  description: CPU type of the ELF file.
+  example: Intel, PowerPC, RISC, etc.
+  flat_name: file.elf.cpu_type
+  ignore_above: 1024
+  level: extended
+  name: cpu_type
+  normalize: []
+  original_fieldset: elf
+  short: CPU type of the ELF file.
+  type: keyword
+file.elf.creation_date:
+  dashed_name: file-elf-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  flat_name: file.elf.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: elf
+  short: Build or compile date.
+  type: date
+file.elf.exports:
+  dashed_name: file-elf-exports
+  description: List of exported element names and types.
+  flat_name: file.elf.exports
+  level: extended
+  name: exports
+  normalize: []
+  original_fieldset: elf
+  short: List of exported element names and types.
+  type: flattened
+file.elf.header.abi_version:
+  dashed_name: file-elf-header-abi-version
+  description: Version of the ELF Application Binary Interface (ABI).
+  flat_name: file.elf.header.abi_version
+  ignore_above: 1024
+  level: extended
+  name: header.abi_version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF Application Binary Interface (ABI).
+  type: keyword
+file.elf.header.class:
+  dashed_name: file-elf-header-class
+  description: Header class of the ELF file.
+  flat_name: file.elf.header.class
+  ignore_above: 1024
+  level: extended
+  name: header.class
+  normalize: []
+  original_fieldset: elf
+  short: Header class of the ELF file.
+  type: keyword
+file.elf.header.data:
+  dashed_name: file-elf-header-data
+  description: Data table of the ELF header.
+  flat_name: file.elf.header.data
+  ignore_above: 1024
+  level: extended
+  name: header.data
+  normalize: []
+  original_fieldset: elf
+  short: Data table of the ELF header.
+  type: keyword
+file.elf.header.entrypoint:
+  dashed_name: file-elf-header-entrypoint
+  description: Header entrypoint of the ELF file.
+  flat_name: file.elf.header.entrypoint
+  format: string
+  level: extended
+  name: header.entrypoint
+  normalize: []
+  original_fieldset: elf
+  short: Header entrypoint of the ELF file.
+  type: long
+file.elf.header.object_version:
+  dashed_name: file-elf-header-object-version
+  description: '"0x1" for original ELF files.'
+  flat_name: file.elf.header.object_version
+  ignore_above: 1024
+  level: extended
+  name: header.object_version
+  normalize: []
+  original_fieldset: elf
+  short: '"0x1" for original ELF files.'
+  type: keyword
+file.elf.header.os_abi:
+  dashed_name: file-elf-header-os-abi
+  description: Application Binary Interface (ABI) of the Linux OS.
+  flat_name: file.elf.header.os_abi
+  ignore_above: 1024
+  level: extended
+  name: header.os_abi
+  normalize: []
+  original_fieldset: elf
+  short: Application Binary Interface (ABI) of the Linux OS.
+  type: keyword
+file.elf.header.type:
+  dashed_name: file-elf-header-type
+  description: Header type of the ELF file.
+  flat_name: file.elf.header.type
+  ignore_above: 1024
+  level: extended
+  name: header.type
+  normalize: []
+  original_fieldset: elf
+  short: Header type of the ELF file.
+  type: keyword
+file.elf.header.version:
+  dashed_name: file-elf-header-version
+  description: Version of the ELF header.
+  flat_name: file.elf.header.version
+  ignore_above: 1024
+  level: extended
+  name: header.version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF header.
+  type: keyword
+file.elf.imports:
+  dashed_name: file-elf-imports
+  description: List of imported element names and types.
+  flat_name: file.elf.imports
+  level: extended
+  name: imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported element names and types.
+  type: flattened
+file.elf.sections:
+  dashed_name: file-elf-sections
+  description: Section information of the ELF file.
+  flat_name: file.elf.sections
+  level: extended
+  name: sections
+  normalize: []
+  original_fieldset: elf
+  short: Section information of the ELF file.
+  type: nested
+file.elf.sections.chi2:
+  dashed_name: file-elf-sections-chi2
+  description: Chi-square probability distribution of the section.
+  flat_name: file.elf.sections.chi2
+  format: number
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: elf
+  short: Chi-square probability distribution of the section.
+  type: long
+file.elf.sections.entropy:
+  dashed_name: file-elf-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: file.elf.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the section.
+  type: long
+file.elf.sections.flags:
+  dashed_name: file-elf-sections-flags
+  description: ELF Section List flags.
+  flat_name: file.elf.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List flags.
+  type: keyword
+file.elf.sections.name:
+  dashed_name: file-elf-sections-name
+  description: ELF Section List name.
+  flat_name: file.elf.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List name.
+  type: keyword
+file.elf.sections.physical_offset:
+  dashed_name: file-elf-sections-physical-offset
+  description: ELF Section List offset.
+  flat_name: file.elf.sections.physical_offset
+  ignore_above: 1024
+  level: extended
+  name: sections.physical_offset
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List offset.
+  type: keyword
+file.elf.sections.physical_size:
+  dashed_name: file-elf-sections-physical-size
+  description: ELF Section List physical size.
+  flat_name: file.elf.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List physical size.
+  type: long
+file.elf.sections.type:
+  dashed_name: file-elf-sections-type
+  description: ELF Section List type.
+  flat_name: file.elf.sections.type
+  ignore_above: 1024
+  level: extended
+  name: sections.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List type.
+  type: keyword
+file.elf.sections.virtual_address:
+  dashed_name: file-elf-sections-virtual-address
+  description: ELF Section List virtual address.
+  flat_name: file.elf.sections.virtual_address
+  format: string
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual address.
+  type: long
+file.elf.sections.virtual_size:
+  dashed_name: file-elf-sections-virtual-size
+  description: ELF Section List virtual size.
+  flat_name: file.elf.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual size.
+  type: long
+file.elf.segments:
+  dashed_name: file-elf-segments
+  description: ELF object segment list.
+  flat_name: file.elf.segments
+  level: extended
+  name: segments
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment list.
+  type: nested
+file.elf.segments.sections:
+  dashed_name: file-elf-segments-sections
+  description: ELF object segment sections.
+  flat_name: file.elf.segments.sections
+  ignore_above: 1024
+  level: extended
+  name: segments.sections
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment sections.
+  type: keyword
+file.elf.segments.type:
+  dashed_name: file-elf-segments-type
+  description: ELF object segment type.
+  flat_name: file.elf.segments.type
+  ignore_above: 1024
+  level: extended
+  name: segments.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment type.
+  type: keyword
+file.elf.shared_libraries:
+  dashed_name: file-elf-shared-libraries
+  description: List of shared libraries used by this ELF object
+  flat_name: file.elf.shared_libraries
+  ignore_above: 1024
+  level: extended
+  name: shared_libraries
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of shared libraries used by this ELF object
+  type: keyword
+file.elf.telfhash:
+  dashed_name: file-elf-telfhash
+  description: telfhash is symbol hash for ELF files, just like imphash is imports
+    hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+  flat_name: file.elf.telfhash
+  ignore_above: 1024
+  level: extended
+  name: telfhash
+  normalize: []
+  original_fieldset: elf
+  short: telfhash hash for ELF files
+  type: keyword
 file.extension:
   dashed_name: file-extension
   description: 'File extension, excluding the leading dot.
@@ -6142,6 +6462,326 @@ process.command_line:
   normalize: []
   short: Full command line that started the process.
   type: wildcard
+process.elf.architecture:
+  dashed_name: process-elf-architecture
+  description: Machine architecture of the ELF file.
+  example: ARM, x86-64, etc
+  flat_name: process.elf.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: elf
+  short: Machine architecture of the ELF file.
+  type: keyword
+process.elf.byte_order:
+  dashed_name: process-elf-byte-order
+  description: Byte sequence of ELF file.
+  example: Little Endian, Big Endian
+  flat_name: process.elf.byte_order
+  ignore_above: 1024
+  level: extended
+  name: byte_order
+  normalize: []
+  original_fieldset: elf
+  short: Byte sequence of ELF file.
+  type: keyword
+process.elf.cpu_type:
+  dashed_name: process-elf-cpu-type
+  description: CPU type of the ELF file.
+  example: Intel, PowerPC, RISC, etc.
+  flat_name: process.elf.cpu_type
+  ignore_above: 1024
+  level: extended
+  name: cpu_type
+  normalize: []
+  original_fieldset: elf
+  short: CPU type of the ELF file.
+  type: keyword
+process.elf.creation_date:
+  dashed_name: process-elf-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  flat_name: process.elf.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: elf
+  short: Build or compile date.
+  type: date
+process.elf.exports:
+  dashed_name: process-elf-exports
+  description: List of exported element names and types.
+  flat_name: process.elf.exports
+  level: extended
+  name: exports
+  normalize: []
+  original_fieldset: elf
+  short: List of exported element names and types.
+  type: flattened
+process.elf.header.abi_version:
+  dashed_name: process-elf-header-abi-version
+  description: Version of the ELF Application Binary Interface (ABI).
+  flat_name: process.elf.header.abi_version
+  ignore_above: 1024
+  level: extended
+  name: header.abi_version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF Application Binary Interface (ABI).
+  type: keyword
+process.elf.header.class:
+  dashed_name: process-elf-header-class
+  description: Header class of the ELF file.
+  flat_name: process.elf.header.class
+  ignore_above: 1024
+  level: extended
+  name: header.class
+  normalize: []
+  original_fieldset: elf
+  short: Header class of the ELF file.
+  type: keyword
+process.elf.header.data:
+  dashed_name: process-elf-header-data
+  description: Data table of the ELF header.
+  flat_name: process.elf.header.data
+  ignore_above: 1024
+  level: extended
+  name: header.data
+  normalize: []
+  original_fieldset: elf
+  short: Data table of the ELF header.
+  type: keyword
+process.elf.header.entrypoint:
+  dashed_name: process-elf-header-entrypoint
+  description: Header entrypoint of the ELF file.
+  flat_name: process.elf.header.entrypoint
+  format: string
+  level: extended
+  name: header.entrypoint
+  normalize: []
+  original_fieldset: elf
+  short: Header entrypoint of the ELF file.
+  type: long
+process.elf.header.object_version:
+  dashed_name: process-elf-header-object-version
+  description: '"0x1" for original ELF files.'
+  flat_name: process.elf.header.object_version
+  ignore_above: 1024
+  level: extended
+  name: header.object_version
+  normalize: []
+  original_fieldset: elf
+  short: '"0x1" for original ELF files.'
+  type: keyword
+process.elf.header.os_abi:
+  dashed_name: process-elf-header-os-abi
+  description: Application Binary Interface (ABI) of the Linux OS.
+  flat_name: process.elf.header.os_abi
+  ignore_above: 1024
+  level: extended
+  name: header.os_abi
+  normalize: []
+  original_fieldset: elf
+  short: Application Binary Interface (ABI) of the Linux OS.
+  type: keyword
+process.elf.header.type:
+  dashed_name: process-elf-header-type
+  description: Header type of the ELF file.
+  flat_name: process.elf.header.type
+  ignore_above: 1024
+  level: extended
+  name: header.type
+  normalize: []
+  original_fieldset: elf
+  short: Header type of the ELF file.
+  type: keyword
+process.elf.header.version:
+  dashed_name: process-elf-header-version
+  description: Version of the ELF header.
+  flat_name: process.elf.header.version
+  ignore_above: 1024
+  level: extended
+  name: header.version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF header.
+  type: keyword
+process.elf.imports:
+  dashed_name: process-elf-imports
+  description: List of imported element names and types.
+  flat_name: process.elf.imports
+  level: extended
+  name: imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported element names and types.
+  type: flattened
+process.elf.sections:
+  dashed_name: process-elf-sections
+  description: Section information of the ELF file.
+  flat_name: process.elf.sections
+  level: extended
+  name: sections
+  normalize: []
+  original_fieldset: elf
+  short: Section information of the ELF file.
+  type: nested
+process.elf.sections.chi2:
+  dashed_name: process-elf-sections-chi2
+  description: Chi-square probability distribution of the section.
+  flat_name: process.elf.sections.chi2
+  format: number
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: elf
+  short: Chi-square probability distribution of the section.
+  type: long
+process.elf.sections.entropy:
+  dashed_name: process-elf-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.elf.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the section.
+  type: long
+process.elf.sections.flags:
+  dashed_name: process-elf-sections-flags
+  description: ELF Section List flags.
+  flat_name: process.elf.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List flags.
+  type: keyword
+process.elf.sections.name:
+  dashed_name: process-elf-sections-name
+  description: ELF Section List name.
+  flat_name: process.elf.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List name.
+  type: keyword
+process.elf.sections.physical_offset:
+  dashed_name: process-elf-sections-physical-offset
+  description: ELF Section List offset.
+  flat_name: process.elf.sections.physical_offset
+  ignore_above: 1024
+  level: extended
+  name: sections.physical_offset
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List offset.
+  type: keyword
+process.elf.sections.physical_size:
+  dashed_name: process-elf-sections-physical-size
+  description: ELF Section List physical size.
+  flat_name: process.elf.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List physical size.
+  type: long
+process.elf.sections.type:
+  dashed_name: process-elf-sections-type
+  description: ELF Section List type.
+  flat_name: process.elf.sections.type
+  ignore_above: 1024
+  level: extended
+  name: sections.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List type.
+  type: keyword
+process.elf.sections.virtual_address:
+  dashed_name: process-elf-sections-virtual-address
+  description: ELF Section List virtual address.
+  flat_name: process.elf.sections.virtual_address
+  format: string
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual address.
+  type: long
+process.elf.sections.virtual_size:
+  dashed_name: process-elf-sections-virtual-size
+  description: ELF Section List virtual size.
+  flat_name: process.elf.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual size.
+  type: long
+process.elf.segments:
+  dashed_name: process-elf-segments
+  description: ELF object segment list.
+  flat_name: process.elf.segments
+  level: extended
+  name: segments
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment list.
+  type: nested
+process.elf.segments.sections:
+  dashed_name: process-elf-segments-sections
+  description: ELF object segment sections.
+  flat_name: process.elf.segments.sections
+  ignore_above: 1024
+  level: extended
+  name: segments.sections
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment sections.
+  type: keyword
+process.elf.segments.type:
+  dashed_name: process-elf-segments-type
+  description: ELF object segment type.
+  flat_name: process.elf.segments.type
+  ignore_above: 1024
+  level: extended
+  name: segments.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment type.
+  type: keyword
+process.elf.shared_libraries:
+  dashed_name: process-elf-shared-libraries
+  description: List of shared libraries used by this ELF object
+  flat_name: process.elf.shared_libraries
+  ignore_above: 1024
+  level: extended
+  name: shared_libraries
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of shared libraries used by this ELF object
+  type: keyword
+process.elf.telfhash:
+  dashed_name: process-elf-telfhash
+  description: telfhash is symbol hash for ELF files, just like imphash is imports
+    hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+  flat_name: process.elf.telfhash
+  ignore_above: 1024
+  level: extended
+  name: telfhash
+  normalize: []
+  original_fieldset: elf
+  short: telfhash hash for ELF files
+  type: keyword
 process.entity_id:
   dashed_name: process-entity-id
   description: 'Unique identifier for the process.
@@ -6409,6 +7049,326 @@ process.parent.command_line:
   original_fieldset: process
   short: Full command line that started the process.
   type: wildcard
+process.parent.elf.architecture:
+  dashed_name: process-parent-elf-architecture
+  description: Machine architecture of the ELF file.
+  example: ARM, x86-64, etc
+  flat_name: process.parent.elf.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: elf
+  short: Machine architecture of the ELF file.
+  type: keyword
+process.parent.elf.byte_order:
+  dashed_name: process-parent-elf-byte-order
+  description: Byte sequence of ELF file.
+  example: Little Endian, Big Endian
+  flat_name: process.parent.elf.byte_order
+  ignore_above: 1024
+  level: extended
+  name: byte_order
+  normalize: []
+  original_fieldset: elf
+  short: Byte sequence of ELF file.
+  type: keyword
+process.parent.elf.cpu_type:
+  dashed_name: process-parent-elf-cpu-type
+  description: CPU type of the ELF file.
+  example: Intel, PowerPC, RISC, etc.
+  flat_name: process.parent.elf.cpu_type
+  ignore_above: 1024
+  level: extended
+  name: cpu_type
+  normalize: []
+  original_fieldset: elf
+  short: CPU type of the ELF file.
+  type: keyword
+process.parent.elf.creation_date:
+  dashed_name: process-parent-elf-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  flat_name: process.parent.elf.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: elf
+  short: Build or compile date.
+  type: date
+process.parent.elf.exports:
+  dashed_name: process-parent-elf-exports
+  description: List of exported element names and types.
+  flat_name: process.parent.elf.exports
+  level: extended
+  name: exports
+  normalize: []
+  original_fieldset: elf
+  short: List of exported element names and types.
+  type: flattened
+process.parent.elf.header.abi_version:
+  dashed_name: process-parent-elf-header-abi-version
+  description: Version of the ELF Application Binary Interface (ABI).
+  flat_name: process.parent.elf.header.abi_version
+  ignore_above: 1024
+  level: extended
+  name: header.abi_version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF Application Binary Interface (ABI).
+  type: keyword
+process.parent.elf.header.class:
+  dashed_name: process-parent-elf-header-class
+  description: Header class of the ELF file.
+  flat_name: process.parent.elf.header.class
+  ignore_above: 1024
+  level: extended
+  name: header.class
+  normalize: []
+  original_fieldset: elf
+  short: Header class of the ELF file.
+  type: keyword
+process.parent.elf.header.data:
+  dashed_name: process-parent-elf-header-data
+  description: Data table of the ELF header.
+  flat_name: process.parent.elf.header.data
+  ignore_above: 1024
+  level: extended
+  name: header.data
+  normalize: []
+  original_fieldset: elf
+  short: Data table of the ELF header.
+  type: keyword
+process.parent.elf.header.entrypoint:
+  dashed_name: process-parent-elf-header-entrypoint
+  description: Header entrypoint of the ELF file.
+  flat_name: process.parent.elf.header.entrypoint
+  format: string
+  level: extended
+  name: header.entrypoint
+  normalize: []
+  original_fieldset: elf
+  short: Header entrypoint of the ELF file.
+  type: long
+process.parent.elf.header.object_version:
+  dashed_name: process-parent-elf-header-object-version
+  description: '"0x1" for original ELF files.'
+  flat_name: process.parent.elf.header.object_version
+  ignore_above: 1024
+  level: extended
+  name: header.object_version
+  normalize: []
+  original_fieldset: elf
+  short: '"0x1" for original ELF files.'
+  type: keyword
+process.parent.elf.header.os_abi:
+  dashed_name: process-parent-elf-header-os-abi
+  description: Application Binary Interface (ABI) of the Linux OS.
+  flat_name: process.parent.elf.header.os_abi
+  ignore_above: 1024
+  level: extended
+  name: header.os_abi
+  normalize: []
+  original_fieldset: elf
+  short: Application Binary Interface (ABI) of the Linux OS.
+  type: keyword
+process.parent.elf.header.type:
+  dashed_name: process-parent-elf-header-type
+  description: Header type of the ELF file.
+  flat_name: process.parent.elf.header.type
+  ignore_above: 1024
+  level: extended
+  name: header.type
+  normalize: []
+  original_fieldset: elf
+  short: Header type of the ELF file.
+  type: keyword
+process.parent.elf.header.version:
+  dashed_name: process-parent-elf-header-version
+  description: Version of the ELF header.
+  flat_name: process.parent.elf.header.version
+  ignore_above: 1024
+  level: extended
+  name: header.version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF header.
+  type: keyword
+process.parent.elf.imports:
+  dashed_name: process-parent-elf-imports
+  description: List of imported element names and types.
+  flat_name: process.parent.elf.imports
+  level: extended
+  name: imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported element names and types.
+  type: flattened
+process.parent.elf.sections:
+  dashed_name: process-parent-elf-sections
+  description: Section information of the ELF file.
+  flat_name: process.parent.elf.sections
+  level: extended
+  name: sections
+  normalize: []
+  original_fieldset: elf
+  short: Section information of the ELF file.
+  type: nested
+process.parent.elf.sections.chi2:
+  dashed_name: process-parent-elf-sections-chi2
+  description: Chi-square probability distribution of the section.
+  flat_name: process.parent.elf.sections.chi2
+  format: number
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: elf
+  short: Chi-square probability distribution of the section.
+  type: long
+process.parent.elf.sections.entropy:
+  dashed_name: process-parent-elf-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.parent.elf.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the section.
+  type: long
+process.parent.elf.sections.flags:
+  dashed_name: process-parent-elf-sections-flags
+  description: ELF Section List flags.
+  flat_name: process.parent.elf.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List flags.
+  type: keyword
+process.parent.elf.sections.name:
+  dashed_name: process-parent-elf-sections-name
+  description: ELF Section List name.
+  flat_name: process.parent.elf.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List name.
+  type: keyword
+process.parent.elf.sections.physical_offset:
+  dashed_name: process-parent-elf-sections-physical-offset
+  description: ELF Section List offset.
+  flat_name: process.parent.elf.sections.physical_offset
+  ignore_above: 1024
+  level: extended
+  name: sections.physical_offset
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List offset.
+  type: keyword
+process.parent.elf.sections.physical_size:
+  dashed_name: process-parent-elf-sections-physical-size
+  description: ELF Section List physical size.
+  flat_name: process.parent.elf.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List physical size.
+  type: long
+process.parent.elf.sections.type:
+  dashed_name: process-parent-elf-sections-type
+  description: ELF Section List type.
+  flat_name: process.parent.elf.sections.type
+  ignore_above: 1024
+  level: extended
+  name: sections.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List type.
+  type: keyword
+process.parent.elf.sections.virtual_address:
+  dashed_name: process-parent-elf-sections-virtual-address
+  description: ELF Section List virtual address.
+  flat_name: process.parent.elf.sections.virtual_address
+  format: string
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual address.
+  type: long
+process.parent.elf.sections.virtual_size:
+  dashed_name: process-parent-elf-sections-virtual-size
+  description: ELF Section List virtual size.
+  flat_name: process.parent.elf.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual size.
+  type: long
+process.parent.elf.segments:
+  dashed_name: process-parent-elf-segments
+  description: ELF object segment list.
+  flat_name: process.parent.elf.segments
+  level: extended
+  name: segments
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment list.
+  type: nested
+process.parent.elf.segments.sections:
+  dashed_name: process-parent-elf-segments-sections
+  description: ELF object segment sections.
+  flat_name: process.parent.elf.segments.sections
+  ignore_above: 1024
+  level: extended
+  name: segments.sections
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment sections.
+  type: keyword
+process.parent.elf.segments.type:
+  dashed_name: process-parent-elf-segments-type
+  description: ELF object segment type.
+  flat_name: process.parent.elf.segments.type
+  ignore_above: 1024
+  level: extended
+  name: segments.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment type.
+  type: keyword
+process.parent.elf.shared_libraries:
+  dashed_name: process-parent-elf-shared-libraries
+  description: List of shared libraries used by this ELF object
+  flat_name: process.parent.elf.shared_libraries
+  ignore_above: 1024
+  level: extended
+  name: shared_libraries
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of shared libraries used by this ELF object
+  type: keyword
+process.parent.elf.telfhash:
+  dashed_name: process-parent-elf-telfhash
+  description: telfhash is symbol hash for ELF files, just like imphash is imports
+    hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+  flat_name: process.parent.elf.telfhash
+  ignore_above: 1024
+  level: extended
+  name: telfhash
+  normalize: []
+  original_fieldset: elf
+  short: telfhash hash for ELF files
+  type: keyword
 process.parent.entity_id:
   dashed_name: process-parent-entity-id
   description: 'Unique identifier for the process.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2574,7 +2574,7 @@ elf:
     elf.architecture:
       dashed_name: elf-architecture
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       flat_name: elf.architecture
       ignore_above: 1024
       level: extended
@@ -2596,7 +2596,7 @@ elf:
     elf.cpu_type:
       dashed_name: elf-cpu-type
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       flat_name: elf.cpu_type
       ignore_above: 1024
       level: extended
@@ -3922,7 +3922,7 @@ file:
     file.elf.architecture:
       dashed_name: file-elf-architecture
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       flat_name: file.elf.architecture
       ignore_above: 1024
       level: extended
@@ -3946,7 +3946,7 @@ file:
     file.elf.cpu_type:
       dashed_name: file-elf-cpu-type
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       flat_name: file.elf.cpu_type
       ignore_above: 1024
       level: extended
@@ -8309,7 +8309,7 @@ process:
     process.elf.architecture:
       dashed_name: process-elf-architecture
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       flat_name: process.elf.architecture
       ignore_above: 1024
       level: extended
@@ -8333,7 +8333,7 @@ process:
     process.elf.cpu_type:
       dashed_name: process-elf-cpu-type
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       flat_name: process.elf.cpu_type
       ignore_above: 1024
       level: extended
@@ -8896,7 +8896,7 @@ process:
     process.parent.elf.architecture:
       dashed_name: process-parent-elf-architecture
       description: Machine architecture of the ELF file.
-      example: ARM, x86-64, etc
+      example: x86-64
       flat_name: process.parent.elf.architecture
       ignore_above: 1024
       level: extended
@@ -8920,7 +8920,7 @@ process:
     process.parent.elf.cpu_type:
       dashed_name: process-parent-elf-cpu-type
       description: CPU type of the ELF file.
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
       flat_name: process.parent.elf.cpu_type
       ignore_above: 1024
       level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2568,6 +2568,315 @@ ecs:
   short: Meta-information specific to ECS.
   title: ECS
   type: group
+elf:
+  description: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  fields:
+    elf.architecture:
+      dashed_name: elf-architecture
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      flat_name: elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      short: Machine architecture of the ELF file.
+      type: keyword
+    elf.byte_order:
+      dashed_name: elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      flat_name: elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      short: Byte sequence of ELF file.
+      type: keyword
+    elf.cpu_type:
+      dashed_name: elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      flat_name: elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      short: CPU type of the ELF file.
+      type: keyword
+    elf.creation_date:
+      dashed_name: elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      short: Build or compile date.
+      type: date
+    elf.exports:
+      dashed_name: elf-exports
+      description: List of exported element names and types.
+      flat_name: elf.exports
+      level: extended
+      name: exports
+      normalize: []
+      short: List of exported element names and types.
+      type: flattened
+    elf.header.abi_version:
+      dashed_name: elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    elf.header.class:
+      dashed_name: elf-header-class
+      description: Header class of the ELF file.
+      flat_name: elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      short: Header class of the ELF file.
+      type: keyword
+    elf.header.data:
+      dashed_name: elf-header-data
+      description: Data table of the ELF header.
+      flat_name: elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      short: Data table of the ELF header.
+      type: keyword
+    elf.header.entrypoint:
+      dashed_name: elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      short: Header entrypoint of the ELF file.
+      type: long
+    elf.header.object_version:
+      dashed_name: elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    elf.header.os_abi:
+      dashed_name: elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    elf.header.type:
+      dashed_name: elf-header-type
+      description: Header type of the ELF file.
+      flat_name: elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      short: Header type of the ELF file.
+      type: keyword
+    elf.header.version:
+      dashed_name: elf-header-version
+      description: Version of the ELF header.
+      flat_name: elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      short: Version of the ELF header.
+      type: keyword
+    elf.imports:
+      dashed_name: elf-imports
+      description: List of imported element names and types.
+      flat_name: elf.imports
+      level: extended
+      name: imports
+      normalize: []
+      short: List of imported element names and types.
+      type: flattened
+    elf.sections:
+      dashed_name: elf-sections
+      description: Section information of the ELF file.
+      flat_name: elf.sections
+      level: extended
+      name: sections
+      normalize: []
+      short: Section information of the ELF file.
+      type: nested
+    elf.sections.chi2:
+      dashed_name: elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      short: Chi-square probability distribution of the section.
+      type: long
+    elf.sections.entropy:
+      dashed_name: elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      short: Shannon entropy calculation from the section.
+      type: long
+    elf.sections.flags:
+      dashed_name: elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      short: ELF Section List flags.
+      type: keyword
+    elf.sections.name:
+      dashed_name: elf-sections-name
+      description: ELF Section List name.
+      flat_name: elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      short: ELF Section List name.
+      type: keyword
+    elf.sections.physical_offset:
+      dashed_name: elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      short: ELF Section List offset.
+      type: keyword
+    elf.sections.physical_size:
+      dashed_name: elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      short: ELF Section List physical size.
+      type: long
+    elf.sections.type:
+      dashed_name: elf-sections-type
+      description: ELF Section List type.
+      flat_name: elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      short: ELF Section List type.
+      type: keyword
+    elf.sections.virtual_address:
+      dashed_name: elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      short: ELF Section List virtual address.
+      type: long
+    elf.sections.virtual_size:
+      dashed_name: elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      short: ELF Section List virtual size.
+      type: long
+    elf.segments:
+      dashed_name: elf-segments
+      description: ELF object segment list.
+      flat_name: elf.segments
+      level: extended
+      name: segments
+      normalize: []
+      short: ELF object segment list.
+      type: nested
+    elf.segments.sections:
+      dashed_name: elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      short: ELF object segment sections.
+      type: keyword
+    elf.segments.type:
+      dashed_name: elf-segments-type
+      description: ELF object segment type.
+      flat_name: elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      short: ELF object segment type.
+      type: keyword
+    elf.shared_libraries:
+      dashed_name: elf-shared-libraries
+      description: List of shared libraries used by this ELF object
+      flat_name: elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      short: List of shared libraries used by this ELF object
+      type: keyword
+    elf.telfhash:
+      dashed_name: elf-telfhash
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      flat_name: elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      short: telfhash hash for ELF files
+      type: keyword
+  group: 2
+  name: elf
+  prefix: elf.
+  reusable:
+    expected:
+    - as: elf
+      at: file
+      full: file.elf
+    - as: elf
+      at: process
+      full: process.elf
+    top_level: false
+  short: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  title: ELF Header
+  type: group
 error:
   description: 'These fields can represent errors of any kind.
 
@@ -3610,6 +3919,326 @@ file:
       normalize: []
       short: Drive letter where the file is located.
       type: keyword
+    file.elf.architecture:
+      dashed_name: file-elf-architecture
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      flat_name: file.elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: elf
+      short: Machine architecture of the ELF file.
+      type: keyword
+    file.elf.byte_order:
+      dashed_name: file-elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      flat_name: file.elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      original_fieldset: elf
+      short: Byte sequence of ELF file.
+      type: keyword
+    file.elf.cpu_type:
+      dashed_name: file-elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      flat_name: file.elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      original_fieldset: elf
+      short: CPU type of the ELF file.
+      type: keyword
+    file.elf.creation_date:
+      dashed_name: file-elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: file.elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: elf
+      short: Build or compile date.
+      type: date
+    file.elf.exports:
+      dashed_name: file-elf-exports
+      description: List of exported element names and types.
+      flat_name: file.elf.exports
+      level: extended
+      name: exports
+      normalize: []
+      original_fieldset: elf
+      short: List of exported element names and types.
+      type: flattened
+    file.elf.header.abi_version:
+      dashed_name: file-elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: file.elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    file.elf.header.class:
+      dashed_name: file-elf-header-class
+      description: Header class of the ELF file.
+      flat_name: file.elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      original_fieldset: elf
+      short: Header class of the ELF file.
+      type: keyword
+    file.elf.header.data:
+      dashed_name: file-elf-header-data
+      description: Data table of the ELF header.
+      flat_name: file.elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      original_fieldset: elf
+      short: Data table of the ELF header.
+      type: keyword
+    file.elf.header.entrypoint:
+      dashed_name: file-elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: file.elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      original_fieldset: elf
+      short: Header entrypoint of the ELF file.
+      type: long
+    file.elf.header.object_version:
+      dashed_name: file-elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: file.elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      original_fieldset: elf
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    file.elf.header.os_abi:
+      dashed_name: file-elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: file.elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      original_fieldset: elf
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    file.elf.header.type:
+      dashed_name: file-elf-header-type
+      description: Header type of the ELF file.
+      flat_name: file.elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      original_fieldset: elf
+      short: Header type of the ELF file.
+      type: keyword
+    file.elf.header.version:
+      dashed_name: file-elf-header-version
+      description: Version of the ELF header.
+      flat_name: file.elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF header.
+      type: keyword
+    file.elf.imports:
+      dashed_name: file-elf-imports
+      description: List of imported element names and types.
+      flat_name: file.elf.imports
+      level: extended
+      name: imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported element names and types.
+      type: flattened
+    file.elf.sections:
+      dashed_name: file-elf-sections
+      description: Section information of the ELF file.
+      flat_name: file.elf.sections
+      level: extended
+      name: sections
+      normalize: []
+      original_fieldset: elf
+      short: Section information of the ELF file.
+      type: nested
+    file.elf.sections.chi2:
+      dashed_name: file-elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: file.elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: elf
+      short: Chi-square probability distribution of the section.
+      type: long
+    file.elf.sections.entropy:
+      dashed_name: file-elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: file.elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the section.
+      type: long
+    file.elf.sections.flags:
+      dashed_name: file-elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: file.elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List flags.
+      type: keyword
+    file.elf.sections.name:
+      dashed_name: file-elf-sections-name
+      description: ELF Section List name.
+      flat_name: file.elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List name.
+      type: keyword
+    file.elf.sections.physical_offset:
+      dashed_name: file-elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: file.elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List offset.
+      type: keyword
+    file.elf.sections.physical_size:
+      dashed_name: file-elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: file.elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List physical size.
+      type: long
+    file.elf.sections.type:
+      dashed_name: file-elf-sections-type
+      description: ELF Section List type.
+      flat_name: file.elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List type.
+      type: keyword
+    file.elf.sections.virtual_address:
+      dashed_name: file-elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: file.elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual address.
+      type: long
+    file.elf.sections.virtual_size:
+      dashed_name: file-elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: file.elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual size.
+      type: long
+    file.elf.segments:
+      dashed_name: file-elf-segments
+      description: ELF object segment list.
+      flat_name: file.elf.segments
+      level: extended
+      name: segments
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment list.
+      type: nested
+    file.elf.segments.sections:
+      dashed_name: file-elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: file.elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment sections.
+      type: keyword
+    file.elf.segments.type:
+      dashed_name: file-elf-segments-type
+      description: ELF object segment type.
+      flat_name: file.elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment type.
+      type: keyword
+    file.elf.shared_libraries:
+      dashed_name: file-elf-shared-libraries
+      description: List of shared libraries used by this ELF object
+      flat_name: file.elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of shared libraries used by this ELF object
+      type: keyword
+    file.elf.telfhash:
+      dashed_name: file-elf-telfhash
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      flat_name: file.elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      original_fieldset: elf
+      short: telfhash hash for ELF files
+      type: keyword
     file.extension:
       dashed_name: file-extension
       description: 'File extension, excluding the leading dot.
@@ -4598,6 +5227,7 @@ file:
   name: file
   nestings:
   - file.code_signature
+  - file.elf
   - file.hash
   - file.pe
   - file.x509
@@ -4621,6 +5251,9 @@ file:
   - full: file.x509
     schema_name: x509
     short: These fields contain x509 certificate metadata.
+  - full: file.elf
+    schema_name: elf
+    short: These fields contain Linux Executable Linkable Format (ELF) metadata.
   short: Fields describing files.
   title: File
   type: group
@@ -7673,6 +8306,326 @@ process:
       normalize: []
       short: Full command line that started the process.
       type: wildcard
+    process.elf.architecture:
+      dashed_name: process-elf-architecture
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      flat_name: process.elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: elf
+      short: Machine architecture of the ELF file.
+      type: keyword
+    process.elf.byte_order:
+      dashed_name: process-elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      flat_name: process.elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      original_fieldset: elf
+      short: Byte sequence of ELF file.
+      type: keyword
+    process.elf.cpu_type:
+      dashed_name: process-elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      flat_name: process.elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      original_fieldset: elf
+      short: CPU type of the ELF file.
+      type: keyword
+    process.elf.creation_date:
+      dashed_name: process-elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: process.elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: elf
+      short: Build or compile date.
+      type: date
+    process.elf.exports:
+      dashed_name: process-elf-exports
+      description: List of exported element names and types.
+      flat_name: process.elf.exports
+      level: extended
+      name: exports
+      normalize: []
+      original_fieldset: elf
+      short: List of exported element names and types.
+      type: flattened
+    process.elf.header.abi_version:
+      dashed_name: process-elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: process.elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    process.elf.header.class:
+      dashed_name: process-elf-header-class
+      description: Header class of the ELF file.
+      flat_name: process.elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      original_fieldset: elf
+      short: Header class of the ELF file.
+      type: keyword
+    process.elf.header.data:
+      dashed_name: process-elf-header-data
+      description: Data table of the ELF header.
+      flat_name: process.elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      original_fieldset: elf
+      short: Data table of the ELF header.
+      type: keyword
+    process.elf.header.entrypoint:
+      dashed_name: process-elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: process.elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      original_fieldset: elf
+      short: Header entrypoint of the ELF file.
+      type: long
+    process.elf.header.object_version:
+      dashed_name: process-elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: process.elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      original_fieldset: elf
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    process.elf.header.os_abi:
+      dashed_name: process-elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: process.elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      original_fieldset: elf
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    process.elf.header.type:
+      dashed_name: process-elf-header-type
+      description: Header type of the ELF file.
+      flat_name: process.elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      original_fieldset: elf
+      short: Header type of the ELF file.
+      type: keyword
+    process.elf.header.version:
+      dashed_name: process-elf-header-version
+      description: Version of the ELF header.
+      flat_name: process.elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF header.
+      type: keyword
+    process.elf.imports:
+      dashed_name: process-elf-imports
+      description: List of imported element names and types.
+      flat_name: process.elf.imports
+      level: extended
+      name: imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported element names and types.
+      type: flattened
+    process.elf.sections:
+      dashed_name: process-elf-sections
+      description: Section information of the ELF file.
+      flat_name: process.elf.sections
+      level: extended
+      name: sections
+      normalize: []
+      original_fieldset: elf
+      short: Section information of the ELF file.
+      type: nested
+    process.elf.sections.chi2:
+      dashed_name: process-elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: process.elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: elf
+      short: Chi-square probability distribution of the section.
+      type: long
+    process.elf.sections.entropy:
+      dashed_name: process-elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.elf.sections.flags:
+      dashed_name: process-elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: process.elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List flags.
+      type: keyword
+    process.elf.sections.name:
+      dashed_name: process-elf-sections-name
+      description: ELF Section List name.
+      flat_name: process.elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List name.
+      type: keyword
+    process.elf.sections.physical_offset:
+      dashed_name: process-elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: process.elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List offset.
+      type: keyword
+    process.elf.sections.physical_size:
+      dashed_name: process-elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: process.elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List physical size.
+      type: long
+    process.elf.sections.type:
+      dashed_name: process-elf-sections-type
+      description: ELF Section List type.
+      flat_name: process.elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List type.
+      type: keyword
+    process.elf.sections.virtual_address:
+      dashed_name: process-elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: process.elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual address.
+      type: long
+    process.elf.sections.virtual_size:
+      dashed_name: process-elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: process.elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual size.
+      type: long
+    process.elf.segments:
+      dashed_name: process-elf-segments
+      description: ELF object segment list.
+      flat_name: process.elf.segments
+      level: extended
+      name: segments
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment list.
+      type: nested
+    process.elf.segments.sections:
+      dashed_name: process-elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: process.elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment sections.
+      type: keyword
+    process.elf.segments.type:
+      dashed_name: process-elf-segments-type
+      description: ELF object segment type.
+      flat_name: process.elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment type.
+      type: keyword
+    process.elf.shared_libraries:
+      dashed_name: process-elf-shared-libraries
+      description: List of shared libraries used by this ELF object
+      flat_name: process.elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of shared libraries used by this ELF object
+      type: keyword
+    process.elf.telfhash:
+      dashed_name: process-elf-telfhash
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      flat_name: process.elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      original_fieldset: elf
+      short: telfhash hash for ELF files
+      type: keyword
     process.entity_id:
       dashed_name: process-entity-id
       description: 'Unique identifier for the process.
@@ -7940,6 +8893,326 @@ process:
       original_fieldset: process
       short: Full command line that started the process.
       type: wildcard
+    process.parent.elf.architecture:
+      dashed_name: process-parent-elf-architecture
+      description: Machine architecture of the ELF file.
+      example: ARM, x86-64, etc
+      flat_name: process.parent.elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: elf
+      short: Machine architecture of the ELF file.
+      type: keyword
+    process.parent.elf.byte_order:
+      dashed_name: process-parent-elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian, Big Endian
+      flat_name: process.parent.elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      original_fieldset: elf
+      short: Byte sequence of ELF file.
+      type: keyword
+    process.parent.elf.cpu_type:
+      dashed_name: process-parent-elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel, PowerPC, RISC, etc.
+      flat_name: process.parent.elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      original_fieldset: elf
+      short: CPU type of the ELF file.
+      type: keyword
+    process.parent.elf.creation_date:
+      dashed_name: process-parent-elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: process.parent.elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: elf
+      short: Build or compile date.
+      type: date
+    process.parent.elf.exports:
+      dashed_name: process-parent-elf-exports
+      description: List of exported element names and types.
+      flat_name: process.parent.elf.exports
+      level: extended
+      name: exports
+      normalize: []
+      original_fieldset: elf
+      short: List of exported element names and types.
+      type: flattened
+    process.parent.elf.header.abi_version:
+      dashed_name: process-parent-elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: process.parent.elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    process.parent.elf.header.class:
+      dashed_name: process-parent-elf-header-class
+      description: Header class of the ELF file.
+      flat_name: process.parent.elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      original_fieldset: elf
+      short: Header class of the ELF file.
+      type: keyword
+    process.parent.elf.header.data:
+      dashed_name: process-parent-elf-header-data
+      description: Data table of the ELF header.
+      flat_name: process.parent.elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      original_fieldset: elf
+      short: Data table of the ELF header.
+      type: keyword
+    process.parent.elf.header.entrypoint:
+      dashed_name: process-parent-elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: process.parent.elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      original_fieldset: elf
+      short: Header entrypoint of the ELF file.
+      type: long
+    process.parent.elf.header.object_version:
+      dashed_name: process-parent-elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: process.parent.elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      original_fieldset: elf
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    process.parent.elf.header.os_abi:
+      dashed_name: process-parent-elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: process.parent.elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      original_fieldset: elf
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    process.parent.elf.header.type:
+      dashed_name: process-parent-elf-header-type
+      description: Header type of the ELF file.
+      flat_name: process.parent.elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      original_fieldset: elf
+      short: Header type of the ELF file.
+      type: keyword
+    process.parent.elf.header.version:
+      dashed_name: process-parent-elf-header-version
+      description: Version of the ELF header.
+      flat_name: process.parent.elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF header.
+      type: keyword
+    process.parent.elf.imports:
+      dashed_name: process-parent-elf-imports
+      description: List of imported element names and types.
+      flat_name: process.parent.elf.imports
+      level: extended
+      name: imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported element names and types.
+      type: flattened
+    process.parent.elf.sections:
+      dashed_name: process-parent-elf-sections
+      description: Section information of the ELF file.
+      flat_name: process.parent.elf.sections
+      level: extended
+      name: sections
+      normalize: []
+      original_fieldset: elf
+      short: Section information of the ELF file.
+      type: nested
+    process.parent.elf.sections.chi2:
+      dashed_name: process-parent-elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: process.parent.elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: elf
+      short: Chi-square probability distribution of the section.
+      type: long
+    process.parent.elf.sections.entropy:
+      dashed_name: process-parent-elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.parent.elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.parent.elf.sections.flags:
+      dashed_name: process-parent-elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: process.parent.elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List flags.
+      type: keyword
+    process.parent.elf.sections.name:
+      dashed_name: process-parent-elf-sections-name
+      description: ELF Section List name.
+      flat_name: process.parent.elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List name.
+      type: keyword
+    process.parent.elf.sections.physical_offset:
+      dashed_name: process-parent-elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: process.parent.elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List offset.
+      type: keyword
+    process.parent.elf.sections.physical_size:
+      dashed_name: process-parent-elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: process.parent.elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List physical size.
+      type: long
+    process.parent.elf.sections.type:
+      dashed_name: process-parent-elf-sections-type
+      description: ELF Section List type.
+      flat_name: process.parent.elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List type.
+      type: keyword
+    process.parent.elf.sections.virtual_address:
+      dashed_name: process-parent-elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: process.parent.elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual address.
+      type: long
+    process.parent.elf.sections.virtual_size:
+      dashed_name: process-parent-elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: process.parent.elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual size.
+      type: long
+    process.parent.elf.segments:
+      dashed_name: process-parent-elf-segments
+      description: ELF object segment list.
+      flat_name: process.parent.elf.segments
+      level: extended
+      name: segments
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment list.
+      type: nested
+    process.parent.elf.segments.sections:
+      dashed_name: process-parent-elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: process.parent.elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment sections.
+      type: keyword
+    process.parent.elf.segments.type:
+      dashed_name: process-parent-elf-segments-type
+      description: ELF object segment type.
+      flat_name: process.parent.elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment type.
+      type: keyword
+    process.parent.elf.shared_libraries:
+      dashed_name: process-parent-elf-shared-libraries
+      description: List of shared libraries used by this ELF object
+      flat_name: process.parent.elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of shared libraries used by this ELF object
+      type: keyword
+    process.parent.elf.telfhash:
+      dashed_name: process-parent-elf-telfhash
+      description: telfhash is symbol hash for ELF files, just like imphash is imports
+        hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      flat_name: process.parent.elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      original_fieldset: elf
+      short: telfhash hash for ELF files
+      type: keyword
     process.parent.entity_id:
       dashed_name: process-parent-entity-id
       description: 'Unique identifier for the process.
@@ -9204,6 +10477,7 @@ process:
   name: process
   nestings:
   - process.code_signature
+  - process.elf
   - process.hash
   - process.parent
   - process.pe
@@ -9224,6 +10498,9 @@ process:
   - full: process.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
+  - full: process.elf
+    schema_name: elf
+    short: These fields contain Linux Executable Linkable Format (ELF) metadata.
   - full: process.parent
     schema_name: process
     short: These fields contain information about a process.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1004,6 +1004,123 @@
             "ignore_above": 1,
             "type": "keyword"
           },
+          "elf": {
+            "properties": {
+              "architecture": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "byte_order": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "cpu_type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "creation_date": {
+                "type": "date"
+              },
+              "exports": {
+                "type": "flattened"
+              },
+              "header": {
+                "properties": {
+                  "abi_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "class": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "data": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "entrypoint": {
+                    "type": "long"
+                  },
+                  "object_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os_abi": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "sections": {
+                "properties": {
+                  "chi2": {
+                    "type": "long"
+                  },
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "flags": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_offset": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "virtual_address": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "segments": {
+                "properties": {
+                  "sections": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                },
+                "type": "nested"
+              },
+              "shared_libraries": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "telfhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "extension": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -2162,6 +2279,123 @@
             },
             "type": "wildcard"
           },
+          "elf": {
+            "properties": {
+              "architecture": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "byte_order": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "cpu_type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "creation_date": {
+                "type": "date"
+              },
+              "exports": {
+                "type": "flattened"
+              },
+              "header": {
+                "properties": {
+                  "abi_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "class": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "data": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "entrypoint": {
+                    "type": "long"
+                  },
+                  "object_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "os_abi": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "sections": {
+                "properties": {
+                  "chi2": {
+                    "type": "long"
+                  },
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "flags": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_offset": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "virtual_address": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "segments": {
+                "properties": {
+                  "sections": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                },
+                "type": "nested"
+              },
+              "shared_libraries": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "telfhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "entity_id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -2257,6 +2491,123 @@
                   }
                 },
                 "type": "wildcard"
+              },
+              "elf": {
+                "properties": {
+                  "architecture": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "byte_order": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "cpu_type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "creation_date": {
+                    "type": "date"
+                  },
+                  "exports": {
+                    "type": "flattened"
+                  },
+                  "header": {
+                    "properties": {
+                      "abi_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "class": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "data": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "entrypoint": {
+                        "type": "long"
+                      },
+                      "object_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "os_abi": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "sections": {
+                    "properties": {
+                      "chi2": {
+                        "type": "long"
+                      },
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "flags": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_offset": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "virtual_address": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "segments": {
+                    "properties": {
+                      "sections": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "shared_libraries": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "telfhash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               },
               "entity_id": {
                 "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -61,6 +61,123 @@
               "ignore_above": 1,
               "type": "keyword"
             },
+            "elf": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flattened"
+                },
+                "header": {
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "sections": {
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "segments": {
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "extension": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -53,6 +53,123 @@
               },
               "type": "wildcard"
             },
+            "elf": {
+              "properties": {
+                "architecture": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "byte_order": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "cpu_type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "creation_date": {
+                  "type": "date"
+                },
+                "exports": {
+                  "type": "flattened"
+                },
+                "header": {
+                  "properties": {
+                    "abi_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "class": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "data": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entrypoint": {
+                      "type": "long"
+                    },
+                    "object_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "os_abi": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "sections": {
+                  "properties": {
+                    "chi2": {
+                      "type": "long"
+                    },
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "flags": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_offset": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "virtual_address": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "segments": {
+                  "properties": {
+                    "sections": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "shared_libraries": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "telfhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "entity_id": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -148,6 +265,123 @@
                     }
                   },
                   "type": "wildcard"
+                },
+                "elf": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "byte_order": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "cpu_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "creation_date": {
+                      "type": "date"
+                    },
+                    "exports": {
+                      "type": "flattened"
+                    },
+                    "header": {
+                      "properties": {
+                        "abi_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "class": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "data": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "entrypoint": {
+                          "type": "long"
+                        },
+                        "object_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "os_abi": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "sections": {
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_offset": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "virtual_address": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "segments": {
+                      "properties": {
+                        "sections": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "shared_libraries": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "telfhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "entity_id": {
                   "ignore_above": 1024,

--- a/experimental/schemas/elf.yml
+++ b/experimental/schemas/elf.yml
@@ -1,0 +1,198 @@
+---
+- name: elf
+  title: ELF Header
+  group: 2
+  description: >
+    These fields contain Linux Executable Linkable Format (ELF) metadata.
+  type: group
+  reusable:
+    top_level: false
+    expected:
+      - file
+      - process
+  fields:
+    - name: creation_date
+      short: Build or compile date.
+      description: >
+        Extracted when possible from the file's metadata. Indicates when it was
+        built or compiled. It can also be faked by malware creators.
+      type: date
+      level: extended
+
+    - name: architecture
+      description: >
+        Machine architecture of the ELF file.
+      type: keyword
+      level: extended
+      example: ARM, x86-64, etc
+
+    - name: byte_order
+      description: >
+        Byte sequence of ELF file.
+      type: keyword
+      level: extended
+      example: Little Endian, Big Endian
+
+    - name: cpu_type
+      description: >
+        CPU type of the ELF file.
+      type: keyword
+      level: extended
+      example: Intel, PowerPC, RISC, etc.
+
+    - name: header.class
+      description: >
+        Header class of the ELF file.
+      type: keyword
+      level: extended
+
+    - name: header.data
+      description: >
+        Data table of the ELF header.
+      type: keyword
+      level: extended
+
+    - name: header.os_abi
+      description: >
+        Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+      level: extended
+
+    - name: header.type
+      description: >
+        Header type of the ELF file.
+      type: keyword
+      level: extended
+
+    - name: header.version
+      description: >
+        Version of the ELF header.
+      type: keyword
+      level: extended
+
+    - name: header.abi_version
+      type: keyword
+      level: extended
+      description: >
+        Version of the ELF Application Binary Interface (ABI).
+
+    - name: header.entrypoint
+      format: string
+      level: extended
+      type: long
+      description: >
+        Header entrypoint of the ELF file.
+
+    - name: header.object_version
+      type: keyword
+      level: extended
+      description: >
+        "0x1" for original ELF files.
+
+    - name: sections
+      description: >
+        Section information of the ELF file.
+      type: nested
+      level: extended
+
+    - name: sections.flags
+      description: >
+        ELF Section List flags.
+      type: keyword
+      level: extended
+
+    - name: sections.name
+      description: >
+        ELF Section List name.
+      type: keyword
+      level: extended
+
+    - name: sections.physical_offset
+      description: >
+        ELF Section List offset.
+      type: keyword
+      level: extended
+
+    - name: sections.type
+      description: >
+        ELF Section List type.
+      type: keyword
+      level: extended
+
+    - name: sections.physical_size
+      description: >
+        ELF Section List physical size.
+      format: bytes
+      type: long
+      level: extended
+
+    - name: sections.virtual_address
+      description: >
+        ELF Section List virtual address.
+      format: string
+      type: long
+      level: extended
+
+    - name: sections.virtual_size
+      description: >
+        ELF Section List virtual size.
+      format: string
+      type: long
+      level: extended
+
+    - name: sections.entropy
+      description: >
+        Shannon entropy calculation from the section.
+      format: number
+      type: long
+      level: extended
+
+    - name: sections.chi2
+      description: >
+        Chi-square probability distribution of the section.
+      format: number
+      type: long
+      level: extended
+
+    - name: exports
+      description: >
+        List of exported element names and types.
+      level: extended
+      type: flattened
+
+    - name: imports
+      description: >
+        List of imported element names and types.
+      type: flattened
+      level: extended
+
+    - name: shared_libraries
+      description: >
+        List of shared libraries used by this ELF object
+      type: keyword
+      level: extended
+      normalize:
+       - array
+
+    - name: telfhash
+      short: telfhash hash for ELF files
+      description: >
+        telfhash is symbol hash for ELF files, just like imphash is imports hash for PE files. Learn more at https://github.com/trendmicro/telfhash.
+      type: keyword
+      level: extended
+
+    - name: segments
+      description: >
+        ELF object segment list.
+      type: nested
+      level: extended
+
+    - name: segments.type
+      description: ELF object segment type.
+      type: keyword
+      level: extended
+
+    - name: segments.sections
+      description: ELF object segment sections.
+      type: keyword
+      level: extended

--- a/experimental/schemas/elf.yml
+++ b/experimental/schemas/elf.yml
@@ -24,7 +24,7 @@
         Machine architecture of the ELF file.
       type: keyword
       level: extended
-      example: ARM, x86-64, etc
+      example: x86-64
 
     - name: byte_order
       description: >
@@ -38,7 +38,7 @@
         CPU type of the ELF file.
       type: keyword
       level: extended
-      example: Intel, PowerPC, RISC, etc.
+      example: Intel
 
     - name: header.class
       description: >


### PR DESCRIPTION
Adding `elf.*` fieldset from [RFC 0015](https://github.com/elastic/ecs/blob/master/rfcs/text/0015-create-file-elf.md) (https://github.com/elastic/ecs/pull/1077) to the experimental schema and artifacts.

For reviewers, the bulk of the changes are located in `experimental/schemas/elf.yml`. Most files are generated automatically based on files in `experimental/schemas`. 