### PR TITLE
Stage 1 changes for RFC 0016 - `process.target` field reuse

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -26,6 +26,7 @@ Thanks, you're awesome :-) -->
 * Extend `threat.*` field set beta. #1438
 * Added `event.agent_id_status` field. #1454
 * `threat.enrichments` added to the experimental schema. #1457
+* `process.target` and `process.target.parent` added to experimental schema. #1467
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5928,6 +5928,1364 @@
       type: date
       description: The time the process started.
       example: '2016-05-23T08:05:34.853Z'
+    - name: target.args
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
+
+        May be filtered to protect sensitive information.'
+      example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+      default_field: false
+    - name: target.args_count
+      level: extended
+      type: long
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how
+        many arguments were provided to start a process. More arguments may be an
+        indication of suspicious activity.'
+      example: 4
+      default_field: false
+    - name: target.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: target.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: target.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity
+        or trust status. Leave unpopulated if the validity or trust of the certificate
+        was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: target.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: target.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: target.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this
+        field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: target.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against
+        the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: target.command_line
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Full command line that started the process, including the absolute
+        path to the executable, and all arguments.
+
+        Some arguments may be filtered to protect sensitive information.'
+      example: /usr/bin/ssh -l user 10.0.0.16
+      default_field: false
+    - name: target.elf.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: x86-64
+      default_field: false
+    - name: target.elf.byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian
+      default_field: false
+    - name: target.elf.cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel
+      default_field: false
+    - name: target.elf.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: target.elf.exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: target.elf.header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: target.elf.header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: target.elf.header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: target.elf.header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: target.elf.header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: target.elf.header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: target.elf.header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: target.elf.header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: target.elf.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: target.elf.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.sections.*`.'
+      default_field: false
+    - name: target.elf.sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: target.elf.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: target.elf.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: target.elf.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: target.elf.sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: target.elf.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: target.elf.sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: target.elf.sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: target.elf.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: target.elf.segments
+      level: extended
+      type: nested
+      description: 'An array containing an object for each segment of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.segments.*`.'
+      default_field: false
+    - name: target.elf.segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: target.elf.segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: target.elf.shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object.
+      default_field: false
+    - name: target.elf.telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash symbol hash for ELF file.
+      default_field: false
+    - name: target.entity_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
+      example: c2c455d9f99375d
+      default_field: false
+    - name: target.executable
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+      default_field: false
+    - name: target.exit_code
+      level: extended
+      type: long
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+      default_field: false
+    - name: target.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: target.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: target.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: target.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: target.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: target.name
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+      default_field: false
+    - name: target.parent.args
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
+
+        May be filtered to protect sensitive information.'
+      example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+      default_field: false
+    - name: target.parent.args_count
+      level: extended
+      type: long
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how
+        many arguments were provided to start a process. More arguments may be an
+        indication of suspicious activity.'
+      example: 4
+      default_field: false
+    - name: target.parent.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: target.parent.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: target.parent.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity
+        or trust status. Leave unpopulated if the validity or trust of the certificate
+        was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: target.parent.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: target.parent.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: target.parent.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this
+        field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: target.parent.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against
+        the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: target.parent.command_line
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Full command line that started the process, including the absolute
+        path to the executable, and all arguments.
+
+        Some arguments may be filtered to protect sensitive information.'
+      example: /usr/bin/ssh -l user 10.0.0.16
+      default_field: false
+    - name: target.parent.elf.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine architecture of the ELF file.
+      example: x86-64
+      default_field: false
+    - name: target.parent.elf.byte_order
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Byte sequence of ELF file.
+      example: Little Endian
+      default_field: false
+    - name: target.parent.elf.cpu_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU type of the ELF file.
+      example: Intel
+      default_field: false
+    - name: target.parent.elf.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      default_field: false
+    - name: target.parent.elf.exports
+      level: extended
+      type: flattened
+      description: List of exported element names and types.
+      default_field: false
+    - name: target.parent.elf.header.abi_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF Application Binary Interface (ABI).
+      default_field: false
+    - name: target.parent.elf.header.class
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header class of the ELF file.
+      default_field: false
+    - name: target.parent.elf.header.data
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Data table of the ELF header.
+      default_field: false
+    - name: target.parent.elf.header.entrypoint
+      level: extended
+      type: long
+      format: string
+      description: Header entrypoint of the ELF file.
+      default_field: false
+    - name: target.parent.elf.header.object_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '"0x1" for original ELF files.'
+      default_field: false
+    - name: target.parent.elf.header.os_abi
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Application Binary Interface (ABI) of the Linux OS.
+      default_field: false
+    - name: target.parent.elf.header.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Header type of the ELF file.
+      default_field: false
+    - name: target.parent.elf.header.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the ELF header.
+      default_field: false
+    - name: target.parent.elf.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: target.parent.elf.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.sections.*`.'
+      default_field: false
+    - name: target.parent.elf.sections.chi2
+      level: extended
+      type: long
+      format: number
+      description: Chi-square probability distribution of the section.
+      default_field: false
+    - name: target.parent.elf.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: target.parent.elf.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List flags.
+      default_field: false
+    - name: target.parent.elf.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List name.
+      default_field: false
+    - name: target.parent.elf.sections.physical_offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List offset.
+      default_field: false
+    - name: target.parent.elf.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: ELF Section List physical size.
+      default_field: false
+    - name: target.parent.elf.sections.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF Section List type.
+      default_field: false
+    - name: target.parent.elf.sections.virtual_address
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual address.
+      default_field: false
+    - name: target.parent.elf.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: ELF Section List virtual size.
+      default_field: false
+    - name: target.parent.elf.segments
+      level: extended
+      type: nested
+      description: 'An array containing an object for each segment of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.segments.*`.'
+      default_field: false
+    - name: target.parent.elf.segments.sections
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment sections.
+      default_field: false
+    - name: target.parent.elf.segments.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: ELF object segment type.
+      default_field: false
+    - name: target.parent.elf.shared_libraries
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of shared libraries used by this ELF object.
+      default_field: false
+    - name: target.parent.elf.telfhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: telfhash symbol hash for ELF file.
+      default_field: false
+    - name: target.parent.entity_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
+      example: c2c455d9f99375d
+      default_field: false
+    - name: target.parent.executable
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+      default_field: false
+    - name: target.parent.exit_code
+      level: extended
+      type: long
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+      default_field: false
+    - name: target.parent.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: target.parent.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: target.parent.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: target.parent.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: target.parent.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: target.parent.name
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+      default_field: false
+    - name: target.parent.pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: target.parent.pe.authentihash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Authentihash of the PE file.
+      example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+      default_field: false
+    - name: target.parent.pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: target.parent.pe.compile_timestamp
+      level: extended
+      type: date
+      description: Compile timestamp of the PE file.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.parent.pe.compiler.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the compiler
+      example: Clang
+      default_field: false
+    - name: target.parent.pe.compiler.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the compiler.
+      example: 11.0.0
+      default_field: false
+    - name: target.parent.pe.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.parent.pe.debug
+      level: extended
+      type: nested
+      description: 'An array containing an object for each debug entry, if present.
+
+        The expected fields for this nested object fall under the `debug.` prefix.'
+      default_field: false
+    - name: target.parent.pe.debug.offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Debug offset information.
+      example: 1296336
+      default_field: false
+    - name: target.parent.pe.debug.size
+      level: extended
+      type: long
+      format: bytes
+      description: Size of the debug information.
+      example: 816
+      default_field: false
+    - name: target.parent.pe.debug.timestamp
+      level: extended
+      type: date
+      description: Timestamp of the debug information.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.parent.pe.debug.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Information type generated by the debug options.
+      example: IMAGE_DEBUG_TYPE_POGO
+      default_field: false
+    - name: target.parent.pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: target.parent.pe.entry_point
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Relative byte offset to the base of the PE file.
+      example: 25856
+      default_field: false
+    - name: target.parent.pe.exports
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of symbols exported by PE
+      example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+      default_field: false
+    - name: target.parent.pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: target.parent.pe.icon.hash.dhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Difference Hash (dhash) to find files with a visually similar icon
+        or thumbnail.
+      example: b806e17c8e330d82
+      default_field: false
+    - name: target.parent.pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: target.parent.pe.imports
+      level: extended
+      type: flattened
+      description: List of all imported functions
+      example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+        }'
+      default_field: false
+    - name: target.parent.pe.machine_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the PE file.
+      example: Intel 386 or later, and compatibles
+      default_field: false
+    - name: target.parent.pe.original_file_name
+      level: extended
+      type: wildcard
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: target.parent.pe.packers
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of packers and tools used.
+      example: '["ASPack v2.12", ".NET executable"]'
+      default_field: false
+    - name: target.parent.pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: target.parent.pe.resources
+      level: extended
+      type: nested
+      description: 'An array containing an object for each PE resource, if present.
+
+        The expected fields for this nested object fall under the `resources.` prefix.'
+      default_field: false
+    - name: target.parent.pe.resources.chi2
+      level: extended
+      type: long
+      description: Chi-square probability distribution.
+      example: -1
+      default_field: false
+    - name: target.parent.pe.resources.entropy
+      level: extended
+      type: long
+      description: Measurement of entropy randomness in the resources section.
+      example: 0, 1
+      default_field: false
+    - name: target.parent.pe.resources.filetype
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: File type of the resources section.
+      example: Data
+      default_field: false
+    - name: target.parent.pe.resources.language
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Language identification.
+      example: CHINESE SIMPLIFIED
+      default_field: false
+    - name: target.parent.pe.resources.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash of resources section.
+      example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      default_field: false
+    - name: target.parent.pe.resources.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Digest of resource types.
+      example: '["RT_VERSION", "RT_MANIFEST"]'
+      default_field: false
+    - name: target.parent.pe.rich_header.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash of the header for the PE file.
+      example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+      default_field: false
+    - name: target.parent.pe.sections
+      level: extended
+      type: nested
+      description: Data about sections of compiled binary PE
+      default_field: false
+    - name: target.parent.pe.sections.chi2
+      level: extended
+      type: long
+      description: Chi-square probability distribution.
+      example: 3027194
+      default_field: false
+    - name: target.parent.pe.sections.entropy
+      level: extended
+      type: float
+      description: Measurement of entropy randomness in the file.
+      example: 6.24
+      default_field: false
+    - name: target.parent.pe.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Section flags of the file.
+      example: rx
+      default_field: false
+    - name: target.parent.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Section names of the file.
+      example: .text, .data
+      default_field: false
+    - name: target.parent.pe.sections.raw_size
+      level: extended
+      type: long
+      format: bytes
+      description: Size of the section or the dize of the initialized data on disk.
+      example: 198144
+      default_field: false
+    - name: target.parent.pe.sections.virtual_address
+      level: extended
+      type: long
+      format: bytes
+      description: Virtual address available to the file.
+      example: 8192
+      default_field: false
+    - name: target.parent.pgid
+      level: extended
+      type: long
+      format: string
+      description: Identifier of the group of processes the process belongs to.
+      default_field: false
+    - name: target.parent.pid
+      level: core
+      type: long
+      format: string
+      description: Process id.
+      example: 4242
+      default_field: false
+    - name: target.parent.ppid
+      level: extended
+      type: long
+      format: string
+      description: Parent process' pid.
+      example: 4241
+      default_field: false
+    - name: target.parent.start
+      level: extended
+      type: date
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+      default_field: false
+    - name: target.parent.thread.id
+      level: extended
+      type: long
+      format: string
+      description: Thread ID.
+      example: 4242
+      default_field: false
+    - name: target.parent.thread.name
+      level: extended
+      type: wildcard
+      description: Thread name.
+      example: thread-0
+      default_field: false
+    - name: target.parent.title
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+      default_field: false
+    - name: target.parent.uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
+      default_field: false
+    - name: target.parent.working_directory
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: The working directory of the process.
+      example: /home/alice
+      default_field: false
+    - name: target.pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: target.pe.authentihash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Authentihash of the PE file.
+      example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+      default_field: false
+    - name: target.pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: target.pe.compile_timestamp
+      level: extended
+      type: date
+      description: Compile timestamp of the PE file.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.pe.compiler.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the compiler
+      example: Clang
+      default_field: false
+    - name: target.pe.compiler.version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Version of the compiler.
+      example: 11.0.0
+      default_field: false
+    - name: target.pe.creation_date
+      level: extended
+      type: date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.pe.debug
+      level: extended
+      type: nested
+      description: 'An array containing an object for each debug entry, if present.
+
+        The expected fields for this nested object fall under the `debug.` prefix.'
+      default_field: false
+    - name: target.pe.debug.offset
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Debug offset information.
+      example: 1296336
+      default_field: false
+    - name: target.pe.debug.size
+      level: extended
+      type: long
+      format: bytes
+      description: Size of the debug information.
+      example: 816
+      default_field: false
+    - name: target.pe.debug.timestamp
+      level: extended
+      type: date
+      description: Timestamp of the debug information.
+      example: '2020-11-05T17:25:47.000Z'
+      default_field: false
+    - name: target.pe.debug.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Information type generated by the debug options.
+      example: IMAGE_DEBUG_TYPE_POGO
+      default_field: false
+    - name: target.pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: target.pe.entry_point
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Relative byte offset to the base of the PE file.
+      example: 25856
+      default_field: false
+    - name: target.pe.exports
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of symbols exported by PE
+      example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+      default_field: false
+    - name: target.pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: target.pe.icon.hash.dhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Difference Hash (dhash) to find files with a visually similar icon
+        or thumbnail.
+      example: b806e17c8e330d82
+      default_field: false
+    - name: target.pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: target.pe.imports
+      level: extended
+      type: flattened
+      description: List of all imported functions
+      example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+        }'
+      default_field: false
+    - name: target.pe.machine_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the PE file.
+      example: Intel 386 or later, and compatibles
+      default_field: false
+    - name: target.pe.original_file_name
+      level: extended
+      type: wildcard
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: target.pe.packers
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: List of packers and tools used.
+      example: '["ASPack v2.12", ".NET executable"]'
+      default_field: false
+    - name: target.pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: target.pe.resources
+      level: extended
+      type: nested
+      description: 'An array containing an object for each PE resource, if present.
+
+        The expected fields for this nested object fall under the `resources.` prefix.'
+      default_field: false
+    - name: target.pe.resources.chi2
+      level: extended
+      type: long
+      description: Chi-square probability distribution.
+      example: -1
+      default_field: false
+    - name: target.pe.resources.entropy
+      level: extended
+      type: long
+      description: Measurement of entropy randomness in the resources section.
+      example: 0, 1
+      default_field: false
+    - name: target.pe.resources.filetype
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: File type of the resources section.
+      example: Data
+      default_field: false
+    - name: target.pe.resources.language
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Language identification.
+      example: CHINESE SIMPLIFIED
+      default_field: false
+    - name: target.pe.resources.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash of resources section.
+      example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      default_field: false
+    - name: target.pe.resources.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Digest of resource types.
+      example: '["RT_VERSION", "RT_MANIFEST"]'
+      default_field: false
+    - name: target.pe.rich_header.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash of the header for the PE file.
+      example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+      default_field: false
+    - name: target.pe.sections
+      level: extended
+      type: nested
+      description: Data about sections of compiled binary PE
+      default_field: false
+    - name: target.pe.sections.chi2
+      level: extended
+      type: long
+      description: Chi-square probability distribution.
+      example: 3027194
+      default_field: false
+    - name: target.pe.sections.entropy
+      level: extended
+      type: float
+      description: Measurement of entropy randomness in the file.
+      example: 6.24
+      default_field: false
+    - name: target.pe.sections.flags
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Section flags of the file.
+      example: rx
+      default_field: false
+    - name: target.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Section names of the file.
+      example: .text, .data
+      default_field: false
+    - name: target.pe.sections.raw_size
+      level: extended
+      type: long
+      format: bytes
+      description: Size of the section or the dize of the initialized data on disk.
+      example: 198144
+      default_field: false
+    - name: target.pe.sections.virtual_address
+      level: extended
+      type: long
+      format: bytes
+      description: Virtual address available to the file.
+      example: 8192
+      default_field: false
+    - name: target.pgid
+      level: extended
+      type: long
+      format: string
+      description: Identifier of the group of processes the process belongs to.
+      default_field: false
+    - name: target.pid
+      level: core
+      type: long
+      format: string
+      description: Process id.
+      example: 4242
+      default_field: false
+    - name: target.ppid
+      level: extended
+      type: long
+      format: string
+      description: Parent process' pid.
+      example: 4241
+      default_field: false
+    - name: target.start
+      level: extended
+      type: date
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+      default_field: false
+    - name: target.thread.id
+      level: extended
+      type: long
+      format: string
+      description: Thread ID.
+      example: 4242
+      default_field: false
+    - name: target.thread.name
+      level: extended
+      type: wildcard
+      description: Thread name.
+      example: thread-0
+      default_field: false
+    - name: target.title
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+      default_field: false
+    - name: target.uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
+      default_field: false
+    - name: target.working_directory
+      level: extended
+      type: wildcard
+      multi_fields:
+      - name: text
+        type: text
+        norms: false
+      description: The working directory of the process.
+      example: /home/alice
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -678,6 +678,206 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 2.0.0-dev+exp,true,process,process.pid,long,core,,4242,Process id.
 2.0.0-dev+exp,true,process,process.ppid,long,extended,,4241,Parent process' pid.
 2.0.0-dev+exp,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
+2.0.0-dev+exp,true,process,process.target.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
+2.0.0-dev+exp,true,process,process.target.args_count,long,extended,,4,Length of the process.args array.
+2.0.0-dev+exp,true,process,process.target.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+2.0.0-dev+exp,true,process,process.target.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+2.0.0-dev+exp,true,process,process.target.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+2.0.0-dev+exp,true,process,process.target.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+2.0.0-dev+exp,true,process,process.target.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+2.0.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
+2.0.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+2.0.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.target.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.target.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.creation_date,date,extended,,,Build or compile date.
+2.0.0-dev+exp,true,process,process.target.elf.exports,flattened,extended,array,,List of exported element names and types.
+2.0.0-dev+exp,true,process,process.target.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+2.0.0-dev+exp,true,process,process.target.elf.header.class,keyword,extended,,,Header class of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.header.data,keyword,extended,,,Data table of the ELF header.
+2.0.0-dev+exp,true,process,process.target.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+2.0.0-dev+exp,true,process,process.target.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+2.0.0-dev+exp,true,process,process.target.elf.header.type,keyword,extended,,,Header type of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.header.version,keyword,extended,,,Version of the ELF header.
+2.0.0-dev+exp,true,process,process.target.elf.imports,flattened,extended,array,,List of imported element names and types.
+2.0.0-dev+exp,true,process,process.target.elf.sections,nested,extended,array,,Section information of the ELF file.
+2.0.0-dev+exp,true,process,process.target.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+2.0.0-dev+exp,true,process,process.target.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+2.0.0-dev+exp,true,process,process.target.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+2.0.0-dev+exp,true,process,process.target.elf.sections.name,keyword,extended,,,ELF Section List name.
+2.0.0-dev+exp,true,process,process.target.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+2.0.0-dev+exp,true,process,process.target.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+2.0.0-dev+exp,true,process,process.target.elf.sections.type,keyword,extended,,,ELF Section List type.
+2.0.0-dev+exp,true,process,process.target.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+2.0.0-dev+exp,true,process,process.target.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+2.0.0-dev+exp,true,process,process.target.elf.segments,nested,extended,array,,ELF object segment list.
+2.0.0-dev+exp,true,process,process.target.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+2.0.0-dev+exp,true,process,process.target.elf.segments.type,keyword,extended,,,ELF object segment type.
+2.0.0-dev+exp,true,process,process.target.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+2.0.0-dev+exp,true,process,process.target.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+2.0.0-dev+exp,true,process,process.target.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
+2.0.0-dev+exp,true,process,process.target.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev+exp,true,process,process.target.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev+exp,true,process,process.target.exit_code,long,extended,,137,The exit code of the process.
+2.0.0-dev+exp,true,process,process.target.hash.md5,keyword,extended,,,MD5 hash.
+2.0.0-dev+exp,true,process,process.target.hash.sha1,keyword,extended,,,SHA1 hash.
+2.0.0-dev+exp,true,process,process.target.hash.sha256,keyword,extended,,,SHA256 hash.
+2.0.0-dev+exp,true,process,process.target.hash.sha512,keyword,extended,,,SHA512 hash.
+2.0.0-dev+exp,true,process,process.target.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+2.0.0-dev+exp,true,process,process.target.name,wildcard,extended,,ssh,Process name.
+2.0.0-dev+exp,true,process,process.target.name.text,text,extended,,ssh,Process name.
+2.0.0-dev+exp,true,process,process.target.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
+2.0.0-dev+exp,true,process,process.target.parent.args_count,long,extended,,4,Length of the process.args array.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
+2.0.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
+2.0.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.target.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+2.0.0-dev+exp,true,process,process.target.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.creation_date,date,extended,,,Build or compile date.
+2.0.0-dev+exp,true,process,process.target.parent.elf.exports,flattened,extended,array,,List of exported element names and types.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.class,keyword,extended,,,Header class of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.data,keyword,extended,,,Data table of the ELF header.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.type,keyword,extended,,,Header type of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.header.version,keyword,extended,,,Version of the ELF header.
+2.0.0-dev+exp,true,process,process.target.parent.elf.imports,flattened,extended,array,,List of imported element names and types.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections,nested,extended,array,,Section information of the ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.name,keyword,extended,,,ELF Section List name.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.type,keyword,extended,,,ELF Section List type.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+2.0.0-dev+exp,true,process,process.target.parent.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+2.0.0-dev+exp,true,process,process.target.parent.elf.segments,nested,extended,array,,ELF object segment list.
+2.0.0-dev+exp,true,process,process.target.parent.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+2.0.0-dev+exp,true,process,process.target.parent.elf.segments.type,keyword,extended,,,ELF object segment type.
+2.0.0-dev+exp,true,process,process.target.parent.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+2.0.0-dev+exp,true,process,process.target.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+2.0.0-dev+exp,true,process,process.target.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
+2.0.0-dev+exp,true,process,process.target.parent.executable,wildcard,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev+exp,true,process,process.target.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+2.0.0-dev+exp,true,process,process.target.parent.exit_code,long,extended,,137,The exit code of the process.
+2.0.0-dev+exp,true,process,process.target.parent.hash.md5,keyword,extended,,,MD5 hash.
+2.0.0-dev+exp,true,process,process.target.parent.hash.sha1,keyword,extended,,,SHA1 hash.
+2.0.0-dev+exp,true,process,process.target.parent.hash.sha256,keyword,extended,,,SHA256 hash.
+2.0.0-dev+exp,true,process,process.target.parent.hash.sha512,keyword,extended,,,SHA512 hash.
+2.0.0-dev+exp,true,process,process.target.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+2.0.0-dev+exp,true,process,process.target.parent.name,wildcard,extended,,ssh,Process name.
+2.0.0-dev+exp,true,process,process.target.parent.name.text,text,extended,,ssh,Process name.
+2.0.0-dev+exp,true,process,process.target.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.parent.pe.compile_timestamp,date,extended,,2020-11-05T17:25:47.000Z,Compile timestamp of the PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.compiler.name,keyword,extended,,Clang,Name of the compiler
+2.0.0-dev+exp,true,process,process.target.parent.pe.compiler.version,keyword,extended,,11.0.0,Version of the compiler.
+2.0.0-dev+exp,true,process,process.target.parent.pe.creation_date,date,extended,,2020-11-05T17:25:47.000Z,Build or compile date.
+2.0.0-dev+exp,true,process,process.target.parent.pe.debug,nested,extended,array,,Debug information
+2.0.0-dev+exp,true,process,process.target.parent.pe.debug.offset,keyword,extended,,1296336,Debug offset information.
+2.0.0-dev+exp,true,process,process.target.parent.pe.debug.size,long,extended,,816,Size of the debug information.
+2.0.0-dev+exp,true,process,process.target.parent.pe.debug.timestamp,date,extended,,2020-11-05T17:25:47.000Z,Timestamp of the debug information.
+2.0.0-dev+exp,true,process,process.target.parent.pe.debug.type,keyword,extended,,IMAGE_DEBUG_TYPE_POGO,Information type generated by the debug options.
+2.0.0-dev+exp,true,process,process.target.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.parent.pe.entry_point,keyword,extended,,25856,Relative byte offset to the base of the PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.exports,keyword,extended,array,"[""DllInstall"", ""DllRegisterServer"", ""DllUnregisterServer""]",List of symbols exported by PE
+2.0.0-dev+exp,true,process,process.target.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+2.0.0-dev+exp,true,process,process.target.parent.pe.icon.hash.dhash,keyword,extended,,b806e17c8e330d82,Difference Hash (dhash) to find files with a visually similar icon or thumbnail.
+2.0.0-dev+exp,true,process,process.target.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.imports,flattened,extended,,"{ ""library_name"" : ""mscoree.dll"", ""imported_functions"" : ""GetFileVersionInfoSizeA"" }",List of all imported functions
+2.0.0-dev+exp,true,process,process.target.parent.pe.machine_type,keyword,extended,,"Intel 386 or later, and compatibles",Machine type of the PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.parent.pe.packers,keyword,extended,array,"[""ASPack v2.12"", "".NET executable""]",List of packers and tools used.
+2.0.0-dev+exp,true,process,process.target.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources,nested,extended,array,,PE resource information
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.chi2,long,extended,,-1,Chi-square probability distribution.
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.entropy,long,extended,,"0, 1",Measurement of entropy randomness in the resources section.
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.filetype,keyword,extended,,Data,File type of the resources section.
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.language,keyword,extended,,CHINESE SIMPLIFIED,Language identification.
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.sha256,keyword,extended,,e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855,SHA256 hash of resources section.
+2.0.0-dev+exp,true,process,process.target.parent.pe.resources.type,keyword,extended,array,"[""RT_VERSION"", ""RT_MANIFEST""]",List of resource types.
+2.0.0-dev+exp,true,process,process.target.parent.pe.rich_header.hash.md5,keyword,extended,,5aa1aa0f2b4be70397a1e9e2b87627cd,MD5 hash of the header for the PE file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections,nested,extended,array,,Data about sections of the compiled binary PE
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.chi2,long,extended,,3027194,Chi-square probability distribution.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.entropy,float,extended,,6.24,Measurement of entropy randomness in the file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.flags,keyword,extended,,rx,Section flags of the file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.name,keyword,extended,,".text, .data",Section names of the file.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.raw_size,long,extended,,198144,Size of the section or the dize of the initialized data on disk.
+2.0.0-dev+exp,true,process,process.target.parent.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
+2.0.0-dev+exp,true,process,process.target.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
+2.0.0-dev+exp,true,process,process.target.parent.pid,long,core,,4242,Process id.
+2.0.0-dev+exp,true,process,process.target.parent.ppid,long,extended,,4241,Parent process' pid.
+2.0.0-dev+exp,true,process,process.target.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
+2.0.0-dev+exp,true,process,process.target.parent.thread.id,long,extended,,4242,Thread ID.
+2.0.0-dev+exp,true,process,process.target.parent.thread.name,wildcard,extended,,thread-0,Thread name.
+2.0.0-dev+exp,true,process,process.target.parent.title,wildcard,extended,,,Process title.
+2.0.0-dev+exp,true,process,process.target.parent.title.text,text,extended,,,Process title.
+2.0.0-dev+exp,true,process,process.target.parent.uptime,long,extended,,1325,Seconds the process has been up.
+2.0.0-dev+exp,true,process,process.target.parent.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
+2.0.0-dev+exp,true,process,process.target.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+2.0.0-dev+exp,true,process,process.target.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+2.0.0-dev+exp,true,process,process.target.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
+2.0.0-dev+exp,true,process,process.target.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.pe.compile_timestamp,date,extended,,2020-11-05T17:25:47.000Z,Compile timestamp of the PE file.
+2.0.0-dev+exp,true,process,process.target.pe.compiler.name,keyword,extended,,Clang,Name of the compiler
+2.0.0-dev+exp,true,process,process.target.pe.compiler.version,keyword,extended,,11.0.0,Version of the compiler.
+2.0.0-dev+exp,true,process,process.target.pe.creation_date,date,extended,,2020-11-05T17:25:47.000Z,Build or compile date.
+2.0.0-dev+exp,true,process,process.target.pe.debug,nested,extended,array,,Debug information
+2.0.0-dev+exp,true,process,process.target.pe.debug.offset,keyword,extended,,1296336,Debug offset information.
+2.0.0-dev+exp,true,process,process.target.pe.debug.size,long,extended,,816,Size of the debug information.
+2.0.0-dev+exp,true,process,process.target.pe.debug.timestamp,date,extended,,2020-11-05T17:25:47.000Z,Timestamp of the debug information.
+2.0.0-dev+exp,true,process,process.target.pe.debug.type,keyword,extended,,IMAGE_DEBUG_TYPE_POGO,Information type generated by the debug options.
+2.0.0-dev+exp,true,process,process.target.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.pe.entry_point,keyword,extended,,25856,Relative byte offset to the base of the PE file.
+2.0.0-dev+exp,true,process,process.target.pe.exports,keyword,extended,array,"[""DllInstall"", ""DllRegisterServer"", ""DllUnregisterServer""]",List of symbols exported by PE
+2.0.0-dev+exp,true,process,process.target.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+2.0.0-dev+exp,true,process,process.target.pe.icon.hash.dhash,keyword,extended,,b806e17c8e330d82,Difference Hash (dhash) to find files with a visually similar icon or thumbnail.
+2.0.0-dev+exp,true,process,process.target.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+2.0.0-dev+exp,true,process,process.target.pe.imports,flattened,extended,,"{ ""library_name"" : ""mscoree.dll"", ""imported_functions"" : ""GetFileVersionInfoSizeA"" }",List of all imported functions
+2.0.0-dev+exp,true,process,process.target.pe.machine_type,keyword,extended,,"Intel 386 or later, and compatibles",Machine type of the PE file.
+2.0.0-dev+exp,true,process,process.target.pe.original_file_name,wildcard,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.pe.packers,keyword,extended,array,"[""ASPack v2.12"", "".NET executable""]",List of packers and tools used.
+2.0.0-dev+exp,true,process,process.target.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+2.0.0-dev+exp,true,process,process.target.pe.resources,nested,extended,array,,PE resource information
+2.0.0-dev+exp,true,process,process.target.pe.resources.chi2,long,extended,,-1,Chi-square probability distribution.
+2.0.0-dev+exp,true,process,process.target.pe.resources.entropy,long,extended,,"0, 1",Measurement of entropy randomness in the resources section.
+2.0.0-dev+exp,true,process,process.target.pe.resources.filetype,keyword,extended,,Data,File type of the resources section.
+2.0.0-dev+exp,true,process,process.target.pe.resources.language,keyword,extended,,CHINESE SIMPLIFIED,Language identification.
+2.0.0-dev+exp,true,process,process.target.pe.resources.sha256,keyword,extended,,e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855,SHA256 hash of resources section.
+2.0.0-dev+exp,true,process,process.target.pe.resources.type,keyword,extended,array,"[""RT_VERSION"", ""RT_MANIFEST""]",List of resource types.
+2.0.0-dev+exp,true,process,process.target.pe.rich_header.hash.md5,keyword,extended,,5aa1aa0f2b4be70397a1e9e2b87627cd,MD5 hash of the header for the PE file.
+2.0.0-dev+exp,true,process,process.target.pe.sections,nested,extended,array,,Data about sections of the compiled binary PE
+2.0.0-dev+exp,true,process,process.target.pe.sections.chi2,long,extended,,3027194,Chi-square probability distribution.
+2.0.0-dev+exp,true,process,process.target.pe.sections.entropy,float,extended,,6.24,Measurement of entropy randomness in the file.
+2.0.0-dev+exp,true,process,process.target.pe.sections.flags,keyword,extended,,rx,Section flags of the file.
+2.0.0-dev+exp,true,process,process.target.pe.sections.name,keyword,extended,,".text, .data",Section names of the file.
+2.0.0-dev+exp,true,process,process.target.pe.sections.raw_size,long,extended,,198144,Size of the section or the dize of the initialized data on disk.
+2.0.0-dev+exp,true,process,process.target.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
+2.0.0-dev+exp,true,process,process.target.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
+2.0.0-dev+exp,true,process,process.target.pid,long,core,,4242,Process id.
+2.0.0-dev+exp,true,process,process.target.ppid,long,extended,,4241,Parent process' pid.
+2.0.0-dev+exp,true,process,process.target.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
+2.0.0-dev+exp,true,process,process.target.thread.id,long,extended,,4242,Thread ID.
+2.0.0-dev+exp,true,process,process.target.thread.name,wildcard,extended,,thread-0,Thread name.
+2.0.0-dev+exp,true,process,process.target.title,wildcard,extended,,,Process title.
+2.0.0-dev+exp,true,process,process.target.title.text,text,extended,,,Process title.
+2.0.0-dev+exp,true,process,process.target.uptime,long,extended,,1325,Seconds the process has been up.
+2.0.0-dev+exp,true,process,process.target.working_directory,wildcard,extended,,/home/alice,The working directory of the process.
+2.0.0-dev+exp,true,process,process.target.working_directory.text,text,extended,,/home/alice,The working directory of the process.
 2.0.0-dev+exp,true,process,process.thread.id,long,extended,,4242,Thread ID.
 2.0.0-dev+exp,true,process,process.thread.name,wildcard,extended,,thread-0,Thread name.
 2.0.0-dev+exp,true,process,process.title,wildcard,extended,,,Process title.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8582,6 +8582,2350 @@ process.start:
   normalize: []
   short: The time the process started.
   type: date
+process.target.args:
+  dashed_name: process-target-args
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
+
+    May be filtered to protect sensitive information.'
+  example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+  flat_name: process.target.args
+  ignore_above: 1024
+  level: extended
+  name: args
+  normalize:
+  - array
+  original_fieldset: process
+  short: Array of process arguments.
+  type: keyword
+process.target.args_count:
+  dashed_name: process-target-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.target.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  original_fieldset: process
+  short: Length of the process.args array.
+  type: long
+process.target.code_signature.exists:
+  dashed_name: process-target-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.target.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.target.code_signature.signing_id:
+  dashed_name: process-target-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.target.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
+process.target.code_signature.status:
+  dashed_name: process-target-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.target.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.target.code_signature.subject_name:
+  dashed_name: process-target-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.target.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.target.code_signature.team_id:
+  dashed_name: process-target-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.target.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
+  type: keyword
+process.target.code_signature.trusted:
+  dashed_name: process-target-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.target.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.target.code_signature.valid:
+  dashed_name: process-target-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.target.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.target.command_line:
+  dashed_name: process-target-command-line
+  description: 'Full command line that started the process, including the absolute
+    path to the executable, and all arguments.
+
+    Some arguments may be filtered to protect sensitive information.'
+  example: /usr/bin/ssh -l user 10.0.0.16
+  flat_name: process.target.command_line
+  level: extended
+  multi_fields:
+  - flat_name: process.target.command_line.text
+    name: text
+    norms: false
+    type: text
+  name: command_line
+  normalize: []
+  original_fieldset: process
+  short: Full command line that started the process.
+  type: wildcard
+process.target.elf.architecture:
+  dashed_name: process-target-elf-architecture
+  description: Machine architecture of the ELF file.
+  example: x86-64
+  flat_name: process.target.elf.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: elf
+  short: Machine architecture of the ELF file.
+  type: keyword
+process.target.elf.byte_order:
+  dashed_name: process-target-elf-byte-order
+  description: Byte sequence of ELF file.
+  example: Little Endian
+  flat_name: process.target.elf.byte_order
+  ignore_above: 1024
+  level: extended
+  name: byte_order
+  normalize: []
+  original_fieldset: elf
+  short: Byte sequence of ELF file.
+  type: keyword
+process.target.elf.cpu_type:
+  dashed_name: process-target-elf-cpu-type
+  description: CPU type of the ELF file.
+  example: Intel
+  flat_name: process.target.elf.cpu_type
+  ignore_above: 1024
+  level: extended
+  name: cpu_type
+  normalize: []
+  original_fieldset: elf
+  short: CPU type of the ELF file.
+  type: keyword
+process.target.elf.creation_date:
+  dashed_name: process-target-elf-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  flat_name: process.target.elf.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: elf
+  short: Build or compile date.
+  type: date
+process.target.elf.exports:
+  dashed_name: process-target-elf-exports
+  description: List of exported element names and types.
+  flat_name: process.target.elf.exports
+  level: extended
+  name: exports
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of exported element names and types.
+  type: flattened
+process.target.elf.header.abi_version:
+  dashed_name: process-target-elf-header-abi-version
+  description: Version of the ELF Application Binary Interface (ABI).
+  flat_name: process.target.elf.header.abi_version
+  ignore_above: 1024
+  level: extended
+  name: header.abi_version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF Application Binary Interface (ABI).
+  type: keyword
+process.target.elf.header.class:
+  dashed_name: process-target-elf-header-class
+  description: Header class of the ELF file.
+  flat_name: process.target.elf.header.class
+  ignore_above: 1024
+  level: extended
+  name: header.class
+  normalize: []
+  original_fieldset: elf
+  short: Header class of the ELF file.
+  type: keyword
+process.target.elf.header.data:
+  dashed_name: process-target-elf-header-data
+  description: Data table of the ELF header.
+  flat_name: process.target.elf.header.data
+  ignore_above: 1024
+  level: extended
+  name: header.data
+  normalize: []
+  original_fieldset: elf
+  short: Data table of the ELF header.
+  type: keyword
+process.target.elf.header.entrypoint:
+  dashed_name: process-target-elf-header-entrypoint
+  description: Header entrypoint of the ELF file.
+  flat_name: process.target.elf.header.entrypoint
+  format: string
+  level: extended
+  name: header.entrypoint
+  normalize: []
+  original_fieldset: elf
+  short: Header entrypoint of the ELF file.
+  type: long
+process.target.elf.header.object_version:
+  dashed_name: process-target-elf-header-object-version
+  description: '"0x1" for original ELF files.'
+  flat_name: process.target.elf.header.object_version
+  ignore_above: 1024
+  level: extended
+  name: header.object_version
+  normalize: []
+  original_fieldset: elf
+  short: '"0x1" for original ELF files.'
+  type: keyword
+process.target.elf.header.os_abi:
+  dashed_name: process-target-elf-header-os-abi
+  description: Application Binary Interface (ABI) of the Linux OS.
+  flat_name: process.target.elf.header.os_abi
+  ignore_above: 1024
+  level: extended
+  name: header.os_abi
+  normalize: []
+  original_fieldset: elf
+  short: Application Binary Interface (ABI) of the Linux OS.
+  type: keyword
+process.target.elf.header.type:
+  dashed_name: process-target-elf-header-type
+  description: Header type of the ELF file.
+  flat_name: process.target.elf.header.type
+  ignore_above: 1024
+  level: extended
+  name: header.type
+  normalize: []
+  original_fieldset: elf
+  short: Header type of the ELF file.
+  type: keyword
+process.target.elf.header.version:
+  dashed_name: process-target-elf-header-version
+  description: Version of the ELF header.
+  flat_name: process.target.elf.header.version
+  ignore_above: 1024
+  level: extended
+  name: header.version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF header.
+  type: keyword
+process.target.elf.imports:
+  dashed_name: process-target-elf-imports
+  description: List of imported element names and types.
+  flat_name: process.target.elf.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of imported element names and types.
+  type: flattened
+process.target.elf.sections:
+  dashed_name: process-target-elf-sections
+  description: 'An array containing an object for each section of the ELF file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `elf.sections.*`.'
+  flat_name: process.target.elf.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: elf
+  short: Section information of the ELF file.
+  type: nested
+process.target.elf.sections.chi2:
+  dashed_name: process-target-elf-sections-chi2
+  description: Chi-square probability distribution of the section.
+  flat_name: process.target.elf.sections.chi2
+  format: number
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: elf
+  short: Chi-square probability distribution of the section.
+  type: long
+process.target.elf.sections.entropy:
+  dashed_name: process-target-elf-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.target.elf.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the section.
+  type: long
+process.target.elf.sections.flags:
+  dashed_name: process-target-elf-sections-flags
+  description: ELF Section List flags.
+  flat_name: process.target.elf.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List flags.
+  type: keyword
+process.target.elf.sections.name:
+  dashed_name: process-target-elf-sections-name
+  description: ELF Section List name.
+  flat_name: process.target.elf.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List name.
+  type: keyword
+process.target.elf.sections.physical_offset:
+  dashed_name: process-target-elf-sections-physical-offset
+  description: ELF Section List offset.
+  flat_name: process.target.elf.sections.physical_offset
+  ignore_above: 1024
+  level: extended
+  name: sections.physical_offset
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List offset.
+  type: keyword
+process.target.elf.sections.physical_size:
+  dashed_name: process-target-elf-sections-physical-size
+  description: ELF Section List physical size.
+  flat_name: process.target.elf.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List physical size.
+  type: long
+process.target.elf.sections.type:
+  dashed_name: process-target-elf-sections-type
+  description: ELF Section List type.
+  flat_name: process.target.elf.sections.type
+  ignore_above: 1024
+  level: extended
+  name: sections.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List type.
+  type: keyword
+process.target.elf.sections.virtual_address:
+  dashed_name: process-target-elf-sections-virtual-address
+  description: ELF Section List virtual address.
+  flat_name: process.target.elf.sections.virtual_address
+  format: string
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual address.
+  type: long
+process.target.elf.sections.virtual_size:
+  dashed_name: process-target-elf-sections-virtual-size
+  description: ELF Section List virtual size.
+  flat_name: process.target.elf.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual size.
+  type: long
+process.target.elf.segments:
+  dashed_name: process-target-elf-segments
+  description: 'An array containing an object for each segment of the ELF file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `elf.segments.*`.'
+  flat_name: process.target.elf.segments
+  level: extended
+  name: segments
+  normalize:
+  - array
+  original_fieldset: elf
+  short: ELF object segment list.
+  type: nested
+process.target.elf.segments.sections:
+  dashed_name: process-target-elf-segments-sections
+  description: ELF object segment sections.
+  flat_name: process.target.elf.segments.sections
+  ignore_above: 1024
+  level: extended
+  name: segments.sections
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment sections.
+  type: keyword
+process.target.elf.segments.type:
+  dashed_name: process-target-elf-segments-type
+  description: ELF object segment type.
+  flat_name: process.target.elf.segments.type
+  ignore_above: 1024
+  level: extended
+  name: segments.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment type.
+  type: keyword
+process.target.elf.shared_libraries:
+  dashed_name: process-target-elf-shared-libraries
+  description: List of shared libraries used by this ELF object.
+  flat_name: process.target.elf.shared_libraries
+  ignore_above: 1024
+  level: extended
+  name: shared_libraries
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of shared libraries used by this ELF object.
+  type: keyword
+process.target.elf.telfhash:
+  dashed_name: process-target-elf-telfhash
+  description: telfhash symbol hash for ELF file.
+  flat_name: process.target.elf.telfhash
+  ignore_above: 1024
+  level: extended
+  name: telfhash
+  normalize: []
+  original_fieldset: elf
+  short: telfhash hash for ELF file.
+  type: keyword
+process.target.entity_id:
+  dashed_name: process-target-entity-id
+  description: 'Unique identifier for the process.
+
+    The implementation of this is specified by the data source, but some examples
+    of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+    or a hash of some uniquely identifying components of a process.
+
+    Constructing a globally unique identifier is a common practice to mitigate PID
+    reuse as well as to identify a specific process over time, across multiple monitored
+    hosts.'
+  example: c2c455d9f99375d
+  flat_name: process.target.entity_id
+  ignore_above: 1024
+  level: extended
+  name: entity_id
+  normalize: []
+  original_fieldset: process
+  short: Unique identifier for the process.
+  type: keyword
+process.target.executable:
+  dashed_name: process-target-executable
+  description: Absolute path to the process executable.
+  example: /usr/bin/ssh
+  flat_name: process.target.executable
+  level: extended
+  multi_fields:
+  - flat_name: process.target.executable.text
+    name: text
+    norms: false
+    type: text
+  name: executable
+  normalize: []
+  original_fieldset: process
+  short: Absolute path to the process executable.
+  type: wildcard
+process.target.exit_code:
+  dashed_name: process-target-exit-code
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.target.exit_code
+  level: extended
+  name: exit_code
+  normalize: []
+  original_fieldset: process
+  short: The exit code of the process.
+  type: long
+process.target.hash.md5:
+  dashed_name: process-target-hash-md5
+  description: MD5 hash.
+  flat_name: process.target.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.target.hash.sha1:
+  dashed_name: process-target-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.target.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.target.hash.sha256:
+  dashed_name: process-target-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.target.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.target.hash.sha512:
+  dashed_name: process-target-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.target.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.target.hash.ssdeep:
+  dashed_name: process-target-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.target.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.target.name:
+  dashed_name: process-target-name
+  description: 'Process name.
+
+    Sometimes called program name or similar.'
+  example: ssh
+  flat_name: process.target.name
+  level: extended
+  multi_fields:
+  - flat_name: process.target.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: process
+  short: Process name.
+  type: wildcard
+process.target.parent.args:
+  dashed_name: process-target-parent-args
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
+
+    May be filtered to protect sensitive information.'
+  example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+  flat_name: process.target.parent.args
+  ignore_above: 1024
+  level: extended
+  name: args
+  normalize:
+  - array
+  original_fieldset: process
+  short: Array of process arguments.
+  type: keyword
+process.target.parent.args_count:
+  dashed_name: process-target-parent-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.target.parent.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  original_fieldset: process
+  short: Length of the process.args array.
+  type: long
+process.target.parent.code_signature.exists:
+  dashed_name: process-target-parent-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.target.parent.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.target.parent.code_signature.signing_id:
+  dashed_name: process-target-parent-code-signature-signing-id
+  description: 'The identifier used to sign the process.
+
+    This is used to identify the application manufactured by a software vendor. The
+    field is relevant to Apple *OS only.'
+  example: com.apple.xpc.proxy
+  flat_name: process.target.parent.code_signature.signing_id
+  ignore_above: 1024
+  level: extended
+  name: signing_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The identifier used to sign the process.
+  type: keyword
+process.target.parent.code_signature.status:
+  dashed_name: process-target-parent-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.target.parent.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.target.parent.code_signature.subject_name:
+  dashed_name: process-target-parent-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.target.parent.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.target.parent.code_signature.team_id:
+  dashed_name: process-target-parent-code-signature-team-id
+  description: 'The team identifier used to sign the process.
+
+    This is used to identify the team or vendor of a software product. The field is
+    relevant to Apple *OS only.'
+  example: EQHXZ8M8AV
+  flat_name: process.target.parent.code_signature.team_id
+  ignore_above: 1024
+  level: extended
+  name: team_id
+  normalize: []
+  original_fieldset: code_signature
+  short: The team identifier used to sign the process.
+  type: keyword
+process.target.parent.code_signature.trusted:
+  dashed_name: process-target-parent-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.target.parent.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.target.parent.code_signature.valid:
+  dashed_name: process-target-parent-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.target.parent.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.target.parent.command_line:
+  dashed_name: process-target-parent-command-line
+  description: 'Full command line that started the process, including the absolute
+    path to the executable, and all arguments.
+
+    Some arguments may be filtered to protect sensitive information.'
+  example: /usr/bin/ssh -l user 10.0.0.16
+  flat_name: process.target.parent.command_line
+  level: extended
+  multi_fields:
+  - flat_name: process.target.parent.command_line.text
+    name: text
+    norms: false
+    type: text
+  name: command_line
+  normalize: []
+  original_fieldset: process
+  short: Full command line that started the process.
+  type: wildcard
+process.target.parent.elf.architecture:
+  dashed_name: process-target-parent-elf-architecture
+  description: Machine architecture of the ELF file.
+  example: x86-64
+  flat_name: process.target.parent.elf.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: elf
+  short: Machine architecture of the ELF file.
+  type: keyword
+process.target.parent.elf.byte_order:
+  dashed_name: process-target-parent-elf-byte-order
+  description: Byte sequence of ELF file.
+  example: Little Endian
+  flat_name: process.target.parent.elf.byte_order
+  ignore_above: 1024
+  level: extended
+  name: byte_order
+  normalize: []
+  original_fieldset: elf
+  short: Byte sequence of ELF file.
+  type: keyword
+process.target.parent.elf.cpu_type:
+  dashed_name: process-target-parent-elf-cpu-type
+  description: CPU type of the ELF file.
+  example: Intel
+  flat_name: process.target.parent.elf.cpu_type
+  ignore_above: 1024
+  level: extended
+  name: cpu_type
+  normalize: []
+  original_fieldset: elf
+  short: CPU type of the ELF file.
+  type: keyword
+process.target.parent.elf.creation_date:
+  dashed_name: process-target-parent-elf-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  flat_name: process.target.parent.elf.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: elf
+  short: Build or compile date.
+  type: date
+process.target.parent.elf.exports:
+  dashed_name: process-target-parent-elf-exports
+  description: List of exported element names and types.
+  flat_name: process.target.parent.elf.exports
+  level: extended
+  name: exports
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of exported element names and types.
+  type: flattened
+process.target.parent.elf.header.abi_version:
+  dashed_name: process-target-parent-elf-header-abi-version
+  description: Version of the ELF Application Binary Interface (ABI).
+  flat_name: process.target.parent.elf.header.abi_version
+  ignore_above: 1024
+  level: extended
+  name: header.abi_version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF Application Binary Interface (ABI).
+  type: keyword
+process.target.parent.elf.header.class:
+  dashed_name: process-target-parent-elf-header-class
+  description: Header class of the ELF file.
+  flat_name: process.target.parent.elf.header.class
+  ignore_above: 1024
+  level: extended
+  name: header.class
+  normalize: []
+  original_fieldset: elf
+  short: Header class of the ELF file.
+  type: keyword
+process.target.parent.elf.header.data:
+  dashed_name: process-target-parent-elf-header-data
+  description: Data table of the ELF header.
+  flat_name: process.target.parent.elf.header.data
+  ignore_above: 1024
+  level: extended
+  name: header.data
+  normalize: []
+  original_fieldset: elf
+  short: Data table of the ELF header.
+  type: keyword
+process.target.parent.elf.header.entrypoint:
+  dashed_name: process-target-parent-elf-header-entrypoint
+  description: Header entrypoint of the ELF file.
+  flat_name: process.target.parent.elf.header.entrypoint
+  format: string
+  level: extended
+  name: header.entrypoint
+  normalize: []
+  original_fieldset: elf
+  short: Header entrypoint of the ELF file.
+  type: long
+process.target.parent.elf.header.object_version:
+  dashed_name: process-target-parent-elf-header-object-version
+  description: '"0x1" for original ELF files.'
+  flat_name: process.target.parent.elf.header.object_version
+  ignore_above: 1024
+  level: extended
+  name: header.object_version
+  normalize: []
+  original_fieldset: elf
+  short: '"0x1" for original ELF files.'
+  type: keyword
+process.target.parent.elf.header.os_abi:
+  dashed_name: process-target-parent-elf-header-os-abi
+  description: Application Binary Interface (ABI) of the Linux OS.
+  flat_name: process.target.parent.elf.header.os_abi
+  ignore_above: 1024
+  level: extended
+  name: header.os_abi
+  normalize: []
+  original_fieldset: elf
+  short: Application Binary Interface (ABI) of the Linux OS.
+  type: keyword
+process.target.parent.elf.header.type:
+  dashed_name: process-target-parent-elf-header-type
+  description: Header type of the ELF file.
+  flat_name: process.target.parent.elf.header.type
+  ignore_above: 1024
+  level: extended
+  name: header.type
+  normalize: []
+  original_fieldset: elf
+  short: Header type of the ELF file.
+  type: keyword
+process.target.parent.elf.header.version:
+  dashed_name: process-target-parent-elf-header-version
+  description: Version of the ELF header.
+  flat_name: process.target.parent.elf.header.version
+  ignore_above: 1024
+  level: extended
+  name: header.version
+  normalize: []
+  original_fieldset: elf
+  short: Version of the ELF header.
+  type: keyword
+process.target.parent.elf.imports:
+  dashed_name: process-target-parent-elf-imports
+  description: List of imported element names and types.
+  flat_name: process.target.parent.elf.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of imported element names and types.
+  type: flattened
+process.target.parent.elf.sections:
+  dashed_name: process-target-parent-elf-sections
+  description: 'An array containing an object for each section of the ELF file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `elf.sections.*`.'
+  flat_name: process.target.parent.elf.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: elf
+  short: Section information of the ELF file.
+  type: nested
+process.target.parent.elf.sections.chi2:
+  dashed_name: process-target-parent-elf-sections-chi2
+  description: Chi-square probability distribution of the section.
+  flat_name: process.target.parent.elf.sections.chi2
+  format: number
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: elf
+  short: Chi-square probability distribution of the section.
+  type: long
+process.target.parent.elf.sections.entropy:
+  dashed_name: process-target-parent-elf-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.target.parent.elf.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the section.
+  type: long
+process.target.parent.elf.sections.flags:
+  dashed_name: process-target-parent-elf-sections-flags
+  description: ELF Section List flags.
+  flat_name: process.target.parent.elf.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List flags.
+  type: keyword
+process.target.parent.elf.sections.name:
+  dashed_name: process-target-parent-elf-sections-name
+  description: ELF Section List name.
+  flat_name: process.target.parent.elf.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List name.
+  type: keyword
+process.target.parent.elf.sections.physical_offset:
+  dashed_name: process-target-parent-elf-sections-physical-offset
+  description: ELF Section List offset.
+  flat_name: process.target.parent.elf.sections.physical_offset
+  ignore_above: 1024
+  level: extended
+  name: sections.physical_offset
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List offset.
+  type: keyword
+process.target.parent.elf.sections.physical_size:
+  dashed_name: process-target-parent-elf-sections-physical-size
+  description: ELF Section List physical size.
+  flat_name: process.target.parent.elf.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List physical size.
+  type: long
+process.target.parent.elf.sections.type:
+  dashed_name: process-target-parent-elf-sections-type
+  description: ELF Section List type.
+  flat_name: process.target.parent.elf.sections.type
+  ignore_above: 1024
+  level: extended
+  name: sections.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List type.
+  type: keyword
+process.target.parent.elf.sections.virtual_address:
+  dashed_name: process-target-parent-elf-sections-virtual-address
+  description: ELF Section List virtual address.
+  flat_name: process.target.parent.elf.sections.virtual_address
+  format: string
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual address.
+  type: long
+process.target.parent.elf.sections.virtual_size:
+  dashed_name: process-target-parent-elf-sections-virtual-size
+  description: ELF Section List virtual size.
+  flat_name: process.target.parent.elf.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: elf
+  short: ELF Section List virtual size.
+  type: long
+process.target.parent.elf.segments:
+  dashed_name: process-target-parent-elf-segments
+  description: 'An array containing an object for each segment of the ELF file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `elf.segments.*`.'
+  flat_name: process.target.parent.elf.segments
+  level: extended
+  name: segments
+  normalize:
+  - array
+  original_fieldset: elf
+  short: ELF object segment list.
+  type: nested
+process.target.parent.elf.segments.sections:
+  dashed_name: process-target-parent-elf-segments-sections
+  description: ELF object segment sections.
+  flat_name: process.target.parent.elf.segments.sections
+  ignore_above: 1024
+  level: extended
+  name: segments.sections
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment sections.
+  type: keyword
+process.target.parent.elf.segments.type:
+  dashed_name: process-target-parent-elf-segments-type
+  description: ELF object segment type.
+  flat_name: process.target.parent.elf.segments.type
+  ignore_above: 1024
+  level: extended
+  name: segments.type
+  normalize: []
+  original_fieldset: elf
+  short: ELF object segment type.
+  type: keyword
+process.target.parent.elf.shared_libraries:
+  dashed_name: process-target-parent-elf-shared-libraries
+  description: List of shared libraries used by this ELF object.
+  flat_name: process.target.parent.elf.shared_libraries
+  ignore_above: 1024
+  level: extended
+  name: shared_libraries
+  normalize:
+  - array
+  original_fieldset: elf
+  short: List of shared libraries used by this ELF object.
+  type: keyword
+process.target.parent.elf.telfhash:
+  dashed_name: process-target-parent-elf-telfhash
+  description: telfhash symbol hash for ELF file.
+  flat_name: process.target.parent.elf.telfhash
+  ignore_above: 1024
+  level: extended
+  name: telfhash
+  normalize: []
+  original_fieldset: elf
+  short: telfhash hash for ELF file.
+  type: keyword
+process.target.parent.entity_id:
+  dashed_name: process-target-parent-entity-id
+  description: 'Unique identifier for the process.
+
+    The implementation of this is specified by the data source, but some examples
+    of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+    or a hash of some uniquely identifying components of a process.
+
+    Constructing a globally unique identifier is a common practice to mitigate PID
+    reuse as well as to identify a specific process over time, across multiple monitored
+    hosts.'
+  example: c2c455d9f99375d
+  flat_name: process.target.parent.entity_id
+  ignore_above: 1024
+  level: extended
+  name: entity_id
+  normalize: []
+  original_fieldset: process
+  short: Unique identifier for the process.
+  type: keyword
+process.target.parent.executable:
+  dashed_name: process-target-parent-executable
+  description: Absolute path to the process executable.
+  example: /usr/bin/ssh
+  flat_name: process.target.parent.executable
+  level: extended
+  multi_fields:
+  - flat_name: process.target.parent.executable.text
+    name: text
+    norms: false
+    type: text
+  name: executable
+  normalize: []
+  original_fieldset: process
+  short: Absolute path to the process executable.
+  type: wildcard
+process.target.parent.exit_code:
+  dashed_name: process-target-parent-exit-code
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.target.parent.exit_code
+  level: extended
+  name: exit_code
+  normalize: []
+  original_fieldset: process
+  short: The exit code of the process.
+  type: long
+process.target.parent.hash.md5:
+  dashed_name: process-target-parent-hash-md5
+  description: MD5 hash.
+  flat_name: process.target.parent.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.target.parent.hash.sha1:
+  dashed_name: process-target-parent-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.target.parent.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.target.parent.hash.sha256:
+  dashed_name: process-target-parent-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.target.parent.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.target.parent.hash.sha512:
+  dashed_name: process-target-parent-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.target.parent.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.target.parent.hash.ssdeep:
+  dashed_name: process-target-parent-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.target.parent.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.target.parent.name:
+  dashed_name: process-target-parent-name
+  description: 'Process name.
+
+    Sometimes called program name or similar.'
+  example: ssh
+  flat_name: process.target.parent.name
+  level: extended
+  multi_fields:
+  - flat_name: process.target.parent.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: process
+  short: Process name.
+  type: wildcard
+process.target.parent.pe.architecture:
+  dashed_name: process-target-parent-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.target.parent.pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.target.parent.pe.authentihash:
+  dashed_name: process-target-parent-pe-authentihash
+  description: Authentihash of the PE file.
+  example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+  flat_name: process.target.parent.pe.authentihash
+  ignore_above: 1024
+  level: extended
+  name: authentihash
+  normalize: []
+  original_fieldset: pe
+  short: Authentihash of the PE file.
+  type: keyword
+process.target.parent.pe.company:
+  dashed_name: process-target-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.target.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.target.parent.pe.compile_timestamp:
+  dashed_name: process-target-parent-pe-compile-timestamp
+  description: Compile timestamp of the PE file.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.parent.pe.compile_timestamp
+  level: extended
+  name: compile_timestamp
+  normalize: []
+  original_fieldset: pe
+  short: Compile timestamp of the PE file.
+  type: date
+process.target.parent.pe.compiler.name:
+  dashed_name: process-target-parent-pe-compiler-name
+  description: Name of the compiler
+  example: Clang
+  flat_name: process.target.parent.pe.compiler.name
+  ignore_above: 1024
+  level: extended
+  name: compiler.name
+  normalize: []
+  original_fieldset: pe
+  short: Name of the compiler
+  type: keyword
+process.target.parent.pe.compiler.version:
+  dashed_name: process-target-parent-pe-compiler-version
+  description: Version of the compiler.
+  example: 11.0.0
+  flat_name: process.target.parent.pe.compiler.version
+  ignore_above: 1024
+  level: extended
+  name: compiler.version
+  normalize: []
+  original_fieldset: pe
+  short: Version of the compiler.
+  type: keyword
+process.target.parent.pe.creation_date:
+  dashed_name: process-target-parent-pe-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.parent.pe.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: pe
+  short: Build or compile date.
+  type: date
+process.target.parent.pe.debug:
+  dashed_name: process-target-parent-pe-debug
+  description: 'An array containing an object for each debug entry, if present.
+
+    The expected fields for this nested object fall under the `debug.` prefix.'
+  flat_name: process.target.parent.pe.debug
+  level: extended
+  name: debug
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Debug information
+  type: nested
+process.target.parent.pe.debug.offset:
+  dashed_name: process-target-parent-pe-debug-offset
+  description: Debug offset information.
+  example: 1296336
+  flat_name: process.target.parent.pe.debug.offset
+  ignore_above: 1024
+  level: extended
+  name: debug.offset
+  normalize: []
+  original_fieldset: pe
+  short: Debug offset information.
+  type: keyword
+process.target.parent.pe.debug.size:
+  dashed_name: process-target-parent-pe-debug-size
+  description: Size of the debug information.
+  example: 816
+  flat_name: process.target.parent.pe.debug.size
+  format: bytes
+  level: extended
+  name: debug.size
+  normalize: []
+  original_fieldset: pe
+  short: Size of the debug information.
+  type: long
+process.target.parent.pe.debug.timestamp:
+  dashed_name: process-target-parent-pe-debug-timestamp
+  description: Timestamp of the debug information.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.parent.pe.debug.timestamp
+  level: extended
+  name: debug.timestamp
+  normalize: []
+  original_fieldset: pe
+  short: Timestamp of the debug information.
+  type: date
+process.target.parent.pe.debug.type:
+  dashed_name: process-target-parent-pe-debug-type
+  description: Information type generated by the debug options.
+  example: IMAGE_DEBUG_TYPE_POGO
+  flat_name: process.target.parent.pe.debug.type
+  ignore_above: 1024
+  level: extended
+  name: debug.type
+  normalize: []
+  original_fieldset: pe
+  short: Information type generated by the debug options.
+  type: keyword
+process.target.parent.pe.description:
+  dashed_name: process-target-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.target.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.target.parent.pe.entry_point:
+  dashed_name: process-target-parent-pe-entry-point
+  description: Relative byte offset to the base of the PE file.
+  example: 25856
+  flat_name: process.target.parent.pe.entry_point
+  ignore_above: 1024
+  level: extended
+  name: entry_point
+  normalize: []
+  original_fieldset: pe
+  short: Relative byte offset to the base of the PE file.
+  type: keyword
+process.target.parent.pe.exports:
+  dashed_name: process-target-parent-pe-exports
+  description: List of symbols exported by PE
+  example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+  flat_name: process.target.parent.pe.exports
+  ignore_above: 1024
+  level: extended
+  name: exports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of symbols exported by PE
+  type: keyword
+process.target.parent.pe.file_version:
+  dashed_name: process-target-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.target.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.target.parent.pe.icon.hash.dhash:
+  dashed_name: process-target-parent-pe-icon-hash-dhash
+  description: Difference Hash (dhash) to find files with a visually similar icon
+    or thumbnail.
+  example: b806e17c8e330d82
+  flat_name: process.target.parent.pe.icon.hash.dhash
+  ignore_above: 1024
+  level: extended
+  name: icon.hash.dhash
+  normalize: []
+  original_fieldset: pe
+  short: Difference Hash (dhash) to find files with a visually similar icon or thumbnail.
+  type: keyword
+process.target.parent.pe.imphash:
+  dashed_name: process-target-parent-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.target.parent.pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.target.parent.pe.imports:
+  dashed_name: process-target-parent-pe-imports
+  description: List of all imported functions
+  example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+    }'
+  flat_name: process.target.parent.pe.imports
+  level: extended
+  name: imports
+  normalize: []
+  original_fieldset: pe
+  short: List of all imported functions
+  type: flattened
+process.target.parent.pe.machine_type:
+  dashed_name: process-target-parent-pe-machine-type
+  description: Machine type of the PE file.
+  example: Intel 386 or later, and compatibles
+  flat_name: process.target.parent.pe.machine_type
+  ignore_above: 1024
+  level: extended
+  name: machine_type
+  normalize: []
+  original_fieldset: pe
+  short: Machine type of the PE file.
+  type: keyword
+process.target.parent.pe.original_file_name:
+  dashed_name: process-target-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.target.parent.pe.original_file_name
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: wildcard
+process.target.parent.pe.packers:
+  dashed_name: process-target-parent-pe-packers
+  description: List of packers and tools used.
+  example: '["ASPack v2.12", ".NET executable"]'
+  flat_name: process.target.parent.pe.packers
+  ignore_above: 1024
+  level: extended
+  name: packers
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of packers and tools used.
+  type: keyword
+process.target.parent.pe.product:
+  dashed_name: process-target-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.target.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.target.parent.pe.resources:
+  dashed_name: process-target-parent-pe-resources
+  description: 'An array containing an object for each PE resource, if present.
+
+    The expected fields for this nested object fall under the `resources.` prefix.'
+  flat_name: process.target.parent.pe.resources
+  level: extended
+  name: resources
+  normalize:
+  - array
+  original_fieldset: pe
+  short: PE resource information
+  type: nested
+process.target.parent.pe.resources.chi2:
+  dashed_name: process-target-parent-pe-resources-chi2
+  description: Chi-square probability distribution.
+  example: -1
+  flat_name: process.target.parent.pe.resources.chi2
+  level: extended
+  name: resources.chi2
+  normalize: []
+  original_fieldset: pe
+  short: Chi-square probability distribution.
+  type: long
+process.target.parent.pe.resources.entropy:
+  dashed_name: process-target-parent-pe-resources-entropy
+  description: Measurement of entropy randomness in the resources section.
+  example: 0, 1
+  flat_name: process.target.parent.pe.resources.entropy
+  level: extended
+  name: resources.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Measurement of entropy randomness in the resources section.
+  type: long
+process.target.parent.pe.resources.filetype:
+  dashed_name: process-target-parent-pe-resources-filetype
+  description: File type of the resources section.
+  example: Data
+  flat_name: process.target.parent.pe.resources.filetype
+  ignore_above: 1024
+  level: extended
+  name: resources.filetype
+  normalize: []
+  original_fieldset: pe
+  short: File type of the resources section.
+  type: keyword
+process.target.parent.pe.resources.language:
+  dashed_name: process-target-parent-pe-resources-language
+  description: Language identification.
+  example: CHINESE SIMPLIFIED
+  flat_name: process.target.parent.pe.resources.language
+  ignore_above: 1024
+  level: extended
+  name: resources.language
+  normalize: []
+  original_fieldset: pe
+  short: Language identification.
+  type: keyword
+process.target.parent.pe.resources.sha256:
+  dashed_name: process-target-parent-pe-resources-sha256
+  description: SHA256 hash of resources section.
+  example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  flat_name: process.target.parent.pe.resources.sha256
+  ignore_above: 1024
+  level: extended
+  name: resources.sha256
+  normalize: []
+  original_fieldset: pe
+  short: SHA256 hash of resources section.
+  type: keyword
+process.target.parent.pe.resources.type:
+  dashed_name: process-target-parent-pe-resources-type
+  description: Digest of resource types.
+  example: '["RT_VERSION", "RT_MANIFEST"]'
+  flat_name: process.target.parent.pe.resources.type
+  ignore_above: 1024
+  level: extended
+  name: resources.type
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of resource types.
+  type: keyword
+process.target.parent.pe.rich_header.hash.md5:
+  dashed_name: process-target-parent-pe-rich-header-hash-md5
+  description: MD5 hash of the header for the PE file.
+  example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+  flat_name: process.target.parent.pe.rich_header.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: rich_header.hash.md5
+  normalize: []
+  original_fieldset: pe
+  short: MD5 hash of the header for the PE file.
+  type: keyword
+process.target.parent.pe.sections:
+  dashed_name: process-target-parent-pe-sections
+  description: Data about sections of compiled binary PE
+  flat_name: process.target.parent.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Data about sections of the compiled binary PE
+  type: nested
+process.target.parent.pe.sections.chi2:
+  dashed_name: process-target-parent-pe-sections-chi2
+  description: Chi-square probability distribution.
+  example: 3027194
+  flat_name: process.target.parent.pe.sections.chi2
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: pe
+  short: Chi-square probability distribution.
+  type: long
+process.target.parent.pe.sections.entropy:
+  dashed_name: process-target-parent-pe-sections-entropy
+  description: Measurement of entropy randomness in the file.
+  example: 6.24
+  flat_name: process.target.parent.pe.sections.entropy
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Measurement of entropy randomness in the file.
+  type: float
+process.target.parent.pe.sections.flags:
+  dashed_name: process-target-parent-pe-sections-flags
+  description: Section flags of the file.
+  example: rx
+  flat_name: process.target.parent.pe.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: pe
+  short: Section flags of the file.
+  type: keyword
+process.target.parent.pe.sections.name:
+  dashed_name: process-target-parent-pe-sections-name
+  description: Section names of the file.
+  example: .text, .data
+  flat_name: process.target.parent.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: Section names of the file.
+  type: keyword
+process.target.parent.pe.sections.raw_size:
+  dashed_name: process-target-parent-pe-sections-raw-size
+  description: Size of the section or the dize of the initialized data on disk.
+  example: 198144
+  flat_name: process.target.parent.pe.sections.raw_size
+  format: bytes
+  level: extended
+  name: sections.raw_size
+  normalize: []
+  original_fieldset: pe
+  short: Size of the section or the dize of the initialized data on disk.
+  type: long
+process.target.parent.pe.sections.virtual_address:
+  dashed_name: process-target-parent-pe-sections-virtual-address
+  description: Virtual address available to the file.
+  example: 8192
+  flat_name: process.target.parent.pe.sections.virtual_address
+  format: bytes
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: pe
+  short: Virtual address available to the file.
+  type: long
+process.target.parent.pgid:
+  dashed_name: process-target-parent-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.target.parent.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  original_fieldset: process
+  short: Identifier of the group of processes the process belongs to.
+  type: long
+process.target.parent.pid:
+  dashed_name: process-target-parent-pid
+  description: Process id.
+  example: 4242
+  flat_name: process.target.parent.pid
+  format: string
+  level: core
+  name: pid
+  normalize: []
+  original_fieldset: process
+  short: Process id.
+  type: long
+process.target.parent.ppid:
+  dashed_name: process-target-parent-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.target.parent.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  original_fieldset: process
+  short: Parent process' pid.
+  type: long
+process.target.parent.start:
+  dashed_name: process-target-parent-start
+  description: The time the process started.
+  example: '2016-05-23T08:05:34.853Z'
+  flat_name: process.target.parent.start
+  level: extended
+  name: start
+  normalize: []
+  original_fieldset: process
+  short: The time the process started.
+  type: date
+process.target.parent.thread.id:
+  dashed_name: process-target-parent-thread-id
+  description: Thread ID.
+  example: 4242
+  flat_name: process.target.parent.thread.id
+  format: string
+  level: extended
+  name: thread.id
+  normalize: []
+  original_fieldset: process
+  short: Thread ID.
+  type: long
+process.target.parent.thread.name:
+  dashed_name: process-target-parent-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.target.parent.thread.name
+  level: extended
+  name: thread.name
+  normalize: []
+  original_fieldset: process
+  short: Thread name.
+  type: wildcard
+process.target.parent.title:
+  dashed_name: process-target-parent-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.target.parent.title
+  level: extended
+  multi_fields:
+  - flat_name: process.target.parent.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  original_fieldset: process
+  short: Process title.
+  type: wildcard
+process.target.parent.uptime:
+  dashed_name: process-target-parent-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.target.parent.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: process
+  short: Seconds the process has been up.
+  type: long
+process.target.parent.working_directory:
+  dashed_name: process-target-parent-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.target.parent.working_directory
+  level: extended
+  multi_fields:
+  - flat_name: process.target.parent.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  original_fieldset: process
+  short: The working directory of the process.
+  type: wildcard
+process.target.pe.architecture:
+  dashed_name: process-target-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.target.pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.target.pe.authentihash:
+  dashed_name: process-target-pe-authentihash
+  description: Authentihash of the PE file.
+  example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+  flat_name: process.target.pe.authentihash
+  ignore_above: 1024
+  level: extended
+  name: authentihash
+  normalize: []
+  original_fieldset: pe
+  short: Authentihash of the PE file.
+  type: keyword
+process.target.pe.company:
+  dashed_name: process-target-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.target.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.target.pe.compile_timestamp:
+  dashed_name: process-target-pe-compile-timestamp
+  description: Compile timestamp of the PE file.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.pe.compile_timestamp
+  level: extended
+  name: compile_timestamp
+  normalize: []
+  original_fieldset: pe
+  short: Compile timestamp of the PE file.
+  type: date
+process.target.pe.compiler.name:
+  dashed_name: process-target-pe-compiler-name
+  description: Name of the compiler
+  example: Clang
+  flat_name: process.target.pe.compiler.name
+  ignore_above: 1024
+  level: extended
+  name: compiler.name
+  normalize: []
+  original_fieldset: pe
+  short: Name of the compiler
+  type: keyword
+process.target.pe.compiler.version:
+  dashed_name: process-target-pe-compiler-version
+  description: Version of the compiler.
+  example: 11.0.0
+  flat_name: process.target.pe.compiler.version
+  ignore_above: 1024
+  level: extended
+  name: compiler.version
+  normalize: []
+  original_fieldset: pe
+  short: Version of the compiler.
+  type: keyword
+process.target.pe.creation_date:
+  dashed_name: process-target-pe-creation-date
+  description: Extracted when possible from the file's metadata. Indicates when it
+    was built or compiled. It can also be faked by malware creators.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.pe.creation_date
+  level: extended
+  name: creation_date
+  normalize: []
+  original_fieldset: pe
+  short: Build or compile date.
+  type: date
+process.target.pe.debug:
+  dashed_name: process-target-pe-debug
+  description: 'An array containing an object for each debug entry, if present.
+
+    The expected fields for this nested object fall under the `debug.` prefix.'
+  flat_name: process.target.pe.debug
+  level: extended
+  name: debug
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Debug information
+  type: nested
+process.target.pe.debug.offset:
+  dashed_name: process-target-pe-debug-offset
+  description: Debug offset information.
+  example: 1296336
+  flat_name: process.target.pe.debug.offset
+  ignore_above: 1024
+  level: extended
+  name: debug.offset
+  normalize: []
+  original_fieldset: pe
+  short: Debug offset information.
+  type: keyword
+process.target.pe.debug.size:
+  dashed_name: process-target-pe-debug-size
+  description: Size of the debug information.
+  example: 816
+  flat_name: process.target.pe.debug.size
+  format: bytes
+  level: extended
+  name: debug.size
+  normalize: []
+  original_fieldset: pe
+  short: Size of the debug information.
+  type: long
+process.target.pe.debug.timestamp:
+  dashed_name: process-target-pe-debug-timestamp
+  description: Timestamp of the debug information.
+  example: '2020-11-05T17:25:47.000Z'
+  flat_name: process.target.pe.debug.timestamp
+  level: extended
+  name: debug.timestamp
+  normalize: []
+  original_fieldset: pe
+  short: Timestamp of the debug information.
+  type: date
+process.target.pe.debug.type:
+  dashed_name: process-target-pe-debug-type
+  description: Information type generated by the debug options.
+  example: IMAGE_DEBUG_TYPE_POGO
+  flat_name: process.target.pe.debug.type
+  ignore_above: 1024
+  level: extended
+  name: debug.type
+  normalize: []
+  original_fieldset: pe
+  short: Information type generated by the debug options.
+  type: keyword
+process.target.pe.description:
+  dashed_name: process-target-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.target.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.target.pe.entry_point:
+  dashed_name: process-target-pe-entry-point
+  description: Relative byte offset to the base of the PE file.
+  example: 25856
+  flat_name: process.target.pe.entry_point
+  ignore_above: 1024
+  level: extended
+  name: entry_point
+  normalize: []
+  original_fieldset: pe
+  short: Relative byte offset to the base of the PE file.
+  type: keyword
+process.target.pe.exports:
+  dashed_name: process-target-pe-exports
+  description: List of symbols exported by PE
+  example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+  flat_name: process.target.pe.exports
+  ignore_above: 1024
+  level: extended
+  name: exports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of symbols exported by PE
+  type: keyword
+process.target.pe.file_version:
+  dashed_name: process-target-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.target.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.target.pe.icon.hash.dhash:
+  dashed_name: process-target-pe-icon-hash-dhash
+  description: Difference Hash (dhash) to find files with a visually similar icon
+    or thumbnail.
+  example: b806e17c8e330d82
+  flat_name: process.target.pe.icon.hash.dhash
+  ignore_above: 1024
+  level: extended
+  name: icon.hash.dhash
+  normalize: []
+  original_fieldset: pe
+  short: Difference Hash (dhash) to find files with a visually similar icon or thumbnail.
+  type: keyword
+process.target.pe.imphash:
+  dashed_name: process-target-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.target.pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.target.pe.imports:
+  dashed_name: process-target-pe-imports
+  description: List of all imported functions
+  example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+    }'
+  flat_name: process.target.pe.imports
+  level: extended
+  name: imports
+  normalize: []
+  original_fieldset: pe
+  short: List of all imported functions
+  type: flattened
+process.target.pe.machine_type:
+  dashed_name: process-target-pe-machine-type
+  description: Machine type of the PE file.
+  example: Intel 386 or later, and compatibles
+  flat_name: process.target.pe.machine_type
+  ignore_above: 1024
+  level: extended
+  name: machine_type
+  normalize: []
+  original_fieldset: pe
+  short: Machine type of the PE file.
+  type: keyword
+process.target.pe.original_file_name:
+  dashed_name: process-target-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.target.pe.original_file_name
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: wildcard
+process.target.pe.packers:
+  dashed_name: process-target-pe-packers
+  description: List of packers and tools used.
+  example: '["ASPack v2.12", ".NET executable"]'
+  flat_name: process.target.pe.packers
+  ignore_above: 1024
+  level: extended
+  name: packers
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of packers and tools used.
+  type: keyword
+process.target.pe.product:
+  dashed_name: process-target-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.target.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.target.pe.resources:
+  dashed_name: process-target-pe-resources
+  description: 'An array containing an object for each PE resource, if present.
+
+    The expected fields for this nested object fall under the `resources.` prefix.'
+  flat_name: process.target.pe.resources
+  level: extended
+  name: resources
+  normalize:
+  - array
+  original_fieldset: pe
+  short: PE resource information
+  type: nested
+process.target.pe.resources.chi2:
+  dashed_name: process-target-pe-resources-chi2
+  description: Chi-square probability distribution.
+  example: -1
+  flat_name: process.target.pe.resources.chi2
+  level: extended
+  name: resources.chi2
+  normalize: []
+  original_fieldset: pe
+  short: Chi-square probability distribution.
+  type: long
+process.target.pe.resources.entropy:
+  dashed_name: process-target-pe-resources-entropy
+  description: Measurement of entropy randomness in the resources section.
+  example: 0, 1
+  flat_name: process.target.pe.resources.entropy
+  level: extended
+  name: resources.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Measurement of entropy randomness in the resources section.
+  type: long
+process.target.pe.resources.filetype:
+  dashed_name: process-target-pe-resources-filetype
+  description: File type of the resources section.
+  example: Data
+  flat_name: process.target.pe.resources.filetype
+  ignore_above: 1024
+  level: extended
+  name: resources.filetype
+  normalize: []
+  original_fieldset: pe
+  short: File type of the resources section.
+  type: keyword
+process.target.pe.resources.language:
+  dashed_name: process-target-pe-resources-language
+  description: Language identification.
+  example: CHINESE SIMPLIFIED
+  flat_name: process.target.pe.resources.language
+  ignore_above: 1024
+  level: extended
+  name: resources.language
+  normalize: []
+  original_fieldset: pe
+  short: Language identification.
+  type: keyword
+process.target.pe.resources.sha256:
+  dashed_name: process-target-pe-resources-sha256
+  description: SHA256 hash of resources section.
+  example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+  flat_name: process.target.pe.resources.sha256
+  ignore_above: 1024
+  level: extended
+  name: resources.sha256
+  normalize: []
+  original_fieldset: pe
+  short: SHA256 hash of resources section.
+  type: keyword
+process.target.pe.resources.type:
+  dashed_name: process-target-pe-resources-type
+  description: Digest of resource types.
+  example: '["RT_VERSION", "RT_MANIFEST"]'
+  flat_name: process.target.pe.resources.type
+  ignore_above: 1024
+  level: extended
+  name: resources.type
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of resource types.
+  type: keyword
+process.target.pe.rich_header.hash.md5:
+  dashed_name: process-target-pe-rich-header-hash-md5
+  description: MD5 hash of the header for the PE file.
+  example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+  flat_name: process.target.pe.rich_header.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: rich_header.hash.md5
+  normalize: []
+  original_fieldset: pe
+  short: MD5 hash of the header for the PE file.
+  type: keyword
+process.target.pe.sections:
+  dashed_name: process-target-pe-sections
+  description: Data about sections of compiled binary PE
+  flat_name: process.target.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Data about sections of the compiled binary PE
+  type: nested
+process.target.pe.sections.chi2:
+  dashed_name: process-target-pe-sections-chi2
+  description: Chi-square probability distribution.
+  example: 3027194
+  flat_name: process.target.pe.sections.chi2
+  level: extended
+  name: sections.chi2
+  normalize: []
+  original_fieldset: pe
+  short: Chi-square probability distribution.
+  type: long
+process.target.pe.sections.entropy:
+  dashed_name: process-target-pe-sections-entropy
+  description: Measurement of entropy randomness in the file.
+  example: 6.24
+  flat_name: process.target.pe.sections.entropy
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Measurement of entropy randomness in the file.
+  type: float
+process.target.pe.sections.flags:
+  dashed_name: process-target-pe-sections-flags
+  description: Section flags of the file.
+  example: rx
+  flat_name: process.target.pe.sections.flags
+  ignore_above: 1024
+  level: extended
+  name: sections.flags
+  normalize: []
+  original_fieldset: pe
+  short: Section flags of the file.
+  type: keyword
+process.target.pe.sections.name:
+  dashed_name: process-target-pe-sections-name
+  description: Section names of the file.
+  example: .text, .data
+  flat_name: process.target.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: Section names of the file.
+  type: keyword
+process.target.pe.sections.raw_size:
+  dashed_name: process-target-pe-sections-raw-size
+  description: Size of the section or the dize of the initialized data on disk.
+  example: 198144
+  flat_name: process.target.pe.sections.raw_size
+  format: bytes
+  level: extended
+  name: sections.raw_size
+  normalize: []
+  original_fieldset: pe
+  short: Size of the section or the dize of the initialized data on disk.
+  type: long
+process.target.pe.sections.virtual_address:
+  dashed_name: process-target-pe-sections-virtual-address
+  description: Virtual address available to the file.
+  example: 8192
+  flat_name: process.target.pe.sections.virtual_address
+  format: bytes
+  level: extended
+  name: sections.virtual_address
+  normalize: []
+  original_fieldset: pe
+  short: Virtual address available to the file.
+  type: long
+process.target.pgid:
+  dashed_name: process-target-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.target.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  original_fieldset: process
+  short: Identifier of the group of processes the process belongs to.
+  type: long
+process.target.pid:
+  dashed_name: process-target-pid
+  description: Process id.
+  example: 4242
+  flat_name: process.target.pid
+  format: string
+  level: core
+  name: pid
+  normalize: []
+  original_fieldset: process
+  short: Process id.
+  type: long
+process.target.ppid:
+  dashed_name: process-target-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.target.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  original_fieldset: process
+  short: Parent process' pid.
+  type: long
+process.target.start:
+  dashed_name: process-target-start
+  description: The time the process started.
+  example: '2016-05-23T08:05:34.853Z'
+  flat_name: process.target.start
+  level: extended
+  name: start
+  normalize: []
+  original_fieldset: process
+  short: The time the process started.
+  type: date
+process.target.thread.id:
+  dashed_name: process-target-thread-id
+  description: Thread ID.
+  example: 4242
+  flat_name: process.target.thread.id
+  format: string
+  level: extended
+  name: thread.id
+  normalize: []
+  original_fieldset: process
+  short: Thread ID.
+  type: long
+process.target.thread.name:
+  dashed_name: process-target-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.target.thread.name
+  level: extended
+  name: thread.name
+  normalize: []
+  original_fieldset: process
+  short: Thread name.
+  type: wildcard
+process.target.title:
+  dashed_name: process-target-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.target.title
+  level: extended
+  multi_fields:
+  - flat_name: process.target.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  original_fieldset: process
+  short: Process title.
+  type: wildcard
+process.target.uptime:
+  dashed_name: process-target-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.target.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: process
+  short: Seconds the process has been up.
+  type: long
+process.target.working_directory:
+  dashed_name: process-target-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.target.working_directory
+  level: extended
+  multi_fields:
+  - flat_name: process.target.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  original_fieldset: process
+  short: The working directory of the process.
+  type: wildcard
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10454,6 +10454,2352 @@ process:
       normalize: []
       short: The time the process started.
       type: date
+    process.target.args:
+      dashed_name: process-target-args
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
+
+        May be filtered to protect sensitive information.'
+      example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+      flat_name: process.target.args
+      ignore_above: 1024
+      level: extended
+      name: args
+      normalize:
+      - array
+      original_fieldset: process
+      short: Array of process arguments.
+      type: keyword
+    process.target.args_count:
+      dashed_name: process-target-args-count
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how
+        many arguments were provided to start a process. More arguments may be an
+        indication of suspicious activity.'
+      example: 4
+      flat_name: process.target.args_count
+      level: extended
+      name: args_count
+      normalize: []
+      original_fieldset: process
+      short: Length of the process.args array.
+      type: long
+    process.target.code_signature.exists:
+      dashed_name: process-target-code-signature-exists
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      flat_name: process.target.code_signature.exists
+      level: core
+      name: exists
+      normalize: []
+      original_fieldset: code_signature
+      short: Boolean to capture if a signature is present.
+      type: boolean
+    process.target.code_signature.signing_id:
+      dashed_name: process-target-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.target.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
+    process.target.code_signature.status:
+      dashed_name: process-target-code-signature-status
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity
+        or trust status. Leave unpopulated if the validity or trust of the certificate
+        was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      flat_name: process.target.code_signature.status
+      ignore_above: 1024
+      level: extended
+      name: status
+      normalize: []
+      original_fieldset: code_signature
+      short: Additional information about the certificate status.
+      type: keyword
+    process.target.code_signature.subject_name:
+      dashed_name: process-target-code-signature-subject-name
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      flat_name: process.target.code_signature.subject_name
+      ignore_above: 1024
+      level: core
+      name: subject_name
+      normalize: []
+      original_fieldset: code_signature
+      short: Subject name of the code signer
+      type: keyword
+    process.target.code_signature.team_id:
+      dashed_name: process-target-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.target.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
+      type: keyword
+    process.target.code_signature.trusted:
+      dashed_name: process-target-code-signature-trusted
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this
+        field should only be populated by tools that actively check the status.'
+      example: 'true'
+      flat_name: process.target.code_signature.trusted
+      level: extended
+      name: trusted
+      normalize: []
+      original_fieldset: code_signature
+      short: Stores the trust status of the certificate chain.
+      type: boolean
+    process.target.code_signature.valid:
+      dashed_name: process-target-code-signature-valid
+      description: 'Boolean to capture if the digital signature is verified against
+        the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      flat_name: process.target.code_signature.valid
+      level: extended
+      name: valid
+      normalize: []
+      original_fieldset: code_signature
+      short: Boolean to capture if the digital signature is verified against the binary
+        content.
+      type: boolean
+    process.target.command_line:
+      dashed_name: process-target-command-line
+      description: 'Full command line that started the process, including the absolute
+        path to the executable, and all arguments.
+
+        Some arguments may be filtered to protect sensitive information.'
+      example: /usr/bin/ssh -l user 10.0.0.16
+      flat_name: process.target.command_line
+      level: extended
+      multi_fields:
+      - flat_name: process.target.command_line.text
+        name: text
+        norms: false
+        type: text
+      name: command_line
+      normalize: []
+      original_fieldset: process
+      short: Full command line that started the process.
+      type: wildcard
+    process.target.elf.architecture:
+      dashed_name: process-target-elf-architecture
+      description: Machine architecture of the ELF file.
+      example: x86-64
+      flat_name: process.target.elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: elf
+      short: Machine architecture of the ELF file.
+      type: keyword
+    process.target.elf.byte_order:
+      dashed_name: process-target-elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian
+      flat_name: process.target.elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      original_fieldset: elf
+      short: Byte sequence of ELF file.
+      type: keyword
+    process.target.elf.cpu_type:
+      dashed_name: process-target-elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel
+      flat_name: process.target.elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      original_fieldset: elf
+      short: CPU type of the ELF file.
+      type: keyword
+    process.target.elf.creation_date:
+      dashed_name: process-target-elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: process.target.elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: elf
+      short: Build or compile date.
+      type: date
+    process.target.elf.exports:
+      dashed_name: process-target-elf-exports
+      description: List of exported element names and types.
+      flat_name: process.target.elf.exports
+      level: extended
+      name: exports
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of exported element names and types.
+      type: flattened
+    process.target.elf.header.abi_version:
+      dashed_name: process-target-elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: process.target.elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    process.target.elf.header.class:
+      dashed_name: process-target-elf-header-class
+      description: Header class of the ELF file.
+      flat_name: process.target.elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      original_fieldset: elf
+      short: Header class of the ELF file.
+      type: keyword
+    process.target.elf.header.data:
+      dashed_name: process-target-elf-header-data
+      description: Data table of the ELF header.
+      flat_name: process.target.elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      original_fieldset: elf
+      short: Data table of the ELF header.
+      type: keyword
+    process.target.elf.header.entrypoint:
+      dashed_name: process-target-elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: process.target.elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      original_fieldset: elf
+      short: Header entrypoint of the ELF file.
+      type: long
+    process.target.elf.header.object_version:
+      dashed_name: process-target-elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: process.target.elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      original_fieldset: elf
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    process.target.elf.header.os_abi:
+      dashed_name: process-target-elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: process.target.elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      original_fieldset: elf
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    process.target.elf.header.type:
+      dashed_name: process-target-elf-header-type
+      description: Header type of the ELF file.
+      flat_name: process.target.elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      original_fieldset: elf
+      short: Header type of the ELF file.
+      type: keyword
+    process.target.elf.header.version:
+      dashed_name: process-target-elf-header-version
+      description: Version of the ELF header.
+      flat_name: process.target.elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF header.
+      type: keyword
+    process.target.elf.imports:
+      dashed_name: process-target-elf-imports
+      description: List of imported element names and types.
+      flat_name: process.target.elf.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of imported element names and types.
+      type: flattened
+    process.target.elf.sections:
+      dashed_name: process-target-elf-sections
+      description: 'An array containing an object for each section of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.sections.*`.'
+      flat_name: process.target.elf.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: elf
+      short: Section information of the ELF file.
+      type: nested
+    process.target.elf.sections.chi2:
+      dashed_name: process-target-elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: process.target.elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: elf
+      short: Chi-square probability distribution of the section.
+      type: long
+    process.target.elf.sections.entropy:
+      dashed_name: process-target-elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.target.elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.target.elf.sections.flags:
+      dashed_name: process-target-elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: process.target.elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List flags.
+      type: keyword
+    process.target.elf.sections.name:
+      dashed_name: process-target-elf-sections-name
+      description: ELF Section List name.
+      flat_name: process.target.elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List name.
+      type: keyword
+    process.target.elf.sections.physical_offset:
+      dashed_name: process-target-elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: process.target.elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List offset.
+      type: keyword
+    process.target.elf.sections.physical_size:
+      dashed_name: process-target-elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: process.target.elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List physical size.
+      type: long
+    process.target.elf.sections.type:
+      dashed_name: process-target-elf-sections-type
+      description: ELF Section List type.
+      flat_name: process.target.elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List type.
+      type: keyword
+    process.target.elf.sections.virtual_address:
+      dashed_name: process-target-elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: process.target.elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual address.
+      type: long
+    process.target.elf.sections.virtual_size:
+      dashed_name: process-target-elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: process.target.elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual size.
+      type: long
+    process.target.elf.segments:
+      dashed_name: process-target-elf-segments
+      description: 'An array containing an object for each segment of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.segments.*`.'
+      flat_name: process.target.elf.segments
+      level: extended
+      name: segments
+      normalize:
+      - array
+      original_fieldset: elf
+      short: ELF object segment list.
+      type: nested
+    process.target.elf.segments.sections:
+      dashed_name: process-target-elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: process.target.elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment sections.
+      type: keyword
+    process.target.elf.segments.type:
+      dashed_name: process-target-elf-segments-type
+      description: ELF object segment type.
+      flat_name: process.target.elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment type.
+      type: keyword
+    process.target.elf.shared_libraries:
+      dashed_name: process-target-elf-shared-libraries
+      description: List of shared libraries used by this ELF object.
+      flat_name: process.target.elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of shared libraries used by this ELF object.
+      type: keyword
+    process.target.elf.telfhash:
+      dashed_name: process-target-elf-telfhash
+      description: telfhash symbol hash for ELF file.
+      flat_name: process.target.elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      original_fieldset: elf
+      short: telfhash hash for ELF file.
+      type: keyword
+    process.target.entity_id:
+      dashed_name: process-target-entity-id
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
+      example: c2c455d9f99375d
+      flat_name: process.target.entity_id
+      ignore_above: 1024
+      level: extended
+      name: entity_id
+      normalize: []
+      original_fieldset: process
+      short: Unique identifier for the process.
+      type: keyword
+    process.target.executable:
+      dashed_name: process-target-executable
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+      flat_name: process.target.executable
+      level: extended
+      multi_fields:
+      - flat_name: process.target.executable.text
+        name: text
+        norms: false
+        type: text
+      name: executable
+      normalize: []
+      original_fieldset: process
+      short: Absolute path to the process executable.
+      type: wildcard
+    process.target.exit_code:
+      dashed_name: process-target-exit-code
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+      flat_name: process.target.exit_code
+      level: extended
+      name: exit_code
+      normalize: []
+      original_fieldset: process
+      short: The exit code of the process.
+      type: long
+    process.target.hash.md5:
+      dashed_name: process-target-hash-md5
+      description: MD5 hash.
+      flat_name: process.target.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    process.target.hash.sha1:
+      dashed_name: process-target-hash-sha1
+      description: SHA1 hash.
+      flat_name: process.target.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    process.target.hash.sha256:
+      dashed_name: process-target-hash-sha256
+      description: SHA256 hash.
+      flat_name: process.target.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    process.target.hash.sha512:
+      dashed_name: process-target-hash-sha512
+      description: SHA512 hash.
+      flat_name: process.target.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    process.target.hash.ssdeep:
+      dashed_name: process-target-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.target.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
+    process.target.name:
+      dashed_name: process-target-name
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+      flat_name: process.target.name
+      level: extended
+      multi_fields:
+      - flat_name: process.target.name.text
+        name: text
+        norms: false
+        type: text
+      name: name
+      normalize: []
+      original_fieldset: process
+      short: Process name.
+      type: wildcard
+    process.target.parent.args:
+      dashed_name: process-target-parent-args
+      description: 'Array of process arguments, starting with the absolute path to
+        the executable.
+
+        May be filtered to protect sensitive information.'
+      example: '["/usr/bin/ssh", "-l", "user", "10.0.0.16"]'
+      flat_name: process.target.parent.args
+      ignore_above: 1024
+      level: extended
+      name: args
+      normalize:
+      - array
+      original_fieldset: process
+      short: Array of process arguments.
+      type: keyword
+    process.target.parent.args_count:
+      dashed_name: process-target-parent-args-count
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how
+        many arguments were provided to start a process. More arguments may be an
+        indication of suspicious activity.'
+      example: 4
+      flat_name: process.target.parent.args_count
+      level: extended
+      name: args_count
+      normalize: []
+      original_fieldset: process
+      short: Length of the process.args array.
+      type: long
+    process.target.parent.code_signature.exists:
+      dashed_name: process-target-parent-code-signature-exists
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      flat_name: process.target.parent.code_signature.exists
+      level: core
+      name: exists
+      normalize: []
+      original_fieldset: code_signature
+      short: Boolean to capture if a signature is present.
+      type: boolean
+    process.target.parent.code_signature.signing_id:
+      dashed_name: process-target-parent-code-signature-signing-id
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor.
+        The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      flat_name: process.target.parent.code_signature.signing_id
+      ignore_above: 1024
+      level: extended
+      name: signing_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The identifier used to sign the process.
+      type: keyword
+    process.target.parent.code_signature.status:
+      dashed_name: process-target-parent-code-signature-status
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity
+        or trust status. Leave unpopulated if the validity or trust of the certificate
+        was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      flat_name: process.target.parent.code_signature.status
+      ignore_above: 1024
+      level: extended
+      name: status
+      normalize: []
+      original_fieldset: code_signature
+      short: Additional information about the certificate status.
+      type: keyword
+    process.target.parent.code_signature.subject_name:
+      dashed_name: process-target-parent-code-signature-subject-name
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      flat_name: process.target.parent.code_signature.subject_name
+      ignore_above: 1024
+      level: core
+      name: subject_name
+      normalize: []
+      original_fieldset: code_signature
+      short: Subject name of the code signer
+      type: keyword
+    process.target.parent.code_signature.team_id:
+      dashed_name: process-target-parent-code-signature-team-id
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field
+        is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      flat_name: process.target.parent.code_signature.team_id
+      ignore_above: 1024
+      level: extended
+      name: team_id
+      normalize: []
+      original_fieldset: code_signature
+      short: The team identifier used to sign the process.
+      type: keyword
+    process.target.parent.code_signature.trusted:
+      dashed_name: process-target-parent-code-signature-trusted
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this
+        field should only be populated by tools that actively check the status.'
+      example: 'true'
+      flat_name: process.target.parent.code_signature.trusted
+      level: extended
+      name: trusted
+      normalize: []
+      original_fieldset: code_signature
+      short: Stores the trust status of the certificate chain.
+      type: boolean
+    process.target.parent.code_signature.valid:
+      dashed_name: process-target-parent-code-signature-valid
+      description: 'Boolean to capture if the digital signature is verified against
+        the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      flat_name: process.target.parent.code_signature.valid
+      level: extended
+      name: valid
+      normalize: []
+      original_fieldset: code_signature
+      short: Boolean to capture if the digital signature is verified against the binary
+        content.
+      type: boolean
+    process.target.parent.command_line:
+      dashed_name: process-target-parent-command-line
+      description: 'Full command line that started the process, including the absolute
+        path to the executable, and all arguments.
+
+        Some arguments may be filtered to protect sensitive information.'
+      example: /usr/bin/ssh -l user 10.0.0.16
+      flat_name: process.target.parent.command_line
+      level: extended
+      multi_fields:
+      - flat_name: process.target.parent.command_line.text
+        name: text
+        norms: false
+        type: text
+      name: command_line
+      normalize: []
+      original_fieldset: process
+      short: Full command line that started the process.
+      type: wildcard
+    process.target.parent.elf.architecture:
+      dashed_name: process-target-parent-elf-architecture
+      description: Machine architecture of the ELF file.
+      example: x86-64
+      flat_name: process.target.parent.elf.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: elf
+      short: Machine architecture of the ELF file.
+      type: keyword
+    process.target.parent.elf.byte_order:
+      dashed_name: process-target-parent-elf-byte-order
+      description: Byte sequence of ELF file.
+      example: Little Endian
+      flat_name: process.target.parent.elf.byte_order
+      ignore_above: 1024
+      level: extended
+      name: byte_order
+      normalize: []
+      original_fieldset: elf
+      short: Byte sequence of ELF file.
+      type: keyword
+    process.target.parent.elf.cpu_type:
+      dashed_name: process-target-parent-elf-cpu-type
+      description: CPU type of the ELF file.
+      example: Intel
+      flat_name: process.target.parent.elf.cpu_type
+      ignore_above: 1024
+      level: extended
+      name: cpu_type
+      normalize: []
+      original_fieldset: elf
+      short: CPU type of the ELF file.
+      type: keyword
+    process.target.parent.elf.creation_date:
+      dashed_name: process-target-parent-elf-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      flat_name: process.target.parent.elf.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: elf
+      short: Build or compile date.
+      type: date
+    process.target.parent.elf.exports:
+      dashed_name: process-target-parent-elf-exports
+      description: List of exported element names and types.
+      flat_name: process.target.parent.elf.exports
+      level: extended
+      name: exports
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of exported element names and types.
+      type: flattened
+    process.target.parent.elf.header.abi_version:
+      dashed_name: process-target-parent-elf-header-abi-version
+      description: Version of the ELF Application Binary Interface (ABI).
+      flat_name: process.target.parent.elf.header.abi_version
+      ignore_above: 1024
+      level: extended
+      name: header.abi_version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF Application Binary Interface (ABI).
+      type: keyword
+    process.target.parent.elf.header.class:
+      dashed_name: process-target-parent-elf-header-class
+      description: Header class of the ELF file.
+      flat_name: process.target.parent.elf.header.class
+      ignore_above: 1024
+      level: extended
+      name: header.class
+      normalize: []
+      original_fieldset: elf
+      short: Header class of the ELF file.
+      type: keyword
+    process.target.parent.elf.header.data:
+      dashed_name: process-target-parent-elf-header-data
+      description: Data table of the ELF header.
+      flat_name: process.target.parent.elf.header.data
+      ignore_above: 1024
+      level: extended
+      name: header.data
+      normalize: []
+      original_fieldset: elf
+      short: Data table of the ELF header.
+      type: keyword
+    process.target.parent.elf.header.entrypoint:
+      dashed_name: process-target-parent-elf-header-entrypoint
+      description: Header entrypoint of the ELF file.
+      flat_name: process.target.parent.elf.header.entrypoint
+      format: string
+      level: extended
+      name: header.entrypoint
+      normalize: []
+      original_fieldset: elf
+      short: Header entrypoint of the ELF file.
+      type: long
+    process.target.parent.elf.header.object_version:
+      dashed_name: process-target-parent-elf-header-object-version
+      description: '"0x1" for original ELF files.'
+      flat_name: process.target.parent.elf.header.object_version
+      ignore_above: 1024
+      level: extended
+      name: header.object_version
+      normalize: []
+      original_fieldset: elf
+      short: '"0x1" for original ELF files.'
+      type: keyword
+    process.target.parent.elf.header.os_abi:
+      dashed_name: process-target-parent-elf-header-os-abi
+      description: Application Binary Interface (ABI) of the Linux OS.
+      flat_name: process.target.parent.elf.header.os_abi
+      ignore_above: 1024
+      level: extended
+      name: header.os_abi
+      normalize: []
+      original_fieldset: elf
+      short: Application Binary Interface (ABI) of the Linux OS.
+      type: keyword
+    process.target.parent.elf.header.type:
+      dashed_name: process-target-parent-elf-header-type
+      description: Header type of the ELF file.
+      flat_name: process.target.parent.elf.header.type
+      ignore_above: 1024
+      level: extended
+      name: header.type
+      normalize: []
+      original_fieldset: elf
+      short: Header type of the ELF file.
+      type: keyword
+    process.target.parent.elf.header.version:
+      dashed_name: process-target-parent-elf-header-version
+      description: Version of the ELF header.
+      flat_name: process.target.parent.elf.header.version
+      ignore_above: 1024
+      level: extended
+      name: header.version
+      normalize: []
+      original_fieldset: elf
+      short: Version of the ELF header.
+      type: keyword
+    process.target.parent.elf.imports:
+      dashed_name: process-target-parent-elf-imports
+      description: List of imported element names and types.
+      flat_name: process.target.parent.elf.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of imported element names and types.
+      type: flattened
+    process.target.parent.elf.sections:
+      dashed_name: process-target-parent-elf-sections
+      description: 'An array containing an object for each section of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.sections.*`.'
+      flat_name: process.target.parent.elf.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: elf
+      short: Section information of the ELF file.
+      type: nested
+    process.target.parent.elf.sections.chi2:
+      dashed_name: process-target-parent-elf-sections-chi2
+      description: Chi-square probability distribution of the section.
+      flat_name: process.target.parent.elf.sections.chi2
+      format: number
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: elf
+      short: Chi-square probability distribution of the section.
+      type: long
+    process.target.parent.elf.sections.entropy:
+      dashed_name: process-target-parent-elf-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.target.parent.elf.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.target.parent.elf.sections.flags:
+      dashed_name: process-target-parent-elf-sections-flags
+      description: ELF Section List flags.
+      flat_name: process.target.parent.elf.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List flags.
+      type: keyword
+    process.target.parent.elf.sections.name:
+      dashed_name: process-target-parent-elf-sections-name
+      description: ELF Section List name.
+      flat_name: process.target.parent.elf.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List name.
+      type: keyword
+    process.target.parent.elf.sections.physical_offset:
+      dashed_name: process-target-parent-elf-sections-physical-offset
+      description: ELF Section List offset.
+      flat_name: process.target.parent.elf.sections.physical_offset
+      ignore_above: 1024
+      level: extended
+      name: sections.physical_offset
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List offset.
+      type: keyword
+    process.target.parent.elf.sections.physical_size:
+      dashed_name: process-target-parent-elf-sections-physical-size
+      description: ELF Section List physical size.
+      flat_name: process.target.parent.elf.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List physical size.
+      type: long
+    process.target.parent.elf.sections.type:
+      dashed_name: process-target-parent-elf-sections-type
+      description: ELF Section List type.
+      flat_name: process.target.parent.elf.sections.type
+      ignore_above: 1024
+      level: extended
+      name: sections.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List type.
+      type: keyword
+    process.target.parent.elf.sections.virtual_address:
+      dashed_name: process-target-parent-elf-sections-virtual-address
+      description: ELF Section List virtual address.
+      flat_name: process.target.parent.elf.sections.virtual_address
+      format: string
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual address.
+      type: long
+    process.target.parent.elf.sections.virtual_size:
+      dashed_name: process-target-parent-elf-sections-virtual-size
+      description: ELF Section List virtual size.
+      flat_name: process.target.parent.elf.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: elf
+      short: ELF Section List virtual size.
+      type: long
+    process.target.parent.elf.segments:
+      dashed_name: process-target-parent-elf-segments
+      description: 'An array containing an object for each segment of the ELF file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `elf.segments.*`.'
+      flat_name: process.target.parent.elf.segments
+      level: extended
+      name: segments
+      normalize:
+      - array
+      original_fieldset: elf
+      short: ELF object segment list.
+      type: nested
+    process.target.parent.elf.segments.sections:
+      dashed_name: process-target-parent-elf-segments-sections
+      description: ELF object segment sections.
+      flat_name: process.target.parent.elf.segments.sections
+      ignore_above: 1024
+      level: extended
+      name: segments.sections
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment sections.
+      type: keyword
+    process.target.parent.elf.segments.type:
+      dashed_name: process-target-parent-elf-segments-type
+      description: ELF object segment type.
+      flat_name: process.target.parent.elf.segments.type
+      ignore_above: 1024
+      level: extended
+      name: segments.type
+      normalize: []
+      original_fieldset: elf
+      short: ELF object segment type.
+      type: keyword
+    process.target.parent.elf.shared_libraries:
+      dashed_name: process-target-parent-elf-shared-libraries
+      description: List of shared libraries used by this ELF object.
+      flat_name: process.target.parent.elf.shared_libraries
+      ignore_above: 1024
+      level: extended
+      name: shared_libraries
+      normalize:
+      - array
+      original_fieldset: elf
+      short: List of shared libraries used by this ELF object.
+      type: keyword
+    process.target.parent.elf.telfhash:
+      dashed_name: process-target-parent-elf-telfhash
+      description: telfhash symbol hash for ELF file.
+      flat_name: process.target.parent.elf.telfhash
+      ignore_above: 1024
+      level: extended
+      name: telfhash
+      normalize: []
+      original_fieldset: elf
+      short: telfhash hash for ELF file.
+      type: keyword
+    process.target.parent.entity_id:
+      dashed_name: process-target-parent-entity-id
+      description: 'Unique identifier for the process.
+
+        The implementation of this is specified by the data source, but some examples
+        of what could be used here are a process-generated UUID, Sysmon Process GUIDs,
+        or a hash of some uniquely identifying components of a process.
+
+        Constructing a globally unique identifier is a common practice to mitigate
+        PID reuse as well as to identify a specific process over time, across multiple
+        monitored hosts.'
+      example: c2c455d9f99375d
+      flat_name: process.target.parent.entity_id
+      ignore_above: 1024
+      level: extended
+      name: entity_id
+      normalize: []
+      original_fieldset: process
+      short: Unique identifier for the process.
+      type: keyword
+    process.target.parent.executable:
+      dashed_name: process-target-parent-executable
+      description: Absolute path to the process executable.
+      example: /usr/bin/ssh
+      flat_name: process.target.parent.executable
+      level: extended
+      multi_fields:
+      - flat_name: process.target.parent.executable.text
+        name: text
+        norms: false
+        type: text
+      name: executable
+      normalize: []
+      original_fieldset: process
+      short: Absolute path to the process executable.
+      type: wildcard
+    process.target.parent.exit_code:
+      dashed_name: process-target-parent-exit-code
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process
+        start).'
+      example: 137
+      flat_name: process.target.parent.exit_code
+      level: extended
+      name: exit_code
+      normalize: []
+      original_fieldset: process
+      short: The exit code of the process.
+      type: long
+    process.target.parent.hash.md5:
+      dashed_name: process-target-parent-hash-md5
+      description: MD5 hash.
+      flat_name: process.target.parent.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    process.target.parent.hash.sha1:
+      dashed_name: process-target-parent-hash-sha1
+      description: SHA1 hash.
+      flat_name: process.target.parent.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    process.target.parent.hash.sha256:
+      dashed_name: process-target-parent-hash-sha256
+      description: SHA256 hash.
+      flat_name: process.target.parent.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    process.target.parent.hash.sha512:
+      dashed_name: process-target-parent-hash-sha512
+      description: SHA512 hash.
+      flat_name: process.target.parent.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    process.target.parent.hash.ssdeep:
+      dashed_name: process-target-parent-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: process.target.parent.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
+    process.target.parent.name:
+      dashed_name: process-target-parent-name
+      description: 'Process name.
+
+        Sometimes called program name or similar.'
+      example: ssh
+      flat_name: process.target.parent.name
+      level: extended
+      multi_fields:
+      - flat_name: process.target.parent.name.text
+        name: text
+        norms: false
+        type: text
+      name: name
+      normalize: []
+      original_fieldset: process
+      short: Process name.
+      type: wildcard
+    process.target.parent.pe.architecture:
+      dashed_name: process-target-parent-pe-architecture
+      description: CPU architecture target for the file.
+      example: x64
+      flat_name: process.target.parent.pe.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: pe
+      short: CPU architecture target for the file.
+      type: keyword
+    process.target.parent.pe.authentihash:
+      dashed_name: process-target-parent-pe-authentihash
+      description: Authentihash of the PE file.
+      example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+      flat_name: process.target.parent.pe.authentihash
+      ignore_above: 1024
+      level: extended
+      name: authentihash
+      normalize: []
+      original_fieldset: pe
+      short: Authentihash of the PE file.
+      type: keyword
+    process.target.parent.pe.company:
+      dashed_name: process-target-parent-pe-company
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      flat_name: process.target.parent.pe.company
+      ignore_above: 1024
+      level: extended
+      name: company
+      normalize: []
+      original_fieldset: pe
+      short: Internal company name of the file, provided at compile-time.
+      type: keyword
+    process.target.parent.pe.compile_timestamp:
+      dashed_name: process-target-parent-pe-compile-timestamp
+      description: Compile timestamp of the PE file.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.parent.pe.compile_timestamp
+      level: extended
+      name: compile_timestamp
+      normalize: []
+      original_fieldset: pe
+      short: Compile timestamp of the PE file.
+      type: date
+    process.target.parent.pe.compiler.name:
+      dashed_name: process-target-parent-pe-compiler-name
+      description: Name of the compiler
+      example: Clang
+      flat_name: process.target.parent.pe.compiler.name
+      ignore_above: 1024
+      level: extended
+      name: compiler.name
+      normalize: []
+      original_fieldset: pe
+      short: Name of the compiler
+      type: keyword
+    process.target.parent.pe.compiler.version:
+      dashed_name: process-target-parent-pe-compiler-version
+      description: Version of the compiler.
+      example: 11.0.0
+      flat_name: process.target.parent.pe.compiler.version
+      ignore_above: 1024
+      level: extended
+      name: compiler.version
+      normalize: []
+      original_fieldset: pe
+      short: Version of the compiler.
+      type: keyword
+    process.target.parent.pe.creation_date:
+      dashed_name: process-target-parent-pe-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.parent.pe.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: pe
+      short: Build or compile date.
+      type: date
+    process.target.parent.pe.debug:
+      dashed_name: process-target-parent-pe-debug
+      description: 'An array containing an object for each debug entry, if present.
+
+        The expected fields for this nested object fall under the `debug.` prefix.'
+      flat_name: process.target.parent.pe.debug
+      level: extended
+      name: debug
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Debug information
+      type: nested
+    process.target.parent.pe.debug.offset:
+      dashed_name: process-target-parent-pe-debug-offset
+      description: Debug offset information.
+      example: 1296336
+      flat_name: process.target.parent.pe.debug.offset
+      ignore_above: 1024
+      level: extended
+      name: debug.offset
+      normalize: []
+      original_fieldset: pe
+      short: Debug offset information.
+      type: keyword
+    process.target.parent.pe.debug.size:
+      dashed_name: process-target-parent-pe-debug-size
+      description: Size of the debug information.
+      example: 816
+      flat_name: process.target.parent.pe.debug.size
+      format: bytes
+      level: extended
+      name: debug.size
+      normalize: []
+      original_fieldset: pe
+      short: Size of the debug information.
+      type: long
+    process.target.parent.pe.debug.timestamp:
+      dashed_name: process-target-parent-pe-debug-timestamp
+      description: Timestamp of the debug information.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.parent.pe.debug.timestamp
+      level: extended
+      name: debug.timestamp
+      normalize: []
+      original_fieldset: pe
+      short: Timestamp of the debug information.
+      type: date
+    process.target.parent.pe.debug.type:
+      dashed_name: process-target-parent-pe-debug-type
+      description: Information type generated by the debug options.
+      example: IMAGE_DEBUG_TYPE_POGO
+      flat_name: process.target.parent.pe.debug.type
+      ignore_above: 1024
+      level: extended
+      name: debug.type
+      normalize: []
+      original_fieldset: pe
+      short: Information type generated by the debug options.
+      type: keyword
+    process.target.parent.pe.description:
+      dashed_name: process-target-parent-pe-description
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      flat_name: process.target.parent.pe.description
+      ignore_above: 1024
+      level: extended
+      name: description
+      normalize: []
+      original_fieldset: pe
+      short: Internal description of the file, provided at compile-time.
+      type: keyword
+    process.target.parent.pe.entry_point:
+      dashed_name: process-target-parent-pe-entry-point
+      description: Relative byte offset to the base of the PE file.
+      example: 25856
+      flat_name: process.target.parent.pe.entry_point
+      ignore_above: 1024
+      level: extended
+      name: entry_point
+      normalize: []
+      original_fieldset: pe
+      short: Relative byte offset to the base of the PE file.
+      type: keyword
+    process.target.parent.pe.exports:
+      dashed_name: process-target-parent-pe-exports
+      description: List of symbols exported by PE
+      example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+      flat_name: process.target.parent.pe.exports
+      ignore_above: 1024
+      level: extended
+      name: exports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of symbols exported by PE
+      type: keyword
+    process.target.parent.pe.file_version:
+      dashed_name: process-target-parent-pe-file-version
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      flat_name: process.target.parent.pe.file_version
+      ignore_above: 1024
+      level: extended
+      name: file_version
+      normalize: []
+      original_fieldset: pe
+      short: Process name.
+      type: keyword
+    process.target.parent.pe.icon.hash.dhash:
+      dashed_name: process-target-parent-pe-icon-hash-dhash
+      description: Difference Hash (dhash) to find files with a visually similar icon
+        or thumbnail.
+      example: b806e17c8e330d82
+      flat_name: process.target.parent.pe.icon.hash.dhash
+      ignore_above: 1024
+      level: extended
+      name: icon.hash.dhash
+      normalize: []
+      original_fieldset: pe
+      short: Difference Hash (dhash) to find files with a visually similar icon or
+        thumbnail.
+      type: keyword
+    process.target.parent.pe.imphash:
+      dashed_name: process-target-parent-pe-imphash
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      flat_name: process.target.parent.pe.imphash
+      ignore_above: 1024
+      level: extended
+      name: imphash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in a PE file.
+      type: keyword
+    process.target.parent.pe.imports:
+      dashed_name: process-target-parent-pe-imports
+      description: List of all imported functions
+      example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+        }'
+      flat_name: process.target.parent.pe.imports
+      level: extended
+      name: imports
+      normalize: []
+      original_fieldset: pe
+      short: List of all imported functions
+      type: flattened
+    process.target.parent.pe.machine_type:
+      dashed_name: process-target-parent-pe-machine-type
+      description: Machine type of the PE file.
+      example: Intel 386 or later, and compatibles
+      flat_name: process.target.parent.pe.machine_type
+      ignore_above: 1024
+      level: extended
+      name: machine_type
+      normalize: []
+      original_fieldset: pe
+      short: Machine type of the PE file.
+      type: keyword
+    process.target.parent.pe.original_file_name:
+      dashed_name: process-target-parent-pe-original-file-name
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      flat_name: process.target.parent.pe.original_file_name
+      level: extended
+      name: original_file_name
+      normalize: []
+      original_fieldset: pe
+      short: Internal name of the file, provided at compile-time.
+      type: wildcard
+    process.target.parent.pe.packers:
+      dashed_name: process-target-parent-pe-packers
+      description: List of packers and tools used.
+      example: '["ASPack v2.12", ".NET executable"]'
+      flat_name: process.target.parent.pe.packers
+      ignore_above: 1024
+      level: extended
+      name: packers
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of packers and tools used.
+      type: keyword
+    process.target.parent.pe.product:
+      dashed_name: process-target-parent-pe-product
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      flat_name: process.target.parent.pe.product
+      ignore_above: 1024
+      level: extended
+      name: product
+      normalize: []
+      original_fieldset: pe
+      short: Internal product name of the file, provided at compile-time.
+      type: keyword
+    process.target.parent.pe.resources:
+      dashed_name: process-target-parent-pe-resources
+      description: 'An array containing an object for each PE resource, if present.
+
+        The expected fields for this nested object fall under the `resources.` prefix.'
+      flat_name: process.target.parent.pe.resources
+      level: extended
+      name: resources
+      normalize:
+      - array
+      original_fieldset: pe
+      short: PE resource information
+      type: nested
+    process.target.parent.pe.resources.chi2:
+      dashed_name: process-target-parent-pe-resources-chi2
+      description: Chi-square probability distribution.
+      example: -1
+      flat_name: process.target.parent.pe.resources.chi2
+      level: extended
+      name: resources.chi2
+      normalize: []
+      original_fieldset: pe
+      short: Chi-square probability distribution.
+      type: long
+    process.target.parent.pe.resources.entropy:
+      dashed_name: process-target-parent-pe-resources-entropy
+      description: Measurement of entropy randomness in the resources section.
+      example: 0, 1
+      flat_name: process.target.parent.pe.resources.entropy
+      level: extended
+      name: resources.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Measurement of entropy randomness in the resources section.
+      type: long
+    process.target.parent.pe.resources.filetype:
+      dashed_name: process-target-parent-pe-resources-filetype
+      description: File type of the resources section.
+      example: Data
+      flat_name: process.target.parent.pe.resources.filetype
+      ignore_above: 1024
+      level: extended
+      name: resources.filetype
+      normalize: []
+      original_fieldset: pe
+      short: File type of the resources section.
+      type: keyword
+    process.target.parent.pe.resources.language:
+      dashed_name: process-target-parent-pe-resources-language
+      description: Language identification.
+      example: CHINESE SIMPLIFIED
+      flat_name: process.target.parent.pe.resources.language
+      ignore_above: 1024
+      level: extended
+      name: resources.language
+      normalize: []
+      original_fieldset: pe
+      short: Language identification.
+      type: keyword
+    process.target.parent.pe.resources.sha256:
+      dashed_name: process-target-parent-pe-resources-sha256
+      description: SHA256 hash of resources section.
+      example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      flat_name: process.target.parent.pe.resources.sha256
+      ignore_above: 1024
+      level: extended
+      name: resources.sha256
+      normalize: []
+      original_fieldset: pe
+      short: SHA256 hash of resources section.
+      type: keyword
+    process.target.parent.pe.resources.type:
+      dashed_name: process-target-parent-pe-resources-type
+      description: Digest of resource types.
+      example: '["RT_VERSION", "RT_MANIFEST"]'
+      flat_name: process.target.parent.pe.resources.type
+      ignore_above: 1024
+      level: extended
+      name: resources.type
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of resource types.
+      type: keyword
+    process.target.parent.pe.rich_header.hash.md5:
+      dashed_name: process-target-parent-pe-rich-header-hash-md5
+      description: MD5 hash of the header for the PE file.
+      example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+      flat_name: process.target.parent.pe.rich_header.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: rich_header.hash.md5
+      normalize: []
+      original_fieldset: pe
+      short: MD5 hash of the header for the PE file.
+      type: keyword
+    process.target.parent.pe.sections:
+      dashed_name: process-target-parent-pe-sections
+      description: Data about sections of compiled binary PE
+      flat_name: process.target.parent.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Data about sections of the compiled binary PE
+      type: nested
+    process.target.parent.pe.sections.chi2:
+      dashed_name: process-target-parent-pe-sections-chi2
+      description: Chi-square probability distribution.
+      example: 3027194
+      flat_name: process.target.parent.pe.sections.chi2
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: pe
+      short: Chi-square probability distribution.
+      type: long
+    process.target.parent.pe.sections.entropy:
+      dashed_name: process-target-parent-pe-sections-entropy
+      description: Measurement of entropy randomness in the file.
+      example: 6.24
+      flat_name: process.target.parent.pe.sections.entropy
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Measurement of entropy randomness in the file.
+      type: float
+    process.target.parent.pe.sections.flags:
+      dashed_name: process-target-parent-pe-sections-flags
+      description: Section flags of the file.
+      example: rx
+      flat_name: process.target.parent.pe.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: pe
+      short: Section flags of the file.
+      type: keyword
+    process.target.parent.pe.sections.name:
+      dashed_name: process-target-parent-pe-sections-name
+      description: Section names of the file.
+      example: .text, .data
+      flat_name: process.target.parent.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: Section names of the file.
+      type: keyword
+    process.target.parent.pe.sections.raw_size:
+      dashed_name: process-target-parent-pe-sections-raw-size
+      description: Size of the section or the dize of the initialized data on disk.
+      example: 198144
+      flat_name: process.target.parent.pe.sections.raw_size
+      format: bytes
+      level: extended
+      name: sections.raw_size
+      normalize: []
+      original_fieldset: pe
+      short: Size of the section or the dize of the initialized data on disk.
+      type: long
+    process.target.parent.pe.sections.virtual_address:
+      dashed_name: process-target-parent-pe-sections-virtual-address
+      description: Virtual address available to the file.
+      example: 8192
+      flat_name: process.target.parent.pe.sections.virtual_address
+      format: bytes
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: pe
+      short: Virtual address available to the file.
+      type: long
+    process.target.parent.pgid:
+      dashed_name: process-target-parent-pgid
+      description: Identifier of the group of processes the process belongs to.
+      flat_name: process.target.parent.pgid
+      format: string
+      level: extended
+      name: pgid
+      normalize: []
+      original_fieldset: process
+      short: Identifier of the group of processes the process belongs to.
+      type: long
+    process.target.parent.pid:
+      dashed_name: process-target-parent-pid
+      description: Process id.
+      example: 4242
+      flat_name: process.target.parent.pid
+      format: string
+      level: core
+      name: pid
+      normalize: []
+      original_fieldset: process
+      short: Process id.
+      type: long
+    process.target.parent.ppid:
+      dashed_name: process-target-parent-ppid
+      description: Parent process' pid.
+      example: 4241
+      flat_name: process.target.parent.ppid
+      format: string
+      level: extended
+      name: ppid
+      normalize: []
+      original_fieldset: process
+      short: Parent process' pid.
+      type: long
+    process.target.parent.start:
+      dashed_name: process-target-parent-start
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+      flat_name: process.target.parent.start
+      level: extended
+      name: start
+      normalize: []
+      original_fieldset: process
+      short: The time the process started.
+      type: date
+    process.target.parent.thread.id:
+      dashed_name: process-target-parent-thread-id
+      description: Thread ID.
+      example: 4242
+      flat_name: process.target.parent.thread.id
+      format: string
+      level: extended
+      name: thread.id
+      normalize: []
+      original_fieldset: process
+      short: Thread ID.
+      type: long
+    process.target.parent.thread.name:
+      dashed_name: process-target-parent-thread-name
+      description: Thread name.
+      example: thread-0
+      flat_name: process.target.parent.thread.name
+      level: extended
+      name: thread.name
+      normalize: []
+      original_fieldset: process
+      short: Thread name.
+      type: wildcard
+    process.target.parent.title:
+      dashed_name: process-target-parent-title
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+      flat_name: process.target.parent.title
+      level: extended
+      multi_fields:
+      - flat_name: process.target.parent.title.text
+        name: text
+        norms: false
+        type: text
+      name: title
+      normalize: []
+      original_fieldset: process
+      short: Process title.
+      type: wildcard
+    process.target.parent.uptime:
+      dashed_name: process-target-parent-uptime
+      description: Seconds the process has been up.
+      example: 1325
+      flat_name: process.target.parent.uptime
+      level: extended
+      name: uptime
+      normalize: []
+      original_fieldset: process
+      short: Seconds the process has been up.
+      type: long
+    process.target.parent.working_directory:
+      dashed_name: process-target-parent-working-directory
+      description: The working directory of the process.
+      example: /home/alice
+      flat_name: process.target.parent.working_directory
+      level: extended
+      multi_fields:
+      - flat_name: process.target.parent.working_directory.text
+        name: text
+        norms: false
+        type: text
+      name: working_directory
+      normalize: []
+      original_fieldset: process
+      short: The working directory of the process.
+      type: wildcard
+    process.target.pe.architecture:
+      dashed_name: process-target-pe-architecture
+      description: CPU architecture target for the file.
+      example: x64
+      flat_name: process.target.pe.architecture
+      ignore_above: 1024
+      level: extended
+      name: architecture
+      normalize: []
+      original_fieldset: pe
+      short: CPU architecture target for the file.
+      type: keyword
+    process.target.pe.authentihash:
+      dashed_name: process-target-pe-authentihash
+      description: Authentihash of the PE file.
+      example: ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78
+      flat_name: process.target.pe.authentihash
+      ignore_above: 1024
+      level: extended
+      name: authentihash
+      normalize: []
+      original_fieldset: pe
+      short: Authentihash of the PE file.
+      type: keyword
+    process.target.pe.company:
+      dashed_name: process-target-pe-company
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      flat_name: process.target.pe.company
+      ignore_above: 1024
+      level: extended
+      name: company
+      normalize: []
+      original_fieldset: pe
+      short: Internal company name of the file, provided at compile-time.
+      type: keyword
+    process.target.pe.compile_timestamp:
+      dashed_name: process-target-pe-compile-timestamp
+      description: Compile timestamp of the PE file.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.pe.compile_timestamp
+      level: extended
+      name: compile_timestamp
+      normalize: []
+      original_fieldset: pe
+      short: Compile timestamp of the PE file.
+      type: date
+    process.target.pe.compiler.name:
+      dashed_name: process-target-pe-compiler-name
+      description: Name of the compiler
+      example: Clang
+      flat_name: process.target.pe.compiler.name
+      ignore_above: 1024
+      level: extended
+      name: compiler.name
+      normalize: []
+      original_fieldset: pe
+      short: Name of the compiler
+      type: keyword
+    process.target.pe.compiler.version:
+      dashed_name: process-target-pe-compiler-version
+      description: Version of the compiler.
+      example: 11.0.0
+      flat_name: process.target.pe.compiler.version
+      ignore_above: 1024
+      level: extended
+      name: compiler.version
+      normalize: []
+      original_fieldset: pe
+      short: Version of the compiler.
+      type: keyword
+    process.target.pe.creation_date:
+      dashed_name: process-target-pe-creation-date
+      description: Extracted when possible from the file's metadata. Indicates when
+        it was built or compiled. It can also be faked by malware creators.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.pe.creation_date
+      level: extended
+      name: creation_date
+      normalize: []
+      original_fieldset: pe
+      short: Build or compile date.
+      type: date
+    process.target.pe.debug:
+      dashed_name: process-target-pe-debug
+      description: 'An array containing an object for each debug entry, if present.
+
+        The expected fields for this nested object fall under the `debug.` prefix.'
+      flat_name: process.target.pe.debug
+      level: extended
+      name: debug
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Debug information
+      type: nested
+    process.target.pe.debug.offset:
+      dashed_name: process-target-pe-debug-offset
+      description: Debug offset information.
+      example: 1296336
+      flat_name: process.target.pe.debug.offset
+      ignore_above: 1024
+      level: extended
+      name: debug.offset
+      normalize: []
+      original_fieldset: pe
+      short: Debug offset information.
+      type: keyword
+    process.target.pe.debug.size:
+      dashed_name: process-target-pe-debug-size
+      description: Size of the debug information.
+      example: 816
+      flat_name: process.target.pe.debug.size
+      format: bytes
+      level: extended
+      name: debug.size
+      normalize: []
+      original_fieldset: pe
+      short: Size of the debug information.
+      type: long
+    process.target.pe.debug.timestamp:
+      dashed_name: process-target-pe-debug-timestamp
+      description: Timestamp of the debug information.
+      example: '2020-11-05T17:25:47.000Z'
+      flat_name: process.target.pe.debug.timestamp
+      level: extended
+      name: debug.timestamp
+      normalize: []
+      original_fieldset: pe
+      short: Timestamp of the debug information.
+      type: date
+    process.target.pe.debug.type:
+      dashed_name: process-target-pe-debug-type
+      description: Information type generated by the debug options.
+      example: IMAGE_DEBUG_TYPE_POGO
+      flat_name: process.target.pe.debug.type
+      ignore_above: 1024
+      level: extended
+      name: debug.type
+      normalize: []
+      original_fieldset: pe
+      short: Information type generated by the debug options.
+      type: keyword
+    process.target.pe.description:
+      dashed_name: process-target-pe-description
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      flat_name: process.target.pe.description
+      ignore_above: 1024
+      level: extended
+      name: description
+      normalize: []
+      original_fieldset: pe
+      short: Internal description of the file, provided at compile-time.
+      type: keyword
+    process.target.pe.entry_point:
+      dashed_name: process-target-pe-entry-point
+      description: Relative byte offset to the base of the PE file.
+      example: 25856
+      flat_name: process.target.pe.entry_point
+      ignore_above: 1024
+      level: extended
+      name: entry_point
+      normalize: []
+      original_fieldset: pe
+      short: Relative byte offset to the base of the PE file.
+      type: keyword
+    process.target.pe.exports:
+      dashed_name: process-target-pe-exports
+      description: List of symbols exported by PE
+      example: '["DllInstall", "DllRegisterServer", "DllUnregisterServer"]'
+      flat_name: process.target.pe.exports
+      ignore_above: 1024
+      level: extended
+      name: exports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of symbols exported by PE
+      type: keyword
+    process.target.pe.file_version:
+      dashed_name: process-target-pe-file-version
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      flat_name: process.target.pe.file_version
+      ignore_above: 1024
+      level: extended
+      name: file_version
+      normalize: []
+      original_fieldset: pe
+      short: Process name.
+      type: keyword
+    process.target.pe.icon.hash.dhash:
+      dashed_name: process-target-pe-icon-hash-dhash
+      description: Difference Hash (dhash) to find files with a visually similar icon
+        or thumbnail.
+      example: b806e17c8e330d82
+      flat_name: process.target.pe.icon.hash.dhash
+      ignore_above: 1024
+      level: extended
+      name: icon.hash.dhash
+      normalize: []
+      original_fieldset: pe
+      short: Difference Hash (dhash) to find files with a visually similar icon or
+        thumbnail.
+      type: keyword
+    process.target.pe.imphash:
+      dashed_name: process-target-pe-imphash
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash
+        -- can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      flat_name: process.target.pe.imphash
+      ignore_above: 1024
+      level: extended
+      name: imphash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in a PE file.
+      type: keyword
+    process.target.pe.imports:
+      dashed_name: process-target-pe-imports
+      description: List of all imported functions
+      example: '{ "library_name" : "mscoree.dll", "imported_functions" : "GetFileVersionInfoSizeA"
+        }'
+      flat_name: process.target.pe.imports
+      level: extended
+      name: imports
+      normalize: []
+      original_fieldset: pe
+      short: List of all imported functions
+      type: flattened
+    process.target.pe.machine_type:
+      dashed_name: process-target-pe-machine-type
+      description: Machine type of the PE file.
+      example: Intel 386 or later, and compatibles
+      flat_name: process.target.pe.machine_type
+      ignore_above: 1024
+      level: extended
+      name: machine_type
+      normalize: []
+      original_fieldset: pe
+      short: Machine type of the PE file.
+      type: keyword
+    process.target.pe.original_file_name:
+      dashed_name: process-target-pe-original-file-name
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      flat_name: process.target.pe.original_file_name
+      level: extended
+      name: original_file_name
+      normalize: []
+      original_fieldset: pe
+      short: Internal name of the file, provided at compile-time.
+      type: wildcard
+    process.target.pe.packers:
+      dashed_name: process-target-pe-packers
+      description: List of packers and tools used.
+      example: '["ASPack v2.12", ".NET executable"]'
+      flat_name: process.target.pe.packers
+      ignore_above: 1024
+      level: extended
+      name: packers
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of packers and tools used.
+      type: keyword
+    process.target.pe.product:
+      dashed_name: process-target-pe-product
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft\xAE Windows\xAE Operating System"
+      flat_name: process.target.pe.product
+      ignore_above: 1024
+      level: extended
+      name: product
+      normalize: []
+      original_fieldset: pe
+      short: Internal product name of the file, provided at compile-time.
+      type: keyword
+    process.target.pe.resources:
+      dashed_name: process-target-pe-resources
+      description: 'An array containing an object for each PE resource, if present.
+
+        The expected fields for this nested object fall under the `resources.` prefix.'
+      flat_name: process.target.pe.resources
+      level: extended
+      name: resources
+      normalize:
+      - array
+      original_fieldset: pe
+      short: PE resource information
+      type: nested
+    process.target.pe.resources.chi2:
+      dashed_name: process-target-pe-resources-chi2
+      description: Chi-square probability distribution.
+      example: -1
+      flat_name: process.target.pe.resources.chi2
+      level: extended
+      name: resources.chi2
+      normalize: []
+      original_fieldset: pe
+      short: Chi-square probability distribution.
+      type: long
+    process.target.pe.resources.entropy:
+      dashed_name: process-target-pe-resources-entropy
+      description: Measurement of entropy randomness in the resources section.
+      example: 0, 1
+      flat_name: process.target.pe.resources.entropy
+      level: extended
+      name: resources.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Measurement of entropy randomness in the resources section.
+      type: long
+    process.target.pe.resources.filetype:
+      dashed_name: process-target-pe-resources-filetype
+      description: File type of the resources section.
+      example: Data
+      flat_name: process.target.pe.resources.filetype
+      ignore_above: 1024
+      level: extended
+      name: resources.filetype
+      normalize: []
+      original_fieldset: pe
+      short: File type of the resources section.
+      type: keyword
+    process.target.pe.resources.language:
+      dashed_name: process-target-pe-resources-language
+      description: Language identification.
+      example: CHINESE SIMPLIFIED
+      flat_name: process.target.pe.resources.language
+      ignore_above: 1024
+      level: extended
+      name: resources.language
+      normalize: []
+      original_fieldset: pe
+      short: Language identification.
+      type: keyword
+    process.target.pe.resources.sha256:
+      dashed_name: process-target-pe-resources-sha256
+      description: SHA256 hash of resources section.
+      example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      flat_name: process.target.pe.resources.sha256
+      ignore_above: 1024
+      level: extended
+      name: resources.sha256
+      normalize: []
+      original_fieldset: pe
+      short: SHA256 hash of resources section.
+      type: keyword
+    process.target.pe.resources.type:
+      dashed_name: process-target-pe-resources-type
+      description: Digest of resource types.
+      example: '["RT_VERSION", "RT_MANIFEST"]'
+      flat_name: process.target.pe.resources.type
+      ignore_above: 1024
+      level: extended
+      name: resources.type
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of resource types.
+      type: keyword
+    process.target.pe.rich_header.hash.md5:
+      dashed_name: process-target-pe-rich-header-hash-md5
+      description: MD5 hash of the header for the PE file.
+      example: 5aa1aa0f2b4be70397a1e9e2b87627cd
+      flat_name: process.target.pe.rich_header.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: rich_header.hash.md5
+      normalize: []
+      original_fieldset: pe
+      short: MD5 hash of the header for the PE file.
+      type: keyword
+    process.target.pe.sections:
+      dashed_name: process-target-pe-sections
+      description: Data about sections of compiled binary PE
+      flat_name: process.target.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Data about sections of the compiled binary PE
+      type: nested
+    process.target.pe.sections.chi2:
+      dashed_name: process-target-pe-sections-chi2
+      description: Chi-square probability distribution.
+      example: 3027194
+      flat_name: process.target.pe.sections.chi2
+      level: extended
+      name: sections.chi2
+      normalize: []
+      original_fieldset: pe
+      short: Chi-square probability distribution.
+      type: long
+    process.target.pe.sections.entropy:
+      dashed_name: process-target-pe-sections-entropy
+      description: Measurement of entropy randomness in the file.
+      example: 6.24
+      flat_name: process.target.pe.sections.entropy
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Measurement of entropy randomness in the file.
+      type: float
+    process.target.pe.sections.flags:
+      dashed_name: process-target-pe-sections-flags
+      description: Section flags of the file.
+      example: rx
+      flat_name: process.target.pe.sections.flags
+      ignore_above: 1024
+      level: extended
+      name: sections.flags
+      normalize: []
+      original_fieldset: pe
+      short: Section flags of the file.
+      type: keyword
+    process.target.pe.sections.name:
+      dashed_name: process-target-pe-sections-name
+      description: Section names of the file.
+      example: .text, .data
+      flat_name: process.target.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: Section names of the file.
+      type: keyword
+    process.target.pe.sections.raw_size:
+      dashed_name: process-target-pe-sections-raw-size
+      description: Size of the section or the dize of the initialized data on disk.
+      example: 198144
+      flat_name: process.target.pe.sections.raw_size
+      format: bytes
+      level: extended
+      name: sections.raw_size
+      normalize: []
+      original_fieldset: pe
+      short: Size of the section or the dize of the initialized data on disk.
+      type: long
+    process.target.pe.sections.virtual_address:
+      dashed_name: process-target-pe-sections-virtual-address
+      description: Virtual address available to the file.
+      example: 8192
+      flat_name: process.target.pe.sections.virtual_address
+      format: bytes
+      level: extended
+      name: sections.virtual_address
+      normalize: []
+      original_fieldset: pe
+      short: Virtual address available to the file.
+      type: long
+    process.target.pgid:
+      dashed_name: process-target-pgid
+      description: Identifier of the group of processes the process belongs to.
+      flat_name: process.target.pgid
+      format: string
+      level: extended
+      name: pgid
+      normalize: []
+      original_fieldset: process
+      short: Identifier of the group of processes the process belongs to.
+      type: long
+    process.target.pid:
+      dashed_name: process-target-pid
+      description: Process id.
+      example: 4242
+      flat_name: process.target.pid
+      format: string
+      level: core
+      name: pid
+      normalize: []
+      original_fieldset: process
+      short: Process id.
+      type: long
+    process.target.ppid:
+      dashed_name: process-target-ppid
+      description: Parent process' pid.
+      example: 4241
+      flat_name: process.target.ppid
+      format: string
+      level: extended
+      name: ppid
+      normalize: []
+      original_fieldset: process
+      short: Parent process' pid.
+      type: long
+    process.target.start:
+      dashed_name: process-target-start
+      description: The time the process started.
+      example: '2016-05-23T08:05:34.853Z'
+      flat_name: process.target.start
+      level: extended
+      name: start
+      normalize: []
+      original_fieldset: process
+      short: The time the process started.
+      type: date
+    process.target.thread.id:
+      dashed_name: process-target-thread-id
+      description: Thread ID.
+      example: 4242
+      flat_name: process.target.thread.id
+      format: string
+      level: extended
+      name: thread.id
+      normalize: []
+      original_fieldset: process
+      short: Thread ID.
+      type: long
+    process.target.thread.name:
+      dashed_name: process-target-thread-name
+      description: Thread name.
+      example: thread-0
+      flat_name: process.target.thread.name
+      level: extended
+      name: thread.name
+      normalize: []
+      original_fieldset: process
+      short: Thread name.
+      type: wildcard
+    process.target.title:
+      dashed_name: process-target-title
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different:
+        for example a browser setting its title to the web page currently opened.'
+      flat_name: process.target.title
+      level: extended
+      multi_fields:
+      - flat_name: process.target.title.text
+        name: text
+        norms: false
+        type: text
+      name: title
+      normalize: []
+      original_fieldset: process
+      short: Process title.
+      type: wildcard
+    process.target.uptime:
+      dashed_name: process-target-uptime
+      description: Seconds the process has been up.
+      example: 1325
+      flat_name: process.target.uptime
+      level: extended
+      name: uptime
+      normalize: []
+      original_fieldset: process
+      short: Seconds the process has been up.
+      type: long
+    process.target.working_directory:
+      dashed_name: process-target-working-directory
+      description: The working directory of the process.
+      example: /home/alice
+      flat_name: process.target.working_directory
+      level: extended
+      multi_fields:
+      - flat_name: process.target.working_directory.text
+        name: text
+        norms: false
+        type: text
+      name: working_directory
+      normalize: []
+      original_fieldset: process
+      short: The working directory of the process.
+      type: wildcard
     process.thread.id:
       dashed_name: process-thread-id
       description: Thread ID.
@@ -10525,6 +12871,8 @@ process:
   - process.hash
   - process.parent
   - process.pe
+  - process.target
+  - process.target.parent
   prefix: process.
   reusable:
     expected:
@@ -10532,6 +12880,12 @@ process:
       at: process
       full: process.parent
       short_override: Information about the parent process.
+    - as: target
+      at: process
+      full: process.target
+    - as: parent
+      at: process.target
+      full: process.target.parent
     top_level: true
   reused_here:
   - full: process.code_signature
@@ -10550,6 +12904,12 @@ process:
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
+  - full: process.target
+    schema_name: process
+    short: These fields contain information about a process.
+  - full: process.target.parent
+    schema_name: process
+    short: These fields contain information about a process.
   short: These fields contain information about a process.
   title: Process
   type: group

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -3044,6 +3044,856 @@
           "start": {
             "type": "date"
           },
+          "target": {
+            "properties": {
+              "args": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "args_count": {
+                "type": "long"
+              },
+              "code_signature": {
+                "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
+                  "signing_id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "status": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "team_id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "command_line": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "type": "wildcard"
+              },
+              "elf": {
+                "properties": {
+                  "architecture": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "byte_order": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "cpu_type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "creation_date": {
+                    "type": "date"
+                  },
+                  "exports": {
+                    "type": "flattened"
+                  },
+                  "header": {
+                    "properties": {
+                      "abi_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "class": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "data": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "entrypoint": {
+                        "type": "long"
+                      },
+                      "object_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "os_abi": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "sections": {
+                    "properties": {
+                      "chi2": {
+                        "type": "long"
+                      },
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "flags": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_offset": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "virtual_address": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "segments": {
+                    "properties": {
+                      "sections": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "shared_libraries": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "telfhash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "entity_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "executable": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "type": "wildcard"
+              },
+              "exit_code": {
+                "type": "long"
+              },
+              "hash": {
+                "properties": {
+                  "md5": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha1": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha256": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha512": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "ssdeep": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "type": "wildcard"
+              },
+              "parent": {
+                "properties": {
+                  "args": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "args_count": {
+                    "type": "long"
+                  },
+                  "code_signature": {
+                    "properties": {
+                      "exists": {
+                        "type": "boolean"
+                      },
+                      "signing_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "status": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "subject_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "team_id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "trusted": {
+                        "type": "boolean"
+                      },
+                      "valid": {
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "command_line": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "type": "wildcard"
+                  },
+                  "elf": {
+                    "properties": {
+                      "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "byte_order": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "cpu_type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "creation_date": {
+                        "type": "date"
+                      },
+                      "exports": {
+                        "type": "flattened"
+                      },
+                      "header": {
+                        "properties": {
+                          "abi_version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "class": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "data": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "entrypoint": {
+                            "type": "long"
+                          },
+                          "object_version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "os_abi": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
+                      "imports": {
+                        "type": "flattened"
+                      },
+                      "sections": {
+                        "properties": {
+                          "chi2": {
+                            "type": "long"
+                          },
+                          "entropy": {
+                            "type": "long"
+                          },
+                          "flags": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "physical_offset": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "physical_size": {
+                            "type": "long"
+                          },
+                          "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "virtual_address": {
+                            "type": "long"
+                          },
+                          "virtual_size": {
+                            "type": "long"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "segments": {
+                        "properties": {
+                          "sections": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "shared_libraries": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "telfhash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "entity_id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "executable": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "type": "wildcard"
+                  },
+                  "exit_code": {
+                    "type": "long"
+                  },
+                  "hash": {
+                    "properties": {
+                      "md5": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha1": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha256": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha512": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "ssdeep": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "name": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "type": "wildcard"
+                  },
+                  "pe": {
+                    "properties": {
+                      "architecture": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "authentihash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "company": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "compile_timestamp": {
+                        "type": "date"
+                      },
+                      "compiler": {
+                        "properties": {
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "version": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
+                      "creation_date": {
+                        "type": "date"
+                      },
+                      "debug": {
+                        "properties": {
+                          "offset": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "size": {
+                            "type": "long"
+                          },
+                          "timestamp": {
+                            "type": "date"
+                          },
+                          "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "description": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "entry_point": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "exports": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "file_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "icon": {
+                        "properties": {
+                          "hash": {
+                            "properties": {
+                              "dhash": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "imphash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "imports": {
+                        "type": "flattened"
+                      },
+                      "machine_type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "original_file_name": {
+                        "type": "wildcard"
+                      },
+                      "packers": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "product": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "resources": {
+                        "properties": {
+                          "chi2": {
+                            "type": "long"
+                          },
+                          "entropy": {
+                            "type": "long"
+                          },
+                          "filetype": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "language": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha256": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "rich_header": {
+                        "properties": {
+                          "hash": {
+                            "properties": {
+                              "md5": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "sections": {
+                        "properties": {
+                          "chi2": {
+                            "type": "long"
+                          },
+                          "entropy": {
+                            "type": "float"
+                          },
+                          "flags": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "raw_size": {
+                            "type": "long"
+                          },
+                          "virtual_address": {
+                            "type": "long"
+                          }
+                        },
+                        "type": "nested"
+                      }
+                    }
+                  },
+                  "pgid": {
+                    "type": "long"
+                  },
+                  "pid": {
+                    "type": "long"
+                  },
+                  "ppid": {
+                    "type": "long"
+                  },
+                  "start": {
+                    "type": "date"
+                  },
+                  "thread": {
+                    "properties": {
+                      "id": {
+                        "type": "long"
+                      },
+                      "name": {
+                        "type": "wildcard"
+                      }
+                    }
+                  },
+                  "title": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "type": "wildcard"
+                  },
+                  "uptime": {
+                    "type": "long"
+                  },
+                  "working_directory": {
+                    "fields": {
+                      "text": {
+                        "norms": false,
+                        "type": "text"
+                      }
+                    },
+                    "type": "wildcard"
+                  }
+                }
+              },
+              "pe": {
+                "properties": {
+                  "architecture": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "authentihash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "company": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "compile_timestamp": {
+                    "type": "date"
+                  },
+                  "compiler": {
+                    "properties": {
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
+                  "creation_date": {
+                    "type": "date"
+                  },
+                  "debug": {
+                    "properties": {
+                      "offset": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "size": {
+                        "type": "long"
+                      },
+                      "timestamp": {
+                        "type": "date"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "description": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "entry_point": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "exports": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "file_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "icon": {
+                    "properties": {
+                      "hash": {
+                        "properties": {
+                          "dhash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "imphash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "machine_type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "original_file_name": {
+                    "type": "wildcard"
+                  },
+                  "packers": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "product": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "resources": {
+                    "properties": {
+                      "chi2": {
+                        "type": "long"
+                      },
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "filetype": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "language": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha256": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "type": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "rich_header": {
+                    "properties": {
+                      "hash": {
+                        "properties": {
+                          "md5": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "sections": {
+                    "properties": {
+                      "chi2": {
+                        "type": "long"
+                      },
+                      "entropy": {
+                        "type": "float"
+                      },
+                      "flags": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "raw_size": {
+                        "type": "long"
+                      },
+                      "virtual_address": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
+                  }
+                }
+              },
+              "pgid": {
+                "type": "long"
+              },
+              "pid": {
+                "type": "long"
+              },
+              "ppid": {
+                "type": "long"
+              },
+              "start": {
+                "type": "date"
+              },
+              "thread": {
+                "properties": {
+                  "id": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "type": "wildcard"
+                  }
+                }
+              },
+              "title": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "type": "wildcard"
+              },
+              "uptime": {
+                "type": "long"
+              },
+              "working_directory": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "type": "wildcard"
+              }
+            }
+          },
           "thread": {
             "properties": {
               "id": {

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -823,6 +823,856 @@
             "start": {
               "type": "date"
             },
+            "target": {
+              "properties": {
+                "args": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "args_count": {
+                  "type": "long"
+                },
+                "code_signature": {
+                  "properties": {
+                    "exists": {
+                      "type": "boolean"
+                    },
+                    "signing_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "status": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "subject_name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "team_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "trusted": {
+                      "type": "boolean"
+                    },
+                    "valid": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "command_line": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "elf": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "byte_order": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "cpu_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "creation_date": {
+                      "type": "date"
+                    },
+                    "exports": {
+                      "type": "flattened"
+                    },
+                    "header": {
+                      "properties": {
+                        "abi_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "class": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "data": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "entrypoint": {
+                          "type": "long"
+                        },
+                        "object_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "os_abi": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "sections": {
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_offset": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "virtual_address": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "segments": {
+                      "properties": {
+                        "sections": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "shared_libraries": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "telfhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "entity_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "executable": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "exit_code": {
+                  "type": "long"
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha512": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "ssdeep": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "name": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "parent": {
+                  "properties": {
+                    "args": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "args_count": {
+                      "type": "long"
+                    },
+                    "code_signature": {
+                      "properties": {
+                        "exists": {
+                          "type": "boolean"
+                        },
+                        "signing_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "status": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "subject_name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "team_id": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "trusted": {
+                          "type": "boolean"
+                        },
+                        "valid": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "command_line": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "elf": {
+                      "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "byte_order": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "cpu_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "creation_date": {
+                          "type": "date"
+                        },
+                        "exports": {
+                          "type": "flattened"
+                        },
+                        "header": {
+                          "properties": {
+                            "abi_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "class": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "data": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "entrypoint": {
+                              "type": "long"
+                            },
+                            "object_version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "os_abi": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "imports": {
+                          "type": "flattened"
+                        },
+                        "sections": {
+                          "properties": {
+                            "chi2": {
+                              "type": "long"
+                            },
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_offset": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "virtual_address": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "segments": {
+                          "properties": {
+                            "sections": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "shared_libraries": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "telfhash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "entity_id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "executable": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "exit_code": {
+                      "type": "long"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "pe": {
+                      "properties": {
+                        "architecture": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "authentihash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "company": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "compile_timestamp": {
+                          "type": "date"
+                        },
+                        "compiler": {
+                          "properties": {
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "version": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
+                        "creation_date": {
+                          "type": "date"
+                        },
+                        "debug": {
+                          "properties": {
+                            "offset": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "size": {
+                              "type": "long"
+                            },
+                            "timestamp": {
+                              "type": "date"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "description": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "entry_point": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "exports": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "file_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "icon": {
+                          "properties": {
+                            "hash": {
+                              "properties": {
+                                "dhash": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "imphash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imports": {
+                          "type": "flattened"
+                        },
+                        "machine_type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "original_file_name": {
+                          "type": "wildcard"
+                        },
+                        "packers": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "product": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "resources": {
+                          "properties": {
+                            "chi2": {
+                              "type": "long"
+                            },
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "filetype": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "language": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "type": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          },
+                          "type": "nested"
+                        },
+                        "rich_header": {
+                          "properties": {
+                            "hash": {
+                              "properties": {
+                                "md5": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "sections": {
+                          "properties": {
+                            "chi2": {
+                              "type": "long"
+                            },
+                            "entropy": {
+                              "type": "float"
+                            },
+                            "flags": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "raw_size": {
+                              "type": "long"
+                            },
+                            "virtual_address": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
+                        }
+                      }
+                    },
+                    "pgid": {
+                      "type": "long"
+                    },
+                    "pid": {
+                      "type": "long"
+                    },
+                    "ppid": {
+                      "type": "long"
+                    },
+                    "start": {
+                      "type": "date"
+                    },
+                    "thread": {
+                      "properties": {
+                        "id": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "type": "wildcard"
+                        }
+                      }
+                    },
+                    "title": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "type": "wildcard"
+                    },
+                    "uptime": {
+                      "type": "long"
+                    },
+                    "working_directory": {
+                      "fields": {
+                        "text": {
+                          "norms": false,
+                          "type": "text"
+                        }
+                      },
+                      "type": "wildcard"
+                    }
+                  }
+                },
+                "pe": {
+                  "properties": {
+                    "architecture": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "authentihash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "company": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "compile_timestamp": {
+                      "type": "date"
+                    },
+                    "compiler": {
+                      "properties": {
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
+                    "creation_date": {
+                      "type": "date"
+                    },
+                    "debug": {
+                      "properties": {
+                        "offset": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "size": {
+                          "type": "long"
+                        },
+                        "timestamp": {
+                          "type": "date"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "description": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "entry_point": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "exports": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "file_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "icon": {
+                      "properties": {
+                        "hash": {
+                          "properties": {
+                            "dhash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "imphash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "machine_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "original_file_name": {
+                      "type": "wildcard"
+                    },
+                    "packers": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "product": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "resources": {
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "filetype": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "language": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "type": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "rich_header": {
+                      "properties": {
+                        "hash": {
+                          "properties": {
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sections": {
+                      "properties": {
+                        "chi2": {
+                          "type": "long"
+                        },
+                        "entropy": {
+                          "type": "float"
+                        },
+                        "flags": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "raw_size": {
+                          "type": "long"
+                        },
+                        "virtual_address": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    }
+                  }
+                },
+                "pgid": {
+                  "type": "long"
+                },
+                "pid": {
+                  "type": "long"
+                },
+                "ppid": {
+                  "type": "long"
+                },
+                "start": {
+                  "type": "date"
+                },
+                "thread": {
+                  "properties": {
+                    "id": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "type": "wildcard"
+                    }
+                  }
+                },
+                "title": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "uptime": {
+                  "type": "long"
+                },
+                "working_directory": {
+                  "fields": {
+                    "text": {
+                      "norms": false,
+                      "type": "text"
+                    }
+                  },
+                  "type": "wildcard"
+                }
+              }
+            },
             "thread": {
               "properties": {
                 "id": {

--- a/experimental/schemas/process.yml
+++ b/experimental/schemas/process.yml
@@ -1,5 +1,12 @@
 ---
 - name: process
+  reusable:
+    top_level: true
+    expected:
+      - at: process
+        as: target
+      - at: process.target
+        as: parent
   fields:
     - name: command_line
       type: wildcard

--- a/experimental/schemas/process.yml
+++ b/experimental/schemas/process.yml
@@ -1,7 +1,6 @@
 ---
 - name: process
   reusable:
-    top_level: true
     expected:
       - at: process
         as: target


### PR DESCRIPTION

Apply stage 1 experimental changes proposed in the `process.target` [RFC 0016](https://github.com/elastic/ecs/blob/master/rfcs/text/0016-target-process.md): #1297 