### PR TITLE
Stage 1 experimental changes for RFC 0018 - extend threat fieldset

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Add `orchestrator` fieldset to experimental schema. #1292
+* Extend `threat.*` experimental fields with proposed changes from RFC 0018. #1344
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -6845,6 +6845,41 @@
         can be provided by detecting systems, evaluated at ingest time, or retrospectively
         tagged to events.
       example: MITRE ATT&CK
+    - name: group.alias
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The alias(es) of the group for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+      example: '[ "Magecart Group 6" ]'
+      default_field: false
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The id of the group for a set of related intrusion activity that\
+        \ are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group id."
+      example: G0037
+      default_field: false
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The name of the group for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group name."
+      example: FIN6
+      default_field: false
+    - name: group.reference
+      level: extended
+      type: url
+      description: "The reference URL of the group for a set of related intrusion\
+        \ activity that are tracked by a common name in the security community. While\
+        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+      example: https://attack.mitre.org/groups/G0037/
+      default_field: false
     - name: indicator.as.number
       level: extended
       type: long
@@ -7657,6 +7692,52 @@
         \ mutex\n  * process\n  * software\n  * url\n  * user-account\n  * windows-registry-key\n\
         \  * x-509-certificate"
       example: ipv4-addr
+      default_field: false
+    - name: software.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The id of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software id."
+      example: S0552
+      default_field: false
+    - name: software.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The name of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software name."
+      example: AdFind
+      default_field: false
+    - name: software.platforms
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The platform of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software platform.\nExpected values\n  * AWS\n  * Azure\n\
+        \  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office 365\n\
+        \  * PRE\n  * SaaS\n  * Windows"
+      example: Windows
+      default_field: false
+    - name: software.reference
+      level: extended
+      type: url
+      description: "The reference URL of the software used by this threat to conduct\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ can use a MITRE ATT&CK\xAE software reference URL."
+      example: https://attack.mitre.org/software/S0552/
+      default_field: false
+    - name: software.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The type of software used by this threat to conduct behavior commonly\
+        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
+        \ ATT&CK\xAE software type.\nExpected values\n  * Malware\n  * Tool"
+      example: Tool
       default_field: false
     - name: tactic.id
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -802,6 +802,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev+exp,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 2.0.0-dev+exp,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
+2.0.0-dev+exp,true,threat,threat.group.alias,keyword,extended,array,"[ ""Magecart Group 6"" ]",Alias of the group.
+2.0.0-dev+exp,true,threat,threat.group.id,keyword,extended,,G0037,ID of the group.
+2.0.0-dev+exp,true,threat,threat.group.name,keyword,extended,,FIN6,Name of the group.
+2.0.0-dev+exp,true,threat,threat.group.reference,url,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 2.0.0-dev+exp,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 2.0.0-dev+exp,true,threat,threat.indicator.as.organization.name,wildcard,extended,,Google LLC,Organization name.
 2.0.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
@@ -914,6 +918,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,threat,threat.indicator.scanner_stats,long,extended,,4,Scanner statistics
 2.0.0-dev+exp,true,threat,threat.indicator.sightings,long,extended,,20,Number of times indicator observed
 2.0.0-dev+exp,true,threat,threat.indicator.type,keyword,extended,,ipv4-addr,Type of indicator
+2.0.0-dev+exp,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
+2.0.0-dev+exp,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
+2.0.0-dev+exp,true,threat,threat.software.platforms,keyword,extended,,Windows,Platform of the software.
+2.0.0-dev+exp,true,threat,threat.software.reference,url,extended,,https://attack.mitre.org/software/S0552/,Software reference URL.
+2.0.0-dev+exp,true,threat,threat.software.type,keyword,extended,,Tool,Software type.
 2.0.0-dev+exp,true,threat,threat.tactic.id,keyword,extended,array,TA0002,Threat tactic id.
 2.0.0-dev+exp,true,threat,threat.tactic.name,keyword,extended,array,Execution,Threat tactic.
 2.0.0-dev+exp,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -10024,6 +10024,58 @@ threat.framework:
   normalize: []
   short: Threat classification framework.
   type: keyword
+threat.group.alias:
+  dashed_name: threat-group-alias
+  description: "The alias(es) of the group for a set of related intrusion activity\
+    \ that are tracked by a common name in the security community. While not required,\
+    \ you can use a MITRE ATT&CK\xAE group alias(es)."
+  example: '[ "Magecart Group 6" ]'
+  flat_name: threat.group.alias
+  ignore_above: 1024
+  level: extended
+  name: group.alias
+  normalize:
+  - array
+  short: Alias of the group.
+  type: keyword
+threat.group.id:
+  dashed_name: threat-group-id
+  description: "The id of the group for a set of related intrusion activity that are\
+    \ tracked by a common name in the security community. While not required, you\
+    \ can use a MITRE ATT&CK\xAE group id."
+  example: G0037
+  flat_name: threat.group.id
+  ignore_above: 1024
+  level: extended
+  name: group.id
+  normalize: []
+  short: ID of the group.
+  type: keyword
+threat.group.name:
+  dashed_name: threat-group-name
+  description: "The name of the group for a set of related intrusion activity that\
+    \ are tracked by a common name in the security community. While not required,\
+    \ you can use a MITRE ATT&CK\xAE group name."
+  example: FIN6
+  flat_name: threat.group.name
+  ignore_above: 1024
+  level: extended
+  name: group.name
+  normalize: []
+  short: Name of the group.
+  type: keyword
+threat.group.reference:
+  dashed_name: threat-group-reference
+  description: "The reference URL of the group for a set of related intrusion activity\
+    \ that are tracked by a common name in the security community. While not required,\
+    \ you can use a MITRE ATT&CK\xAE group reference URL."
+  example: https://attack.mitre.org/groups/G0037/
+  flat_name: threat.group.reference
+  level: extended
+  name: group.reference
+  normalize: []
+  short: Reference URL of the group.
+  type: url
 threat.indicator.as.number:
   dashed_name: threat-indicator-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
@@ -11373,6 +11425,72 @@ threat.indicator.type:
   name: indicator.type
   normalize: []
   short: Type of indicator
+  type: keyword
+threat.software.id:
+  dashed_name: threat-software-id
+  description: "The id of the software used by this threat to conduct behavior commonly\
+    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ software id."
+  example: S0552
+  flat_name: threat.software.id
+  ignore_above: 1024
+  level: extended
+  name: software.id
+  normalize: []
+  short: ID of the software
+  type: keyword
+threat.software.name:
+  dashed_name: threat-software-name
+  description: "The name of the software used by this threat to conduct behavior commonly\
+    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ software name."
+  example: AdFind
+  flat_name: threat.software.name
+  ignore_above: 1024
+  level: extended
+  name: software.name
+  normalize: []
+  short: Name of the software.
+  type: keyword
+threat.software.platforms:
+  dashed_name: threat-software-platforms
+  description: "The platform of the software used by this threat to conduct behavior\
+    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
+    \ ATT&CK\xAE software platform.\nExpected values\n  * AWS\n  * Azure\n  * Azure\
+    \ AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office 365\n  * PRE\n  *\
+    \ SaaS\n  * Windows"
+  example: Windows
+  flat_name: threat.software.platforms
+  ignore_above: 1024
+  level: extended
+  name: software.platforms
+  normalize: []
+  short: Platform of the software.
+  type: keyword
+threat.software.reference:
+  dashed_name: threat-software-reference
+  description: "The reference URL of the software used by this threat to conduct behavior\
+    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
+    \ ATT&CK\xAE software reference URL."
+  example: https://attack.mitre.org/software/S0552/
+  flat_name: threat.software.reference
+  level: extended
+  name: software.reference
+  normalize: []
+  short: Software reference URL.
+  type: url
+threat.software.type:
+  dashed_name: threat-software-type
+  description: "The type of software used by this threat to conduct behavior commonly\
+    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ software type.\nExpected values\n  * Malware\n  * Tool"
+  example: Tool
+  flat_name: threat.software.type
+  ignore_above: 1024
+  level: extended
+  name: software.type
+  normalize: []
+  short: Software type.
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -12030,6 +12030,58 @@ threat:
       normalize: []
       short: Threat classification framework.
       type: keyword
+    threat.group.alias:
+      dashed_name: threat-group-alias
+      description: "The alias(es) of the group for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+      example: '[ "Magecart Group 6" ]'
+      flat_name: threat.group.alias
+      ignore_above: 1024
+      level: extended
+      name: group.alias
+      normalize:
+      - array
+      short: Alias of the group.
+      type: keyword
+    threat.group.id:
+      dashed_name: threat-group-id
+      description: "The id of the group for a set of related intrusion activity that\
+        \ are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group id."
+      example: G0037
+      flat_name: threat.group.id
+      ignore_above: 1024
+      level: extended
+      name: group.id
+      normalize: []
+      short: ID of the group.
+      type: keyword
+    threat.group.name:
+      dashed_name: threat-group-name
+      description: "The name of the group for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community. While not required,\
+        \ you can use a MITRE ATT&CK\xAE group name."
+      example: FIN6
+      flat_name: threat.group.name
+      ignore_above: 1024
+      level: extended
+      name: group.name
+      normalize: []
+      short: Name of the group.
+      type: keyword
+    threat.group.reference:
+      dashed_name: threat-group-reference
+      description: "The reference URL of the group for a set of related intrusion\
+        \ activity that are tracked by a common name in the security community. While\
+        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+      example: https://attack.mitre.org/groups/G0037/
+      flat_name: threat.group.reference
+      level: extended
+      name: group.reference
+      normalize: []
+      short: Reference URL of the group.
+      type: url
     threat.indicator.as.number:
       dashed_name: threat-indicator-as-number
       description: Unique number allocated to the autonomous system. The autonomous
@@ -13382,6 +13434,72 @@ threat:
       name: indicator.type
       normalize: []
       short: Type of indicator
+      type: keyword
+    threat.software.id:
+      dashed_name: threat-software-id
+      description: "The id of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software id."
+      example: S0552
+      flat_name: threat.software.id
+      ignore_above: 1024
+      level: extended
+      name: software.id
+      normalize: []
+      short: ID of the software
+      type: keyword
+    threat.software.name:
+      dashed_name: threat-software-name
+      description: "The name of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software name."
+      example: AdFind
+      flat_name: threat.software.name
+      ignore_above: 1024
+      level: extended
+      name: software.name
+      normalize: []
+      short: Name of the software.
+      type: keyword
+    threat.software.platforms:
+      dashed_name: threat-software-platforms
+      description: "The platform of the software used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ a MITRE ATT&CK\xAE software platform.\nExpected values\n  * AWS\n  * Azure\n\
+        \  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office 365\n\
+        \  * PRE\n  * SaaS\n  * Windows"
+      example: Windows
+      flat_name: threat.software.platforms
+      ignore_above: 1024
+      level: extended
+      name: software.platforms
+      normalize: []
+      short: Platform of the software.
+      type: keyword
+    threat.software.reference:
+      dashed_name: threat-software-reference
+      description: "The reference URL of the software used by this threat to conduct\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ can use a MITRE ATT&CK\xAE software reference URL."
+      example: https://attack.mitre.org/software/S0552/
+      flat_name: threat.software.reference
+      level: extended
+      name: software.reference
+      normalize: []
+      short: Software reference URL.
+      type: url
+    threat.software.type:
+      dashed_name: threat-software-type
+      description: "The type of software used by this threat to conduct behavior commonly\
+        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
+        \ ATT&CK\xAE software type.\nExpected values\n  * Malware\n  * Tool"
+      example: Tool
+      flat_name: threat.software.type
+      ignore_above: 1024
+      level: extended
+      name: software.type
+      normalize: []
+      short: Software type.
       type: keyword
     threat.tactic.id:
       dashed_name: threat-tactic-id

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -3622,6 +3622,25 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "group": {
+            "properties": {
+              "alias": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "reference": {
+                "type": "url"
+              }
+            }
+          },
           "indicator": {
             "properties": {
               "as": {
@@ -4107,6 +4126,29 @@
               },
               "sightings": {
                 "type": "long"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "software": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "platforms": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "reference": {
+                "type": "url"
               },
               "type": {
                 "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -12,6 +12,25 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "group": {
+              "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "type": "url"
+                }
+              }
+            },
             "indicator": {
               "properties": {
                 "as": {
@@ -497,6 +516,29 @@
                 },
                 "sightings": {
                   "type": "long"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "software": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "platforms": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "type": "url"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/experimental/schemas/threat.yml
+++ b/experimental/schemas/threat.yml
@@ -194,3 +194,103 @@
       Identifies the type of the atomic indicator that matched a local environment endpoint or network event.
 
     example: domain-name
+
+  - name: software.id
+    level: extended
+    type: keyword
+    short: ID of the software
+    description: >
+      The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software id.
+
+    example: "S0552"
+
+  - name: software.name
+    level: extended
+    type: keyword
+    short: Name of the software.
+    description: >
+      The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software name.
+
+    example: "AdFind"
+
+  - name: software.platforms
+    level: extended
+    type: keyword
+    short: Platform of the software.
+    description: >
+      The platform of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software platform.
+
+      Expected values
+        * AWS
+        * Azure
+        * Azure AD
+        * GCP
+        * Linux
+        * macOS
+        * Network
+        * Office 365
+        * PRE
+        * SaaS
+        * Windows
+
+    example: "Windows"
+
+  - name: software.reference
+    level: extended
+    type: url
+    short: Software reference URL.
+    description: >
+      The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software reference URL.
+
+    example: "https://attack.mitre.org/software/S0552/"
+
+  - name: software.type
+    level: extended
+    type: keyword
+    short: Software type.
+    description: >
+      The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software type.
+
+      Expected values
+        * Malware
+        * Tool
+
+    example: "Tool"
+
+  - name: group.alias
+    level: extended
+    type: keyword
+    short: Alias of the group.
+    description: >
+      The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group alias(es).
+
+    example: '[ "Magecart Group 6" ]'
+    normalize:
+      - array
+
+  - name: group.id
+    level: extended
+    type: keyword
+    short: ID of the group.
+    description: >
+      The id of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group id.
+
+    example: "G0037"
+
+  - name: group.name
+    level: extended
+    type: keyword
+    short: Name of the group.
+    description: >
+      The name of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group name.
+
+    example: "FIN6"
+
+  - name: group.reference
+    level: extended
+    type: url
+    short: Reference URL of the group.
+    description: >
+      The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group reference URL.
+
+    example: "https://attack.mitre.org/groups/G0037/"


### PR DESCRIPTION
Extends `threat.*` fieldset with proposed changes from [RFC 0018](https://github.com/elastic/ecs/blob/master/rfcs/text/0018-extend-threat-group-software.md) (https://github.com/elastic/ecs/pull/1335) in the experimental schema and artifacts.
