### PR TITLE
[1.x] lowercasing component names for es template (#1323)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -29,6 +29,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Correcting fieldset name capitalization for generated ES template #1323
+
 #### Added
 
 #### Improvements

--- a/generated/elasticsearch/README.md
+++ b/generated/elasticsearch/README.md
@@ -56,7 +56,7 @@ auth="elastic:elastic"
 version="$(cat version)"
 for file in `ls generated/elasticsearch/component/*.json`
 do
-  fieldset=`echo $file | cut -d/ -f4 | cut -d. -f1`
+  fieldset=`echo $file | cut -d/ -f4 | cut -d. -f1 | tr A-Z a-z`
   component_name="ecs_${version}_${fieldset}"
   api="_component_template/${component_name}"
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -77,7 +77,7 @@ def component_name_convention(ecs_version, ecs_nested):
     version = ecs_version.replace('+', '-')
     names = []
     for (fieldset_name, fieldset) in candidate_components(ecs_nested).items():
-        names.append("ecs_{}_{}".format(version, fieldset_name))
+        names.append("ecs_{}_{}".format(version, fieldset_name.lower()))
     return names
 
 

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -222,6 +222,17 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         es_template.es6_type_fallback(test_map)
         self.assertEqual(test_map, exp)
 
+    def test_component_composable_template_name(self):
+        version = "1.8"
+        test_map = {
+            "Acme": {
+                "name": "Acme",
+            }
+        }
+
+        exp = ["ecs_{}_acme".format(version)]
+        self.assertEqual(es_template.component_name_convention(version, test_map), exp)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Backports the following commits to 1.x:
 - lowercasing component names for es template (#1323)