### PR TITLE
Improve cloud region and AZ field descriptions

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,7 @@ Thanks, you're awesome :-) -->
 * Fix ecs GitHub repo link source branch #1393
 * Add --exclude flag to Generator to support field removal testing #1411
 * Explicitly include user identifiers in `relater.user` description. #1420
+* Improve descriptions for `cloud.region` and `cloud.availability` fields. #1452
 
 #### Deprecated
 

--- a/code/go/ecs/cloud.go
+++ b/code/go/ecs/cloud.go
@@ -25,10 +25,10 @@ type Cloud struct {
 	// digitalocean.
 	Provider string `ecs:"provider"`
 
-	// Availability zone in which this host is running.
+	// Availability zone in which this host, resource, or service is located.
 	AvailabilityZone string `ecs:"availability_zone"`
 
-	// Region in which this host is running.
+	// Region in which this host, resource, or service is located.
 	Region string `ecs:"region"`
 
 	// Instance ID of the host machine.

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -607,7 +607,7 @@ example: `elastic-dev`
 [[field-cloud-availability-zone]]
 <<field-cloud-availability-zone, cloud.availability_zone>>
 
-| Availability zone in which this host is running.
+| Availability zone in which this host, resource, or service is located.
 
 type: keyword
 
@@ -723,7 +723,7 @@ example: `aws`
 [[field-cloud-region]]
 <<field-cloud-region, cloud.region>>
 
-| Region in which this host is running.
+| Region in which this host, resource, or service is located.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -456,7 +456,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Availability zone in which this host is running.
+      description: Availability zone in which this host, resource, or service is located.
       example: us-east-1c
     - name: instance.id
       level: extended
@@ -504,7 +504,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Region in which this host is running.
+      description: Region in which this host, resource, or service is located.
       example: us-east-1
     - name: service.name
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -49,14 +49,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev+exp,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 2.0.0-dev+exp,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
-2.0.0-dev+exp,true,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,Availability zone in which this host is running.
+2.0.0-dev+exp,true,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
 2.0.0-dev+exp,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
 2.0.0-dev+exp,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev+exp,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev+exp,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
-2.0.0-dev+exp,true,cloud,cloud.region,keyword,extended,,us-east-1,Region in which this host is running.
+2.0.0-dev+exp,true,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
 2.0.0-dev+exp,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
 2.0.0-dev+exp,true,container,container.id,keyword,core,,,Unique container id.
 2.0.0-dev+exp,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -581,14 +581,14 @@ cloud.account.name:
   type: keyword
 cloud.availability_zone:
   dashed_name: cloud-availability-zone
-  description: Availability zone in which this host is running.
+  description: Availability zone in which this host, resource, or service is located.
   example: us-east-1c
   flat_name: cloud.availability_zone
   ignore_above: 1024
   level: extended
   name: availability_zone
   normalize: []
-  short: Availability zone in which this host is running.
+  short: Availability zone in which this host, resource, or service is located.
   type: keyword
 cloud.instance.id:
   dashed_name: cloud-instance-id
@@ -662,14 +662,14 @@ cloud.provider:
   type: keyword
 cloud.region:
   dashed_name: cloud-region
-  description: Region in which this host is running.
+  description: Region in which this host, resource, or service is located.
   example: us-east-1
   flat_name: cloud.region
   ignore_above: 1024
   level: extended
   name: region
   normalize: []
-  short: Region in which this host is running.
+  short: Region in which this host, resource, or service is located.
   type: keyword
 cloud.service.name:
   dashed_name: cloud-service-name

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -754,14 +754,14 @@ cloud:
       type: keyword
     cloud.availability_zone:
       dashed_name: cloud-availability-zone
-      description: Availability zone in which this host is running.
+      description: Availability zone in which this host, resource, or service is located.
       example: us-east-1c
       flat_name: cloud.availability_zone
       ignore_above: 1024
       level: extended
       name: availability_zone
       normalize: []
-      short: Availability zone in which this host is running.
+      short: Availability zone in which this host, resource, or service is located.
       type: keyword
     cloud.instance.id:
       dashed_name: cloud-instance-id
@@ -835,14 +835,14 @@ cloud:
       type: keyword
     cloud.region:
       dashed_name: cloud-region
-      description: Region in which this host is running.
+      description: Region in which this host, resource, or service is located.
       example: us-east-1
       flat_name: cloud.region
       ignore_above: 1024
       level: extended
       name: region
       normalize: []
-      short: Region in which this host is running.
+      short: Region in which this host, resource, or service is located.
       type: keyword
     cloud.service.name:
       dashed_name: cloud-service-name

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -465,7 +465,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Availability zone in which this host is running.
+      description: Availability zone in which this host, resource, or service is located.
       example: us-east-1c
     - name: instance.id
       level: extended
@@ -513,7 +513,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: Region in which this host is running.
+      description: Region in which this host, resource, or service is located.
       example: us-east-1
     - name: service.name
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -49,14 +49,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 2.0.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 2.0.0-dev,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
-2.0.0-dev,true,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,Availability zone in which this host is running.
+2.0.0-dev,true,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
 2.0.0-dev,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 2.0.0-dev,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 2.0.0-dev,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
 2.0.0-dev,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 2.0.0-dev,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 2.0.0-dev,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
-2.0.0-dev,true,cloud,cloud.region,keyword,extended,,us-east-1,Region in which this host is running.
+2.0.0-dev,true,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
 2.0.0-dev,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
 2.0.0-dev,true,container,container.id,keyword,core,,,Unique container id.
 2.0.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -589,14 +589,14 @@ cloud.account.name:
   type: keyword
 cloud.availability_zone:
   dashed_name: cloud-availability-zone
-  description: Availability zone in which this host is running.
+  description: Availability zone in which this host, resource, or service is located.
   example: us-east-1c
   flat_name: cloud.availability_zone
   ignore_above: 1024
   level: extended
   name: availability_zone
   normalize: []
-  short: Availability zone in which this host is running.
+  short: Availability zone in which this host, resource, or service is located.
   type: keyword
 cloud.instance.id:
   dashed_name: cloud-instance-id
@@ -670,14 +670,14 @@ cloud.provider:
   type: keyword
 cloud.region:
   dashed_name: cloud-region
-  description: Region in which this host is running.
+  description: Region in which this host, resource, or service is located.
   example: us-east-1
   flat_name: cloud.region
   ignore_above: 1024
   level: extended
   name: region
   normalize: []
-  short: Region in which this host is running.
+  short: Region in which this host, resource, or service is located.
   type: keyword
 cloud.service.name:
   dashed_name: cloud-service-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -760,14 +760,14 @@ cloud:
       type: keyword
     cloud.availability_zone:
       dashed_name: cloud-availability-zone
-      description: Availability zone in which this host is running.
+      description: Availability zone in which this host, resource, or service is located.
       example: us-east-1c
       flat_name: cloud.availability_zone
       ignore_above: 1024
       level: extended
       name: availability_zone
       normalize: []
-      short: Availability zone in which this host is running.
+      short: Availability zone in which this host, resource, or service is located.
       type: keyword
     cloud.instance.id:
       dashed_name: cloud-instance-id
@@ -841,14 +841,14 @@ cloud:
       type: keyword
     cloud.region:
       dashed_name: cloud-region
-      description: Region in which this host is running.
+      description: Region in which this host, resource, or service is located.
       example: us-east-1
       flat_name: cloud.region
       ignore_above: 1024
       level: extended
       name: region
       normalize: []
-      short: Region in which this host is running.
+      short: Region in which this host, resource, or service is located.
       type: keyword
     cloud.service.name:
       dashed_name: cloud-service-name

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -28,14 +28,14 @@
       example: us-east-1c
       type: keyword
       description: >
-        Availability zone in which this host is running.
+        Availability zone in which this host, resource, or service is located.
 
     - name: region
       level: extended
       type: keyword
       example: us-east-1
       description: >
-        Region in which this host is running.
+        Region in which this host, resource, or service is located.
 
     - name: instance.id
       level: extended


### PR DESCRIPTION
Expand the field definitions for `cloud.region` and `cloud.availability_zone` to include services or resources. The current definition implies these fields are limited to hosts/VMs running in an IaaS service like EC2 or GCE.

Closes #1287 