### PR TITLE
[1.x] Correct data type for `group.ref` and `software.ref` experimental fields (#1351)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,7 +17,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Add `orchestrator` fieldset to experimental schema. #1292
-* Extend `threat.*` experimental fields with proposed changes from RFC 0018. #1344
+* Extend `threat.*` experimental fields with proposed changes from RFC 0018. #1344, #1351
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -6874,7 +6874,8 @@
       default_field: false
     - name: group.reference
       level: extended
-      type: url
+      type: keyword
+      ignore_above: 1024
       description: "The reference URL of the group for a set of related intrusion\
         \ activity that are tracked by a common name in the security community. While\
         \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
@@ -7724,7 +7725,8 @@
       default_field: false
     - name: software.reference
       level: extended
-      type: url
+      type: keyword
+      ignore_above: 1024
       description: "The reference URL of the software used by this threat to conduct\
         \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
         \ can use a MITRE ATT&CK\xAE software reference URL."

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -805,7 +805,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.10.0-dev+exp,true,threat,threat.group.alias,keyword,extended,array,"[ ""Magecart Group 6"" ]",Alias of the group.
 1.10.0-dev+exp,true,threat,threat.group.id,keyword,extended,,G0037,ID of the group.
 1.10.0-dev+exp,true,threat,threat.group.name,keyword,extended,,FIN6,Name of the group.
-1.10.0-dev+exp,true,threat,threat.group.reference,url,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
+1.10.0-dev+exp,true,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 1.10.0-dev+exp,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.10.0-dev+exp,true,threat,threat.indicator.as.organization.name,wildcard,extended,,Google LLC,Organization name.
 1.10.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
@@ -921,7 +921,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.10.0-dev+exp,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
 1.10.0-dev+exp,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
 1.10.0-dev+exp,true,threat,threat.software.platforms,keyword,extended,,Windows,Platform of the software.
-1.10.0-dev+exp,true,threat,threat.software.reference,url,extended,,https://attack.mitre.org/software/S0552/,Software reference URL.
+1.10.0-dev+exp,true,threat,threat.software.reference,keyword,extended,,https://attack.mitre.org/software/S0552/,Software reference URL.
 1.10.0-dev+exp,true,threat,threat.software.type,keyword,extended,,Tool,Software type.
 1.10.0-dev+exp,true,threat,threat.tactic.id,keyword,extended,array,TA0002,Threat tactic id.
 1.10.0-dev+exp,true,threat,threat.tactic.name,keyword,extended,array,Execution,Threat tactic.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -10071,11 +10071,12 @@ threat.group.reference:
     \ you can use a MITRE ATT&CK\xAE group reference URL."
   example: https://attack.mitre.org/groups/G0037/
   flat_name: threat.group.reference
+  ignore_above: 1024
   level: extended
   name: group.reference
   normalize: []
   short: Reference URL of the group.
-  type: url
+  type: keyword
 threat.indicator.as.number:
   dashed_name: threat-indicator-as-number
   description: Unique number allocated to the autonomous system. The autonomous system
@@ -11474,11 +11475,12 @@ threat.software.reference:
     \ ATT&CK\xAE software reference URL."
   example: https://attack.mitre.org/software/S0552/
   flat_name: threat.software.reference
+  ignore_above: 1024
   level: extended
   name: software.reference
   normalize: []
   short: Software reference URL.
-  type: url
+  type: keyword
 threat.software.type:
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -12077,11 +12077,12 @@ threat:
         \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       flat_name: threat.group.reference
+      ignore_above: 1024
       level: extended
       name: group.reference
       normalize: []
       short: Reference URL of the group.
-      type: url
+      type: keyword
     threat.indicator.as.number:
       dashed_name: threat-indicator-as-number
       description: Unique number allocated to the autonomous system. The autonomous
@@ -13483,11 +13484,12 @@ threat:
         \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       flat_name: threat.software.reference
+      ignore_above: 1024
       level: extended
       name: software.reference
       normalize: []
       short: Software reference URL.
-      type: url
+      type: keyword
     threat.software.type:
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -3637,7 +3637,8 @@
                 "type": "keyword"
               },
               "reference": {
-                "type": "url"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -4148,7 +4149,8 @@
                 "type": "keyword"
               },
               "reference": {
-                "type": "url"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "type": {
                 "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -27,7 +27,8 @@
                   "type": "keyword"
                 },
                 "reference": {
-                  "type": "url"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -538,7 +539,8 @@
                   "type": "keyword"
                 },
                 "reference": {
-                  "type": "url"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/experimental/schemas/threat.yml
+++ b/experimental/schemas/threat.yml
@@ -237,7 +237,7 @@
 
   - name: software.reference
     level: extended
-    type: url
+    type: keyword
     short: Software reference URL.
     description: >
       The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software reference URL.
@@ -288,7 +288,7 @@
 
   - name: group.reference
     level: extended
-    type: url
+    type: keyword
     short: Reference URL of the group.
     description: >
       The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group reference URL.


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Correct data type for `group.ref` and `software.ref` experimental fields (#1351)