### PR TITLE
[1.x] Client port is wrongly documented (#1402)

### DIFF
--- a/docs/using-mapping-network-events.asciidoc
+++ b/docs/using-mapping-network-events.asciidoc
@@ -79,7 +79,7 @@ Looking back at the original event, it shows the source device is the DNS client
 ----
   "client": {
     "ip": "192.168.86.222",
-    "port": 64734
+    "port": 54162
   }
 ----
 


### PR DESCRIPTION
Forward ports the following commits to `1.x`:

* Client port is wrongly documented (#1402)
