### PR TITLE
[1.x] lock go version in actions (#1283)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.13.1'
+          go-version: '1.15.x'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'


### PR DESCRIPTION
Backports the following commits to 1.x:
 - lock go version in actions (#1283)