### PR TITLE
Stage 1 experimental changes for RFC 0012 - orchestrator fieldset

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Add `orchestrator` fieldset to experimental schema. #1292
+
 #### Improvements
 
 ### Tooling and Artifact Changes

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -4163,7 +4163,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Organization affected by the event (for multi-tenant orchestrator
+      description: Organization affected by the event (for multi-tenant orchestrator setups).
         setups).
       example: elastic
       default_field: false

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -4120,6 +4120,74 @@
       type: keyword
       ignore_above: 1024
       description: Observer version.
+  - name: orchestrator
+    title: Orchestrator
+    group: 2
+    description: Fields that describe the resources which container orchestrators
+      manage or act upon.
+    type: group
+    fields:
+    - name: api_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: API version being used to carry out the action
+      example: v1beta1
+      default_field: false
+    - name: cluster.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cluster.
+      default_field: false
+    - name: cluster.url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: URL of the cluster.
+      default_field: false
+    - name: cluster.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The version of the cluster.
+      default_field: false
+    - name: namespace
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Namespace in which the action is taking place.
+      example: kube-system
+      default_field: false
+    - name: organization
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Organization affected by the event (for multi-tenant orchestrator
+        setups).
+      example: elastic
+      default_field: false
+    - name: resource.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the resource being acted upon.
+      example: test-pod-cdcws
+      default_field: false
+    - name: resource.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Type of resource being acted upon.
+      example: service
+      default_field: false
+    - name: type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+      example: kubernetes
+      default_field: false
   - name: organization
     title: Organization
     group: 2

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -4144,7 +4144,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: URL of the cluster.
+      description: URL of the API used to manage the cluster.
       default_field: false
     - name: cluster.version
       level: extended
@@ -4163,7 +4163,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Organization affected by the event (for multi-tenant orchestrator setups).
+      description: Organization affected by the event (for multi-tenant orchestrator
         setups).
       example: elastic
       default_field: false

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -473,7 +473,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.version,keyword,core,,,Observer version.
 2.0.0-dev+exp,true,orchestrator,orchestrator.api_version,keyword,extended,,v1beta1,API version being used to carry out the action
 2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.name,keyword,extended,,,Name of the cluster.
-2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the cluster.
+2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the API used to manage the cluster.
 2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.
 2.0.0-dev+exp,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
 2.0.0-dev+exp,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -471,6 +471,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.type,keyword,core,,firewall,The type of the observer the data is coming from.
 2.0.0-dev+exp,true,observer,observer.vendor,keyword,core,,Symantec,Vendor name of the observer.
 2.0.0-dev+exp,true,observer,observer.version,keyword,core,,,Observer version.
+2.0.0-dev+exp,true,orchestrator,orchestrator.api_version,keyword,extended,,v1beta1,API version being used to carry out the action
+2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.name,keyword,extended,,,Name of the cluster.
+2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the cluster.
+2.0.0-dev+exp,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.
+2.0.0-dev+exp,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
+2.0.0-dev+exp,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
+2.0.0-dev+exp,true,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
+2.0.0-dev+exp,true,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
+2.0.0-dev+exp,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 2.0.0-dev+exp,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 2.0.0-dev+exp,true,organization,organization.name,wildcard,extended,,,Organization name.
 2.0.0-dev+exp,true,organization,organization.name.text,text,extended,,,Organization name.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6144,6 +6144,102 @@ observer.version:
   normalize: []
   short: Observer version.
   type: keyword
+orchestrator.api_version:
+  dashed_name: orchestrator-api-version
+  description: API version being used to carry out the action
+  example: v1beta1
+  flat_name: orchestrator.api_version
+  ignore_above: 1024
+  level: extended
+  name: api_version
+  normalize: []
+  short: API version being used to carry out the action
+  type: keyword
+orchestrator.cluster.name:
+  dashed_name: orchestrator-cluster-name
+  description: Name of the cluster.
+  flat_name: orchestrator.cluster.name
+  ignore_above: 1024
+  level: extended
+  name: cluster.name
+  normalize: []
+  short: Name of the cluster.
+  type: keyword
+orchestrator.cluster.url:
+  dashed_name: orchestrator-cluster-url
+  description: URL of the cluster.
+  flat_name: orchestrator.cluster.url
+  ignore_above: 1024
+  level: extended
+  name: cluster.url
+  normalize: []
+  short: URL of the cluster.
+  type: keyword
+orchestrator.cluster.version:
+  dashed_name: orchestrator-cluster-version
+  description: The version of the cluster.
+  flat_name: orchestrator.cluster.version
+  ignore_above: 1024
+  level: extended
+  name: cluster.version
+  normalize: []
+  short: The version of the cluster.
+  type: keyword
+orchestrator.namespace:
+  dashed_name: orchestrator-namespace
+  description: Namespace in which the action is taking place.
+  example: kube-system
+  flat_name: orchestrator.namespace
+  ignore_above: 1024
+  level: extended
+  name: namespace
+  normalize: []
+  short: Namespace in which the action is taking place.
+  type: keyword
+orchestrator.organization:
+  dashed_name: orchestrator-organization
+  description: Organization affected by the event (for multi-tenant orchestrator setups).
+  example: elastic
+  flat_name: orchestrator.organization
+  ignore_above: 1024
+  level: extended
+  name: organization
+  normalize: []
+  short: Organization affected by the event (for multi-tenant orchestrator setups).
+  type: keyword
+orchestrator.resource.name:
+  dashed_name: orchestrator-resource-name
+  description: Name of the resource being acted upon.
+  example: test-pod-cdcws
+  flat_name: orchestrator.resource.name
+  ignore_above: 1024
+  level: extended
+  name: resource.name
+  normalize: []
+  short: Name of the resource being acted upon.
+  type: keyword
+orchestrator.resource.type:
+  dashed_name: orchestrator-resource-type
+  description: Type of resource being acted upon.
+  example: service
+  flat_name: orchestrator.resource.type
+  ignore_above: 1024
+  level: extended
+  name: resource.type
+  normalize: []
+  short: Type of resource being acted upon.
+  type: keyword
+orchestrator.type:
+  dashed_name: orchestrator-type
+  description: Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+  example: kubernetes
+  flat_name: orchestrator.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  short: Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+  type: keyword
 organization.id:
   dashed_name: organization-id
   description: Unique identifier for the organization.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6167,13 +6167,13 @@ orchestrator.cluster.name:
   type: keyword
 orchestrator.cluster.url:
   dashed_name: orchestrator-cluster-url
-  description: URL of the cluster.
+  description: URL of the API used to manage the cluster.
   flat_name: orchestrator.cluster.url
   ignore_above: 1024
   level: extended
   name: cluster.url
   normalize: []
-  short: URL of the cluster.
+  short: URL of the API used to manage the cluster.
   type: keyword
 orchestrator.cluster.version:
   dashed_name: orchestrator-cluster-version

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7422,13 +7422,13 @@ orchestrator:
       type: keyword
     orchestrator.cluster.url:
       dashed_name: orchestrator-cluster-url
-      description: URL of the cluster.
+      description: URL of the API used to manage the cluster.
       flat_name: orchestrator.cluster.url
       ignore_above: 1024
       level: extended
       name: cluster.url
       normalize: []
-      short: URL of the cluster.
+      short: URL of the API used to manage the cluster.
       type: keyword
     orchestrator.cluster.version:
       dashed_name: orchestrator-cluster-version

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7395,6 +7395,113 @@ observer:
   short: Fields describing an entity observing the event from outside the host.
   title: Observer
   type: group
+orchestrator:
+  description: Fields that describe the resources which container orchestrators manage
+    or act upon.
+  fields:
+    orchestrator.api_version:
+      dashed_name: orchestrator-api-version
+      description: API version being used to carry out the action
+      example: v1beta1
+      flat_name: orchestrator.api_version
+      ignore_above: 1024
+      level: extended
+      name: api_version
+      normalize: []
+      short: API version being used to carry out the action
+      type: keyword
+    orchestrator.cluster.name:
+      dashed_name: orchestrator-cluster-name
+      description: Name of the cluster.
+      flat_name: orchestrator.cluster.name
+      ignore_above: 1024
+      level: extended
+      name: cluster.name
+      normalize: []
+      short: Name of the cluster.
+      type: keyword
+    orchestrator.cluster.url:
+      dashed_name: orchestrator-cluster-url
+      description: URL of the cluster.
+      flat_name: orchestrator.cluster.url
+      ignore_above: 1024
+      level: extended
+      name: cluster.url
+      normalize: []
+      short: URL of the cluster.
+      type: keyword
+    orchestrator.cluster.version:
+      dashed_name: orchestrator-cluster-version
+      description: The version of the cluster.
+      flat_name: orchestrator.cluster.version
+      ignore_above: 1024
+      level: extended
+      name: cluster.version
+      normalize: []
+      short: The version of the cluster.
+      type: keyword
+    orchestrator.namespace:
+      dashed_name: orchestrator-namespace
+      description: Namespace in which the action is taking place.
+      example: kube-system
+      flat_name: orchestrator.namespace
+      ignore_above: 1024
+      level: extended
+      name: namespace
+      normalize: []
+      short: Namespace in which the action is taking place.
+      type: keyword
+    orchestrator.organization:
+      dashed_name: orchestrator-organization
+      description: Organization affected by the event (for multi-tenant orchestrator
+        setups).
+      example: elastic
+      flat_name: orchestrator.organization
+      ignore_above: 1024
+      level: extended
+      name: organization
+      normalize: []
+      short: Organization affected by the event (for multi-tenant orchestrator setups).
+      type: keyword
+    orchestrator.resource.name:
+      dashed_name: orchestrator-resource-name
+      description: Name of the resource being acted upon.
+      example: test-pod-cdcws
+      flat_name: orchestrator.resource.name
+      ignore_above: 1024
+      level: extended
+      name: resource.name
+      normalize: []
+      short: Name of the resource being acted upon.
+      type: keyword
+    orchestrator.resource.type:
+      dashed_name: orchestrator-resource-type
+      description: Type of resource being acted upon.
+      example: service
+      flat_name: orchestrator.resource.type
+      ignore_above: 1024
+      level: extended
+      name: resource.type
+      normalize: []
+      short: Type of resource being acted upon.
+      type: keyword
+    orchestrator.type:
+      dashed_name: orchestrator-type
+      description: Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+      example: kubernetes
+      flat_name: orchestrator.type
+      ignore_above: 1024
+      level: extended
+      name: type
+      normalize: []
+      short: Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+      type: keyword
+  group: 2
+  name: orchestrator
+  prefix: orchestrator.
+  short: Fields relevant to container orchestrators.
+  title: Orchestrator
+  type: group
 organization:
   description: 'The organization fields enrich data with information about the company
     or entity the data is associated with.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -2161,6 +2161,54 @@
           }
         }
       },
+      "orchestrator": {
+        "properties": {
+          "api_version": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "cluster": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "url": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "namespace": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "organization": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "resource": {
+            "properties": {
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
       "organization": {
         "properties": {
           "id": {

--- a/experimental/generated/elasticsearch/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/component/orchestrator.json
@@ -1,0 +1,60 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html",
+    "ecs_version": "2.0.0-dev+exp"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "orchestrator": {
+          "properties": {
+            "api_version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "cluster": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "url": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "namespace": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "organization": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "resource": {
+              "properties": {
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experimental/generated/elasticsearch/template.json
+++ b/experimental/generated/elasticsearch/template.json
@@ -38,7 +38,8 @@
     "ecs_2.0.0-dev-exp_user",
     "ecs_2.0.0-dev-exp_user_agent",
     "ecs_2.0.0-dev-exp_vulnerability",
-    "ecs_2.0.0-dev-exp_data_stream"
+    "ecs_2.0.0-dev-exp_data_stream",
+    "ecs_2.0.0-dev-exp_orchestrator"
   ],
   "index_patterns": [
     "try-ecs-*"

--- a/experimental/schemas/orchestrator.yml
+++ b/experimental/schemas/orchestrator.yml
@@ -18,7 +18,7 @@
       level: extended
       type: keyword
       description: >
-        URL of the cluster.
+        URL of the API used to manage the cluster.
 
     - name: cluster.version
       level: extended

--- a/experimental/schemas/orchestrator.yml
+++ b/experimental/schemas/orchestrator.yml
@@ -1,0 +1,69 @@
+---
+- name: orchestrator
+  title: Orchestrator
+  group: 2
+  short: Fields relevant to container orchestrators.
+  description: >
+    Fields that describe the resources which container orchestrators manage or
+    act upon.
+  type: group
+  fields:
+    - name: cluster.name
+      level: extended
+      type: keyword
+      description: >
+        Name of the cluster.
+
+    - name: cluster.url
+      level: extended
+      type: keyword
+      description: >
+        URL of the cluster.
+
+    - name: cluster.version
+      level: extended
+      type: keyword
+      description: >
+        The version of the cluster.
+
+    - name: type
+      level: extended
+      type: keyword
+      example: kubernetes
+      description: >
+        Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry).
+
+    - name: organization
+      level: extended
+      type: keyword
+      example: elastic
+      description: >
+        Organization affected by the event (for multi-tenant orchestrator setups).
+
+    - name: namespace
+      level: extended
+      type: keyword
+      example: kube-system
+      description: >
+        Namespace in which the action is taking place.
+
+    - name: resource.name
+      level: extended
+      type: keyword
+      example: test-pod-cdcws
+      description: >
+        Name of the resource being acted upon.
+
+    - name: resource.type
+      level: extended
+      type: keyword
+      example: service
+      description: >
+        Type of resource being acted upon.
+
+    - name: api_version
+      level: extended
+      example: v1beta1
+      type: keyword
+      description: >
+        API version being used to carry out the action


### PR DESCRIPTION
Adds `orchestrator.*` fieldset from [RFC 0012](https://github.com/elastic/ecs/blob/master/rfcs/text/0012-orchestrator-field-set.md) (https://github.com/elastic/ecs/pull/1230) to the experimental schema and artifacts.