### PR TITLE
[1.x] Add `user` to process schema (#1387)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -9,6 +9,7 @@ Thanks, you're awesome :-) -->
 ## Unreleased
 
 ### Schema Changes
+* Added `process.user`. #1380
 
 #### Breaking changes
 

--- a/code/go/ecs/process.go
+++ b/code/go/ecs/process.go
@@ -45,6 +45,9 @@ type Process struct {
 	// Sometimes called program name or similar.
 	Name string `ecs:"name"`
 
+	// User associated with the running process.
+	User string `ecs:"user"`
+
 	// Parent process' pid.
 	PPID int64 `ecs:"ppid"`
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -5825,6 +5825,22 @@ example: `1325`
 // ===============================================================
 
 |
+[[field-process-user]]
+<<field-process-user, process.user>>
+
+| User associated with the running process.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-process-working-directory]]
 <<field-process-working-directory, process.working_directory>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5657,6 +5657,12 @@
       description: Seconds the process has been up.
       example: 1325
       default_field: false
+    - name: parent.user
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User associated with the running process.
+      default_field: false
     - name: parent.working_directory
       level: extended
       type: wildcard
@@ -5979,6 +5985,12 @@
       type: long
       description: Seconds the process has been up.
       example: 1325
+    - name: user
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User associated with the running process.
+      default_field: false
     - name: working_directory
       level: extended
       type: wildcard

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -694,6 +694,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev+exp,true,process,process.title,wildcard,extended,,,Process title.
 1.11.0-dev+exp,true,process,process.title.text,text,extended,,,Process title.
 1.11.0-dev+exp,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev+exp,true,process,process.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev+exp,true,process,process.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
 1.11.0-dev+exp,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 1.11.0-dev+exp,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -645,6 +645,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev+exp,true,process,process.parent.title,wildcard,extended,,,Process title.
 1.11.0-dev+exp,true,process,process.parent.title.text,text,extended,,,Process title.
 1.11.0-dev+exp,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev+exp,true,process,process.parent.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev+exp,true,process,process.parent.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
 1.11.0-dev+exp,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 1.11.0-dev+exp,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8137,6 +8137,17 @@ process.parent.uptime:
   original_fieldset: process
   short: Seconds the process has been up.
   type: long
+process.parent.user:
+  dashed_name: process-parent-user
+  description: User associated with the running process.
+  flat_name: process.parent.user
+  ignore_above: 1024
+  level: extended
+  name: user
+  normalize: []
+  original_fieldset: process
+  short: User associated with the running process.
+  type: keyword
 process.parent.working_directory:
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
@@ -8701,6 +8712,16 @@ process.uptime:
   normalize: []
   short: Seconds the process has been up.
   type: long
+process.user:
+  dashed_name: process-user
+  description: User associated with the running process.
+  flat_name: process.user
+  ignore_above: 1024
+  level: extended
+  name: user
+  normalize: []
+  short: User associated with the running process.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9995,6 +9995,17 @@ process:
       original_fieldset: process
       short: Seconds the process has been up.
       type: long
+    process.parent.user:
+      dashed_name: process-parent-user
+      description: User associated with the running process.
+      flat_name: process.parent.user
+      ignore_above: 1024
+      level: extended
+      name: user
+      normalize: []
+      original_fieldset: process
+      short: User associated with the running process.
+      type: keyword
     process.parent.working_directory:
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
@@ -10560,6 +10571,16 @@ process:
       normalize: []
       short: Seconds the process has been up.
       type: long
+    process.user:
+      dashed_name: process-user
+      description: User associated with the running process.
+      flat_name: process.user
+      ignore_above: 1024
+      level: extended
+      name: user
+      normalize: []
+      short: User associated with the running process.
+      type: keyword
     process.working_directory:
       dashed_name: process-working-directory
       description: The working directory of the process.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -2907,6 +2907,10 @@
               "uptime": {
                 "type": "long"
               },
+              "user": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "working_directory": {
                 "fields": {
                   "text": {
@@ -3118,6 +3122,10 @@
           },
           "uptime": {
             "type": "long"
+          },
+          "user": {
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "working_directory": {
             "fields": {

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -633,6 +633,10 @@
                 "uptime": {
                   "type": "long"
                 },
+                "user": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "working_directory": {
                   "fields": {
                     "text": {
@@ -844,6 +848,10 @@
             },
             "uptime": {
               "type": "long"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "working_directory": {
               "fields": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4172,6 +4172,12 @@
       description: Seconds the process has been up.
       example: 1325
       default_field: false
+    - name: parent.user
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User associated with the running process.
+      default_field: false
     - name: parent.working_directory
       level: extended
       type: keyword
@@ -4288,6 +4294,12 @@
       type: long
       description: Seconds the process has been up.
       example: 1325
+    - name: user
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User associated with the running process.
+      default_field: false
     - name: working_directory
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -281,6 +281,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.11.0-dev,true,host,host.type,keyword,core,,,Type of host.
 1.11.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
+1.11.0-dev,true,process,process.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev,true,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.11.0-dev,true,host,host.user.email,keyword,extended,,,User email address.
 1.11.0-dev,true,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -281,7 +281,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 1.11.0-dev,true,host,host.type,keyword,core,,,Type of host.
 1.11.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
-1.11.0-dev,true,process,process.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev,true,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.11.0-dev,true,host,host.user.email,keyword,extended,,,User email address.
 1.11.0-dev,true,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
@@ -466,6 +465,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,process,process.parent.title,keyword,extended,,,Process title.
 1.11.0-dev,true,process,process.parent.title.text,text,extended,,,Process title.
 1.11.0-dev,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev,true,process,process.parent.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 1.11.0-dev,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 1.11.0-dev,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
@@ -484,6 +484,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,process,process.title,keyword,extended,,,Process title.
 1.11.0-dev,true,process,process.title.text,text,extended,,,Process title.
 1.11.0-dev,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev,true,process,process.user,keyword,extended,,,User associated with the running process.
 1.11.0-dev,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 1.11.0-dev,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 1.11.0-dev,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6117,6 +6117,17 @@ process.parent.uptime:
   original_fieldset: process
   short: Seconds the process has been up.
   type: long
+process.parent.user:
+  dashed_name: process-parent-user
+  description: User associated with the running process.
+  flat_name: process.parent.user
+  ignore_above: 1024
+  level: extended
+  name: user
+  normalize: []
+  original_fieldset: process
+  short: User associated with the running process.
+  type: keyword
 process.parent.working_directory:
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
@@ -6314,6 +6325,16 @@ process.uptime:
   normalize: []
   short: Seconds the process has been up.
   type: long
+process.user:
+  dashed_name: process-user
+  description: User associated with the running process.
+  flat_name: process.user
+  ignore_above: 1024
+  level: extended
+  name: user
+  normalize: []
+  short: User associated with the running process.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7305,6 +7305,17 @@ process:
       original_fieldset: process
       short: Seconds the process has been up.
       type: long
+    process.parent.user:
+      dashed_name: process-parent-user
+      description: User associated with the running process.
+      flat_name: process.parent.user
+      ignore_above: 1024
+      level: extended
+      name: user
+      normalize: []
+      original_fieldset: process
+      short: User associated with the running process.
+      type: keyword
     process.parent.working_directory:
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
@@ -7502,6 +7513,16 @@ process:
       normalize: []
       short: Seconds the process has been up.
       type: long
+    process.user:
+      dashed_name: process-user
+      description: User associated with the running process.
+      flat_name: process.user
+      ignore_above: 1024
+      level: extended
+      name: user
+      normalize: []
+      short: User associated with the running process.
+      type: keyword
     process.working_directory:
       dashed_name: process-working-directory
       description: The working directory of the process.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2205,6 +2205,10 @@
                 "uptime": {
                   "type": "long"
                 },
+                "user": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "working_directory": {
                   "fields": {
                     "text": {
@@ -2284,6 +2288,10 @@
             },
             "uptime": {
               "type": "long"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "working_directory": {
               "fields": {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2201,6 +2201,10 @@
               "uptime": {
                 "type": "long"
               },
+              "user": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "working_directory": {
                 "fields": {
                   "text": {
@@ -2280,6 +2284,10 @@
           },
           "uptime": {
             "type": "long"
+          },
+          "user": {
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "working_directory": {
             "fields": {

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -272,6 +272,10 @@
                 "uptime": {
                   "type": "long"
                 },
+                "user": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "working_directory": {
                   "fields": {
                     "text": {
@@ -351,6 +355,10 @@
             },
             "uptime": {
               "type": "long"
+            },
+            "user": {
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "working_directory": {
               "fields": {

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -56,6 +56,12 @@
       - type: text
         name: text
 
+    - name: user
+      level: extended
+      type: keyword
+      description: >
+        User associated with the running process.
+
     - name: ppid
       format: string
       level: extended


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add `user` to process schema (#1387)