### PR TITLE
[1.x] Add flattened type support to Go code generator (#1302)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -32,6 +32,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Go code generator now supports the `flattened` data type. #1302
+
 #### Deprecated
 
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -286,7 +286,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 		return "time.Time"
 	case "boolean":
 		return "bool"
-	case "object":
+	case "object", "flattened":
 		return "map[string]interface{}"
 	default:
 		log.Fatalf("no translation for %v (field %s)", elasticsearchDataType, fieldName)


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add flattened type support to Go code generator (#1302)