### PR TITLE
Add `os.build` field

### DIFF
--- a/code/go/ecs/os.go
+++ b/code/go/ecs/os.go
@@ -47,4 +47,15 @@ type Os struct {
 
 	// Operating system kernel version as a raw string.
 	Kernel string `ecs:"kernel"`
+
+	// Operating system build.
+	// On Windows, this is the value of `SOFTWARE\Microsoft\Windows
+	// NT\CurrentVersion\CurrentBuild` registry key. Optionally, the update
+	// build revision (UBR) can be added to `CurrentBuild` and be separated by
+	// a period (`.`). Example: `17763.1817`
+	// For macOS, this is the value of returned by the `sw_vers -buildVersion`
+	// command.
+	// On some Linux systems, this may be the value of the `BUILD_ID` parameter
+	// specified in `/etc/os-release`.
+	Build string `ecs:"build"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4904,6 +4904,28 @@ The OS fields contain information about the operating system.
 // ===============================================================
 
 |
+[[field-os-build]]
+<<field-os-build, os.build>>
+
+| Operating system build.
+
+On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild` registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+On some Linux systems, this may be the value of the `BUILD_ID` parameter specified in `/etc/os-release`.
+
+type: keyword
+
+
+
+example: `17763.1817`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-os-family]]
 <<field-os-family, os.family>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3226,6 +3226,22 @@
       description: The number of packets (gauge) received on all network interfaces
         by the host since the last metric collection.
       default_field: false
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword
@@ -4030,6 +4046,22 @@
 
         If no custom name is needed, the field can be left empty.'
       example: 1_proxySG
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword
@@ -4218,6 +4250,22 @@
     description: The OS fields contain information about the operating system.
     type: group
     fields:
+    - name: build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: family
       level: extended
       type: keyword
@@ -8899,6 +8947,22 @@
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -361,6 +361,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,host,host.network.egress.packets,long,extended,,,The number of packets sent on all network interfaces.
 2.0.0-dev+exp,true,host,host.network.ingress.bytes,long,extended,,,The number of bytes received on all network interfaces.
 2.0.0-dev+exp,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
+2.0.0-dev+exp,true,host,host.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev+exp,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev+exp,true,host,host.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev+exp,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -457,6 +458,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,observer,observer.ip,ip,core,array,,IP addresses of the observer.
 2.0.0-dev+exp,true,observer,observer.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",MAC addresses of the observer.
 2.0.0-dev+exp,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
+2.0.0-dev+exp,true,observer,observer.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev+exp,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev+exp,true,observer,observer.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev+exp,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -1081,6 +1083,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 2.0.0-dev+exp,true,user_agent,user_agent.original,wildcard,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 2.0.0-dev+exp,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+2.0.0-dev+exp,true,user_agent,user_agent.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev+exp,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev+exp,true,user_agent,user_agent.os.full,wildcard,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev+exp,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4769,6 +4769,27 @@ host.network.ingress.packets:
   normalize: []
   short: The number of packets received on all network interfaces.
   type: long
+host.os.build:
+  dashed_name: host-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: host.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
+  type: keyword
 host.os.family:
   dashed_name: host-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
@@ -5981,6 +6002,27 @@ observer.name:
   name: name
   normalize: []
   short: Custom name of the observer.
+  type: keyword
+observer.os.build:
+  dashed_name: observer-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: observer.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
   type: keyword
 observer.os.family:
   dashed_name: observer-os-family
@@ -13363,6 +13405,27 @@ user_agent.original:
   normalize: []
   short: Unparsed user_agent string.
   type: wildcard
+user_agent.os.build:
+  dashed_name: user-agent-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: user_agent.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
+  type: keyword
 user_agent.os.family:
   dashed_name: user-agent-os-family
   description: OS family (such as redhat, debian, freebsd, windows).

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5867,6 +5867,27 @@ host:
       normalize: []
       short: The number of packets received on all network interfaces.
       type: long
+    host.os.build:
+      dashed_name: host-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: host.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
+      type: keyword
     host.os.family:
       dashed_name: host-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -7200,6 +7221,27 @@ observer:
       normalize: []
       short: Custom name of the observer.
       type: keyword
+    observer.os.build:
+      dashed_name: observer-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: observer.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
+      type: keyword
     observer.os.family:
       dashed_name: observer-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -7536,6 +7578,26 @@ organization:
 os:
   description: The OS fields contain information about the operating system.
   fields:
+    os.build:
+      dashed_name: os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      short: Operation system build.
+      type: keyword
     os.family:
       dashed_name: os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -15538,6 +15600,27 @@ user_agent:
       normalize: []
       short: Unparsed user_agent string.
       type: wildcard
+    user_agent.os.build:
+      dashed_name: user-agent-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: user_agent.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
+      type: keyword
     user_agent.os.family:
       dashed_name: user-agent-os-family
       description: OS family (such as redhat, debian, freebsd, windows).

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1624,6 +1624,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2099,6 +2103,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -4889,6 +4897,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/experimental/generated/elasticsearch/component/host.json
+++ b/experimental/generated/elasticsearch/component/host.json
@@ -132,6 +132,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/component/observer.json
+++ b/experimental/generated/elasticsearch/component/observer.json
@@ -145,6 +145,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/component/user_agent.json
+++ b/experimental/generated/elasticsearch/component/user_agent.json
@@ -31,6 +31,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2431,6 +2431,22 @@
       description: The number of packets (gauge) received on all network interfaces
         by the host since the last metric collection.
       default_field: false
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword
@@ -3246,6 +3262,22 @@
 
         If no custom name is needed, the field can be left empty.'
       example: 1_proxySG
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword
@@ -3437,6 +3469,22 @@
     description: The OS fields contain information about the operating system.
     type: group
     fields:
+    - name: build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: family
       level: extended
       type: keyword
@@ -6304,6 +6352,22 @@
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
+    - name: os.build
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      default_field: false
     - name: os.family
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -267,6 +267,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,host,host.network.egress.packets,long,extended,,,The number of packets sent on all network interfaces.
 2.0.0-dev,true,host,host.network.ingress.bytes,long,extended,,,The number of bytes received on all network interfaces.
 2.0.0-dev,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
+2.0.0-dev,true,host,host.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -363,6 +364,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,observer,observer.ip,ip,core,array,,IP addresses of the observer.
 2.0.0-dev,true,observer,observer.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",MAC addresses of the observer.
 2.0.0-dev,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
+2.0.0-dev,true,observer,observer.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
@@ -746,6 +748,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 2.0.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 2.0.0-dev,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+2.0.0-dev,true,user_agent,user_agent.os.build,keyword,extended,,17763.1817,Operation system build.
 2.0.0-dev,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 2.0.0-dev,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 2.0.0-dev,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3691,6 +3691,27 @@ host.network.ingress.packets:
   normalize: []
   short: The number of packets received on all network interfaces.
   type: long
+host.os.build:
+  dashed_name: host-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: host.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
+  type: keyword
 host.os.family:
   dashed_name: host-os-family
   description: OS family (such as redhat, debian, freebsd, windows).
@@ -4914,6 +4935,27 @@ observer.name:
   name: name
   normalize: []
   short: Custom name of the observer.
+  type: keyword
+observer.os.build:
+  dashed_name: observer-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: observer.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
   type: keyword
 observer.os.family:
   dashed_name: observer-os-family
@@ -9503,6 +9545,27 @@ user_agent.original:
   name: original
   normalize: []
   short: Unparsed user_agent string.
+  type: keyword
+user_agent.os.build:
+  dashed_name: user-agent-os-build
+  description: 'Operating system build.
+
+    On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+    registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild`
+    and be separated by a period (`.`). Example: `17763.1817`
+
+    For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+    On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+    in `/etc/os-release`.'
+  example: '17763.1817'
+  flat_name: user_agent.os.build
+  ignore_above: 1024
+  level: extended
+  name: build
+  normalize: []
+  original_fieldset: os
+  short: Operation system build.
   type: keyword
 user_agent.os.family:
   dashed_name: user-agent-os-family

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4438,6 +4438,27 @@ host:
       normalize: []
       short: The number of packets received on all network interfaces.
       type: long
+    host.os.build:
+      dashed_name: host-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: host.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
+      type: keyword
     host.os.family:
       dashed_name: host-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -5782,6 +5803,27 @@ observer:
       normalize: []
       short: Custom name of the observer.
       type: keyword
+    observer.os.build:
+      dashed_name: observer-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: observer.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
+      type: keyword
     observer.os.family:
       dashed_name: observer-os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -6121,6 +6163,26 @@ organization:
 os:
   description: The OS fields contain information about the operating system.
   fields:
+    os.build:
+      dashed_name: os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      short: Operation system build.
+      type: keyword
     os.family:
       dashed_name: os-family
       description: OS family (such as redhat, debian, freebsd, windows).
@@ -10945,6 +11007,27 @@ user_agent:
       name: original
       normalize: []
       short: Unparsed user_agent string.
+      type: keyword
+    user_agent.os.build:
+      dashed_name: user-agent-os-build
+      description: 'Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to
+        `CurrentBuild` and be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.'
+      example: '17763.1817'
+      flat_name: user_agent.os.build
+      ignore_above: 1024
+      level: extended
+      name: build
+      normalize: []
+      original_fieldset: os
+      short: Operation system build.
       type: keyword
     user_agent.os.family:
       dashed_name: user-agent-os-family

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1253,6 +1253,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -1739,6 +1743,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -3547,6 +3555,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1252,6 +1252,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -1738,6 +1742,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -3546,6 +3554,10 @@
           },
           "os": {
             "properties": {
+              "build": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "family": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -134,6 +134,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -146,6 +146,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/component/user_agent.json
+++ b/generated/elasticsearch/component/user_agent.json
@@ -32,6 +32,10 @@
             },
             "os": {
               "properties": {
+                "build": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "family": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -79,6 +79,7 @@
       level: extended
       type: keyword
       example: "17763.1817"
+      short: Operation system build.
       description: >
         Operating system build.
 

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -74,3 +74,19 @@
       example: "4.4.0-112-generic"
       description: >
         Operating system kernel version as a raw string.
+
+    - name: build
+      level: extended
+      type: keyword
+      example: "17763.1817"
+      description: >
+        Operating system build.
+
+        On Windows, this is the value of `SOFTWARE\Microsoft\Windows NT\CurrentVersion\CurrentBuild`
+        registry key. Optionally, the update build revision (UBR) can be added to `CurrentBuild` and
+        be separated by a period (`.`). Example: `17763.1817`
+
+        For macOS, this is the value of returned by the `sw_vers -buildVersion` command.
+
+        On some Linux systems, this may be the value of the `BUILD_ID` parameter specified
+        in `/etc/os-release`.


### PR DESCRIPTION
The `*.os.build` field is populated by several Elastic data sources and is part of the output of the [`add_host_metadata` processor](https://www.elastic.co/guide/en/beats/metricbeat/current/add-host-metadata.html).

This PR is a proposal that the field is officially added.
