### PR TITLE
Remove guidance to lowercase `http.request.method`.

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -13,6 +13,7 @@ Thanks, you're awesome :-) -->
 * Removing deprecated --oss from generator #1404
 * Removing use-cases directory #1405
 * Remove `host.user.*` field reuse. #1439
+* Remove deprecation notice on `http.request.method`. #1443
 
 ### Schema Changes
 

--- a/code/go/ecs/http.go
+++ b/code/go/ecs/http.go
@@ -29,11 +29,8 @@ type Http struct {
 	RequestID string `ecs:"request.id"`
 
 	// HTTP request method.
-	// Prior to ECS 1.6.0 the following guidance was provided:
-	// "The field value must be normalized to lowercase for querying."
-	// As of ECS 1.6.0, the guidance is deprecated because the original case of
-	// the method may be useful in anomaly detection.  Original case will be
-	// mandated in ECS 2.0.0
+	// The value should retain its casing from the original event. For example,
+	// `GET`, `get`, and `GeT` are all considered valid values for this field.
 	RequestMethod string `ecs:"request.method"`
 
 	// Mime type of the body of the request.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4235,17 +4235,13 @@ example: `123e4567-e89b-12d3-a456-426614174000`
 
 | HTTP request method.
 
-Prior to ECS 1.6.0 the following guidance was provided:
-
-"The field value must be normalized to lowercase for querying."
-
-As of ECS 1.6.0, the guidance is deprecated because the original case of the method may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0
+The value should retain its casing from the original event. For example, `GET`, `get`, and `GeT` are all considered valid values for this field.
 
 type: keyword
 
 
 
-example: `GET, POST, PUT, PoST`
+example: `POST`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3355,14 +3355,9 @@
       ignore_above: 1024
       description: 'HTTP request method.
 
-        Prior to ECS 1.6.0 the following guidance was provided:
-
-        "The field value must be normalized to lowercase for querying."
-
-        As of ECS 1.6.0, the guidance is deprecated because the original case of the
-        method may be useful in anomaly detection.  Original case will be mandated
-        in ECS 2.0.0'
-      example: GET, POST, PUT, PoST
+        The value should retain its casing from the original event. For example, `GET`,
+        `get`, and `GeT` are all considered valid values for this field.'
+      example: POST
     - name: request.mime_type
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -377,7 +377,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
 2.0.0-dev+exp,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 2.0.0-dev+exp,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
-2.0.0-dev+exp,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
+2.0.0-dev+exp,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 2.0.0-dev+exp,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 2.0.0-dev+exp,true,http,http.request.referrer,wildcard,extended,,https://blog.example.com/,Referrer for this HTTP request.
 2.0.0-dev+exp,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -4956,13 +4956,9 @@ http.request.method:
   dashed_name: http-request-method
   description: 'HTTP request method.
 
-    Prior to ECS 1.6.0 the following guidance was provided:
-
-    "The field value must be normalized to lowercase for querying."
-
-    As of ECS 1.6.0, the guidance is deprecated because the original case of the method
-    may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0'
-  example: GET, POST, PUT, PoST
+    The value should retain its casing from the original event. For example, `GET`,
+    `get`, and `GeT` are all considered valid values for this field.'
+  example: POST
   flat_name: http.request.method
   ignore_above: 1024
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6090,14 +6090,9 @@ http:
       dashed_name: http-request-method
       description: 'HTTP request method.
 
-        Prior to ECS 1.6.0 the following guidance was provided:
-
-        "The field value must be normalized to lowercase for querying."
-
-        As of ECS 1.6.0, the guidance is deprecated because the original case of the
-        method may be useful in anomaly detection.  Original case will be mandated
-        in ECS 2.0.0'
-      example: GET, POST, PUT, PoST
+        The value should retain its casing from the original event. For example, `GET`,
+        `get`, and `GeT` are all considered valid values for this field.'
+      example: POST
       flat_name: http.request.method
       ignore_above: 1024
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2969,14 +2969,9 @@
       ignore_above: 1024
       description: 'HTTP request method.
 
-        Prior to ECS 1.6.0 the following guidance was provided:
-
-        "The field value must be normalized to lowercase for querying."
-
-        As of ECS 1.6.0, the guidance is deprecated because the original case of the
-        method may be useful in anomaly detection.  Original case will be mandated
-        in ECS 2.0.0'
-      example: GET, POST, PUT, PoST
+        The value should retain its casing from the original event. For example, `GET`,
+        `get`, and `GeT` are all considered valid values for this field.'
+      example: POST
     - name: request.mime_type
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -315,7 +315,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
 2.0.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 2.0.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
-2.0.0-dev,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
+2.0.0-dev,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
 2.0.0-dev,true,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
 2.0.0-dev,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 2.0.0-dev,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4247,13 +4247,9 @@ http.request.method:
   dashed_name: http-request-method
   description: 'HTTP request method.
 
-    Prior to ECS 1.6.0 the following guidance was provided:
-
-    "The field value must be normalized to lowercase for querying."
-
-    As of ECS 1.6.0, the guidance is deprecated because the original case of the method
-    may be useful in anomaly detection.  Original case will be mandated in ECS 2.0.0'
-  example: GET, POST, PUT, PoST
+    The value should retain its casing from the original event. For example, `GET`,
+    `get`, and `GeT` are all considered valid values for this field.'
+  example: POST
   flat_name: http.request.method
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5366,14 +5366,9 @@ http:
       dashed_name: http-request-method
       description: 'HTTP request method.
 
-        Prior to ECS 1.6.0 the following guidance was provided:
-
-        "The field value must be normalized to lowercase for querying."
-
-        As of ECS 1.6.0, the guidance is deprecated because the original case of the
-        method may be useful in anomaly detection.  Original case will be mandated
-        in ECS 2.0.0'
-      example: GET, POST, PUT, PoST
+        The value should retain its casing from the original event. For example, `GET`,
+        `get`, and `GeT` are all considered valid values for this field.'
+      example: POST
       flat_name: http.request.method
       ignore_above: 1024
       level: extended

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -28,16 +28,11 @@
       description: >
         HTTP request method.
 
-        Prior to ECS 1.6.0 the following guidance was provided:
+        The value should retain its casing from the original event.
+        For example, `GET`, `get`, and `GeT` are all considered valid values
+        for this field.
 
-        "The field value must be normalized to lowercase for
-        querying."
-
-        As of ECS 1.6.0, the guidance is deprecated because the
-        original case of the method may be useful in anomaly
-        detection.  Original case will be mandated in ECS 2.0.0
-
-      example: GET, POST, PUT, PoST
+      example: POST
 
     - name: request.mime_type
       level: extended


### PR DESCRIPTION
In addition to removing the deprecation note, I included [new guidance](https://github.com/elastic/ecs/pull/1443/files#diff-535c241aff61a02effef7c3af2446d787e3c4641139ca0f9e53b507ed7225086R4238) about retaining the casing from the original event.

I also limited the `Example` attribute to a single value since this field is not expected to be an array. 

Closes #1363 