### PR TITLE
[1.x] Add 2 fields to code_signature (#1269)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -23,6 +23,7 @@ Thanks, you're awesome :-) -->
 * Added additional host fields. #1248
 * Added `geo.timezone`, `geo.postal_code`, and `geo.continent_code`. #1229
 * Extended `pe` fields added to experimental schema. #1256
+* Added `code_signature.team_id`, `code_signature.signing_id`. #1249
 
 #### Improvements
 

--- a/code/go/ecs/code_signature.go
+++ b/code/go/ecs/code_signature.go
@@ -43,4 +43,14 @@ type CodeSignature struct {
 	// validity or trust status. Leave unpopulated if the validity or trust of
 	// the certificate was unchecked.
 	Status string `ecs:"status"`
+
+	// The team identifier used to sign the process.
+	// This is used to identify the team or vendor of a software product. The
+	// field is relevant to Apple *OS only.
+	TeamID string `ecs:"team_id"`
+
+	// The identifier used to sign the process.
+	// This is used to identify the application manufactured by a software
+	// vendor. The field is relevant to Apple *OS only.
+	SigningID string `ecs:"signing_id"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -783,6 +783,24 @@ example: `true`
 // ===============================================================
 
 |
+[[field-code-signature-signing-id]]
+<<field-code-signature-signing-id, code_signature.signing_id>>
+
+| The identifier used to sign the process.
+
+This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.
+
+type: keyword
+
+
+
+example: `com.apple.xpc.proxy`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-code-signature-status]]
 <<field-code-signature-status, code_signature.status>>
 
@@ -813,6 +831,24 @@ type: keyword
 example: `Microsoft Corporation`
 
 | core
+
+// ===============================================================
+
+|
+[[field-code-signature-team-id]]
+<<field-code-signature-team-id, code_signature.team_id>>
+
+| The team identifier used to sign the process.
+
+This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.
+
+type: keyword
+
+
+
+example: `EQHXZ8M8AV`
+
+| extended
 
 // ===============================================================
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -529,6 +529,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: status
       level: extended
       type: keyword
@@ -546,6 +556,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: trusted
       level: extended
@@ -951,6 +971,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -968,6 +998,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -1846,6 +1886,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -1863,6 +1913,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4196,6 +4256,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -4213,6 +4283,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4343,6 +4423,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: parent.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: parent.code_signature.status
       level: extended
       type: keyword
@@ -4360,6 +4450,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: parent.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: parent.code_signature.trusted
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -106,8 +106,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
 1.9.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.9.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev+exp,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev+exp,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev+exp,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev+exp,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev+exp,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev+exp,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -208,8 +210,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.9.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 1.9.0-dev+exp,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev+exp,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev+exp,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev+exp,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev+exp,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev+exp,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev+exp,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev+exp,true,file,file.created,date,extended,,,File creation time.
@@ -457,8 +461,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.9.0-dev+exp,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 1.9.0-dev+exp,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev+exp,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev+exp,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev+exp,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev+exp,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -477,8 +483,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.9.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.9.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev+exp,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev+exp,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev+exp,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev+exp,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1255,6 +1255,21 @@ dll.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+dll.code_signature.signing_id:
+  dashed_name: dll-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: dll.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 dll.code_signature.status:
   dashed_name: dll-code-signature-status
   description: 'Additional information about the certificate status.
@@ -1282,6 +1297,21 @@ dll.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+dll.code_signature.team_id:
+  dashed_name: dll-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: dll.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
@@ -2954,6 +2984,21 @@ file.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+file.code_signature.signing_id:
+  dashed_name: file-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: file.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 file.code_signature.status:
   dashed_name: file-code-signature-status
   description: 'Additional information about the certificate status.
@@ -2981,6 +3026,21 @@ file.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+file.code_signature.team_id:
+  dashed_name: file-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: file.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
@@ -5977,6 +6037,21 @@ process.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+process.code_signature.signing_id:
+  dashed_name: process-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 process.code_signature.status:
   dashed_name: process-code-signature-status
   description: 'Additional information about the certificate status.
@@ -6004,6 +6079,21 @@ process.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+process.code_signature.team_id:
+  dashed_name: process-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
@@ -6213,6 +6303,21 @@ process.parent.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+process.parent.code_signature.signing_id:
+  dashed_name: process-parent-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.parent.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 process.parent.code_signature.status:
   dashed_name: process-parent-code-signature-status
   description: 'Additional information about the certificate status.
@@ -6240,6 +6345,21 @@ process.parent.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+process.parent.code_signature.team_id:
+  dashed_name: process-parent-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.parent.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -880,6 +880,20 @@ code_signature:
       normalize: []
       short: Boolean to capture if a signature is present.
       type: boolean
+    code_signature.signing_id:
+      dashed_name: code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      short: The identifier used to sign the process.
+      type: keyword
     code_signature.status:
       dashed_name: code-signature-status
       description: 'Additional information about the certificate status.
@@ -905,6 +919,20 @@ code_signature:
       name: subject_name
       normalize: []
       short: Subject name of the code signer
+      type: keyword
+    code_signature.team_id:
+      dashed_name: code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      short: The team identifier used to sign the process.
       type: keyword
     code_signature.trusted:
       dashed_name: code-signature-trusted
@@ -1601,6 +1629,21 @@ dll:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    dll.code_signature.signing_id:
+      dashed_name: dll-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: dll.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     dll.code_signature.status:
       dashed_name: dll-code-signature-status
       description: 'Additional information about the certificate status.
@@ -1628,6 +1671,21 @@ dll:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    dll.code_signature.team_id:
+      dashed_name: dll-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: dll.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
@@ -3403,6 +3461,21 @@ file:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    file.code_signature.signing_id:
+      dashed_name: file-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: file.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     file.code_signature.status:
       dashed_name: file-code-signature-status
       description: 'Additional information about the certificate status.
@@ -3430,6 +3503,21 @@ file:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    file.code_signature.team_id:
+      dashed_name: file-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: file.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
@@ -7462,6 +7550,21 @@ process:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    process.code_signature.signing_id:
+      dashed_name: process-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     process.code_signature.status:
       dashed_name: process-code-signature-status
       description: 'Additional information about the certificate status.
@@ -7489,6 +7592,21 @@ process:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    process.code_signature.team_id:
+      dashed_name: process-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
@@ -7698,6 +7816,21 @@ process:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    process.parent.code_signature.signing_id:
+      dashed_name: process-parent-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.parent.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     process.parent.code_signature.status:
       dashed_name: process-parent-code-signature-status
       description: 'Additional information about the certificate status.
@@ -7725,6 +7858,21 @@ process:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    process.parent.code_signature.team_id:
+      dashed_name: process-parent-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.parent.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -514,11 +514,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -955,11 +963,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -2113,11 +2129,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -2201,11 +2225,19 @@
                   "exists": {
                     "type": "boolean"
                   },
+                  "signing_id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "status": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
                   "subject_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },

--- a/experimental/generated/elasticsearch/component/dll.json
+++ b/experimental/generated/elasticsearch/component/dll.json
@@ -13,11 +13,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -20,11 +20,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -20,11 +20,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -108,11 +116,19 @@
                     "exists": {
                       "type": "boolean"
                     },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "status": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
                     "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -538,6 +538,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: status
       level: extended
       type: keyword
@@ -555,6 +565,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: trusted
       level: extended
@@ -915,6 +935,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -932,6 +962,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -1606,6 +1646,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -1623,6 +1673,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -3562,6 +3622,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: code_signature.status
       level: extended
       type: keyword
@@ -3579,6 +3649,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -3712,6 +3792,16 @@
       description: Boolean to capture if a signature is present.
       example: 'true'
       default_field: false
+    - name: parent.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
     - name: parent.code_signature.status
       level: extended
       type: keyword
@@ -3729,6 +3819,16 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: parent.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
       default_field: false
     - name: parent.code_signature.trusted
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -103,8 +103,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
 1.9.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.9.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -174,8 +176,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.9.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 1.9.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev,true,file,file.created,date,extended,,,File creation time.
@@ -392,8 +396,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.9.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
 1.9.0-dev,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev,true,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -412,8 +418,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.9.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.9.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.9.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+1.9.0-dev,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.9.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.9.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.9.0-dev,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
 1.9.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.9.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.9.0-dev,true,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1224,6 +1224,21 @@ dll.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+dll.code_signature.signing_id:
+  dashed_name: dll-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: dll.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 dll.code_signature.status:
   dashed_name: dll-code-signature-status
   description: 'Additional information about the certificate status.
@@ -1251,6 +1266,21 @@ dll.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+dll.code_signature.team_id:
+  dashed_name: dll-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: dll.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
@@ -2559,6 +2589,21 @@ file.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+file.code_signature.signing_id:
+  dashed_name: file-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: file.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 file.code_signature.status:
   dashed_name: file-code-signature-status
   description: 'Additional information about the certificate status.
@@ -2586,6 +2631,21 @@ file.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+file.code_signature.team_id:
+  dashed_name: file-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: file.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
@@ -5233,6 +5293,21 @@ process.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+process.code_signature.signing_id:
+  dashed_name: process-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 process.code_signature.status:
   dashed_name: process-code-signature-status
   description: 'Additional information about the certificate status.
@@ -5260,6 +5335,21 @@ process.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+process.code_signature.team_id:
+  dashed_name: process-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
@@ -5472,6 +5562,21 @@ process.parent.code_signature.exists:
   original_fieldset: code_signature
   short: Boolean to capture if a signature is present.
   type: boolean
+process.parent.code_signature.signing_id:
+  dashed_name: process-parent-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.parent.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
 process.parent.code_signature.status:
   dashed_name: process-parent-code-signature-status
   description: 'Additional information about the certificate status.
@@ -5499,6 +5604,21 @@ process.parent.code_signature.subject_name:
   normalize: []
   original_fieldset: code_signature
   short: Subject name of the code signer
+  type: keyword
+process.parent.code_signature.team_id:
+  dashed_name: process-parent-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.parent.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
   type: keyword
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -889,6 +889,20 @@ code_signature:
       normalize: []
       short: Boolean to capture if a signature is present.
       type: boolean
+    code_signature.signing_id:
+      dashed_name: code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      short: The identifier used to sign the process.
+      type: keyword
     code_signature.status:
       dashed_name: code-signature-status
       description: 'Additional information about the certificate status.
@@ -914,6 +928,20 @@ code_signature:
       name: subject_name
       normalize: []
       short: Subject name of the code signer
+      type: keyword
+    code_signature.team_id:
+      dashed_name: code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      short: The team identifier used to sign the process.
       type: keyword
     code_signature.trusted:
       dashed_name: code-signature-trusted
@@ -1548,6 +1576,21 @@ dll:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    dll.code_signature.signing_id:
+      dashed_name: dll-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: dll.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     dll.code_signature.status:
       dashed_name: dll-code-signature-status
       description: 'Additional information about the certificate status.
@@ -1575,6 +1618,21 @@ dll:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    dll.code_signature.team_id:
+      dashed_name: dll-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: dll.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
@@ -2985,6 +3043,21 @@ file:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    file.code_signature.signing_id:
+      dashed_name: file-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: file.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     file.code_signature.status:
       dashed_name: file-code-signature-status
       description: 'Additional information about the certificate status.
@@ -3012,6 +3085,21 @@ file:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    file.code_signature.team_id:
+      dashed_name: file-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: file.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
@@ -6357,6 +6445,21 @@ process:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    process.code_signature.signing_id:
+      dashed_name: process-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     process.code_signature.status:
       dashed_name: process-code-signature-status
       description: 'Additional information about the certificate status.
@@ -6384,6 +6487,21 @@ process:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    process.code_signature.team_id:
+      dashed_name: process-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
@@ -6596,6 +6714,21 @@ process:
       original_fieldset: code_signature
       short: Boolean to capture if a signature is present.
       type: boolean
+    process.parent.code_signature.signing_id:
+      dashed_name: process-parent-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.parent.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
     process.parent.code_signature.status:
       dashed_name: process-parent-code-signature-status
       description: 'Additional information about the certificate status.
@@ -6623,6 +6756,21 @@ process:
       normalize: []
       original_fieldset: code_signature
       short: Subject name of the code signer
+      type: keyword
+    process.parent.code_signature.team_id:
+      dashed_name: process-parent-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.parent.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
       type: keyword
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -517,11 +517,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -829,11 +837,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -1873,11 +1889,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -1964,11 +1988,19 @@
                     "exists": {
                       "type": "boolean"
                     },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "status": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
                     "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -516,11 +516,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -828,11 +836,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -1872,11 +1888,19 @@
               "exists": {
                 "type": "boolean"
               },
+              "signing_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "status": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
               "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
               },
@@ -1963,11 +1987,19 @@
                   "exists": {
                     "type": "boolean"
                   },
+                  "signing_id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "status": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
                   "subject_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   },

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -13,11 +13,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -20,11 +20,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -20,11 +20,19 @@
                 "exists": {
                   "type": "boolean"
                 },
+                "signing_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "status": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
                 "subject_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
@@ -111,11 +119,19 @@
                     "exists": {
                       "type": "boolean"
                     },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "status": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
                     "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     },

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -57,3 +57,25 @@
         This is useful for logging cryptographic errors with the certificate validity or trust status.
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
+      
+    - name: team_id
+      level: extended
+      type: keyword
+      short: The team identifier used to sign the process.
+      description: >
+        The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product.
+        The field is relevant to Apple *OS only.
+      example: EQHXZ8M8AV
+      
+    - name: signing_id
+      level: extended
+      type: keyword
+      short: The identifier used to sign the process.
+      description: >
+        The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.
+      example: com.apple.xpc.proxy


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add 2 fields to code_signature (#1269)