### PR TITLE
[1.x] Cut 1.9 FF CHANGELOG.next.md (#1277)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -10,9 +10,14 @@ Thanks, you're awesome :-) -->
 
 ### Schema Changes
 
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
 #### Improvements
 
-* `user.changes.*`, `user.effective.*`, and `user.target.*` field reuses are GA. #1271
 ### Tooling and Artifact Changes
 
 #### Breaking changes
@@ -21,22 +26,33 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Added `http.request.id`. #1208
-* Added `cloud.service.name`. #1204
+#### Improvements
+
+#### Deprecated
+
+
+## 1.9.0 (Feature Freeze)
+
+### Schema Changes
+
+#### Added
+
 * Added `hash.ssdeep`. #1169
-* Added additional host fields. #1248
+* Added `cloud.service.name`. #1204
+* Added `http.request.id`. #1208
+* `data_stream.*` fieldset introduced in experimental schema and artifacts. #1215
 * Added `geo.timezone`, `geo.postal_code`, and `geo.continent_code`. #1229
-* Extended `pe` fields added to experimental schema. #1256
+* Added `beta` host metrics fields. #1248
 * Added `code_signature.team_id`, `code_signature.signing_id`. #1249
-* Add `threat.indicator` fields to experimental schema. #1268
+* Extended `pe` fields added to experimental schema. #1256
 * Add `elf` fieldset to experimental schema. #1261
+* Add `threat.indicator` fields to experimental schema. #1268
 
 #### Improvements
 
 * Include formatting guidance and examples for MAC address fields. #456
-
-#### Deprecated
-
+* New section in ECS detailing event categorization fields usage. #1242
+* `user.changes.*`, `user.effective.*`, and `user.target.*` field reuses are GA. #1271
 
 <!-- All empty sections:
 


### PR DESCRIPTION
Forward ports the following commits to 1.x:

* Cut 1.9 FF CHANGELOG.next.md #1277
