### PR TITLE
[RFC] 0008: Correct expected indicator.type value for X509 Certificates

### DIFF
--- a/rfcs/text/0008/threat.yml
+++ b/rfcs/text/0008/threat.yml
@@ -53,7 +53,7 @@
         * url
         * user-account
         * windows-registry-key
-        * x-509-certificate
+        * x509-certificate
 
     example: ipv4-addr
 


### PR DESCRIPTION
This is a minor change to a field's description in RFC 0008 (Threat Intel).

The documentation for the `indicator.type` field lists `x-509-certificate` as an expected value. However, the correct STIX 2.0 Cyber Observable type name for X509 Certificates is `x509-certificate`, according to [the STIX 2.0 docs.](http://docs.oasis-open.org/cti/stix/v2.0/cs01/part4-cyber-observable-objects/stix-v2.0-cs01-part4-cyber-observable-objects.html#_Toc496716295)

