### PR TITLE
[1.x] Support `match_only_text` in Go code generator (#1418)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -28,6 +28,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Support `match_only_text` data type in Go code generator. #1418
+
 #### Improvements
 
 #### Deprecated

--- a/scripts/cmd/gocodegen/gocodegen.go
+++ b/scripts/cmd/gocodegen/gocodegen.go
@@ -321,7 +321,7 @@ func goDataType(fieldName, elasticsearchDataType string) string {
 	}
 
 	switch elasticsearchDataType {
-	case "keyword", "wildcard", "version", "constant_keyword", "text", "ip", "geo_point":
+	case "keyword", "wildcard", "version", "constant_keyword", "text", "match_only_text", "ip", "geo_point":
 		return "string"
 	case "long":
 		return "int64"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Support `match_only_text` in Go code generator (#1418)