### PR TITLE
[1.x] Fix ecs GitHub repo link source branch (#1393)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ build
 # experimental exclusions
 experimental/generated/elasticsearch/6
 experimental/generated/docs
+
+# patches are vital to cross-barch testing but don't want in GitHub
+*.patch

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Fix ecs GitHub repo link source branch #1393
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -21,8 +21,8 @@ from schema import subset_filter
 def main():
     args = argument_parser()
 
-    ecs_version = read_version(args.ref)
-    print('Running generator. ECS version ' + ecs_version)
+    ecs_generated_version = read_version(args.ref)
+    print('Running generator. ECS version ' + ecs_generated_version)
 
     # default location to save files
     out_dir = 'generated'
@@ -43,7 +43,8 @@ def main():
 
     # Detect usage of experimental changes to tweak artifact version label
     if args.include and loader.EXPERIMENTAL_SCHEMA_DIR in args.include:
-        ecs_version += "+exp"
+        ecs_generated_version += "+exp"
+        print('Experimental ECS version ' + ecs_generated_version)
 
     fields = loader.load_schemas(ref=args.ref, included_files=args.include)
     if args.oss:
@@ -56,14 +57,15 @@ def main():
     if args.intermediate_only:
         exit()
 
-    csv_generator.generate(flat, ecs_version, out_dir)
-    es_template.generate(nested, ecs_version, out_dir, args.mapping_settings)
-    es_template.generate_legacy(flat, ecs_version, out_dir, args.template_settings, args.mapping_settings)
-    beats.generate(nested, ecs_version, out_dir)
+    csv_generator.generate(flat, ecs_generated_version, out_dir)
+    es_template.generate(nested, ecs_generated_version, out_dir, args.mapping_settings)
+    es_template.generate_legacy(flat, ecs_generated_version, out_dir, args.template_settings, args.mapping_settings)
+    beats.generate(nested, ecs_generated_version, out_dir)
     if args.include or args.subset:
         exit()
 
-    asciidoc_fields.generate(nested, ecs_version, docs_dir)
+    ecs_helpers.make_dirs(docs_dir)
+    asciidoc_fields.generate(nested, ecs_generated_version, docs_dir)
 
 
 def argument_parser():

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -6,8 +6,9 @@ import jinja2
 from generators import ecs_helpers
 
 
-def generate(nested, ecs_version, out_dir):
-    save_asciidoc(path.join(out_dir, 'fields.asciidoc'), page_field_index(nested, ecs_version))
+def generate(nested, ecs_generated_version, out_dir):
+    save_asciidoc(path.join(out_dir, 'index.asciidoc'), page_index(ecs_generated_version))
+    save_asciidoc(path.join(out_dir, 'fields.asciidoc'), page_field_index(nested, ecs_generated_version))
     save_asciidoc(path.join(out_dir, 'field-details.asciidoc'), page_field_details(nested))
     save_asciidoc(path.join(out_dir, 'field-values.asciidoc'), page_field_values(nested))
 
@@ -125,13 +126,21 @@ template_env = jinja2.Environment(loader=template_loader)
 
 # Rendering schemas
 
+# Index
+
+
+@templated('index.j2')
+def page_index(ecs_generated_version):
+    return dict(ecs_generated_version=ecs_generated_version)
+
+
 # Field Index
 
 
 @templated('fields.j2')
-def page_field_index(nested, ecs_version):
+def page_field_index(nested, ecs_generated_version):
     fieldsets = ecs_helpers.dict_sorted_by_keys(nested, ['group', 'name'])
-    return dict(ecs_version=ecs_version, fieldsets=fieldsets)
+    return dict(ecs_generated_version=ecs_generated_version, fieldsets=fieldsets)
 
 
 # Field Details Page

--- a/scripts/templates/fields.j2
+++ b/scripts/templates/fields.j2
@@ -2,7 +2,7 @@
 [[ecs-field-reference]]
 == {ecs} Field Reference
 
-This is the documentation of ECS version {{ ecs_version }}.
+This is the documentation of ECS version {{ ecs_generated_version }}.
 
 ECS defines multiple groups of related fields. They are called "field sets".
 The <<ecs-base,Base>> field set is the only one whose fields are defined

--- a/scripts/templates/index.j2
+++ b/scripts/templates/index.j2
@@ -10,7 +10,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 [[ecs-reference]]
 == Overview
 
-This is the documentation of ECS version 1.11.0-dev.
+This is the documentation of ECS version {{ ecs_generated_version }}.
 
 [float]
 === What is ECS?


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Fix ecs GitHub repo link source branch (#1393)