### PR TITLE
[DOCS] Bulleted list of expected nesting locations

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -50,6 +50,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Use a bullet points to list field reuses. #1473
+
 #### Deprecated
 
 <!-- All empty sections:

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -288,7 +288,7 @@ The `as` fields are expected to be nested at:
 * `server.as`
 
 * `source.as`
-.
+
 
 Note also that the `as` fields are not expected to be used directly at the root of the events.
 
@@ -914,7 +914,7 @@ The `code_signature` fields are expected to be nested at:
 * `file.code_signature`
 
 * `process.code_signature`
-.
+
 
 Note also that the `code_signature` fields are not expected to be used directly at the root of the events.
 
@@ -2377,7 +2377,7 @@ The `elf` fields are expected to be nested at:
 * `file.elf`
 
 * `process.elf`
-.
+
 
 Note also that the `elf` fields are not expected to be used directly at the root of the events.
 
@@ -3687,7 +3687,7 @@ The `geo` fields are expected to be nested at:
 * `server.geo`
 
 * `source.geo`
-.
+
 
 Note also that the `geo` fields are not expected to be used directly at the root of the events.
 
@@ -3767,7 +3767,7 @@ The `group` fields are expected to be nested at:
 
 
 * `user.group`
-.
+
 
 Note also that the `group` fields may be used directly at the root of the events.
 
@@ -3885,7 +3885,7 @@ The `hash` fields are expected to be nested at:
 * `file.hash`
 
 * `process.hash`
-.
+
 
 Note also that the `hash` fields are not expected to be used directly at the root of the events.
 
@@ -4540,7 +4540,7 @@ The `interface` fields are expected to be nested at:
 * `observer.egress.interface`
 
 * `observer.ingress.interface`
-.
+
 
 Note also that the `interface` fields are not expected to be used directly at the root of the events.
 
@@ -5748,7 +5748,7 @@ The `os` fields are expected to be nested at:
 * `observer.os`
 
 * `user_agent.os`
-.
+
 
 Note also that the `os` fields are not expected to be used directly at the root of the events.
 
@@ -6126,7 +6126,7 @@ The `pe` fields are expected to be nested at:
 * `file.pe`
 
 * `process.pe`
-.
+
 
 Note also that the `pe` fields are not expected to be used directly at the root of the events.
 
@@ -6463,7 +6463,7 @@ The `process` fields are expected to be nested at:
 
 
 * `process.parent`
-.
+
 
 Note also that the `process` fields may be used directly at the root of the events.
 
@@ -9072,7 +9072,7 @@ The `user` fields are expected to be nested at:
 * `user.effective`
 
 * `user.target`
-.
+
 
 Note also that the `user` fields may be used directly at the root of the events.
 
@@ -9310,7 +9310,7 @@ The `vlan` fields are expected to be nested at:
 * `observer.egress.vlan`
 
 * `observer.ingress.vlan`
-.
+
 
 Note also that the `vlan` fields are not expected to be used directly at the root of the events.
 
@@ -10014,7 +10014,7 @@ The `x509` fields are expected to be nested at:
 * `tls.client.x509`
 
 * `tls.server.x509`
-.
+
 
 Note also that the `x509` fields are not expected to be used directly at the root of the events.
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -278,7 +278,17 @@ example: `Google LLC`
 [discrete]
 ==== Field Reuse
 
-The `as` fields are expected to be nested at: `client.as`, `destination.as`, `server.as`, `source.as`.
+The `as` fields are expected to be nested at:
+
+
+* `client.as`
+
+* `destination.as`
+
+* `server.as`
+
+* `source.as`
+.
 
 Note also that the `as` fields are not expected to be used directly at the root of the events.
 
@@ -896,7 +906,15 @@ example: `true`
 [discrete]
 ==== Field Reuse
 
-The `code_signature` fields are expected to be nested at: `dll.code_signature`, `file.code_signature`, `process.code_signature`.
+The `code_signature` fields are expected to be nested at:
+
+
+* `dll.code_signature`
+
+* `file.code_signature`
+
+* `process.code_signature`
+.
 
 Note also that the `code_signature` fields are not expected to be used directly at the root of the events.
 
@@ -2353,7 +2371,13 @@ type: keyword
 [discrete]
 ==== Field Reuse
 
-The `elf` fields are expected to be nested at: `file.elf`, `process.elf`.
+The `elf` fields are expected to be nested at:
+
+
+* `file.elf`
+
+* `process.elf`
+.
 
 Note also that the `elf` fields are not expected to be used directly at the root of the events.
 
@@ -3649,7 +3673,21 @@ example: `America/Argentina/Buenos_Aires`
 [discrete]
 ==== Field Reuse
 
-The `geo` fields are expected to be nested at: `client.geo`, `destination.geo`, `host.geo`, `observer.geo`, `server.geo`, `source.geo`.
+The `geo` fields are expected to be nested at:
+
+
+* `client.geo`
+
+* `destination.geo`
+
+* `host.geo`
+
+* `observer.geo`
+
+* `server.geo`
+
+* `source.geo`
+.
 
 Note also that the `geo` fields are not expected to be used directly at the root of the events.
 
@@ -3725,7 +3763,11 @@ type: keyword
 [discrete]
 ==== Field Reuse
 
-The `group` fields are expected to be nested at: `user.group`.
+The `group` fields are expected to be nested at:
+
+
+* `user.group`
+.
 
 Note also that the `group` fields may be used directly at the root of the events.
 
@@ -3835,7 +3877,15 @@ type: keyword
 [discrete]
 ==== Field Reuse
 
-The `hash` fields are expected to be nested at: `dll.hash`, `file.hash`, `process.hash`.
+The `hash` fields are expected to be nested at:
+
+
+* `dll.hash`
+
+* `file.hash`
+
+* `process.hash`
+.
 
 Note also that the `hash` fields are not expected to be used directly at the root of the events.
 
@@ -4484,7 +4534,13 @@ example: `eth0`
 [discrete]
 ==== Field Reuse
 
-The `interface` fields are expected to be nested at: `observer.egress.interface`, `observer.ingress.interface`.
+The `interface` fields are expected to be nested at:
+
+
+* `observer.egress.interface`
+
+* `observer.ingress.interface`
+.
 
 Note also that the `interface` fields are not expected to be used directly at the root of the events.
 
@@ -5684,7 +5740,15 @@ example: `10.14.1`
 [discrete]
 ==== Field Reuse
 
-The `os` fields are expected to be nested at: `host.os`, `observer.os`, `user_agent.os`.
+The `os` fields are expected to be nested at:
+
+
+* `host.os`
+
+* `observer.os`
+
+* `user_agent.os`
+.
 
 Note also that the `os` fields are not expected to be used directly at the root of the events.
 
@@ -6054,7 +6118,15 @@ example: `Microsoft® Windows® Operating System`
 [discrete]
 ==== Field Reuse
 
-The `pe` fields are expected to be nested at: `dll.pe`, `file.pe`, `process.pe`.
+The `pe` fields are expected to be nested at:
+
+
+* `dll.pe`
+
+* `file.pe`
+
+* `process.pe`
+.
 
 Note also that the `pe` fields are not expected to be used directly at the root of the events.
 
@@ -6387,7 +6459,11 @@ example: `/home/alice`
 [discrete]
 ==== Field Reuse
 
-The `process` fields are expected to be nested at: `process.parent`.
+The `process` fields are expected to be nested at:
+
+
+* `process.parent`
+.
 
 Note also that the `process` fields may be used directly at the root of the events.
 
@@ -8980,7 +9056,23 @@ example: `["kibana_admin", "reporting_user"]`
 [discrete]
 ==== Field Reuse
 
-The `user` fields are expected to be nested at: `client.user`, `destination.user`, `server.user`, `source.user`, `user.changes`, `user.effective`, `user.target`.
+The `user` fields are expected to be nested at:
+
+
+* `client.user`
+
+* `destination.user`
+
+* `server.user`
+
+* `source.user`
+
+* `user.changes`
+
+* `user.effective`
+
+* `user.target`
+.
 
 Note also that the `user` fields may be used directly at the root of the events.
 
@@ -9208,7 +9300,17 @@ example: `outside`
 [discrete]
 ==== Field Reuse
 
-The `vlan` fields are expected to be nested at: `network.inner.vlan`, `network.vlan`, `observer.egress.vlan`, `observer.ingress.vlan`.
+The `vlan` fields are expected to be nested at:
+
+
+* `network.inner.vlan`
+
+* `network.vlan`
+
+* `observer.egress.vlan`
+
+* `observer.ingress.vlan`
+.
 
 Note also that the `vlan` fields are not expected to be used directly at the root of the events.
 
@@ -9904,7 +10006,15 @@ example: `3`
 [discrete]
 ==== Field Reuse
 
-The `x509` fields are expected to be nested at: `file.x509`, `tls.client.x509`, `tls.server.x509`.
+The `x509` fields are expected to be nested at:
+
+
+* `file.x509`
+
+* `tls.client.x509`
+
+* `tls.server.x509`
+.
 
 Note also that the `x509` fields are not expected to be used directly at the root of the events.
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -94,7 +94,7 @@ The `{{ fieldset['name'] }}` fields are expected to be nested at:
 
 {% for entry in sorted_reuse_fields %}
 * `{{ entry }}`
-{% endfor %}.
+{% endfor %}
 
 {% if 'top_level' in fieldset['reusable'] and fieldset['reusable']['top_level'] -%}
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -90,7 +90,11 @@ example: `{{ field['example'] }}`
 
 {% if 'reusable' in fieldset -%}
 
-The `{{ fieldset['name'] }}` fields are expected to be nested at: `{{ sorted_reuse_fields|join("`, `") }}`.
+The `{{ fieldset['name'] }}` fields are expected to be nested at:
+
+{% for entry in sorted_reuse_fields %}
+* `{{ entry }}`
+{% endfor %}.
 
 {% if 'top_level' in fieldset['reusable'] and fieldset['reusable']['top_level'] -%}
 


### PR DESCRIPTION
### Summary

Change the flat, comma-separated list of expected field reuse locations into a bulleted list. As the number of included reuses has grown for some field sets, I think the bulleted list is easier to consume.

### Current

<img width="762" alt="Screen Shot 2021-06-24 at 2 45 02 PM" src="https://user-images.githubusercontent.com/7226265/123323173-c6f83580-d4fa-11eb-9a8b-b959076558a5.png">

### Proposed Change

<img width="599" alt="Screen Shot 2021-06-24 at 2 45 25 PM" src="https://user-images.githubusercontent.com/7226265/123323227-d4adbb00-d4fa-11eb-9fc8-826a59f05477.png">

[Docs preview](https://ecs_1473.docs-preview.app.elstc.co/diff)