### PR TITLE
[1.x] [DOCS] Swap `Field Reuse` column headers (#1476)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -45,7 +45,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Swap `Location` and `Field Set` columns in `Field Reuse` table for better readability. #1472
+* Swap `Location` and `Field Set` columns in `Field Reuse` table for better readability. #1472, #1476
 
 #### Deprecated
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -525,7 +525,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -1346,7 +1346,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -1446,7 +1446,7 @@ example: `C:\Windows\System32\kernel32.dll`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -3403,7 +3403,7 @@ example: `1001`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -4152,7 +4152,7 @@ example: `1325`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -5010,7 +5010,7 @@ example: `ipv4`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -5283,7 +5283,7 @@ type: keyword
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -6411,7 +6411,7 @@ Note also that the `process` fields may be used directly at the root of the even
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -7108,7 +7108,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -7524,7 +7524,7 @@ example: `co.uk`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -8466,7 +8466,7 @@ example: `tls`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -9004,7 +9004,7 @@ Note also that the `user` fields may be used directly at the root of the events.
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 
@@ -9148,7 +9148,7 @@ example: `12.0`
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -112,7 +112,7 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 [options="header"]
 |=====
-| Field Set | Location | Description
+| Location | Field Set | Description
 
 // ===============================================================
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - [DOCS] Swap `Field Reuse` column headers (#1476)