### PR TITLE
Provide updated descriptions for `user.*` field reuses

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -49,6 +49,7 @@ Thanks, you're awesome :-) -->
 * Host metrics fields from RFC 0005 are now GA. #1319
 * Adjustments to the field set "usage" docs #1345
 * Adjustments to the sidebar naming convention for usage and examples docs #1354
+* Update `user.*` field reuse descriptions. #1382
 
 ### Tooling and Artifact Changes
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -8260,14 +8260,14 @@ Note also that the `user` fields may be used directly at the root of the events.
 
 | <<ecs-user,user>>
 | `user.changes.*`
-| Fields to describe the user relevant to the event.
+| Captures changes made to a user.
 
 // ===============================================================
 
 
 | <<ecs-user,user>>
 | `user.effective.*`
-| Fields to describe the user relevant to the event.
+| User whose privileges were assumed.
 
 // ===============================================================
 
@@ -8281,7 +8281,7 @@ Note also that the `user` fields may be used directly at the root of the events.
 
 | <<ecs-user,user>>
 | `user.target.*`
-| Fields to describe the user relevant to the event.
+| Targeted user of action taken.
 
 // ===============================================================
 

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -15474,12 +15474,15 @@ user:
     - as: target
       at: user
       full: user.target
+      short_override: Targeted user of action taken.
     - as: effective
       at: user
       full: user.effective
+      short_override: User whose privileges were assumed.
     - as: changes
       at: user
       full: user.changes
+      short_override: Captures changes made to a user.
     top_level: true
   reused_here:
   - full: user.group
@@ -15487,13 +15490,13 @@ user:
     short: User's group relevant to the event.
   - full: user.target
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: Targeted user of action taken.
   - full: user.effective
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: User whose privileges were assumed.
   - full: user.changes
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: Captures changes made to a user.
   short: Fields to describe the user relevant to the event.
   title: User
   type: group

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10950,12 +10950,15 @@ user:
     - as: target
       at: user
       full: user.target
+      short_override: Targeted user of action taken.
     - as: effective
       at: user
       full: user.effective
+      short_override: User whose privileges were assumed.
     - as: changes
       at: user
       full: user.changes
+      short_override: Captures changes made to a user.
     top_level: true
   reused_here:
   - full: user.group
@@ -10963,13 +10966,13 @@ user:
     short: User's group relevant to the event.
   - full: user.target
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: Targeted user of action taken.
   - full: user.effective
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: User whose privileges were assumed.
   - full: user.changes
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: Captures changes made to a user.
   short: Fields to describe the user relevant to the event.
   title: User
   type: group

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -20,10 +20,13 @@
       - source
       - at: user
         as: target
+        short_override: Targeted user of action taken.
       - at: user
         as: effective
+        short_override: User whose privileges were assumed.
       - at: user
         as: changes
+        short_override: Captures changes made to a user.
 
   type: group
   fields:


### PR DESCRIPTION
Using the `short_override` field, update the field reuse descriptions for these three `users.*` reuses:

* `user.changes.*`
* `user.effective.*`
* `user.target.*`

These updated descriptions will better describe the use of each.