### PR TITLE
Stage 3 changes for RFC 0007 - remove beta attribute

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -9,6 +9,10 @@ Thanks, you're awesome :-) -->
 ## Unreleased
 
 ### Schema Changes
+
+#### Improvements
+
+* `user.changes.*`, `user.effective.*`, and `user.target.*` field reuses are GA. #1271
 ### Tooling and Artifact Changes
 
 #### Breaking changes

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -7954,16 +7954,14 @@ Note also that the `user` fields may be used directly at the root of the events.
 // ===============================================================
 
 
-| <<ecs-user,user.changes.*>>| beta:[ Reusing the user fields in this location is currently considered beta.]
-
-Fields to describe the user relevant to the event.
+| <<ecs-user,user.changes.*>>
+| Fields to describe the user relevant to the event.
 
 // ===============================================================
 
 
-| <<ecs-user,user.effective.*>>| beta:[ Reusing the user fields in this location is currently considered beta.]
-
-Fields to describe the user relevant to the event.
+| <<ecs-user,user.effective.*>>
+| Fields to describe the user relevant to the event.
 
 // ===============================================================
 
@@ -7974,9 +7972,8 @@ Fields to describe the user relevant to the event.
 // ===============================================================
 
 
-| <<ecs-user,user.target.*>>| beta:[ Reusing the user fields in this location is currently considered beta.]
-
-Fields to describe the user relevant to the event.
+| <<ecs-user,user.target.*>>
+| Fields to describe the user relevant to the event.
 
 // ===============================================================
 

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -12422,31 +12422,25 @@ user:
       full: source.user
     - as: target
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.target
     - as: effective
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.effective
     - as: changes
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.changes
     top_level: true
   reused_here:
   - full: user.group
     schema_name: group
     short: User's group relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.target
+  - full: user.target
     schema_name: user
     short: Fields to describe the user relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.effective
+  - full: user.effective
     schema_name: user
     short: Fields to describe the user relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.changes
+  - full: user.changes
     schema_name: user
     short: Fields to describe the user relevant to the event.
   short: Fields to describe the user relevant to the event.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10629,31 +10629,25 @@ user:
       full: source.user
     - as: target
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.target
     - as: effective
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.effective
     - as: changes
       at: user
-      beta: Reusing the user fields in this location is currently considered beta.
       full: user.changes
     top_level: true
   reused_here:
   - full: user.group
     schema_name: group
     short: User's group relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.target
+  - full: user.target
     schema_name: user
     short: Fields to describe the user relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.effective
+  - full: user.effective
     schema_name: user
     short: Fields to describe the user relevant to the event.
-  - beta: Reusing the user fields in this location is currently considered beta.
-    full: user.changes
+  - full: user.changes
     schema_name: user
     short: Fields to describe the user relevant to the event.
   short: Fields to describe the user relevant to the event.

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -20,13 +20,10 @@
       - source
       - at: user
         as: target
-        beta: Reusing the user fields in this location is currently considered beta.
       - at: user
         as: effective
-        beta: Reusing the user fields in this location is currently considered beta.
       - at: user
         as: changes
-        beta: Reusing the user fields in this location is currently considered beta.
 
   type: group
   fields:


### PR DESCRIPTION
Remove the `beta` attribute in the schema and the ECS docs for the multiple users reuses from [RFC 0007](https://github.com/elastic/ecs/blob/master/rfcs/text/0007-multiple-users.md):

* `user.effective.*`
* `user.changes.*`
* `user.target.*`

The RFC has advanced to stage 3 (https://github.com/elastic/ecs/pull/1239) as is considered finished. By removing `beta`, these fields will be GA.