### PR TITLE
Client port is wrongly documented

### DIFF
--- a/docs/using-mapping-network-events.asciidoc
+++ b/docs/using-mapping-network-events.asciidoc
@@ -79,7 +79,7 @@ Looking back at the original event, it shows the source device is the DNS client
 ----
   "client": {
     "ip": "192.168.86.222",
-    "port": 64734
+    "port": 54162
   }
 ----
 


### PR DESCRIPTION
The client port is wrongly documented as 64734 instead of 54162.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/master/CONTRIBUTING.md)?
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/master/rfcs/README.md)?
- If submitting code/script changes, have you verified all tests pass locally using `make test`?
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
- Is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/master/CHANGELOG.next.md)?
