### PR TITLE
[1.x] Allow custom descriptions for self-nesting reuses (#1366)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -19,6 +19,7 @@ Thanks, you're awesome :-) -->
 * Add `data_stream` fieldset. #1307
 * Add `orchestrator` fieldset as beta fields. #1326
 * Extend `threat.*` experimental fields with proposed changes from RFC 0018. #1344, #1351
+* Allow custom descriptions for self-nesting reuses via `short_override` #1366
 
 #### Improvements
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -525,24 +525,27 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-as,client.as.*>>
+| <<ecs-as,as>>
+| `client.as.*`
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,client.geo.*>>
+| <<ecs-geo,geo>>
+| `client.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,client.user.*>>
+| <<ecs-user,user>>
+| `client.user.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1343,24 +1346,27 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-as,destination.as.*>>
+| <<ecs-as,as>>
+| `destination.as.*`
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,destination.geo.*>>
+| <<ecs-geo,geo>>
+| `destination.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,destination.user.*>>
+| <<ecs-user,user>>
+| `destination.user.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1440,24 +1446,27 @@ example: `C:\Windows\System32\kernel32.dll`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-code_signature,dll.code_signature.*>>
+| <<ecs-code_signature,code_signature>>
+| `dll.code_signature.*`
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-hash,dll.hash.*>>
+| <<ecs-hash,hash>>
+| `dll.hash.*`
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-pe,dll.pe.*>>
+| <<ecs-pe,pe>>
+| `dll.pe.*`
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
@@ -2853,30 +2862,34 @@ example: `1001`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-code_signature,file.code_signature.*>>
+| <<ecs-code_signature,code_signature>>
+| `file.code_signature.*`
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-hash,file.hash.*>>
+| <<ecs-hash,hash>>
+| `file.hash.*`
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-pe,file.pe.*>>
+| <<ecs-pe,pe>>
+| `file.pe.*`
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
 
 
-| <<ecs-x509,file.x509.*>>
+| <<ecs-x509,x509>>
+| `file.x509.*`
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
@@ -3590,24 +3603,27 @@ example: `1325`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-geo,host.geo.*>>
+| <<ecs-geo,geo>>
+| `host.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-os,host.os.*>>
+| <<ecs-os,os>>
+| `host.os.*`
 | OS fields contain information about the operating system.
 
 // ===============================================================
 
 
-| <<ecs-user,host.user.*>>
+| <<ecs-user,user>>
+| `host.user.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -4445,18 +4461,20 @@ example: `ipv4`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-vlan,network.inner.vlan.*>>
+| <<ecs-vlan,vlan>>
+| `network.inner.vlan.*`
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,network.vlan.*>>
+| <<ecs-vlan,vlan>>
+| `network.vlan.*`
 | Fields to describe observed VLAN information.
 
 // ===============================================================
@@ -4716,42 +4734,48 @@ type: keyword
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-interface,observer.egress.interface.*>>
+| <<ecs-interface,interface>>
+| `observer.egress.interface.*`
 | Fields to describe observer interface information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,observer.egress.vlan.*>>
+| <<ecs-vlan,vlan>>
+| `observer.egress.vlan.*`
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-geo,observer.geo.*>>
+| <<ecs-geo,geo>>
+| `observer.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-interface,observer.ingress.interface.*>>
+| <<ecs-interface,interface>>
+| `observer.ingress.interface.*`
 | Fields to describe observer interface information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,observer.ingress.vlan.*>>
+| <<ecs-vlan,vlan>>
+| `observer.ingress.vlan.*`
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-os,observer.os.*>>
+| <<ecs-os,os>>
+| `observer.os.*`
 | OS fields contain information about the operating system.
 
 // ===============================================================
@@ -5840,30 +5864,34 @@ Note also that the `process` fields may be used directly at the root of the even
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-code_signature,process.code_signature.*>>
+| <<ecs-code_signature,code_signature>>
+| `process.code_signature.*`
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-hash,process.hash.*>>
+| <<ecs-hash,hash>>
+| `process.hash.*`
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-process,process.parent.*>>
-| These fields contain information about a process.
+| <<ecs-process,process>>
+| `process.parent.*`
+| Information about the parent process.
 
 // ===============================================================
 
 
-| <<ecs-pe,process.pe.*>>
+| <<ecs-pe,pe>>
+| `process.pe.*`
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
@@ -6525,24 +6553,27 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-as,server.as.*>>
+| <<ecs-as,as>>
+| `server.as.*`
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,server.geo.*>>
+| <<ecs-geo,geo>>
+| `server.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,server.user.*>>
+| <<ecs-user,user>>
+| `server.user.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -6938,24 +6969,27 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-as,source.as.*>>
+| <<ecs-as,as>>
+| `source.as.*`
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,source.geo.*>>
+| <<ecs-geo,geo>>
+| `source.geo.*`
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,source.user.*>>
+| <<ecs-user,user>>
+| `source.user.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -7681,18 +7715,20 @@ example: `tls`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-x509,tls.client.x509.*>>
+| <<ecs-x509,x509>>
+| `tls.client.x509.*`
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
 
 
-| <<ecs-x509,tls.server.x509.*>>
+| <<ecs-x509,x509>>
+| `tls.server.x509.*`
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
@@ -8217,30 +8253,34 @@ Note also that the `user` fields may be used directly at the root of the events.
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-user,user.changes.*>>
+| <<ecs-user,user>>
+| `user.changes.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
 
 
-| <<ecs-user,user.effective.*>>
+| <<ecs-user,user>>
+| `user.effective.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
 
 
-| <<ecs-group,user.group.*>>
+| <<ecs-group,group>>
+| `user.group.*`
 | User's group relevant to the event.
 
 // ===============================================================
 
 
-| <<ecs-user,user.target.*>>
+| <<ecs-user,user>>
+| `user.target.*`
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -8357,12 +8397,13 @@ example: `12.0`
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
 
-| <<ecs-os,user_agent.os.*>>
+| <<ecs-os,os>>
+| `user_agent.os.*`
 | OS fields contain information about the operating system.
 
 // ===============================================================

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10589,6 +10589,7 @@ process:
     - as: parent
       at: process
       full: process.parent
+      short_override: Information about the parent process.
     top_level: true
   reused_here:
   - full: process.code_signature
@@ -10605,7 +10606,7 @@ process:
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
   - full: process.parent
     schema_name: process
-    short: These fields contain information about a process.
+    short: Information about the parent process.
   short: These fields contain information about a process.
   title: Process
   type: group

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7531,6 +7531,7 @@ process:
     - as: parent
       at: process
       full: process.parent
+      short_override: Information about the parent process.
     top_level: true
   reused_here:
   - full: process.code_signature
@@ -7544,7 +7545,7 @@ process:
     short: These fields contain Windows Portable Executable (PE) metadata.
   - full: process.parent
     schema_name: process
-    short: These fields contain information about a process.
+    short: Information about the parent process.
   short: These fields contain information about a process.
   title: Process
   type: group

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -32,6 +32,8 @@ Optional field set attributes:
 - type (ignored): at this level, should always be `group`
 - reusable (optional): Used to identify which field sets are expected to be reused in multiple places.
   See "Field set reuse" for details.
+- short_override: Used to override the top-level fieldset's short description when nesting. 
+  See "Field set reuse" for details.
 - beta: Adds a beta marker for the entire fieldset. The text provided in this attribute is used as content of the beta marker in the documentation.
   Beta notices should not have newlines.
 
@@ -51,12 +53,14 @@ multiple places, like for example `geo`, which can appear under `source`, `desti
 }
 ```
 
-The `reusable` attribute is composed of `top_level` and `expected` sub-attributes:
+The `reusable` attribute is composed of `top_level`, `expected`, and `short_override` sub-attributes:
 
 - top\_level (optional, default true): Is this field set expected at the root of
   events or is it only expected in the nested locations?
 - expected (default []): list of places the field set's fields are expected.
   There are two valid notations to list expected locations.
+- short_override (optional, default null): Sets the short description for the 
+  nested field, overriding the default top-level short description.
 
 The "flat" (or dotted) notation to represent where the fields are nested:
 
@@ -116,6 +120,18 @@ Beta notices should not have newlines.
     - at: user
       as: target
       beta: Reusing these fields in this location is currently considered beta.
+```
+
+The `short_override` marker can optionally be used along with `at` and `as` to set the short description of the nested field, instead of defaulting to the top-level fieldset's short description. 
+Like short, descriptions must not have newlines.
+
+```
+  reusable:
+    top_level: true
+    expected:
+    - at: user
+      as: target
+      short_override: My special target short description.
 ```
 
 ### List of fields

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -14,6 +14,7 @@
     expected:
       - at: process
         as: parent
+        short_override: Information about the parent process.
 
   fields:
 

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -78,6 +78,8 @@ def schema_assertions_and_warnings(schema):
     single_line_short_description(schema, strict=strict_mode)
     if 'beta' in schema['field_details']:
         single_line_beta_description(schema, strict=strict_mode)
+    if 'reusable' in schema['schema_details']:
+        single_line_short_override_description(schema, strict=strict_mode)
 
 
 def normalize_reuse_notation(schema):
@@ -197,18 +199,37 @@ def field_assertions_and_warnings(field):
 SHORT_LIMIT = 120
 
 
-def single_line_short_description(schema_or_field, strict=True):
-    short_length = len(schema_or_field['field_details']['short'])
-    if "\n" in schema_or_field['field_details']['short'] or short_length > SHORT_LIMIT:
+def single_line_short_check(short_to_check, short_name):
+    short_length = len(short_to_check)
+    if "\n" in short_to_check or short_length > SHORT_LIMIT:
         msg = "Short descriptions must be single line, and under {} characters (current length: {}).\n".format(
             SHORT_LIMIT, short_length)
         msg += "Offending field or field set: {}\nShort description:\n  {}".format(
-            schema_or_field['field_details']['name'],
-            schema_or_field['field_details']['short'])
+            short_name,
+            short_to_check)
+        return msg
+    return None
+
+
+def single_line_short_description(schema_or_field, strict=True):
+    error = single_line_short_check(schema_or_field['field_details']['short'], schema_or_field['field_details']['name'])
+    if error:
         if strict:
-            raise ValueError(msg)
+            raise ValueError(error)
         else:
-            ecs_helpers.strict_warning(msg)
+            ecs_helpers.strict_warning(error)
+
+
+def single_line_short_override_description(schema_or_field, strict=True):
+    for field in schema_or_field['schema_details']['reusable']['expected']:
+        if not 'short_override' in field:
+            continue
+        error = single_line_short_check(field['short_override'], field['full'])
+        if error:
+            if strict:
+                raise ValueError(error)
+            else:
+                ecs_helpers.strict_warning(error)
 
 
 def check_example_value(field, strict=True):

--- a/scripts/schema/finalizer.py
+++ b/scripts/schema/finalizer.py
@@ -126,7 +126,8 @@ def append_reused_here(reused_schema, reuse_entry, destination_schema):
     reused_here_entry = {
         'schema_name': reused_schema['field_details']['name'],
         'full': reuse_entry['full'],
-        'short': reused_schema['field_details']['short'],
+        # Check for a short override, if not present, fall back to the top-level fieldset's short
+        'short': reuse_entry['short_override'] if 'short_override' in reuse_entry else reused_schema['field_details']['short']
     }
     # Check for beta attribute
     if 'beta' in reuse_entry:

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -112,7 +112,7 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 [options="header"]
 |=====
-| Nested fields | Description
+| Field Set | Location | Description
 
 // ===============================================================
 
@@ -120,7 +120,8 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 {% for entry in render_nestings_reuse_section -%}
 
 {#- Beta marker on nested fields -#}
-| <<ecs-{{ entry['name'] }},{{ entry['flat_nesting'] }}>>
+| <<ecs-{{ entry['name'] }},{{ entry['name'] }}>>
+| `{{ entry['flat_nesting'] }}`
 {#- Beta marker on nested fields -#}
 {%- if entry['beta'] -%}
 | beta:[ {{ entry['beta'] }}]

--- a/scripts/tests/unit/test_schema_cleaner.py
+++ b/scripts/tests/unit/test_schema_cleaner.py
@@ -358,6 +358,72 @@ class TestSchemaCleaner(unittest.TestCase):
         except Exception:
             self.fail("cleaner.check_example_value() raised Exception unexpectedly.")
 
+    def test_very_long_short_override_description_raises(self):
+        schema = {
+            'schema_details': {
+                'reusable': {
+                    'expected':
+                        [{'at': 'process',
+                          'as': 'parent',
+                          'full': 'process.parent',
+                          'short_override': "Single line but really long. " * 10}]
+                }
+            }
+        }
+        with self.assertRaisesRegex(ValueError, 'under 120 characters \(current length: 290\)'):
+            cleaner.single_line_short_override_description(schema)
+
+    def test_multiline_short_override_description_raises(self):
+        schema = {
+            'schema_details': {
+                'reusable': {
+                    'expected':
+                        [{'at': 'process',
+                          'as': 'parent',
+                          'full': 'process.parent',
+                          'short_override': "multiple\nlines"}]
+                }
+            }
+        }
+        with self.assertRaisesRegex(ValueError, 'single line'):
+            cleaner.single_line_short_override_description(schema)
+
+    def test_very_long_short_override_description_warns_strict_disabled(self):
+        schema = {
+            'schema_details': {
+                'reusable': {
+                    'expected':
+                        [{'at': 'process',
+                          'as': 'parent',
+                          'full': 'process.parent',
+                          'short_override': "Single line but really long. " * 10}]
+                }
+            }
+        }
+        try:
+            with self.assertWarnsRegex(UserWarning, 'under 120 characters \(current length: 290\)'):
+                cleaner.single_line_short_override_description(schema, strict=False)
+        except Exception:
+            self.fail("cleaner.single_line_short_override_description() raised Exception unexpectedly.")
+
+    def test_multiline_short_override_description_warns_strict_disabled(self):
+        schema = {
+            'schema_details': {
+                'reusable': {
+                    'expected':
+                        [{'at': 'process',
+                          'as': 'parent',
+                          'full': 'process.parent',
+                          'short_override': "multiple\nlines"}]
+                }
+            }
+        }
+        try:
+            with self.assertWarnsRegex(UserWarning, 'single line'):
+                cleaner.single_line_short_override_description(schema, strict=False)
+        except Exception:
+            self.fail("cleaner.single_line_short_override_description() raised Exception unexpectedly.")
+
     def test_clean(self):
         '''A high level sanity test'''
         fields = self.schema_process()

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -46,7 +46,8 @@ class TestSchemaFinalizer(unittest.TestCase):
                         'top_level': True,
                         'order': 2,
                         'expected': [
-                            {'full': 'process.parent', 'at': 'process', 'as': 'parent'},
+                            {'full': 'process.parent', 'at': 'process', 'as': 'parent',
+                                'short_override': 'short override desc'},
                             {'full': 'reuse.process', 'at': 'reuse', 'as': 'process'},
                             {'full': 'reuse.process.parent', 'at': 'reuse.process', 'as': 'parent'},
                         ]
@@ -207,7 +208,7 @@ class TestSchemaFinalizer(unittest.TestCase):
         self.assertIn('server.user', fields['server']['schema_details']['nestings'])
         self.assertIn('reuse.process.parent', fields['reuse']['schema_details']['nestings'])
         # Attribute 'reused_here' lists nestings inside a destination schema
-        self.assertIn({'full': 'process.parent', 'schema_name': 'process', 'short': 'short desc'},
+        self.assertIn({'full': 'process.parent', 'schema_name': 'process', 'short': 'short override desc'},
                       fields['process']['schema_details']['reused_here'])
         self.assertIn({'full': 'user.effective', 'schema_name': 'user', 'short': 'short desc'},
                       fields['user']['schema_details']['reused_here'])


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Allow custom descriptions for self-nesting reuses (#1366)