### PR TITLE
[DOCS] Swap `Field Reuse` column headers

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -50,7 +50,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Swap `Location` and `Field Set` columns in `Field Reuse` table for better readability. #1472
+* Swap `Location` and `Field Set` columns in `Field Reuse` table for better readability. #1472, #1476
 
 #### Deprecated
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -525,7 +525,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -1346,7 +1346,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -1446,7 +1446,7 @@ example: `C:\Windows\System32\kernel32.dll`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -3403,7 +3403,7 @@ example: `1001`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -4152,7 +4152,7 @@ example: `1325`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -4999,7 +4999,7 @@ example: `ipv4`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -5272,7 +5272,7 @@ type: keyword
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -6400,7 +6400,7 @@ Note also that the `process` fields may be used directly at the root of the even
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -7097,7 +7097,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -7513,7 +7513,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -8455,7 +8455,7 @@ example: `tls`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -8993,7 +8993,7 @@ Note also that the `user` fields may be used directly at the root of the events.
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -9137,7 +9137,7 @@ example: `12.0`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -112,7 +112,7 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 


### PR DESCRIPTION
With #1472 implemented, the table column headers also need updated.

Follow-up fix for the change introduced in #1472.