### PR TITLE
Correct advancement date for RFC 0009 Stage 3

### DIFF
--- a/rfcs/text/0009-data_stream-fields.md
+++ b/rfcs/text/0009-data_stream-fields.md
@@ -247,6 +247,7 @@ e.g.:
 * Discussion on [field value restrictions](https://github.com/elastic/kibana/issues/75846)
 * Restrictions on [index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html)
 * Blog post: [An introduction to the Elastic data stream naming scheme](https://www.elastic.co/blog/an-introduction-to-the-elastic-data-stream-naming-scheme)
+* Elasticsearch documentation on [data stream naming scheme](https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html#elastic-data-stream-naming-scheme.)
 
 ### RFC Pull Requests
 

--- a/rfcs/text/0009-data_stream-fields.md
+++ b/rfcs/text/0009-data_stream-fields.md
@@ -2,7 +2,7 @@
 <!-- Leave this ID at 0000. The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC. -->
 
 - Stage: **3 (finished)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
-- Date: **2021-01-04** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
+- Date: **2021-03-18** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
 
 When introducing the new indexing strategy for Elastic Agent which uses data streams, we found that adding a few [constant_keyword](https://www.elastic.co/guide/en/elasticsearch/reference/master/keyword.html#constant-keyword-field-type) fields corresponding to the central components in the new indexing strategy would be advantageous.
 
@@ -254,6 +254,7 @@ e.g.:
 
 * Stage 1: https://github.com/elastic/ecs/pull/980
 * Stage 2: https://github.com/elastic/ecs/pull/1145
+* Stage 3: https://github.com/elastic/ecs/pull/1212
 <!--
 * Stage 1: https://github.com/elastic/ecs/pull/NNN
 ...

--- a/rfcs/text/0009-data_stream-fields.md
+++ b/rfcs/text/0009-data_stream-fields.md
@@ -256,6 +256,7 @@ e.g.:
 * Stage 1: https://github.com/elastic/ecs/pull/980
 * Stage 2: https://github.com/elastic/ecs/pull/1145
 * Stage 3: https://github.com/elastic/ecs/pull/1212
+  * Stage 3 date correction: https://github.com/elastic/ecs/pull/1306
 <!--
 * Stage 1: https://github.com/elastic/ecs/pull/NNN
 ...


### PR DESCRIPTION
In addition to correcting the advancement date:

* Added the stage 3 PR link
* Added an additional reference to the Elasticsearch data stream naming docs.
