### PR TITLE
[1.x] Support multi-field type fallback (#1528)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -19,6 +19,7 @@ Thanks, you're awesome :-) -->
 
 * Added `file.fork_name` field. #1288
 * Beta migration on some `keyword` fields to `wildcard`. #1517
+* Support ES 6.x type fallback for `match_only_text` field types. #1528
 
 #### Improvements
 

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -277,5 +277,13 @@ def es6_type_fallback(mappings):
             if fallback_type:
                 mappings[name]['type'] = fallback_type
                 field_or_multi_field_datatype_defaults(mappings[name])
+        # support multi-fields
+        if 'fields' in details:
+            # potentially multiple multi-fields
+            for field_name, field_value in details['fields'].items():
+                fallback_type = TYPE_FALLBACKS.get(field_value['type'])
+                if fallback_type:
+                    mappings[name]['fields'][field_name]['type'] = fallback_type
+                    field_or_multi_field_datatype_defaults(mappings[name]['fields'][field_name])
         if 'properties' in details:
             es6_type_fallback(details['properties'])

--- a/scripts/schema/oss.py
+++ b/scripts/schema/oss.py
@@ -15,7 +15,8 @@ from schema import visitor
 TYPE_FALLBACKS = {
     'constant_keyword': 'keyword',
     'wildcard': 'keyword',
-    'version': 'keyword'
+    'version': 'keyword',
+    'match_only_text': 'text'
 }
 
 

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -222,6 +222,112 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         es_template.es6_type_fallback(test_map)
         self.assertEqual(test_map, exp)
 
+    def test_es6_fallback_base_case_match_only_text(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "type": "match_only_text"
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "type": "text",
+                "norms": False
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_recursive_case_match_only_text(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "match_only_text"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "name": "field",
+                        "type": "text",
+                        "norms": False
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_multifield_base_match_only_text(self):
+        test_map = {
+            "field": {
+                "name": "field",
+                "fields": {
+                    "text": {
+                        "type": "match_only_text"
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "field": {
+                "name": "field",
+                "fields": {
+                    "text": {
+                        "type": "text",
+                        "norms": False
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
+    def test_es6_fallback_multifield_recursive_match_only_text(self):
+        test_map = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "fields": {
+                            "text": {
+                                "type": "match_only_text"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        exp = {
+            "top_field": {
+                "properties": {
+                    "field": {
+                        "fields": {
+                            "text": {
+                                "type": "text",
+                                "norms": False
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        es_template.es6_type_fallback(test_map)
+        self.assertEqual(test_map, exp)
+
     def test_component_composable_template_name(self):
         version = "1.8"
         test_map = {


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Support multi-field type fallback (#1528)