### PR TITLE
Support `match_only_text` in Go code generator

### DIFF
--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -321,7 +321,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point":
+	case "keyword", "wildcard", "version", "constant_keyword", "text", "match_only_text", "ip", "geo_point":
 		return "string"
 	case "long":
 		return "int64"


### PR DESCRIPTION
Running `make gocodegen` (and in turn, `make`) will fail if a type isn't explicitly handled in `scripts/cmd/gocodegen/gocodegen.go`.

Adding support in the tooling for `match_only_text` as we look to introduce the type into ECS ([RFC 0023](https://github.com/elastic/ecs/blob/master/rfcs/text/0023-match_only_text-data-type.md)).