### PR TITLE
[1.x] Stage 3 changes for RFC 0005 (host metrics) (#1319)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -21,6 +21,7 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Updated descriptions to use Elastic Security #1305
+* Host metrics fields from RFC 0005 are now GA. #1319
 
 ### Tooling and Artifact Changes
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -3228,9 +3228,7 @@ example: `x86_64`
 [[field-host-cpu-usage]]
 <<field-host-cpu-usage, host.cpu.usage>>
 
-| beta:[ This field is currently considered beta. ]
-
-Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1.
+| Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1.
 
 Scaling factor: 1000.
 
@@ -3250,9 +3248,7 @@ type: scaled_float
 [[field-host-disk-read-bytes]]
 <<field-host-disk-read-bytes, host.disk.read.bytes>>
 
-| beta:[ This field is currently considered beta. ]
-
-The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.
+| The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.
 
 type: long
 
@@ -3268,9 +3264,7 @@ type: long
 [[field-host-disk-write-bytes]]
 <<field-host-disk-write-bytes, host.disk.write.bytes>>
 
-| beta:[ This field is currently considered beta. ]
-
-The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.
+| The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.
 
 type: long
 
@@ -3400,9 +3394,7 @@ type: keyword
 [[field-host-network-egress-bytes]]
 <<field-host-network-egress-bytes, host.network.egress.bytes>>
 
-| beta:[ This field is currently considered beta. ]
-
-The number of bytes (gauge) sent out on all network interfaces by the host since the last metric collection.
+| The number of bytes (gauge) sent out on all network interfaces by the host since the last metric collection.
 
 type: long
 
@@ -3418,9 +3410,7 @@ type: long
 [[field-host-network-egress-packets]]
 <<field-host-network-egress-packets, host.network.egress.packets>>
 
-| beta:[ This field is currently considered beta. ]
-
-The number of packets (gauge) sent out on all network interfaces by the host since the last metric collection.
+| The number of packets (gauge) sent out on all network interfaces by the host since the last metric collection.
 
 type: long
 
@@ -3436,9 +3426,7 @@ type: long
 [[field-host-network-ingress-bytes]]
 <<field-host-network-ingress-bytes, host.network.ingress.bytes>>
 
-| beta:[ This field is currently considered beta. ]
-
-The number of bytes received (gauge) on all network interfaces by the host since the last metric collection.
+| The number of bytes received (gauge) on all network interfaces by the host since the last metric collection.
 
 type: long
 
@@ -3454,9 +3442,7 @@ type: long
 [[field-host-network-ingress-packets]]
 <<field-host-network-ingress-packets, host.network.ingress.packets>>
 
-| beta:[ This field is currently considered beta. ]
-
-The number of packets (gauge) received on all network interfaces by the host since the last metric collection.
+| The number of packets (gauge) received on all network interfaces by the host since the last metric collection.
 
 type: long
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4477,7 +4477,6 @@ host.architecture:
   short: Operating system architecture.
   type: keyword
 host.cpu.usage:
-  beta: This field is currently considered beta.
   dashed_name: host-cpu-usage
   description: 'Percent CPU used which is normalized by the number of CPU cores and
     it ranges from 0 to 1.
@@ -4494,7 +4493,6 @@ host.cpu.usage:
   short: Percent CPU used, between 0 and 1.
   type: scaled_float
 host.disk.read.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-disk-read-bytes
   description: The total number of bytes (gauge) read successfully (aggregated from
     all disks) since the last metric collection.
@@ -4505,7 +4503,6 @@ host.disk.read.bytes:
   short: The number of bytes read by all disks.
   type: long
 host.disk.write.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-disk-write-bytes
   description: The total number of bytes (gauge) written successfully (aggregated
     from all disks) since the last metric collection.
@@ -4733,7 +4730,6 @@ host.name:
   short: Name of the host.
   type: keyword
 host.network.egress.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-network-egress-bytes
   description: The number of bytes (gauge) sent out on all network interfaces by the
     host since the last metric collection.
@@ -4744,7 +4740,6 @@ host.network.egress.bytes:
   short: The number of bytes sent on all network interfaces.
   type: long
 host.network.egress.packets:
-  beta: This field is currently considered beta.
   dashed_name: host-network-egress-packets
   description: The number of packets (gauge) sent out on all network interfaces by
     the host since the last metric collection.
@@ -4755,7 +4750,6 @@ host.network.egress.packets:
   short: The number of packets sent on all network interfaces.
   type: long
 host.network.ingress.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-network-ingress-bytes
   description: The number of bytes received (gauge) on all network interfaces by the
     host since the last metric collection.
@@ -4766,7 +4760,6 @@ host.network.ingress.bytes:
   short: The number of bytes received on all network interfaces.
   type: long
 host.network.ingress.packets:
-  beta: This field is currently considered beta.
   dashed_name: host-network-ingress-packets
   description: The number of packets (gauge) received on all network interfaces by
     the host since the last metric collection.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5572,7 +5572,6 @@ host:
       short: Operating system architecture.
       type: keyword
     host.cpu.usage:
-      beta: This field is currently considered beta.
       dashed_name: host-cpu-usage
       description: 'Percent CPU used which is normalized by the number of CPU cores
         and it ranges from 0 to 1.
@@ -5589,7 +5588,6 @@ host:
       short: Percent CPU used, between 0 and 1.
       type: scaled_float
     host.disk.read.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-disk-read-bytes
       description: The total number of bytes (gauge) read successfully (aggregated
         from all disks) since the last metric collection.
@@ -5600,7 +5598,6 @@ host:
       short: The number of bytes read by all disks.
       type: long
     host.disk.write.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-disk-write-bytes
       description: The total number of bytes (gauge) written successfully (aggregated
         from all disks) since the last metric collection.
@@ -5831,7 +5828,6 @@ host:
       short: Name of the host.
       type: keyword
     host.network.egress.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-network-egress-bytes
       description: The number of bytes (gauge) sent out on all network interfaces
         by the host since the last metric collection.
@@ -5842,7 +5838,6 @@ host:
       short: The number of bytes sent on all network interfaces.
       type: long
     host.network.egress.packets:
-      beta: This field is currently considered beta.
       dashed_name: host-network-egress-packets
       description: The number of packets (gauge) sent out on all network interfaces
         by the host since the last metric collection.
@@ -5853,7 +5848,6 @@ host:
       short: The number of packets sent on all network interfaces.
       type: long
     host.network.ingress.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-network-ingress-bytes
       description: The number of bytes received (gauge) on all network interfaces
         by the host since the last metric collection.
@@ -5864,7 +5858,6 @@ host:
       short: The number of bytes received on all network interfaces.
       type: long
     host.network.ingress.packets:
-      beta: This field is currently considered beta.
       dashed_name: host-network-ingress-packets
       description: The number of packets (gauge) received on all network interfaces
         by the host since the last metric collection.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3397,7 +3397,6 @@ host.architecture:
   short: Operating system architecture.
   type: keyword
 host.cpu.usage:
-  beta: This field is currently considered beta.
   dashed_name: host-cpu-usage
   description: 'Percent CPU used which is normalized by the number of CPU cores and
     it ranges from 0 to 1.
@@ -3414,7 +3413,6 @@ host.cpu.usage:
   short: Percent CPU used, between 0 and 1.
   type: scaled_float
 host.disk.read.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-disk-read-bytes
   description: The total number of bytes (gauge) read successfully (aggregated from
     all disks) since the last metric collection.
@@ -3425,7 +3423,6 @@ host.disk.read.bytes:
   short: The number of bytes read by all disks.
   type: long
 host.disk.write.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-disk-write-bytes
   description: The total number of bytes (gauge) written successfully (aggregated
     from all disks) since the last metric collection.
@@ -3655,7 +3652,6 @@ host.name:
   short: Name of the host.
   type: keyword
 host.network.egress.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-network-egress-bytes
   description: The number of bytes (gauge) sent out on all network interfaces by the
     host since the last metric collection.
@@ -3666,7 +3662,6 @@ host.network.egress.bytes:
   short: The number of bytes sent on all network interfaces.
   type: long
 host.network.egress.packets:
-  beta: This field is currently considered beta.
   dashed_name: host-network-egress-packets
   description: The number of packets (gauge) sent out on all network interfaces by
     the host since the last metric collection.
@@ -3677,7 +3672,6 @@ host.network.egress.packets:
   short: The number of packets sent on all network interfaces.
   type: long
 host.network.ingress.bytes:
-  beta: This field is currently considered beta.
   dashed_name: host-network-ingress-bytes
   description: The number of bytes received (gauge) on all network interfaces by the
     host since the last metric collection.
@@ -3688,7 +3682,6 @@ host.network.ingress.bytes:
   short: The number of bytes received on all network interfaces.
   type: long
 host.network.ingress.packets:
-  beta: This field is currently considered beta.
   dashed_name: host-network-ingress-packets
   description: The number of packets (gauge) received on all network interfaces by
     the host since the last metric collection.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4141,7 +4141,6 @@ host:
       short: Operating system architecture.
       type: keyword
     host.cpu.usage:
-      beta: This field is currently considered beta.
       dashed_name: host-cpu-usage
       description: 'Percent CPU used which is normalized by the number of CPU cores
         and it ranges from 0 to 1.
@@ -4158,7 +4157,6 @@ host:
       short: Percent CPU used, between 0 and 1.
       type: scaled_float
     host.disk.read.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-disk-read-bytes
       description: The total number of bytes (gauge) read successfully (aggregated
         from all disks) since the last metric collection.
@@ -4169,7 +4167,6 @@ host:
       short: The number of bytes read by all disks.
       type: long
     host.disk.write.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-disk-write-bytes
       description: The total number of bytes (gauge) written successfully (aggregated
         from all disks) since the last metric collection.
@@ -4402,7 +4399,6 @@ host:
       short: Name of the host.
       type: keyword
     host.network.egress.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-network-egress-bytes
       description: The number of bytes (gauge) sent out on all network interfaces
         by the host since the last metric collection.
@@ -4413,7 +4409,6 @@ host:
       short: The number of bytes sent on all network interfaces.
       type: long
     host.network.egress.packets:
-      beta: This field is currently considered beta.
       dashed_name: host-network-egress-packets
       description: The number of packets (gauge) sent out on all network interfaces
         by the host since the last metric collection.
@@ -4424,7 +4419,6 @@ host:
       short: The number of packets sent on all network interfaces.
       type: long
     host.network.ingress.bytes:
-      beta: This field is currently considered beta.
       dashed_name: host-network-ingress-bytes
       description: The number of bytes received (gauge) on all network interfaces
         by the host since the last metric collection.
@@ -4435,7 +4429,6 @@ host:
       short: The number of bytes received on all network interfaces.
       type: long
     host.network.ingress.packets:
-      beta: This field is currently considered beta.
       dashed_name: host-network-ingress-packets
       description: The number of packets (gauge) received on all network interfaces
         by the host since the last metric collection.

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -108,7 +108,6 @@
       type: scaled_float
       scaling_factor: 1000
       short: Percent CPU used, between 0 and 1.
-      beta: This field is currently considered beta.
       description: >
         Percent CPU used which is normalized by the number of CPU cores and it
         ranges from 0 to 1.
@@ -122,7 +121,6 @@
       type: long
       level: extended
       short: The number of bytes read by all disks.
-      beta: This field is currently considered beta.
       description: >
         The total number of bytes (gauge) read successfully (aggregated from all
         disks) since the last metric collection.
@@ -131,7 +129,6 @@
       type: long
       level: extended
       short: The number of bytes written on all disks.
-      beta: This field is currently considered beta.
       description: >
         The total number of bytes (gauge) written successfully (aggregated from
         all disks) since the last metric collection.
@@ -140,7 +137,6 @@
       type: long
       level: extended
       short: The number of bytes received on all network interfaces.
-      beta: This field is currently considered beta.
       description: >
         The number of bytes received (gauge) on all network interfaces by the
         host since the last metric collection.
@@ -149,7 +145,6 @@
       type: long
       level: extended
       short: The number of packets received on all network interfaces.
-      beta: This field is currently considered beta.
       description: >
         The number of packets (gauge) received on all network interfaces by the
         host since the last metric collection.
@@ -158,7 +153,6 @@
       type: long
       level: extended
       short: The number of bytes sent on all network interfaces.
-      beta: This field is currently considered beta.
       description: >
         The number of bytes (gauge) sent out on all network interfaces by the
         host since the last metric collection.
@@ -167,7 +161,6 @@
       type: long
       level: extended
       short: The number of packets sent on all network interfaces.
-      beta: This field is currently considered beta.
       description: >
         The number of packets (gauge) sent out on all network interfaces by the
         host since the last metric collection.


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Stage 3 changes for RFC 0005 (host metrics) (#1319)