### PR TITLE
Add flattened type support to Go code generator

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Go code generator now supports the `flattened` data type. #1302
+
 #### Deprecated
 
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -274,7 +274,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point":
+	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point", "flattened":
 		return "string"
 	case "long":
 		return "int64"

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -274,7 +274,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point", "flattened":
+	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point":
 		return "string"
 	case "long":
 		return "int64"
@@ -286,7 +286,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 		return "time.Time"
 	case "boolean":
 		return "bool"
-	case "object":
+	case "object", "flattened":
 		return "map[string]interface{}"
 	default:
 		log.Fatalf("no translation for %v (field %s)", elasticsearchDataType, fieldName)


### PR DESCRIPTION
Separating implementation of `flattened` type into the go code generator from #1254. I believe `flattened` should be a more straight-forward change.

Opted to use `string` since `flattened` fields do not support defining sub-fields like other object types, such as `object` or `nested`. 