### PR TITLE
[1.x] Implement Deprecation Notice relating to RFC 0017: Remove log.original (#1469)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -34,6 +34,7 @@ Thanks, you're awesome :-) -->
 #### Deprecated
 
 * Note deprecation of the `host.user.*` field reuse. #1422
+* Note deprecation of `log.original` superseded by `event.original` #1469
 
 ### Tooling and Artifact Changes
 

--- a/code/go/ecs/event.go
+++ b/code/go/ecs/event.go
@@ -130,11 +130,13 @@ type Event struct {
 	// to `event.severity`.
 	Severity int64 `ecs:"severity"`
 
-	// Raw text message of entire event. Used to demonstrate log integrity.
+	// Raw text message of entire event. Used to demonstrate log integrity  or
+	// where the full log message (before splitting it up in multiple  parts)
+	// may be required, e.g. for reindex.
 	// This field is not indexed and doc_values are disabled. It cannot be
 	// searched, but it can be retrieved from `_source`. If users wish to
-	// override this and index this field, consider using the wildcard data
-	// type.
+	// override this and index this field, please see `Field data types` in the
+	// `Elasticsearch Reference`.
 	Original string `ecs:"original"`
 
 	// Hash (perhaps logstash fingerprint) of raw field to be able to

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -39,6 +39,8 @@ type Log struct {
 	// If the event wasn't read from a log file, do not populate this field.
 	FilePath string `ecs:"file.path"`
 
+	// Deprecated for removal in next major version release. This field is
+	// superseded by  `event.original`.
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.
 	// In contrast to the `message` field which can contain an extracted part

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2777,9 +2777,9 @@ example: `apache`
 [[field-event-original]]
 <<field-event-original, event.original>>
 
-| Raw text message of entire event. Used to demonstrate log integrity.
+| Raw text message of entire event. Used to demonstrate log integrity  or where the full log message (before splitting it up in multiple  parts) may be required, e.g. for reindex.
 
-This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. If users wish to override this and index this field, consider using the wildcard data type.
+This field is not indexed and doc_values are disabled. It cannot be searched, but it can be retrieved from `_source`. If users wish to override this and index this field, please see `Field data types` in the `Elasticsearch Reference`.
 
 type: keyword
 
@@ -4684,7 +4684,9 @@ example: `init`
 [[field-log-original]]
 <<field-log-original, log.original>>
 
-| This is the original log message and contains the full log message before splitting it up in multiple parts.
+| Deprecated for removal in next major version release. This field is superseded by  `event.original`.
+
+This is the original log message and contains the full log message before splitting it up in multiple parts.
 
 In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1926,11 +1926,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       index: false
@@ -3625,8 +3627,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is the original log message and contains the full log message
-        before splitting it up in multiple parts.
+      description: 'Deprecated for removal in next major version release. This field
+        is superseded by  `event.original`.
+
+        This is the original log message and contains the full log message before
+        splitting it up in multiple parts.
 
         In contrast to the `message` field which can contain an extracted part of
         the log message, this field contains the original, full log message. It can
@@ -8446,11 +8451,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       index: false

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -406,7 +406,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev+exp,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
 1.11.0-dev+exp,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 1.11.0-dev+exp,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
-1.11.0-dev+exp,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
+1.11.0-dev+exp,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."
 1.11.0-dev+exp,true,log,log.syslog,object,extended,,,Syslog metadata
 1.11.0-dev+exp,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 1.11.0-dev+exp,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2644,11 +2644,13 @@ event.module:
   type: keyword
 event.original:
   dashed_name: event-original
-  description: 'Raw text message of entire event. Used to demonstrate log integrity.
+  description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+    where the full log message (before splitting it up in multiple  parts) may be
+    required, e.g. for reindex.
 
     This field is not indexed and doc_values are disabled. It cannot be searched,
     but it can be retrieved from `_source`. If users wish to override this and index
-    this field, consider using the wildcard data type.'
+    this field, please see `Field data types` in the `Elasticsearch Reference`.'
   doc_values: false
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
@@ -5329,8 +5331,11 @@ log.origin.function:
   type: keyword
 log.original:
   dashed_name: log-original
-  description: 'This is the original log message and contains the full log message
-    before splitting it up in multiple parts.
+  description: 'Deprecated for removal in next major version release. This field is
+    superseded by  `event.original`.
+
+    This is the original log message and contains the full log message before splitting
+    it up in multiple parts.
 
     In contrast to the `message` field which can contain an extracted part of the
     log message, this field contains the original, full log message. It can have already
@@ -5347,7 +5352,8 @@ log.original:
   level: core
   name: original
   normalize: []
-  short: Original log message with light interpretation only (encoding, newlines).
+  short: Deprecated original log message with light interpretation only (encoding,
+    newlines).
   type: keyword
 log.syslog:
   dashed_name: log-syslog
@@ -12912,11 +12918,13 @@ threat.enrichments.event.module:
   type: keyword
 threat.enrichments.event.original:
   dashed_name: threat-enrichments-event-original
-  description: 'Raw text message of entire event. Used to demonstrate log integrity.
+  description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+    where the full log message (before splitting it up in multiple  parts) may be
+    required, e.g. for reindex.
 
     This field is not indexed and doc_values are disabled. It cannot be searched,
     but it can be retrieved from `_source`. If users wish to override this and index
-    this field, consider using the wildcard data type.'
+    this field, please see `Field data types` in the `Elasticsearch Reference`.'
   doc_values: false
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3421,11 +3421,13 @@ event:
       type: keyword
     event.original:
       dashed_name: event-original
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       doc_values: false
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
@@ -6533,8 +6535,11 @@ log:
       type: keyword
     log.original:
       dashed_name: log-original
-      description: 'This is the original log message and contains the full log message
-        before splitting it up in multiple parts.
+      description: 'Deprecated for removal in next major version release. This field
+        is superseded by  `event.original`.
+
+        This is the original log message and contains the full log message before
+        splitting it up in multiple parts.
 
         In contrast to the `message` field which can contain an extracted part of
         the log message, this field contains the original, full log message. It can
@@ -6551,7 +6556,8 @@ log:
       level: core
       name: original
       normalize: []
-      short: Original log message with light interpretation only (encoding, newlines).
+      short: Deprecated original log message with light interpretation only (encoding,
+        newlines).
       type: keyword
     log.syslog:
       dashed_name: log-syslog
@@ -14962,11 +14968,13 @@ threat:
       type: keyword
     threat.enrichments.event.original:
       dashed_name: threat-enrichments-event-original
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       doc_values: false
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1738,11 +1738,13 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
       index: false
@@ -3246,8 +3248,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: 'This is the original log message and contains the full log message
-        before splitting it up in multiple parts.
+      description: 'Deprecated for removal in next major version release. This field
+        is superseded by  `event.original`.
+
+        This is the original log message and contains the full log message before
+        splitting it up in multiple parts.
 
         In contrast to the `message` field which can contain an extracted part of
         the log message, this field contains the original, full log message. It can

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -344,7 +344,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.11.0-dev,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
 1.11.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 1.11.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
-1.11.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Original log message with light interpretation only (encoding, newlines)."
+1.11.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."
 1.11.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata
 1.11.0-dev,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 1.11.0-dev,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2295,11 +2295,13 @@ event.module:
   type: keyword
 event.original:
   dashed_name: event-original
-  description: 'Raw text message of entire event. Used to demonstrate log integrity.
+  description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+    where the full log message (before splitting it up in multiple  parts) may be
+    required, e.g. for reindex.
 
     This field is not indexed and doc_values are disabled. It cannot be searched,
     but it can be retrieved from `_source`. If users wish to override this and index
-    this field, consider using the wildcard data type.'
+    this field, please see `Field data types` in the `Elasticsearch Reference`.'
   doc_values: false
   example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
     worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
@@ -4627,8 +4629,11 @@ log.origin.function:
   type: keyword
 log.original:
   dashed_name: log-original
-  description: 'This is the original log message and contains the full log message
-    before splitting it up in multiple parts.
+  description: 'Deprecated for removal in next major version release. This field is
+    superseded by  `event.original`.
+
+    This is the original log message and contains the full log message before splitting
+    it up in multiple parts.
 
     In contrast to the `message` field which can contain an extracted part of the
     log message, this field contains the original, full log message. It can have already
@@ -4645,7 +4650,8 @@ log.original:
   level: core
   name: original
   normalize: []
-  short: Original log message with light interpretation only (encoding, newlines).
+  short: Deprecated original log message with light interpretation only (encoding,
+    newlines).
   type: keyword
 log.syslog:
   dashed_name: log-syslog

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3069,11 +3069,13 @@ event:
       type: keyword
     event.original:
       dashed_name: event-original
-      description: 'Raw text message of entire event. Used to demonstrate log integrity.
+      description: 'Raw text message of entire event. Used to demonstrate log integrity  or
+        where the full log message (before splitting it up in multiple  parts) may
+        be required, e.g. for reindex.
 
         This field is not indexed and doc_values are disabled. It cannot be searched,
         but it can be retrieved from `_source`. If users wish to override this and
-        index this field, consider using the wildcard data type.'
+        index this field, please see `Field data types` in the `Elasticsearch Reference`.'
       doc_values: false
       example: Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124;
         worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232
@@ -5810,8 +5812,11 @@ log:
       type: keyword
     log.original:
       dashed_name: log-original
-      description: 'This is the original log message and contains the full log message
-        before splitting it up in multiple parts.
+      description: 'Deprecated for removal in next major version release. This field
+        is superseded by  `event.original`.
+
+        This is the original log message and contains the full log message before
+        splitting it up in multiple parts.
 
         In contrast to the `message` field which can contain an extracted part of
         the log message, this field contains the original, full log message. It can
@@ -5828,7 +5833,8 @@ log:
       level: core
       name: original
       normalize: []
-      short: Original log message with light interpretation only (encoding, newlines).
+      short: Deprecated original log message with light interpretation only (encoding,
+        newlines).
       type: keyword
     log.syslog:
       dashed_name: log-syslog

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -587,12 +587,14 @@
           dst=2.1.2.2spt=1232"
       short: Raw text message of entire event.
       description: >
-          Raw text message of entire event. Used to demonstrate log integrity.
+          Raw text message of entire event. Used to demonstrate log integrity 
+          or where the full log message (before splitting it up in multiple 
+          parts) may be required, e.g. for reindex.
 
           This field is not indexed and doc_values are disabled. It cannot be
           searched, but it can be retrieved from `_source`. If users wish to
-          override this and index this field, consider using the wildcard
-          data type.
+          override this and index this field, please see `Field data types`
+          in the `Elasticsearch Reference`.
       index: false
       doc_values: false
 

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -47,8 +47,11 @@
       example: "Sep 19 08:26:10 localhost My log"
       index: false
       doc_values: false
-      short: Original log message with light interpretation only (encoding, newlines).
+      short: Deprecated original log message with light interpretation only (encoding, newlines).
       description: >
+        Deprecated for removal in next major version release. This field is superseded by 
+        `event.original`.
+
         This is the original log message and contains the full log message
         before splitting it up in multiple parts.
 


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Implement Deprecation Notice relating to RFC 0017: Remove log.original (#1469)