### PR TITLE
[DOCS] Swap columns in field reuse table

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -50,6 +50,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Swap `Location` and `Field Set` columns in `Field Reuse` table for better readability. #1472
+
 #### Deprecated
 
 <!-- All empty sections:

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -530,22 +530,22 @@ example: `co.uk`
 // ===============================================================
 
 
-| <<ecs-as,as>>
 | `client.as.*`
+| <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `client.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `client.user.*`
+| <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1351,22 +1351,22 @@ example: `co.uk`
 // ===============================================================
 
 
-| <<ecs-as,as>>
 | `destination.as.*`
+| <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `destination.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `destination.user.*`
+| <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -1451,22 +1451,22 @@ example: `C:\Windows\System32\kernel32.dll`
 // ===============================================================
 
 
-| <<ecs-code_signature,code_signature>>
 | `dll.code_signature.*`
+| <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-hash,hash>>
 | `dll.hash.*`
+| <<ecs-hash,hash>>
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-pe,pe>>
 | `dll.pe.*`
+| <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
@@ -3408,37 +3408,37 @@ example: `1001`
 // ===============================================================
 
 
-| <<ecs-code_signature,code_signature>>
 | `file.code_signature.*`
+| <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-elf,elf>>
-| `file.elf.*`| beta:[ This field reuse is beta and subject to change.]
+| `file.elf.*`
+| <<ecs-elf,elf>>| beta:[ This field reuse is beta and subject to change.]
 
 These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 // ===============================================================
 
 
-| <<ecs-hash,hash>>
 | `file.hash.*`
+| <<ecs-hash,hash>>
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-pe,pe>>
 | `file.pe.*`
+| <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
 
 
-| <<ecs-x509,x509>>
 | `file.x509.*`
+| <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
@@ -4157,15 +4157,15 @@ example: `1325`
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `host.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-os,os>>
 | `host.os.*`
+| <<ecs-os,os>>
 | OS fields contain information about the operating system.
 
 // ===============================================================
@@ -5004,15 +5004,15 @@ example: `ipv4`
 // ===============================================================
 
 
-| <<ecs-vlan,vlan>>
 | `network.inner.vlan.*`
+| <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,vlan>>
 | `network.vlan.*`
+| <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
 // ===============================================================
@@ -5277,43 +5277,43 @@ type: keyword
 // ===============================================================
 
 
-| <<ecs-interface,interface>>
 | `observer.egress.interface.*`
+| <<ecs-interface,interface>>
 | Fields to describe observer interface information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,vlan>>
 | `observer.egress.vlan.*`
+| <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `observer.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-interface,interface>>
 | `observer.ingress.interface.*`
+| <<ecs-interface,interface>>
 | Fields to describe observer interface information.
 
 // ===============================================================
 
 
-| <<ecs-vlan,vlan>>
 | `observer.ingress.vlan.*`
+| <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
 // ===============================================================
 
 
-| <<ecs-os,os>>
 | `observer.os.*`
+| <<ecs-os,os>>
 | OS fields contain information about the operating system.
 
 // ===============================================================
@@ -6405,37 +6405,37 @@ Note also that the `process` fields may be used directly at the root of the even
 // ===============================================================
 
 
-| <<ecs-code_signature,code_signature>>
 | `process.code_signature.*`
+| <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
 // ===============================================================
 
 
-| <<ecs-elf,elf>>
-| `process.elf.*`| beta:[ This field reuse is beta and subject to change.]
+| `process.elf.*`
+| <<ecs-elf,elf>>| beta:[ This field reuse is beta and subject to change.]
 
 These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 // ===============================================================
 
 
-| <<ecs-hash,hash>>
 | `process.hash.*`
+| <<ecs-hash,hash>>
 | Hashes, usually file hashes.
 
 // ===============================================================
 
 
-| <<ecs-process,process>>
 | `process.parent.*`
+| <<ecs-process,process>>
 | Information about the parent process.
 
 // ===============================================================
 
 
-| <<ecs-pe,pe>>
 | `process.pe.*`
+| <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
@@ -7102,22 +7102,22 @@ example: `co.uk`
 // ===============================================================
 
 
-| <<ecs-as,as>>
 | `server.as.*`
+| <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `server.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `server.user.*`
+| <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -7518,22 +7518,22 @@ example: `co.uk`
 // ===============================================================
 
 
-| <<ecs-as,as>>
 | `source.as.*`
+| <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
-| <<ecs-geo,geo>>
 | `source.geo.*`
+| <<ecs-geo,geo>>
 | Fields describing a location.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `source.user.*`
+| <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
 
 // ===============================================================
@@ -8460,15 +8460,15 @@ example: `tls`
 // ===============================================================
 
 
-| <<ecs-x509,x509>>
 | `tls.client.x509.*`
+| <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
 
 
-| <<ecs-x509,x509>>
 | `tls.server.x509.*`
+| <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
 
 // ===============================================================
@@ -8998,29 +8998,29 @@ Note also that the `user` fields may be used directly at the root of the events.
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `user.changes.*`
+| <<ecs-user,user>>
 | Captures changes made to a user.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `user.effective.*`
+| <<ecs-user,user>>
 | User whose privileges were assumed.
 
 // ===============================================================
 
 
-| <<ecs-group,group>>
 | `user.group.*`
+| <<ecs-group,group>>
 | User's group relevant to the event.
 
 // ===============================================================
 
 
-| <<ecs-user,user>>
 | `user.target.*`
+| <<ecs-user,user>>
 | Targeted user of action taken.
 
 // ===============================================================
@@ -9142,8 +9142,8 @@ example: `12.0`
 // ===============================================================
 
 
-| <<ecs-os,os>>
 | `user_agent.os.*`
+| <<ecs-os,os>>
 | OS fields contain information about the operating system.
 
 // ===============================================================

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -120,8 +120,8 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 {% for entry in render_nestings_reuse_section -%}
 
 {#- Beta marker on nested fields -#}
-| <<ecs-{{ entry['name'] }},{{ entry['name'] }}>>
 | `{{ entry['flat_nesting'] }}`
+| <<ecs-{{ entry['name'] }},{{ entry['name'] }}>>
 {#- Beta marker on nested fields -#}
 {%- if entry['beta'] -%}
 | beta:[ {{ entry['beta'] }}]


### PR DESCRIPTION
### Summary

Swap positions of the `Field Set` and `Location` columns in the `Field Reuse` sections of the ECS Field Reference docs.

### Background

After adding a link to the original field set, long location names were being wrapped when generated on the docs site:

<img width="769" alt="Screen Shot 2021-06-24 at 2 07 07 PM" src="https://user-images.githubusercontent.com/7226265/123319040-85b15700-d4f5-11eb-81aa-fe8369ba2fa1.png">

### Solution

Swapping the location of the `Field Set` and `Location` columns is a quick solution to render the `Location` as a single line:

<img width="798" alt="Screen Shot 2021-06-24 at 2 08 14 PM" src="https://user-images.githubusercontent.com/7226265/123319137-a4175280-d4f5-11eb-9569-0171013da1b5.png">

This does place the field set link in the middle of the table versus on the left-hand side, but I don't think that will be an issue for users. 

[Docs Preview](https://ecs_1472.docs-preview.app.elstc.co/diff)