### PR TITLE
[1.x] Add `host.user.*` deprecation notice in field reuse description (#1422)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -25,6 +25,8 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
+* Note deprecation of the `host.user.*` field reuse. #1422
+
 ### Tooling and Artifact Changes
 
 #### Bugfixes

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4143,7 +4143,7 @@ example: `1325`
 
 | <<ecs-user,user>>
 | `host.user.*`
-| Fields to describe the user relevant to the event.
+| This reuse is deprecated and will be removed in the next major ECS version.
 
 // ===============================================================
 

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6159,7 +6159,7 @@ host:
     short: OS fields contain information about the operating system.
   - full: host.user
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: This reuse is deprecated and will be removed in the next major ECS version.
   short: Fields describing the relevant computing instance.
   title: Host
   type: group
@@ -15832,9 +15832,6 @@ user:
       at: destination
       full: destination.user
     - as: user
-      at: host
-      full: host.user
-    - as: user
       at: server
       full: server.user
     - as: user
@@ -15852,6 +15849,11 @@ user:
       at: user
       full: user.changes
       short_override: Captures changes made to a user.
+    - as: user
+      at: host
+      full: host.user
+      short_override: This reuse is deprecated and will be removed in the next major
+        ECS version.
     top_level: true
   reused_here:
   - full: user.group

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5437,7 +5437,7 @@ host:
     short: OS fields contain information about the operating system.
   - full: host.user
     schema_name: user
-    short: Fields to describe the user relevant to the event.
+    short: This reuse is deprecated and will be removed in the next major ECS version.
   short: Fields describing the relevant computing instance.
   title: Host
   type: group
@@ -12256,9 +12256,6 @@ user:
       at: destination
       full: destination.user
     - as: user
-      at: host
-      full: host.user
-    - as: user
       at: server
       full: server.user
     - as: user
@@ -12276,6 +12273,11 @@ user:
       at: user
       full: user.changes
       short_override: Captures changes made to a user.
+    - as: user
+      at: host
+      full: host.user
+      short_override: This reuse is deprecated and will be removed in the next major
+        ECS version.
     top_level: true
   reused_here:
   - full: user.group

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -15,7 +15,6 @@
     expected:
       - client
       - destination
-      - host
       - server
       - source
       - at: user
@@ -27,6 +26,9 @@
       - at: user
         as: changes
         short_override: Captures changes made to a user.
+      - at: host
+        as: user
+        short_override: This reuse is deprecated and will be removed in the next major ECS version.
 
       # TODO Temporarily commented out to simplify initial rewrite review
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add `host.user.*` deprecation notice in field reuse description (#1422)