### PR TITLE
[1.x] Remove extra newline from Go code generator (#1350)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,7 +36,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Support `nested` types in go code generator. #1254
+* Support `nested` types in go code generator. #1254, #1350
 * Go code generator now supports the `flattened` data type. #1302
 * Adjustments to use terminology that doesn't have negative connotation. #1315
 

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -75,7 +75,6 @@ type {{.Name}} struct {
 	{{$field.Name}} {{$field.Type}} \u0060ecs:"{{$field.JSONKey}}"\u0060
 {{ end -}}
 }
-
 {{ range $nestedField := .NestedTypes }}
 type {{$nestedField.Name}} struct {
 {{- range $field := $nestedField.Fields}}


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Remove extra newline from Go code generator (#1350)