### PR TITLE
Correct RFC stages in the `experimental` README

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,9 +1,9 @@
 # ECS Experimental Definitions
 
-ECS experimental definitions are changes and features which have reached [stage two](https://elastic.github.io/ecs/stages.html) in the ECS [RFC process](../rfcs)
+ECS experimental definitions are changes and features which have reached [stage one](https://elastic.github.io/ecs/stages.html) in the ECS [RFC process](../rfcs)
 
-Stage two changes only appear in the experimental artifacts in this directory, but aren't yet reflected in the official ECS documentation.
-Note that stage three and four proposals do appear in the official ECS documentation.
+Stage one changes only appear in the experimental artifacts in this directory but aren't yet reflected in the official ECS documentation.
+Note that stage two and three proposals do appear in the official ECS documentation.
 
 These experimental changes to ECS are comprehensive but not necessarily final. They are also still subject to breaking changes.
 
@@ -18,8 +18,8 @@ $ python scripts/generator.py --include experimental/schemas ../myproject/fields
     --out ../myproject/fields/generated
 ```
 
-The above would include all experimental changes to ECS along with your custom fields, and output the artifacts in `myproject/fields/generated`.
+The above would include all experimental changes to ECS along with your custom fields and output the artifacts in `myproject/fields/generated`.
 
 ## Generated Artifacts
 
-Various files generated based on the experimental ECS spec. The artifacts are generated using `make experimental` and published [here](./generated).
+Various generated files based on the experimental ECS spec. The artifacts are generated using `make experimental` and published [here](./generated).


### PR DESCRIPTION
The `experimental` README has not been updated since ECS RFC stage 4 was [removed](https://github.com/elastic/ecs/pull/1194).

The ECS experimental schema should contain RFC changes that have made it to stage 1.