### PR TITLE
Set go version to 1.15.x in tests 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.1'
+          go-version: '1.15.x'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'


### PR DESCRIPTION
Current Github action config allows `go` version to update the minor, which was causing [unexpected errors](https://github.com/elastic/ecs/pull/1230#issuecomment-787019042) when CI runs `make check`.

This change will lock the `go-version` at `1.15`.