### PR TITLE
[1.x] Explicitly include user identifiers in `related.user` field description (#1420)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -23,6 +23,7 @@ Thanks, you're awesome :-) -->
 
 * Fix ecs GitHub repo link source branch #1393
 * Add --exclude flag to Generator to support field removal testing #1411
+* Explicitly include user identifiers in `relater.user` description. #1420
 
 #### Deprecated
 

--- a/code/go/ecs/related.go
+++ b/code/go/ecs/related.go
@@ -31,7 +31,7 @@ type Related struct {
 	// All of the IPs seen on your event.
 	IP string `ecs:"ip"`
 
-	// All the user names seen on your event.
+	// All the user names or other user identifiers seen on the event.
 	User string `ecs:"user"`
 
 	// All the hashes seen on your event. Populating this field, then using it

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6638,7 +6638,7 @@ Note: this field should contain an array of values.
 [[field-related-user]]
 <<field-related-user, related.user>>
 
-| All the user names seen on your event.
+| All the user names or other user identifiers seen on the event.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -6111,7 +6111,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: All the user names seen on your event.
+      description: All the user names or other user identifiers seen on the event.
       default_field: false
   - name: rule
     title: Rule

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -706,7 +706,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev+exp,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
 1.11.0-dev+exp,true,related,related.hosts,keyword,extended,array,,All the host identifiers seen on your event.
 1.11.0-dev+exp,true,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
-1.11.0-dev+exp,true,related,related.user,keyword,extended,array,,All the user names seen on your event.
+1.11.0-dev+exp,true,related,related.user,keyword,extended,array,,All the user names or other user identifiers seen on the event.
 1.11.0-dev+exp,true,rule,rule.author,keyword,extended,array,"[""Star-Lord""]",Rule author
 1.11.0-dev+exp,true,rule,rule.category,keyword,extended,,Attempted Information Leak,Rule category
 1.11.0-dev+exp,true,rule,rule.description,keyword,extended,,Block requests to public DNS over HTTPS / TLS protocols,Rule description

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8866,14 +8866,14 @@ related.ip:
   type: ip
 related.user:
   dashed_name: related-user
-  description: All the user names seen on your event.
+  description: All the user names or other user identifiers seen on the event.
   flat_name: related.user
   ignore_above: 1024
   level: extended
   name: user
   normalize:
   - array
-  short: All the user names seen on your event.
+  short: All the user names or other user identifiers seen on the event.
   type: keyword
 rule.author:
   dashed_name: rule-author

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10800,14 +10800,14 @@ related:
       type: ip
     related.user:
       dashed_name: related-user
-      description: All the user names seen on your event.
+      description: All the user names or other user identifiers seen on the event.
       flat_name: related.user
       ignore_above: 1024
       level: extended
       name: user
       normalize:
       - array
-      short: All the user names seen on your event.
+      short: All the user names or other user identifiers seen on the event.
       type: keyword
   group: 2
   name: related

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5126,7 +5126,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: All the user names seen on your event.
+      description: All the user names or other user identifiers seen on the event.
       default_field: false
   - name: rule
     title: Rule

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -582,7 +582,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
 1.11.0-dev,true,related,related.hosts,keyword,extended,array,,All the host identifiers seen on your event.
 1.11.0-dev,true,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
-1.11.0-dev,true,related,related.user,keyword,extended,array,,All the user names seen on your event.
+1.11.0-dev,true,related,related.user,keyword,extended,array,,All the user names or other user identifiers seen on the event.
 1.11.0-dev,true,rule,rule.author,keyword,extended,array,"[""Star-Lord""]",Rule author
 1.11.0-dev,true,rule,rule.category,keyword,extended,,Attempted Information Leak,Rule category
 1.11.0-dev,true,rule,rule.description,keyword,extended,,Block requests to public DNS over HTTPS / TLS protocols,Rule description

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7443,14 +7443,14 @@ related.ip:
   type: ip
 related.user:
   dashed_name: related-user
-  description: All the user names seen on your event.
+  description: All the user names or other user identifiers seen on the event.
   flat_name: related.user
   ignore_above: 1024
   level: extended
   name: user
   normalize:
   - array
-  short: All the user names seen on your event.
+  short: All the user names or other user identifiers seen on the event.
   type: keyword
 rule.author:
   dashed_name: rule-author

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9013,14 +9013,14 @@ related:
       type: ip
     related.user:
       dashed_name: related-user
-      description: All the user names seen on your event.
+      description: All the user names or other user identifiers seen on the event.
       flat_name: related.user
       ignore_above: 1024
       level: extended
       name: user
       normalize:
       - array
-      short: All the user names seen on your event.
+      short: All the user names or other user identifiers seen on the event.
       type: keyword
   group: 2
   name: related

--- a/schemas/related.yml
+++ b/schemas/related.yml
@@ -29,7 +29,8 @@
       level: extended
       type: keyword
       description: >
-        All the user names seen on your event.
+        All the user names or other user identifiers seen on the event.
+
       normalize:
         - array
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Explicitly include user identifiers in `related.user` field description (#1420)