### PR TITLE
[1.x] Consolidate `Breaking changes` sections in `CHANGELOG.next` (#1408)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -8,9 +8,9 @@ Thanks, you're awesome :-) -->
 
 ## Unreleased
 
-### Schema Changes
+### Breaking Changes
 
-#### Breaking changes
+### Schema Changes
 
 #### Bugfixes
 
@@ -23,8 +23,6 @@ Thanks, you're awesome :-) -->
 #### Deprecated
 
 ### Tooling and Artifact Changes
-
-#### Breaking changes
 
 #### Bugfixes
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - consolidate breaking changes section: https://github.com/elastic/ecs/pull/1408/commits/0b82cb9fc8966acb45d4155545c4094c9bccdf00
