### PR TITLE
[1.9] Bump pyyaml from 5.3b1 to 5.4 in /scripts (#1318)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -53,7 +53,7 @@ Thanks, you're awesome :-) -->
 * Include formatting guidance and examples for MAC address fields. #456
 * New section in ECS detailing event categorization fields usage. #1242
 * `user.changes.*`, `user.effective.*`, and `user.target.*` field reuses are GA. #1271
-* Bump jinja2 from 2.11.2 to 2.11.3 #1310
+* Update Python dependencies #1310, #1318
 
 <!-- All empty sections:
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 pip
-PyYAML==5.3b1
+PyYAML==5.4
 autopep8==1.4.4
 yamllint==1.19.0
 mock==4.0.2


### PR DESCRIPTION
Backports the following commits to 1.9:
 - Bump pyyaml from 5.3b1 to 5.4 in /scripts (#1318)