### PR TITLE
[1.9] Bump jinja2 from 2.11.2 to 2.11.3 in /scripts (#1310)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -53,6 +53,7 @@ Thanks, you're awesome :-) -->
 * Include formatting guidance and examples for MAC address fields. #456
 * New section in ECS detailing event categorization fields usage. #1242
 * `user.changes.*`, `user.effective.*`, and `user.target.*` field reuses are GA. #1271
+* Bump jinja2 from 2.11.2 to 2.11.3 #1310
 
 <!-- All empty sections:
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -4,4 +4,4 @@ autopep8==1.4.4
 yamllint==1.19.0
 mock==4.0.2
 gitpython==3.1.2
-Jinja2==2.11.2
+Jinja2==2.11.3


### PR DESCRIPTION
Backports the following commits to 1.9:
 - Bump jinja2 from 2.11.2 to 2.11.3 in /scripts (#1310)