### PR TITLE
[RFC] `match_only_text` - stage 2 beta changes

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -28,6 +28,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532
 #### Deprecated
 
 ## 1.11.0 (Feature Freeze)

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -58,13 +58,15 @@ example: `{"application": "foo-bar", "env": "production"}`
 [[field-message]]
 <<field-message, message>>
 
-| For log events the message field contains the log message, optimized for viewing in a log viewer.
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
+
+For log events the message field contains the log message, optimized for viewing in a log viewer.
 
 For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
 
 If multiple messages exist, they can be combined into one message.
 
-type: text
+type: match_only_text
 
 
 
@@ -255,13 +257,15 @@ example: `15169`
 [[field-as-organization-name]]
 <<field-as-organization-name, as.organization.name>>
 
-| Organization name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Organization name.
 
 type: keyword
 
 Multi-fields:
 
-* as.organization.name.text (type: text)
+* as.organization.name.text (type: match_only_text)
 
 
 
@@ -2440,9 +2444,11 @@ type: keyword
 [[field-error-message]]
 <<field-error-message, error.message>>
 
-| Error message.
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
-type: text
+Error message.
+
+type: match_only_text
 
 
 
@@ -2456,7 +2462,7 @@ type: text
 [[field-error-stack-trace]]
 <<field-error-stack-trace, error.stack_trace>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The stack trace of this error in plain text.
 
@@ -2464,7 +2470,7 @@ type: wildcard
 
 Multi-fields:
 
-* error.stack_trace.text (type: text)
+* error.stack_trace.text (type: match_only_text)
 
 
 
@@ -3349,13 +3355,15 @@ example: `alice`
 [[field-file-path]]
 <<field-file-path, file.path>>
 
-| Full path to the file, including the file name. It should include the drive letter, when appropriate.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Full path to the file, including the file name. It should include the drive letter, when appropriate.
 
 type: keyword
 
 Multi-fields:
 
-* file.path.text (type: text)
+* file.path.text (type: match_only_text)
 
 
 
@@ -3389,13 +3397,15 @@ example: `16384`
 [[field-file-target-path]]
 <<field-file-target-path, file.target_path>>
 
-| Target path for symlinks.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Target path for symlinks.
 
 type: keyword
 
 Multi-fields:
 
-* file.target_path.text (type: text)
+* file.target_path.text (type: match_only_text)
 
 
 
@@ -5677,13 +5687,15 @@ example: `debian`
 [[field-os-full]]
 <<field-os-full, os.full>>
 
-| Operating system name, including the version or code name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Operating system name, including the version or code name.
 
 type: keyword
 
 Multi-fields:
 
-* os.full.text (type: text)
+* os.full.text (type: match_only_text)
 
 
 
@@ -5715,13 +5727,15 @@ example: `4.4.0-112-generic`
 [[field-os-name]]
 <<field-os-name, os.name>>
 
-| Operating system name, without the version.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Operating system name, without the version.
 
 type: keyword
 
 Multi-fields:
 
-* os.name.text (type: text)
+* os.name.text (type: match_only_text)
 
 
 
@@ -6246,7 +6260,7 @@ example: `4`
 [[field-process-command-line]]
 <<field-process-command-line, process.command_line>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 Full command line that started the process, including the absolute path to the executable, and all arguments.
 
@@ -6256,7 +6270,7 @@ type: wildcard
 
 Multi-fields:
 
-* process.command_line.text (type: text)
+* process.command_line.text (type: match_only_text)
 
 
 
@@ -6292,13 +6306,15 @@ example: `c2c455d9f99375d`
 [[field-process-executable]]
 <<field-process-executable, process.executable>>
 
-| Absolute path to the process executable.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Absolute path to the process executable.
 
 type: keyword
 
 Multi-fields:
 
-* process.executable.text (type: text)
+* process.executable.text (type: match_only_text)
 
 
 
@@ -6332,7 +6348,9 @@ example: `137`
 [[field-process-name]]
 <<field-process-name, process.name>>
 
-| Process name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Process name.
 
 Sometimes called program name or similar.
 
@@ -6340,7 +6358,7 @@ type: keyword
 
 Multi-fields:
 
-* process.name.text (type: text)
+* process.name.text (type: match_only_text)
 
 
 
@@ -6452,7 +6470,9 @@ example: `thread-0`
 [[field-process-title]]
 <<field-process-title, process.title>>
 
-| Process title.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Process title.
 
 The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
 
@@ -6460,7 +6480,7 @@ type: keyword
 
 Multi-fields:
 
-* process.title.text (type: text)
+* process.title.text (type: match_only_text)
 
 
 
@@ -6492,13 +6512,15 @@ example: `1325`
 [[field-process-working-directory]]
 <<field-process-working-directory, process.working_directory>>
 
-| The working directory of the process.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The working directory of the process.
 
 type: keyword
 
 Multi-fields:
 
-* process.working_directory.text (type: text)
+* process.working_directory.text (type: match_only_text)
 
 
 
@@ -8739,13 +8761,15 @@ example: `T1059`
 [[field-threat-technique-name]]
 <<field-threat-technique-name, threat.technique.name>>
 
-| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
 Multi-fields:
 
-* threat.technique.name.text (type: text)
+* threat.technique.name.text (type: match_only_text)
 
 
 
@@ -8802,13 +8826,15 @@ example: `T1059.001`
 [[field-threat-technique-subtechnique-name]]
 <<field-threat-technique-subtechnique-name, threat.technique.subtechnique.name>>
 
-| The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
 
 type: keyword
 
 Multi-fields:
 
-* threat.technique.subtechnique.name.text (type: text)
+* threat.technique.subtechnique.name.text (type: match_only_text)
 
 
 
@@ -9663,7 +9689,7 @@ type: keyword
 [[field-url-full]]
 <<field-url-full, url.full>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta ]
 
 If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
 
@@ -9671,7 +9697,7 @@ type: wildcard
 
 Multi-fields:
 
-* url.full.text (type: text)
+* url.full.text (type: match_only_text)
 
 
 
@@ -9687,7 +9713,7 @@ example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 [[field-url-original]]
 <<field-url-original, url.original>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 Unmodified original url as seen in the event source.
 
@@ -9699,7 +9725,7 @@ type: wildcard
 
 Multi-fields:
 
-* url.original.text (type: text)
+* url.original.text (type: match_only_text)
 
 
 
@@ -9941,13 +9967,15 @@ type: keyword
 [[field-user-full-name]]
 <<field-user-full-name, user.full_name>>
 
-| User's full name, if available.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+User's full name, if available.
 
 type: keyword
 
 Multi-fields:
 
-* user.full_name.text (type: text)
+* user.full_name.text (type: match_only_text)
 
 
 
@@ -9997,13 +10025,15 @@ type: keyword
 [[field-user-name]]
 <<field-user-name, user.name>>
 
-| Short name or login of the user.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Short name or login of the user.
 
 type: keyword
 
 Multi-fields:
 
-* user.name.text (type: text)
+* user.name.text (type: match_only_text)
 
 
 
@@ -10164,13 +10194,15 @@ example: `Safari`
 [[field-user-agent-original]]
 <<field-user-agent-original, user_agent.original>>
 
-| Unparsed user_agent string.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Unparsed user_agent string.
 
 type: keyword
 
 Multi-fields:
 
-* user_agent.original.text (type: text)
+* user_agent.original.text (type: match_only_text)
 
 
 
@@ -10355,13 +10387,15 @@ example: `CVSS`
 [[field-vulnerability-description]]
 <<field-vulnerability-description, vulnerability.description>>
 
-| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
 
 type: keyword
 
 Multi-fields:
 
-* vulnerability.description.text (type: text)
+* vulnerability.description.text (type: match_only_text)
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -33,7 +33,7 @@
     example: '{"application": "foo-bar", "env": "production"}'
   - name: message
     level: core
-    type: text
+    type: match_only_text
     description: 'For log events the message field contains the log message, optimized
       for viewing in a log viewer.
 
@@ -140,8 +140,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -187,8 +186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -376,8 +374,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -418,8 +415,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -722,8 +718,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -910,8 +905,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -952,8 +946,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -1745,15 +1738,14 @@
       description: Unique identifier for the error.
     - name: message
       level: core
-      type: text
+      type: match_only_text
       description: Error message.
     - name: stack_trace
       level: extended
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The stack trace of this error in plain text.
     - name: type
@@ -2504,8 +2496,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -2786,8 +2777,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Target path for symlinks.
     - name: type
@@ -3330,8 +3320,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3347,8 +3336,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4069,8 +4057,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -4086,8 +4073,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4260,8 +4246,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -4277,8 +4262,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4772,8 +4756,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -4980,8 +4963,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -5026,8 +5008,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process name.
 
@@ -5120,8 +5101,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -5328,8 +5308,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -5378,8 +5357,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -5694,8 +5672,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -5713,8 +5690,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -6090,8 +6066,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -6298,8 +6273,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -6348,8 +6322,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -6442,8 +6415,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -6650,8 +6622,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -6700,8 +6671,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -7016,8 +6986,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -7035,8 +7004,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -7349,8 +7317,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -7368,8 +7335,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -7391,8 +7357,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process title.
 
@@ -7409,8 +7374,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The working directory of the process.
       example: /home/alice
@@ -7656,8 +7620,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -7845,8 +7808,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -7887,8 +7849,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -8022,8 +7983,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -8211,8 +8171,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -8253,8 +8212,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -8301,8 +8259,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -8721,8 +8678,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -8741,8 +8697,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: enrichments.indicator.file.type
@@ -9320,8 +9275,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -9332,8 +9286,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -9695,8 +9648,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -10115,8 +10067,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -10135,8 +10086,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: indicator.file.type
@@ -10714,8 +10664,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -10726,8 +10675,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -11075,8 +11023,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -11102,8 +11049,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
@@ -11774,8 +11720,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11786,8 +11731,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Unmodified original url as seen in the event source.
 
@@ -11903,8 +11847,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -11950,8 +11893,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -11989,8 +11931,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -12036,8 +11977,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -12059,8 +11999,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -12101,8 +12040,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -12133,8 +12071,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -12180,8 +12117,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -12218,8 +12154,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
@@ -12235,8 +12170,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -12252,8 +12186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -12358,8 +12291,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 8.0.0-dev+exp,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-8.0.0-dev+exp,true,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
+8.0.0-dev+exp,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 8.0.0-dev+exp,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.0.0-dev+exp,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 8.0.0-dev+exp,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -12,7 +12,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,client,client.address,keyword,extended,,,Client network address.
 8.0.0-dev+exp,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 8.0.0-dev+exp,true,client,client.domain,keyword,core,,,Client domain.
 8.0.0-dev+exp,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
@@ -38,14 +38,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,client,client.user.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,client,client.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,client,client.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 8.0.0-dev+exp,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -70,7 +70,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,destination,destination.address,keyword,extended,,,Destination network address.
 8.0.0-dev+exp,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 8.0.0-dev+exp,true,destination,destination.domain,keyword,core,,,Destination domain.
 8.0.0-dev+exp,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
@@ -96,14 +96,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,destination,destination.user.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,destination,destination.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
@@ -178,9 +178,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
 8.0.0-dev+exp,true,error,error.code,keyword,core,,,Error code describing the error.
 8.0.0-dev+exp,true,error,error.id,keyword,core,,,Unique identifier for the error.
-8.0.0-dev+exp,true,error,error.message,text,core,,,Error message.
+8.0.0-dev+exp,true,error,error.message,match_only_text,core,,,Error message.
 8.0.0-dev+exp,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
-8.0.0-dev+exp,true,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+8.0.0-dev+exp,true,error,error.stack_trace.text,match_only_text,extended,,,The stack trace of this error in plain text.
 8.0.0-dev+exp,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 8.0.0-dev+exp,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 8.0.0-dev+exp,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -267,7 +267,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev+exp,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev+exp,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev+exp,true,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev+exp,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev+exp,true,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev+exp,true,file,file.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 8.0.0-dev+exp,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -308,7 +308,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,file,file.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 8.0.0-dev+exp,true,file,file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev+exp,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev+exp,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev+exp,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev+exp,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev+exp,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev+exp,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
@@ -365,10 +365,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
 8.0.0-dev+exp,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev+exp,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev+exp,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev+exp,true,host,host.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev+exp,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev+exp,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev+exp,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev+exp,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev+exp,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev+exp,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev+exp,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -449,10 +449,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 8.0.0-dev+exp,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev+exp,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev+exp,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev+exp,true,observer,observer.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev+exp,true,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev+exp,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev+exp,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev+exp,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev+exp,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev+exp,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev+exp,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -496,7 +496,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev+exp,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev+exp,true,process,process.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev+exp,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev+exp,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -528,7 +528,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev+exp,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev+exp,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev+exp,true,process,process.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev+exp,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -536,7 +536,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev+exp,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
-8.0.0-dev+exp,true,process,process.name.text,text,extended,,ssh,Process name.
+8.0.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 8.0.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -547,7 +547,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev+exp,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev+exp,true,process,process.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev+exp,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev+exp,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -579,7 +579,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev+exp,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev+exp,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev+exp,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev+exp,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev+exp,true,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev+exp,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -587,7 +587,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev+exp,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-8.0.0-dev+exp,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+8.0.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev+exp,true,process,process.parent.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 8.0.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -633,10 +633,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev+exp,true,process,process.parent.title,keyword,extended,,,Process title.
-8.0.0-dev+exp,true,process,process.parent.title.text,text,extended,,,Process title.
+8.0.0-dev+exp,true,process,process.parent.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev+exp,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev+exp,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev+exp,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev+exp,true,process,process.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev+exp,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev+exp,true,process,process.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 8.0.0-dev+exp,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -689,7 +689,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev+exp,true,process,process.target.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev+exp,true,process,process.target.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev+exp,true,process,process.target.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev+exp,true,process,process.target.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev+exp,true,process,process.target.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -721,7 +721,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev+exp,true,process,process.target.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev+exp,true,process,process.target.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev+exp,true,process,process.target.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev+exp,true,process,process.target.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev+exp,true,process,process.target.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev+exp,true,process,process.target.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev+exp,true,process,process.target.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -729,7 +729,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev+exp,true,process,process.target.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev+exp,true,process,process.target.name,keyword,extended,,ssh,Process name.
-8.0.0-dev+exp,true,process,process.target.name.text,text,extended,,ssh,Process name.
+8.0.0-dev+exp,true,process,process.target.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.target.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.target.parent.args_count,long,extended,,4,Length of the process.args array.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -740,7 +740,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev+exp,true,process,process.target.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev+exp,true,process,process.target.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev+exp,true,process,process.target.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev+exp,true,process,process.target.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev+exp,true,process,process.target.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -772,7 +772,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev+exp,true,process,process.target.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev+exp,true,process,process.target.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev+exp,true,process,process.target.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev+exp,true,process,process.target.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev+exp,true,process,process.target.parent.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev+exp,true,process,process.target.parent.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev+exp,true,process,process.target.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -780,7 +780,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev+exp,true,process,process.target.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev+exp,true,process,process.target.parent.name,keyword,extended,,ssh,Process name.
-8.0.0-dev+exp,true,process,process.target.parent.name.text,text,extended,,ssh,Process name.
+8.0.0-dev+exp,true,process,process.target.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.target.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev+exp,true,process,process.target.parent.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 8.0.0-dev+exp,true,process,process.target.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -826,10 +826,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.target.parent.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev+exp,true,process,process.target.parent.title,keyword,extended,,,Process title.
-8.0.0-dev+exp,true,process,process.target.parent.title.text,text,extended,,,Process title.
+8.0.0-dev+exp,true,process,process.target.parent.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev+exp,true,process,process.target.parent.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev+exp,true,process,process.target.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev+exp,true,process,process.target.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev+exp,true,process,process.target.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev+exp,true,process,process.target.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev+exp,true,process,process.target.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 8.0.0-dev+exp,true,process,process.target.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -875,17 +875,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.target.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev+exp,true,process,process.target.title,keyword,extended,,,Process title.
-8.0.0-dev+exp,true,process,process.target.title.text,text,extended,,,Process title.
+8.0.0-dev+exp,true,process,process.target.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev+exp,true,process,process.target.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev+exp,true,process,process.target.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev+exp,true,process,process.target.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev+exp,true,process,process.target.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev+exp,true,process,process.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev+exp,true,process,process.title,keyword,extended,,,Process title.
-8.0.0-dev+exp,true,process,process.title.text,text,extended,,,Process title.
+8.0.0-dev+exp,true,process,process.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev+exp,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev+exp,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev+exp,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev+exp,true,process,process.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev+exp,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
 8.0.0-dev+exp,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 8.0.0-dev+exp,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
@@ -910,7 +910,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,server,server.address,keyword,extended,,,Server network address.
 8.0.0-dev+exp,true,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 8.0.0-dev+exp,true,server,server.domain,keyword,core,,,Server domain.
 8.0.0-dev+exp,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
@@ -936,14 +936,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,server,server.user.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,server,server.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.0.0-dev+exp,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
@@ -955,7 +955,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,source,source.address,keyword,extended,,,Source network address.
 8.0.0-dev+exp,true,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 8.0.0-dev+exp,true,source,source.domain,keyword,core,,,Source domain.
 8.0.0-dev+exp,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
@@ -981,21 +981,21 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,source,source.user.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,source,source.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,source,source.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 8.0.0-dev+exp,true,threat,threat.enrichments,nested,extended,,,List of objects containing indicators enriching the event.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator,object,extended,,,Object containing indicators enriching the event.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -1053,10 +1053,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -1135,9 +1135,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1183,7 +1183,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 8.0.0-dev+exp,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 8.0.0-dev+exp,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev+exp,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -1241,10 +1241,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev+exp,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev+exp,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev+exp,true,threat,threat.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev+exp,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev+exp,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev+exp,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev+exp,true,threat,threat.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev+exp,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev+exp,true,threat,threat.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev+exp,true,threat,threat.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev+exp,true,threat,threat.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -1323,9 +1323,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev+exp,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev+exp,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev+exp,true,threat,threat.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev+exp,true,threat,threat.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev+exp,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev+exp,true,threat,threat.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev+exp,true,threat,threat.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev+exp,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
 8.0.0-dev+exp,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev+exp,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1369,11 +1369,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
 8.0.0-dev+exp,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
 8.0.0-dev+exp,true,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
-8.0.0-dev+exp,true,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+8.0.0-dev+exp,true,threat,threat.technique.name.text,match_only_text,extended,,Command and Scripting Interpreter,Threat technique name.
 8.0.0-dev+exp,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
 8.0.0-dev+exp,true,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
 8.0.0-dev+exp,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
-8.0.0-dev+exp,true,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+8.0.0-dev+exp,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.0.0-dev+exp,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
 8.0.0-dev+exp,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.0.0-dev+exp,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
@@ -1458,9 +1458,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev+exp,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev+exp,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev+exp,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev+exp,true,url,url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev+exp,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev+exp,true,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev+exp,true,url,url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev+exp,true,url,url.password,keyword,extended,,,Password of the request.
 8.0.0-dev+exp,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev+exp,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1473,61 +1473,61 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,user,user.changes.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,user,user.changes.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,user,user.changes.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,user,user.effective.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,user,user.effective.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,user,user.effective.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,user,user.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,user,user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,user,user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,user,user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,user,user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,user,user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev+exp,true,user,user.target.email,keyword,extended,,,User email address.
 8.0.0-dev+exp,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev+exp,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev+exp,true,user,user.target.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev+exp,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev+exp,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev+exp,true,user,user.target.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev+exp,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev+exp,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev+exp,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev+exp,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev+exp,true,user,user.target.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 8.0.0-dev+exp,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 8.0.0-dev+exp,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
-8.0.0-dev+exp,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+8.0.0-dev+exp,true,user_agent,user_agent.original.text,match_only_text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 8.0.0-dev+exp,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev+exp,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev+exp,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev+exp,true,user_agent,user_agent.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev+exp,true,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev+exp,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev+exp,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev+exp,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev+exp,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev+exp,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev+exp,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -1535,7 +1535,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
 8.0.0-dev+exp,true,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
 8.0.0-dev+exp,true,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
-8.0.0-dev+exp,true,vulnerability,vulnerability.description.text,text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+8.0.0-dev+exp,true,vulnerability,vulnerability.description.text,match_only_text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 8.0.0-dev+exp,true,vulnerability,vulnerability.enumeration,keyword,extended,,CVE,Identifier of the vulnerability.
 8.0.0-dev+exp,true,vulnerability,vulnerability.id,keyword,extended,,CVE-2019-00001,ID of the vulnerability.
 8.0.0-dev+exp,true,vulnerability,vulnerability.reference,keyword,extended,,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -129,6 +129,8 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -138,8 +140,7 @@ client.as.organization.name:
   multi_fields:
   - flat_name: client.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -452,6 +453,8 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -461,8 +464,7 @@ client.user.full_name:
   multi_fields:
   - flat_name: client.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -530,6 +532,8 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
@@ -539,8 +543,7 @@ client.user.name:
   multi_fields:
   - flat_name: client.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -830,6 +833,8 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -839,8 +844,7 @@ destination.as.organization.name:
   multi_fields:
   - flat_name: destination.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -1152,6 +1156,8 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1161,8 +1167,7 @@ destination.user.full_name:
   multi_fields:
   - flat_name: destination.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -1230,6 +1235,8 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
@@ -1239,8 +1246,7 @@ destination.user.name:
   multi_fields:
   - flat_name: destination.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -2184,17 +2190,18 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
   level: core
   name: message
   normalize: []
-  norms: false
   short: Error message.
-  type: text
+  type: match_only_text
 error.stack_trace:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -2202,8 +2209,7 @@ error.stack_trace:
   multi_fields:
   - flat_name: error.stack_trace.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: stack_trace
   normalize: []
   short: The stack trace of this error in plain text.
@@ -3697,6 +3703,8 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -3707,8 +3715,7 @@ file.path:
   multi_fields:
   - flat_name: file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   short: Full path to the file, including the file name.
@@ -4185,6 +4192,8 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -4193,8 +4202,7 @@ file.target_path:
   multi_fields:
   - flat_name: file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   short: Target path for symlinks.
@@ -4878,6 +4886,8 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4887,8 +4897,7 @@ host.os.full:
   multi_fields:
   - flat_name: host.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -4907,6 +4916,8 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4916,8 +4927,7 @@ host.os.name:
   multi_fields:
   - flat_name: host.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -5359,6 +5369,7 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -5372,9 +5383,8 @@ message:
   level: core
   name: message
   normalize: []
-  norms: false
   short: Log message optimized for viewing in a log viewer.
-  type: text
+  type: match_only_text
 network.application:
   dashed_name: network-application
   description: 'A name given to an application level protocol. This can be arbitrarily
@@ -5969,6 +5979,8 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -5978,8 +5990,7 @@ observer.os.full:
   multi_fields:
   - flat_name: observer.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -5998,6 +6009,8 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -6007,8 +6020,7 @@ observer.os.name:
   multi_fields:
   - flat_name: observer.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -6511,7 +6523,8 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6523,8 +6536,7 @@ process.command_line:
   multi_fields:
   - flat_name: process.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   short: Full command line that started the process.
@@ -6878,6 +6890,8 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6887,8 +6901,7 @@ process.executable:
   multi_fields:
   - flat_name: process.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   short: Absolute path to the process executable.
@@ -6962,6 +6975,8 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -6973,8 +6988,7 @@ process.name:
   multi_fields:
   - flat_name: process.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Process name.
@@ -7109,7 +7123,8 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7121,8 +7136,7 @@ process.parent.command_line:
   multi_fields:
   - flat_name: process.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -7478,6 +7492,8 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -7487,8 +7503,7 @@ process.parent.executable:
   multi_fields:
   - flat_name: process.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -7564,6 +7579,8 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -7575,8 +7592,7 @@ process.parent.name:
   multi_fields:
   - flat_name: process.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -8112,6 +8128,8 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -8123,8 +8141,7 @@ process.parent.title:
   multi_fields:
   - flat_name: process.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -8142,6 +8159,8 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -8151,8 +8170,7 @@ process.parent.working_directory:
   multi_fields:
   - flat_name: process.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -8789,7 +8807,8 @@ process.target.code_signature.valid:
     content.
   type: boolean
 process.target.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-target-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -8801,8 +8820,7 @@ process.target.command_line:
   multi_fields:
   - flat_name: process.target.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -9158,6 +9176,8 @@ process.target.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -9167,8 +9187,7 @@ process.target.executable:
   multi_fields:
   - flat_name: process.target.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -9244,6 +9263,8 @@ process.target.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-name
   description: 'Process name.
 
@@ -9255,8 +9276,7 @@ process.target.name:
   multi_fields:
   - flat_name: process.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -9392,7 +9412,8 @@ process.target.parent.code_signature.valid:
     content.
   type: boolean
 process.target.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-target-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -9404,8 +9425,7 @@ process.target.parent.command_line:
   multi_fields:
   - flat_name: process.target.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -9761,6 +9781,8 @@ process.target.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -9770,8 +9792,7 @@ process.target.parent.executable:
   multi_fields:
   - flat_name: process.target.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -9847,6 +9868,8 @@ process.target.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-name
   description: 'Process name.
 
@@ -9858,8 +9881,7 @@ process.target.parent.name:
   multi_fields:
   - flat_name: process.target.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -10395,6 +10417,8 @@ process.target.parent.thread.name:
   short: Thread name.
   type: keyword
 process.target.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-title
   description: 'Process title.
 
@@ -10406,8 +10430,7 @@ process.target.parent.title:
   multi_fields:
   - flat_name: process.target.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -10425,6 +10448,8 @@ process.target.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -10434,8 +10459,7 @@ process.target.parent.working_directory:
   multi_fields:
   - flat_name: process.target.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -10971,6 +10995,8 @@ process.target.thread.name:
   short: Thread name.
   type: keyword
 process.target.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-title
   description: 'Process title.
 
@@ -10982,8 +11008,7 @@ process.target.title:
   multi_fields:
   - flat_name: process.target.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -11001,6 +11026,8 @@ process.target.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11010,8 +11037,7 @@ process.target.working_directory:
   multi_fields:
   - flat_name: process.target.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -11040,6 +11066,8 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -11051,8 +11079,7 @@ process.title:
   multi_fields:
   - flat_name: process.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   short: Process title.
@@ -11068,6 +11095,8 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11077,8 +11106,7 @@ process.working_directory:
   multi_fields:
   - flat_name: process.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   short: The working directory of the process.
@@ -11368,6 +11396,8 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -11377,8 +11407,7 @@ server.as.organization.name:
   multi_fields:
   - flat_name: server.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -11691,6 +11720,8 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -11700,8 +11731,7 @@ server.user.full_name:
   multi_fields:
   - flat_name: server.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -11769,6 +11799,8 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
@@ -11778,8 +11810,7 @@ server.user.name:
   multi_fields:
   - flat_name: server.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -11938,6 +11969,8 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -11947,8 +11980,7 @@ source.as.organization.name:
   multi_fields:
   - flat_name: source.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -12261,6 +12293,8 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -12270,8 +12304,7 @@ source.user.full_name:
   multi_fields:
   - flat_name: source.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -12339,6 +12372,8 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
@@ -12348,8 +12383,7 @@ source.user.name:
   multi_fields:
   - flat_name: source.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -12428,6 +12462,8 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -12437,8 +12473,7 @@ threat.enrichments.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.enrichments.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -13141,6 +13176,8 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -13151,8 +13188,7 @@ threat.enrichments.indicator.file.path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -13172,6 +13208,8 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -13180,8 +13218,7 @@ threat.enrichments.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -14148,7 +14185,8 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -14158,15 +14196,15 @@ threat.enrichments.indicator.url.full:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -14180,8 +14218,7 @@ threat.enrichments.indicator.url.original:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -14771,6 +14808,8 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -14780,8 +14819,7 @@ threat.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -15484,6 +15522,8 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -15494,8 +15534,7 @@ threat.indicator.file.path:
   multi_fields:
   - flat_name: threat.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -15515,6 +15554,8 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -15523,8 +15564,7 @@ threat.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -16491,7 +16531,8 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -16501,15 +16542,15 @@ threat.indicator.url.full:
   multi_fields:
   - flat_name: threat.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -16523,8 +16564,7 @@ threat.indicator.url.original:
   multi_fields:
   - flat_name: threat.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -17094,6 +17134,8 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -17104,8 +17146,7 @@ threat.technique.name:
   multi_fields:
   - flat_name: threat.technique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.name
   normalize:
   - array
@@ -17138,6 +17179,8 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -17148,8 +17191,7 @@ threat.technique.subtechnique.name:
   multi_fields:
   - flat_name: threat.technique.subtechnique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.subtechnique.name
   normalize:
   - array
@@ -18216,7 +18258,8 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -18226,14 +18269,14 @@ url.full:
   multi_fields:
   - flat_name: url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -18247,8 +18290,7 @@ url.original:
   multi_fields:
   - flat_name: url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unmodified original url as seen in the event source.
@@ -18400,6 +18442,8 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18409,8 +18453,7 @@ user.changes.full_name:
   multi_fields:
   - flat_name: user.changes.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -18478,6 +18521,8 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
@@ -18487,8 +18532,7 @@ user.changes.name:
   multi_fields:
   - flat_name: user.changes.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -18544,6 +18588,8 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18553,8 +18599,7 @@ user.effective.full_name:
   multi_fields:
   - flat_name: user.effective.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -18622,6 +18667,8 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
@@ -18631,8 +18678,7 @@ user.effective.name:
   multi_fields:
   - flat_name: user.effective.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -18662,6 +18708,8 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18671,8 +18719,7 @@ user.full_name:
   multi_fields:
   - flat_name: user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   short: User's full name, if available.
@@ -18737,6 +18784,8 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
@@ -18746,8 +18795,7 @@ user.name:
   multi_fields:
   - flat_name: user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Short name or login of the user.
@@ -18789,6 +18837,8 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18798,8 +18848,7 @@ user.target.full_name:
   multi_fields:
   - flat_name: user.target.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -18867,6 +18916,8 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
@@ -18876,8 +18927,7 @@ user.target.name:
   multi_fields:
   - flat_name: user.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -18919,6 +18969,8 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -18929,8 +18981,7 @@ user_agent.original:
   multi_fields:
   - flat_name: user_agent.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unparsed user_agent string.
@@ -18948,6 +18999,8 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -18957,8 +19010,7 @@ user_agent.os.full:
   multi_fields:
   - flat_name: user_agent.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -18977,6 +19029,8 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -18986,8 +19040,7 @@ user_agent.os.name:
   multi_fields:
   - flat_name: user_agent.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -19077,6 +19130,8 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -19088,8 +19143,7 @@ vulnerability.description:
   multi_fields:
   - flat_name: vulnerability.description.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: description
   normalize: []
   short: Description of the vulnerability.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -119,6 +119,8 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -128,8 +130,7 @@ as:
       multi_fields:
       - flat_name: as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       short: Organization name.
@@ -203,6 +204,7 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -216,9 +218,8 @@ base:
       level: core
       name: message
       normalize: []
-      norms: false
       short: Log message optimized for viewing in a log viewer.
-      type: text
+      type: match_only_text
     tags:
       dashed_name: tags
       description: List of keywords used to tag each event.
@@ -283,6 +284,8 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -292,8 +295,7 @@ client:
       multi_fields:
       - flat_name: client.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -607,6 +609,8 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -616,8 +620,7 @@ client:
       multi_fields:
       - flat_name: client.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -685,6 +688,8 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
@@ -694,8 +699,7 @@ client:
       multi_fields:
       - flat_name: client.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -1179,6 +1183,8 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1188,8 +1194,7 @@ destination:
       multi_fields:
       - flat_name: destination.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -1502,6 +1507,8 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1511,8 +1518,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -1580,6 +1586,8 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
@@ -1589,8 +1597,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -2941,17 +2948,18 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
       level: core
       name: message
       normalize: []
-      norms: false
       short: Error message.
-      type: text
+      type: match_only_text
     error.stack_trace:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -2959,8 +2967,7 @@ error:
       multi_fields:
       - flat_name: error.stack_trace.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: stack_trace
       normalize: []
       short: The stack trace of this error in plain text.
@@ -4505,6 +4512,8 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -4515,8 +4524,7 @@ file:
       multi_fields:
       - flat_name: file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       short: Full path to the file, including the file name.
@@ -4994,6 +5002,8 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -5002,8 +5012,7 @@ file:
       multi_fields:
       - flat_name: file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       short: Target path for symlinks.
@@ -6012,6 +6021,8 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6021,8 +6032,7 @@ host:
       multi_fields:
       - flat_name: host.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -6041,6 +6051,8 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6050,8 +6062,7 @@ host:
       multi_fields:
       - flat_name: host.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -7218,6 +7229,8 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7227,8 +7240,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -7247,6 +7259,8 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7256,8 +7270,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -7555,6 +7568,8 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7564,8 +7579,7 @@ os:
       multi_fields:
       - flat_name: os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Operating system name, including the version or code name.
@@ -7582,6 +7596,8 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7591,8 +7607,7 @@ os:
       multi_fields:
       - flat_name: os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Operating system name, without the version.
@@ -8405,7 +8420,8 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -8417,8 +8433,7 @@ process:
       multi_fields:
       - flat_name: process.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       short: Full command line that started the process.
@@ -8772,6 +8787,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -8781,8 +8798,7 @@ process:
       multi_fields:
       - flat_name: process.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       short: Absolute path to the process executable.
@@ -8856,6 +8872,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -8867,8 +8885,7 @@ process:
       multi_fields:
       - flat_name: process.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Process name.
@@ -9003,7 +9020,8 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9015,8 +9033,7 @@ process:
       multi_fields:
       - flat_name: process.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -9372,6 +9389,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -9381,8 +9400,7 @@ process:
       multi_fields:
       - flat_name: process.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -9458,6 +9476,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -9469,8 +9489,7 @@ process:
       multi_fields:
       - flat_name: process.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -10007,6 +10026,8 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -10018,8 +10039,7 @@ process:
       multi_fields:
       - flat_name: process.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -10037,6 +10057,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -10046,8 +10068,7 @@ process:
       multi_fields:
       - flat_name: process.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -10685,7 +10706,8 @@ process:
         content.
       type: boolean
     process.target.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-target-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -10697,8 +10719,7 @@ process:
       multi_fields:
       - flat_name: process.target.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -11054,6 +11075,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -11063,8 +11086,7 @@ process:
       multi_fields:
       - flat_name: process.target.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -11140,6 +11162,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-name
       description: 'Process name.
 
@@ -11151,8 +11175,7 @@ process:
       multi_fields:
       - flat_name: process.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -11288,7 +11311,8 @@ process:
         content.
       type: boolean
     process.target.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-target-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -11300,8 +11324,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -11657,6 +11680,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -11666,8 +11691,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -11743,6 +11767,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-name
       description: 'Process name.
 
@@ -11754,8 +11780,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -12292,6 +12317,8 @@ process:
       short: Thread name.
       type: keyword
     process.target.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-title
       description: 'Process title.
 
@@ -12303,8 +12330,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -12322,6 +12348,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -12331,8 +12359,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -12869,6 +12896,8 @@ process:
       short: Thread name.
       type: keyword
     process.target.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-title
       description: 'Process title.
 
@@ -12880,8 +12909,7 @@ process:
       multi_fields:
       - flat_name: process.target.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -12899,6 +12927,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -12908,8 +12938,7 @@ process:
       multi_fields:
       - flat_name: process.target.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -12938,6 +12967,8 @@ process:
       short: Thread name.
       type: keyword
     process.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -12949,8 +12980,7 @@ process:
       multi_fields:
       - flat_name: process.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       short: Process title.
@@ -12966,6 +12996,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -12975,8 +13007,7 @@ process:
       multi_fields:
       - flat_name: process.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       short: The working directory of the process.
@@ -13389,6 +13420,8 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -13398,8 +13431,7 @@ server:
       multi_fields:
       - flat_name: server.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -13713,6 +13745,8 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -13722,8 +13756,7 @@ server:
       multi_fields:
       - flat_name: server.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -13791,6 +13824,8 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
@@ -13800,8 +13835,7 @@ server:
       multi_fields:
       - flat_name: server.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -14004,6 +14038,8 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14013,8 +14049,7 @@ source:
       multi_fields:
       - flat_name: source.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -14328,6 +14363,8 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -14337,8 +14374,7 @@ source:
       multi_fields:
       - flat_name: source.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -14406,6 +14442,8 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
@@ -14415,8 +14453,7 @@ source:
       multi_fields:
       - flat_name: source.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -14498,6 +14535,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14507,8 +14546,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -15211,6 +15249,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -15221,8 +15261,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -15242,6 +15281,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -15250,8 +15291,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -16222,7 +16262,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -16233,15 +16274,15 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -16255,8 +16296,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -16846,6 +16886,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -16855,8 +16897,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -17559,6 +17600,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -17569,8 +17612,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -17590,6 +17632,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -17598,8 +17642,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -18570,7 +18613,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -18581,15 +18625,15 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -18603,8 +18647,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -19174,6 +19217,8 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -19184,8 +19229,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.name
       normalize:
       - array
@@ -19218,6 +19262,8 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -19228,8 +19274,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.subtechnique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.subtechnique.name
       normalize:
       - array
@@ -20447,7 +20492,8 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -20458,14 +20504,14 @@ url:
       multi_fields:
       - flat_name: url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -20479,8 +20525,7 @@ url:
       multi_fields:
       - flat_name: url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unmodified original url as seen in the event source.
@@ -20656,6 +20701,8 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -20665,8 +20712,7 @@ user:
       multi_fields:
       - flat_name: user.changes.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -20734,6 +20780,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
@@ -20743,8 +20791,7 @@ user:
       multi_fields:
       - flat_name: user.changes.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -20800,6 +20847,8 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -20809,8 +20858,7 @@ user:
       multi_fields:
       - flat_name: user.effective.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -20878,6 +20926,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
@@ -20887,8 +20937,7 @@ user:
       multi_fields:
       - flat_name: user.effective.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -20918,6 +20967,8 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -20927,8 +20978,7 @@ user:
       multi_fields:
       - flat_name: user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       short: User's full name, if available.
@@ -20993,6 +21043,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
@@ -21002,8 +21054,7 @@ user:
       multi_fields:
       - flat_name: user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Short name or login of the user.
@@ -21045,6 +21096,8 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21054,8 +21107,7 @@ user:
       multi_fields:
       - flat_name: user.target.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -21123,6 +21175,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
@@ -21132,8 +21186,7 @@ user:
       multi_fields:
       - flat_name: user.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -21231,6 +21284,8 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -21241,8 +21296,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unparsed user_agent string.
@@ -21260,6 +21314,8 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -21269,8 +21325,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -21289,6 +21344,8 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -21298,8 +21355,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -21467,6 +21523,8 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -21478,8 +21536,7 @@ vulnerability:
       multi_fields:
       - flat_name: vulnerability.description.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: description
       normalize: []
       short: Description of the vulnerability.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -70,8 +70,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -183,8 +182,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -217,8 +215,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -360,8 +357,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -473,8 +469,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -507,8 +502,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -853,14 +847,12 @@
             "type": "keyword"
           },
           "message": {
-            "norms": false,
-            "type": "text"
+            "type": "match_only_text"
           },
           "stack_trace": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -1210,8 +1202,7 @@
           "path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1391,8 +1382,7 @@
           "target_path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1665,8 +1655,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1679,8 +1668,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1864,8 +1852,7 @@
         }
       },
       "message": {
-        "norms": false,
-        "type": "text"
+        "type": "match_only_text"
       },
       "network": {
         "properties": {
@@ -2088,8 +2075,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2102,8 +2088,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2306,8 +2291,7 @@
           "command_line": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -2436,8 +2420,7 @@
           "executable": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2473,8 +2456,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2521,8 +2503,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -2651,8 +2632,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2688,8 +2668,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2889,8 +2868,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2902,8 +2880,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3132,8 +3109,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -3262,8 +3238,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3299,8 +3274,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3347,8 +3321,7 @@
                   "command_line": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -3477,8 +3450,7 @@
                   "executable": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3514,8 +3486,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3715,8 +3686,7 @@
                   "title": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3728,8 +3698,7 @@
                   "working_directory": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3931,8 +3900,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3944,8 +3912,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3967,8 +3934,7 @@
           "title": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -3980,8 +3946,7 @@
           "working_directory": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -4103,8 +4068,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4216,8 +4180,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4250,8 +4213,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4317,8 +4279,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4430,8 +4391,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4464,8 +4424,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4507,8 +4466,7 @@
                           "name": {
                             "fields": {
                               "text": {
-                                "norms": false,
-                                "type": "text"
+                                "type": "match_only_text"
                               }
                             },
                             "ignore_above": 1024,
@@ -4749,8 +4707,7 @@
                       "path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -4762,8 +4719,7 @@
                       "target_path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -5111,8 +5067,7 @@
                       "full": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -5120,8 +5075,7 @@
                       "original": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -5334,8 +5288,7 @@
                       "name": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -5576,8 +5529,7 @@
                   "path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -5589,8 +5541,7 @@
                   "target_path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -5938,8 +5889,7 @@
                   "full": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -5947,8 +5897,7 @@
                   "original": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -6146,8 +6095,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6166,8 +6114,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -6558,8 +6505,7 @@
           "full": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -6567,8 +6513,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -6624,8 +6569,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6658,8 +6602,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6688,8 +6631,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6722,8 +6664,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6742,8 +6683,7 @@
           "full_name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6776,8 +6716,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6800,8 +6739,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6834,8 +6772,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6866,8 +6803,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6882,8 +6818,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6896,8 +6831,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6936,8 +6870,7 @@
           "description": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/base.json
+++ b/experimental/generated/elasticsearch/component/base.json
@@ -13,8 +13,7 @@
           "type": "object"
         },
         "message": {
-          "norms": false,
-          "type": "text"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/client.json
+++ b/experimental/generated/elasticsearch/component/client.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/destination.json
+++ b/experimental/generated/elasticsearch/component/destination.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/error.json
+++ b/experimental/generated/elasticsearch/component/error.json
@@ -17,14 +17,12 @@
               "type": "keyword"
             },
             "message": {
-              "norms": false,
-              "type": "text"
+              "type": "match_only_text"
             },
             "stack_trace": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -245,8 +245,7 @@
             "path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -426,8 +425,7 @@
             "target_path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/host.json
+++ b/experimental/generated/elasticsearch/component/host.json
@@ -141,8 +141,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -155,8 +154,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/observer.json
+++ b/experimental/generated/elasticsearch/component/observer.json
@@ -153,8 +153,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -167,8 +166,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -47,8 +47,7 @@
             "command_line": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -177,8 +176,7 @@
             "executable": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -214,8 +212,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -262,8 +259,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -392,8 +388,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -429,8 +424,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -630,8 +624,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -643,8 +636,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -873,8 +865,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -1003,8 +994,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1040,8 +1030,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1088,8 +1077,7 @@
                     "command_line": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1218,8 +1206,7 @@
                     "executable": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1255,8 +1242,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1456,8 +1442,7 @@
                     "title": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1469,8 +1454,7 @@
                     "working_directory": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1672,8 +1656,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1685,8 +1668,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1708,8 +1690,7 @@
             "title": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -1721,8 +1702,7 @@
             "working_directory": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/server.json
+++ b/experimental/generated/elasticsearch/component/server.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/source.json
+++ b/experimental/generated/elasticsearch/component/source.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -22,8 +22,7 @@
                             "name": {
                               "fields": {
                                 "text": {
-                                  "norms": false,
-                                  "type": "text"
+                                  "type": "match_only_text"
                                 }
                               },
                               "ignore_above": 1024,
@@ -264,8 +263,7 @@
                         "path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -277,8 +275,7 @@
                         "target_path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -626,8 +623,7 @@
                         "full": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -635,8 +631,7 @@
                         "original": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -849,8 +844,7 @@
                         "name": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -1091,8 +1085,7 @@
                     "path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1104,8 +1097,7 @@
                     "target_path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1453,8 +1445,7 @@
                     "full": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1462,8 +1453,7 @@
                     "original": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1661,8 +1651,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1681,8 +1670,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/url.json
+++ b/experimental/generated/elasticsearch/component/url.json
@@ -23,8 +23,7 @@
             "full": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -32,8 +31,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/user.json
+++ b/experimental/generated/elasticsearch/component/user.json
@@ -21,8 +21,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -55,8 +54,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -85,8 +83,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -119,8 +116,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -139,8 +135,7 @@
             "full_name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -173,8 +168,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -197,8 +191,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -231,8 +224,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/user_agent.json
+++ b/experimental/generated/elasticsearch/component/user_agent.json
@@ -23,8 +23,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -39,8 +38,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -53,8 +51,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/vulnerability.json
+++ b/experimental/generated/elasticsearch/component/vulnerability.json
@@ -19,8 +19,7 @@
             "description": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -33,7 +33,7 @@
     example: '{"application": "foo-bar", "env": "production"}'
   - name: message
     level: core
-    type: text
+    type: match_only_text
     description: 'For log events the message field contains the log message, optimized
       for viewing in a log viewer.
 
@@ -140,8 +140,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -187,8 +186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -376,8 +374,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -418,8 +415,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -722,8 +718,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -910,8 +905,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -952,8 +946,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -1535,15 +1528,14 @@
       description: Unique identifier for the error.
     - name: message
       level: core
-      type: text
+      type: match_only_text
       description: Error message.
     - name: stack_trace
       level: extended
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The stack trace of this error in plain text.
     - name: type
@@ -2294,8 +2286,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -2366,8 +2357,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Target path for symlinks.
     - name: type
@@ -2910,8 +2900,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -2927,8 +2916,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -3649,8 +3637,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3666,8 +3653,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -3840,8 +3826,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3857,8 +3842,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4142,8 +4126,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -4350,8 +4333,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -4396,8 +4378,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process name.
 
@@ -4490,8 +4471,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -4698,8 +4678,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -4748,8 +4727,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -4854,8 +4832,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -4873,8 +4850,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -4971,8 +4947,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process title.
 
@@ -4989,8 +4964,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The working directory of the process.
       example: /home/alice
@@ -5236,8 +5210,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -5425,8 +5398,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -5467,8 +5439,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -5602,8 +5573,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -5791,8 +5761,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -5833,8 +5802,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -5881,8 +5849,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -6301,8 +6268,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -6321,8 +6287,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: enrichments.indicator.file.type
@@ -6690,8 +6655,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -6702,8 +6666,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -7065,8 +7028,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -7485,8 +7447,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -7505,8 +7466,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: indicator.file.type
@@ -7874,8 +7834,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -7886,8 +7845,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -8235,8 +8193,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -8262,8 +8219,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
@@ -8934,8 +8890,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -8946,8 +8901,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Unmodified original url as seen in the event source.
 
@@ -9063,8 +9017,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9110,8 +9063,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9149,8 +9101,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9196,8 +9147,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9219,8 +9169,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -9261,8 +9210,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -9293,8 +9241,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9340,8 +9287,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9378,8 +9324,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
@@ -9395,8 +9340,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -9412,8 +9356,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -9518,8 +9461,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 8.0.0-dev,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-8.0.0-dev,true,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
+8.0.0-dev,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 8.0.0-dev,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 8.0.0-dev,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 8.0.0-dev,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -12,7 +12,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,client,client.address,keyword,extended,,,Client network address.
 8.0.0-dev,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 8.0.0-dev,true,client,client.domain,keyword,core,,,Client domain.
 8.0.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
@@ -38,14 +38,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,client,client.user.email,keyword,extended,,,User email address.
 8.0.0-dev,true,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,client,client.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,client,client.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 8.0.0-dev,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -70,7 +70,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,destination,destination.address,keyword,extended,,,Destination network address.
 8.0.0-dev,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 8.0.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
 8.0.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
@@ -96,14 +96,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,destination,destination.user.email,keyword,extended,,,User email address.
 8.0.0-dev,true,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,destination,destination.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
@@ -147,9 +147,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
 8.0.0-dev,true,error,error.code,keyword,core,,,Error code describing the error.
 8.0.0-dev,true,error,error.id,keyword,core,,,Unique identifier for the error.
-8.0.0-dev,true,error,error.message,text,core,,,Error message.
+8.0.0-dev,true,error,error.message,match_only_text,core,,,Error message.
 8.0.0-dev,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
-8.0.0-dev,true,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+8.0.0-dev,true,error,error.stack_trace.text,match_only_text,extended,,,The stack trace of this error in plain text.
 8.0.0-dev,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 8.0.0-dev,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 8.0.0-dev,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -236,7 +236,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev,true,file,file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev,true,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev,true,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.0.0-dev,true,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -246,7 +246,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,file,file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 8.0.0-dev,true,file,file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
@@ -303,10 +303,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
 8.0.0-dev,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev,true,host,host.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -387,10 +387,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 8.0.0-dev,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev,true,observer,observer.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev,true,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -434,7 +434,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev,true,process,process.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -466,7 +466,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev,true,process,process.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -474,7 +474,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
-8.0.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
+8.0.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 8.0.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -485,7 +485,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-8.0.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+8.0.0-dev,true,process,process.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.0.0-dev,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 8.0.0-dev,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 8.0.0-dev,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -517,7 +517,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 8.0.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.0.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-8.0.0-dev,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+8.0.0-dev,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.0.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 8.0.0-dev,true,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
 8.0.0-dev,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -525,7 +525,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 8.0.0-dev,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.0.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-8.0.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+8.0.0-dev,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.0.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -540,10 +540,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev,true,process,process.parent.title,keyword,extended,,,Process title.
-8.0.0-dev,true,process,process.parent.title.text,text,extended,,,Process title.
+8.0.0-dev,true,process,process.parent.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev,true,process,process.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.0.0-dev,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.0.0-dev,true,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -558,10 +558,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 8.0.0-dev,true,process,process.title,keyword,extended,,,Process title.
-8.0.0-dev,true,process,process.title.text,text,extended,,,Process title.
+8.0.0-dev,true,process,process.title.text,match_only_text,extended,,,Process title.
 8.0.0-dev,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
 8.0.0-dev,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-8.0.0-dev,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+8.0.0-dev,true,process,process.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 8.0.0-dev,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
 8.0.0-dev,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 8.0.0-dev,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
@@ -586,7 +586,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,server,server.address,keyword,extended,,,Server network address.
 8.0.0-dev,true,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 8.0.0-dev,true,server,server.domain,keyword,core,,,Server domain.
 8.0.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
@@ -612,14 +612,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,server,server.user.email,keyword,extended,,,User email address.
 8.0.0-dev,true,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,server,server.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.0.0-dev,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
@@ -631,7 +631,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,source,source.address,keyword,extended,,,Source network address.
 8.0.0-dev,true,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 8.0.0-dev,true,source,source.domain,keyword,core,,,Source domain.
 8.0.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
@@ -657,21 +657,21 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,source,source.user.email,keyword,extended,,,User email address.
 8.0.0-dev,true,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,source,source.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,source,source.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 8.0.0-dev,true,threat,threat.enrichments,nested,extended,,,List of objects containing indicators enriching the event.
 8.0.0-dev,true,threat,threat.enrichments.indicator,object,extended,,,Object containing indicators enriching the event.
 8.0.0-dev,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,threat,threat.enrichments.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 8.0.0-dev,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -729,10 +729,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev,true,threat,threat.enrichments.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev,true,threat,threat.enrichments.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev,true,threat,threat.enrichments.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -780,9 +780,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev,true,threat,threat.enrichments.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev,true,threat,threat.enrichments.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev,true,threat,threat.enrichments.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev,true,threat,threat.enrichments.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -828,7 +828,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 8.0.0-dev,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-8.0.0-dev,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+8.0.0-dev,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.0.0-dev,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 8.0.0-dev,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -886,10 +886,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 8.0.0-dev,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 8.0.0-dev,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-8.0.0-dev,true,threat,threat.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+8.0.0-dev,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 8.0.0-dev,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 8.0.0-dev,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-8.0.0-dev,true,threat,threat.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+8.0.0-dev,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 8.0.0-dev,true,threat,threat.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 8.0.0-dev,true,threat,threat.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 8.0.0-dev,true,threat,threat.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -937,9 +937,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev,true,threat,threat.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev,true,threat,threat.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev,true,threat,threat.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev,true,threat,threat.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
 8.0.0-dev,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -983,11 +983,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
 8.0.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
 8.0.0-dev,true,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
-8.0.0-dev,true,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+8.0.0-dev,true,threat,threat.technique.name.text,match_only_text,extended,,Command and Scripting Interpreter,Threat technique name.
 8.0.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
 8.0.0-dev,true,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
 8.0.0-dev,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
-8.0.0-dev,true,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+8.0.0-dev,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.0.0-dev,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
 8.0.0-dev,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.0.0-dev,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
@@ -1072,9 +1072,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 8.0.0-dev,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 8.0.0-dev,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-8.0.0-dev,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+8.0.0-dev,true,url,url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 8.0.0-dev,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-8.0.0-dev,true,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+8.0.0-dev,true,url,url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 8.0.0-dev,true,url,url.password,keyword,extended,,,Password of the request.
 8.0.0-dev,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 8.0.0-dev,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1087,61 +1087,61 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,user,user.changes.email,keyword,extended,,,User email address.
 8.0.0-dev,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,user,user.changes.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,user,user.changes.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,user,user.effective.email,keyword,extended,,,User email address.
 8.0.0-dev,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,user,user.effective.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,user,user.effective.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,user,user.email,keyword,extended,,,User email address.
 8.0.0-dev,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,user,user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,user,user.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,user,user.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,user,user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.0.0-dev,true,user,user.target.email,keyword,extended,,,User email address.
 8.0.0-dev,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-8.0.0-dev,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+8.0.0-dev,true,user,user.target.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 8.0.0-dev,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 8.0.0-dev,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.0.0-dev,true,user,user.target.group.name,keyword,extended,,,Name of the group.
 8.0.0-dev,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 8.0.0-dev,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
 8.0.0-dev,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
-8.0.0-dev,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
+8.0.0-dev,true,user,user.target.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 8.0.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 8.0.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
-8.0.0-dev,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+8.0.0-dev,true,user_agent,user_agent.original.text,match_only_text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 8.0.0-dev,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 8.0.0-dev,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-8.0.0-dev,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+8.0.0-dev,true,user_agent,user_agent.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 8.0.0-dev,true,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 8.0.0-dev,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-8.0.0-dev,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+8.0.0-dev,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.0.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 8.0.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 8.0.0-dev,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -1149,7 +1149,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
 8.0.0-dev,true,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
 8.0.0-dev,true,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
-8.0.0-dev,true,vulnerability,vulnerability.description.text,text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+8.0.0-dev,true,vulnerability,vulnerability.description.text,match_only_text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 8.0.0-dev,true,vulnerability,vulnerability.enumeration,keyword,extended,,CVE,Identifier of the vulnerability.
 8.0.0-dev,true,vulnerability,vulnerability.id,keyword,extended,,CVE-2019-00001,ID of the vulnerability.
 8.0.0-dev,true,vulnerability,vulnerability.reference,keyword,extended,,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -129,6 +129,8 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -138,8 +140,7 @@ client.as.organization.name:
   multi_fields:
   - flat_name: client.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -452,6 +453,8 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -461,8 +464,7 @@ client.user.full_name:
   multi_fields:
   - flat_name: client.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -530,6 +532,8 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
@@ -539,8 +543,7 @@ client.user.name:
   multi_fields:
   - flat_name: client.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -830,6 +833,8 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -839,8 +844,7 @@ destination.as.organization.name:
   multi_fields:
   - flat_name: destination.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -1152,6 +1156,8 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1161,8 +1167,7 @@ destination.user.full_name:
   multi_fields:
   - flat_name: destination.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -1230,6 +1235,8 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
@@ -1239,8 +1246,7 @@ destination.user.name:
   multi_fields:
   - flat_name: destination.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -1813,17 +1819,18 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
   level: core
   name: message
   normalize: []
-  norms: false
   short: Error message.
-  type: text
+  type: match_only_text
 error.stack_trace:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -1831,8 +1838,7 @@ error.stack_trace:
   multi_fields:
   - flat_name: error.stack_trace.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: stack_trace
   normalize: []
   short: The stack trace of this error in plain text.
@@ -3326,6 +3332,8 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -3336,8 +3344,7 @@ file.path:
   multi_fields:
   - flat_name: file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   short: Full path to the file, including the file name.
@@ -3443,6 +3450,8 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -3451,8 +3460,7 @@ file.target_path:
   multi_fields:
   - flat_name: file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   short: Target path for symlinks.
@@ -4136,6 +4144,8 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4145,8 +4155,7 @@ host.os.full:
   multi_fields:
   - flat_name: host.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -4165,6 +4174,8 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4174,8 +4185,7 @@ host.os.name:
   multi_fields:
   - flat_name: host.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -4617,6 +4627,7 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -4630,9 +4641,8 @@ message:
   level: core
   name: message
   normalize: []
-  norms: false
   short: Log message optimized for viewing in a log viewer.
-  type: text
+  type: match_only_text
 network.application:
   dashed_name: network-application
   description: 'A name given to an application level protocol. This can be arbitrarily
@@ -5227,6 +5237,8 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -5236,8 +5248,7 @@ observer.os.full:
   multi_fields:
   - flat_name: observer.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -5256,6 +5267,8 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -5265,8 +5278,7 @@ observer.os.name:
   multi_fields:
   - flat_name: observer.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -5769,7 +5781,8 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -5781,8 +5794,7 @@ process.command_line:
   multi_fields:
   - flat_name: process.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   short: Full command line that started the process.
@@ -6136,6 +6148,8 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6145,8 +6159,7 @@ process.executable:
   multi_fields:
   - flat_name: process.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   short: Absolute path to the process executable.
@@ -6220,6 +6233,8 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -6231,8 +6246,7 @@ process.name:
   multi_fields:
   - flat_name: process.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Process name.
@@ -6367,7 +6381,8 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6379,8 +6394,7 @@ process.parent.command_line:
   multi_fields:
   - flat_name: process.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -6736,6 +6750,8 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6745,8 +6761,7 @@ process.parent.executable:
   multi_fields:
   - flat_name: process.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -6822,6 +6837,8 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -6833,8 +6850,7 @@ process.parent.name:
   multi_fields:
   - flat_name: process.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -6999,6 +7015,8 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -7010,8 +7028,7 @@ process.parent.title:
   multi_fields:
   - flat_name: process.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -7029,6 +7046,8 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7038,8 +7057,7 @@ process.parent.working_directory:
   multi_fields:
   - flat_name: process.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -7198,6 +7216,8 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -7209,8 +7229,7 @@ process.title:
   multi_fields:
   - flat_name: process.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   short: Process title.
@@ -7226,6 +7245,8 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7235,8 +7256,7 @@ process.working_directory:
   multi_fields:
   - flat_name: process.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   short: The working directory of the process.
@@ -7526,6 +7546,8 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -7535,8 +7557,7 @@ server.as.organization.name:
   multi_fields:
   - flat_name: server.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -7849,6 +7870,8 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -7858,8 +7881,7 @@ server.user.full_name:
   multi_fields:
   - flat_name: server.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -7927,6 +7949,8 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
@@ -7936,8 +7960,7 @@ server.user.name:
   multi_fields:
   - flat_name: server.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -8096,6 +8119,8 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -8105,8 +8130,7 @@ source.as.organization.name:
   multi_fields:
   - flat_name: source.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -8419,6 +8443,8 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8428,8 +8454,7 @@ source.user.full_name:
   multi_fields:
   - flat_name: source.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -8497,6 +8522,8 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
@@ -8506,8 +8533,7 @@ source.user.name:
   multi_fields:
   - flat_name: source.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -8586,6 +8612,8 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -8595,8 +8623,7 @@ threat.enrichments.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.enrichments.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -9299,6 +9326,8 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -9309,8 +9338,7 @@ threat.enrichments.indicator.file.path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -9330,6 +9358,8 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -9338,8 +9368,7 @@ threat.enrichments.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -9935,7 +9964,8 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -9945,15 +9975,15 @@ threat.enrichments.indicator.url.full:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -9967,8 +9997,7 @@ threat.enrichments.indicator.url.original:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -10558,6 +10587,8 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -10567,8 +10598,7 @@ threat.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -11271,6 +11301,8 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -11281,8 +11313,7 @@ threat.indicator.file.path:
   multi_fields:
   - flat_name: threat.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -11302,6 +11333,8 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -11310,8 +11343,7 @@ threat.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -11907,7 +11939,8 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -11917,15 +11950,15 @@ threat.indicator.url.full:
   multi_fields:
   - flat_name: threat.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -11939,8 +11972,7 @@ threat.indicator.url.original:
   multi_fields:
   - flat_name: threat.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -12510,6 +12542,8 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -12520,8 +12554,7 @@ threat.technique.name:
   multi_fields:
   - flat_name: threat.technique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.name
   normalize:
   - array
@@ -12554,6 +12587,8 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -12564,8 +12599,7 @@ threat.technique.subtechnique.name:
   multi_fields:
   - flat_name: threat.technique.subtechnique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.subtechnique.name
   normalize:
   - array
@@ -13632,7 +13666,8 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -13642,14 +13677,14 @@ url.full:
   multi_fields:
   - flat_name: url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -13663,8 +13698,7 @@ url.original:
   multi_fields:
   - flat_name: url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unmodified original url as seen in the event source.
@@ -13816,6 +13850,8 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -13825,8 +13861,7 @@ user.changes.full_name:
   multi_fields:
   - flat_name: user.changes.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -13894,6 +13929,8 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
@@ -13903,8 +13940,7 @@ user.changes.name:
   multi_fields:
   - flat_name: user.changes.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -13960,6 +13996,8 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -13969,8 +14007,7 @@ user.effective.full_name:
   multi_fields:
   - flat_name: user.effective.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -14038,6 +14075,8 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
@@ -14047,8 +14086,7 @@ user.effective.name:
   multi_fields:
   - flat_name: user.effective.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -14078,6 +14116,8 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14087,8 +14127,7 @@ user.full_name:
   multi_fields:
   - flat_name: user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   short: User's full name, if available.
@@ -14153,6 +14192,8 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
@@ -14162,8 +14203,7 @@ user.name:
   multi_fields:
   - flat_name: user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Short name or login of the user.
@@ -14205,6 +14245,8 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14214,8 +14256,7 @@ user.target.full_name:
   multi_fields:
   - flat_name: user.target.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -14283,6 +14324,8 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
@@ -14292,8 +14335,7 @@ user.target.name:
   multi_fields:
   - flat_name: user.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -14335,6 +14377,8 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -14345,8 +14389,7 @@ user_agent.original:
   multi_fields:
   - flat_name: user_agent.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unparsed user_agent string.
@@ -14364,6 +14407,8 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -14373,8 +14418,7 @@ user_agent.os.full:
   multi_fields:
   - flat_name: user_agent.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -14393,6 +14437,8 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -14402,8 +14448,7 @@ user_agent.os.name:
   multi_fields:
   - flat_name: user_agent.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -14493,6 +14538,8 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -14504,8 +14551,7 @@ vulnerability.description:
   multi_fields:
   - flat_name: vulnerability.description.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: description
   normalize: []
   short: Description of the vulnerability.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -119,6 +119,8 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -128,8 +130,7 @@ as:
       multi_fields:
       - flat_name: as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       short: Organization name.
@@ -203,6 +204,7 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -216,9 +218,8 @@ base:
       level: core
       name: message
       normalize: []
-      norms: false
       short: Log message optimized for viewing in a log viewer.
-      type: text
+      type: match_only_text
     tags:
       dashed_name: tags
       description: List of keywords used to tag each event.
@@ -283,6 +284,8 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -292,8 +295,7 @@ client:
       multi_fields:
       - flat_name: client.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -607,6 +609,8 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -616,8 +620,7 @@ client:
       multi_fields:
       - flat_name: client.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -685,6 +688,8 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
@@ -694,8 +699,7 @@ client:
       multi_fields:
       - flat_name: client.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -1179,6 +1183,8 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1188,8 +1194,7 @@ destination:
       multi_fields:
       - flat_name: destination.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -1502,6 +1507,8 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1511,8 +1518,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -1580,6 +1586,8 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
@@ -1589,8 +1597,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -2569,17 +2576,18 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
       level: core
       name: message
       normalize: []
-      norms: false
       short: Error message.
-      type: text
+      type: match_only_text
     error.stack_trace:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -2587,8 +2595,7 @@ error:
       multi_fields:
       - flat_name: error.stack_trace.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: stack_trace
       normalize: []
       short: The stack trace of this error in plain text.
@@ -4133,6 +4140,8 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -4143,8 +4152,7 @@ file:
       multi_fields:
       - flat_name: file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       short: Full path to the file, including the file name.
@@ -4250,6 +4258,8 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -4258,8 +4268,7 @@ file:
       multi_fields:
       - flat_name: file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       short: Target path for symlinks.
@@ -5268,6 +5277,8 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -5277,8 +5288,7 @@ host:
       multi_fields:
       - flat_name: host.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -5297,6 +5307,8 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -5306,8 +5318,7 @@ host:
       multi_fields:
       - flat_name: host.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -6474,6 +6485,8 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6483,8 +6496,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -6503,6 +6515,8 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6512,8 +6526,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -6811,6 +6824,8 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6820,8 +6835,7 @@ os:
       multi_fields:
       - flat_name: os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Operating system name, including the version or code name.
@@ -6838,6 +6852,8 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6847,8 +6863,7 @@ os:
       multi_fields:
       - flat_name: os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Operating system name, without the version.
@@ -7320,7 +7335,8 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -7332,8 +7348,7 @@ process:
       multi_fields:
       - flat_name: process.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       short: Full command line that started the process.
@@ -7687,6 +7702,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -7696,8 +7713,7 @@ process:
       multi_fields:
       - flat_name: process.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       short: Absolute path to the process executable.
@@ -7771,6 +7787,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -7782,8 +7800,7 @@ process:
       multi_fields:
       - flat_name: process.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Process name.
@@ -7918,7 +7935,8 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -7930,8 +7948,7 @@ process:
       multi_fields:
       - flat_name: process.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -8287,6 +8304,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -8296,8 +8315,7 @@ process:
       multi_fields:
       - flat_name: process.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -8373,6 +8391,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -8384,8 +8404,7 @@ process:
       multi_fields:
       - flat_name: process.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -8550,6 +8569,8 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -8561,8 +8582,7 @@ process:
       multi_fields:
       - flat_name: process.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -8580,6 +8600,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -8589,8 +8611,7 @@ process:
       multi_fields:
       - flat_name: process.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -8749,6 +8770,8 @@ process:
       short: Thread name.
       type: keyword
     process.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -8760,8 +8783,7 @@ process:
       multi_fields:
       - flat_name: process.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       short: Process title.
@@ -8777,6 +8799,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -8786,8 +8810,7 @@ process:
       multi_fields:
       - flat_name: process.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       short: The working directory of the process.
@@ -9186,6 +9209,8 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -9195,8 +9220,7 @@ server:
       multi_fields:
       - flat_name: server.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -9510,6 +9534,8 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -9519,8 +9545,7 @@ server:
       multi_fields:
       - flat_name: server.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -9588,6 +9613,8 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
@@ -9597,8 +9624,7 @@ server:
       multi_fields:
       - flat_name: server.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -9801,6 +9827,8 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -9810,8 +9838,7 @@ source:
       multi_fields:
       - flat_name: source.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -10125,6 +10152,8 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10134,8 +10163,7 @@ source:
       multi_fields:
       - flat_name: source.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -10203,6 +10231,8 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
@@ -10212,8 +10242,7 @@ source:
       multi_fields:
       - flat_name: source.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -10295,6 +10324,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -10304,8 +10335,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -11008,6 +11038,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -11018,8 +11050,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -11039,6 +11070,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -11047,8 +11080,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -11647,7 +11679,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11658,15 +11691,15 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -11680,8 +11713,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -12271,6 +12303,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -12280,8 +12314,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -12984,6 +13017,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -12994,8 +13029,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -13015,6 +13049,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -13023,8 +13059,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -13623,7 +13658,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -13634,15 +13670,15 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -13656,8 +13692,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -14227,6 +14262,8 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -14237,8 +14274,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.name
       normalize:
       - array
@@ -14271,6 +14307,8 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -14281,8 +14319,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.subtechnique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.subtechnique.name
       normalize:
       - array
@@ -15500,7 +15537,8 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -15511,14 +15549,14 @@ url:
       multi_fields:
       - flat_name: url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -15532,8 +15570,7 @@ url:
       multi_fields:
       - flat_name: url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unmodified original url as seen in the event source.
@@ -15709,6 +15746,8 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -15718,8 +15757,7 @@ user:
       multi_fields:
       - flat_name: user.changes.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -15787,6 +15825,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
@@ -15796,8 +15836,7 @@ user:
       multi_fields:
       - flat_name: user.changes.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -15853,6 +15892,8 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -15862,8 +15903,7 @@ user:
       multi_fields:
       - flat_name: user.effective.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -15931,6 +15971,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
@@ -15940,8 +15982,7 @@ user:
       multi_fields:
       - flat_name: user.effective.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -15971,6 +16012,8 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -15980,8 +16023,7 @@ user:
       multi_fields:
       - flat_name: user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       short: User's full name, if available.
@@ -16046,6 +16088,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
@@ -16055,8 +16099,7 @@ user:
       multi_fields:
       - flat_name: user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Short name or login of the user.
@@ -16098,6 +16141,8 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16107,8 +16152,7 @@ user:
       multi_fields:
       - flat_name: user.target.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -16176,6 +16220,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
@@ -16185,8 +16231,7 @@ user:
       multi_fields:
       - flat_name: user.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -16284,6 +16329,8 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -16294,8 +16341,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unparsed user_agent string.
@@ -16313,6 +16359,8 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -16322,8 +16370,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -16342,6 +16389,8 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -16351,8 +16400,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -16520,6 +16568,8 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -16531,8 +16581,7 @@ vulnerability:
       multi_fields:
       - flat_name: vulnerability.description.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: description
       normalize: []
       short: Description of the vulnerability.

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -70,8 +70,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -183,8 +182,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -217,8 +215,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -360,8 +357,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -473,8 +469,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -507,8 +502,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -717,14 +711,12 @@
             "type": "keyword"
           },
           "message": {
-            "norms": false,
-            "type": "text"
+            "type": "match_only_text"
           },
           "stack_trace": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -1074,8 +1066,7 @@
           "path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1119,8 +1110,7 @@
           "target_path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1393,8 +1383,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1407,8 +1396,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1592,8 +1580,7 @@
         }
       },
       "message": {
-        "norms": false,
-        "type": "text"
+        "type": "match_only_text"
       },
       "network": {
         "properties": {
@@ -1816,8 +1803,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1830,8 +1816,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2034,8 +2019,7 @@
           "command_line": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -2164,8 +2148,7 @@
           "executable": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2201,8 +2184,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2249,8 +2231,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -2379,8 +2360,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2416,8 +2396,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2481,8 +2460,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2494,8 +2472,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2561,8 +2538,7 @@
           "title": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2574,8 +2550,7 @@
           "working_directory": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2697,8 +2672,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -2810,8 +2784,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2844,8 +2817,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2911,8 +2883,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3024,8 +2995,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3058,8 +3028,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3101,8 +3070,7 @@
                           "name": {
                             "fields": {
                               "text": {
-                                "norms": false,
-                                "type": "text"
+                                "type": "match_only_text"
                               }
                             },
                             "ignore_above": 1024,
@@ -3343,8 +3311,7 @@
                       "path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -3356,8 +3323,7 @@
                       "target_path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -3569,8 +3535,7 @@
                       "full": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -3578,8 +3543,7 @@
                       "original": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -3792,8 +3756,7 @@
                       "name": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -4034,8 +3997,7 @@
                   "path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4047,8 +4009,7 @@
                   "target_path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4260,8 +4221,7 @@
                   "full": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -4269,8 +4229,7 @@
                   "original": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -4468,8 +4427,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4488,8 +4446,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4880,8 +4837,7 @@
           "full": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -4889,8 +4845,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -4946,8 +4901,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4980,8 +4934,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5010,8 +4963,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5044,8 +4996,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5064,8 +5015,7 @@
           "full_name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5098,8 +5048,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5122,8 +5071,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5156,8 +5104,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5188,8 +5135,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5204,8 +5150,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5218,8 +5163,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5258,8 +5202,7 @@
           "description": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/generated/elasticsearch/component/base.json
+++ b/generated/elasticsearch/component/base.json
@@ -13,8 +13,7 @@
           "type": "object"
         },
         "message": {
-          "norms": false,
-          "type": "text"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/error.json
+++ b/generated/elasticsearch/component/error.json
@@ -17,14 +17,12 @@
               "type": "keyword"
             },
             "message": {
-              "norms": false,
-              "type": "text"
+              "type": "match_only_text"
             },
             "stack_trace": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -245,8 +245,7 @@
             "path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -290,8 +289,7 @@
             "target_path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -141,8 +141,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -155,8 +154,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -153,8 +153,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -167,8 +166,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -47,8 +47,7 @@
             "command_line": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -177,8 +176,7 @@
             "executable": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -214,8 +212,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -262,8 +259,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -392,8 +388,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -429,8 +424,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -494,8 +488,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -507,8 +500,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -574,8 +566,7 @@
             "title": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -587,8 +578,7 @@
             "working_directory": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -22,8 +22,7 @@
                             "name": {
                               "fields": {
                                 "text": {
-                                  "norms": false,
-                                  "type": "text"
+                                  "type": "match_only_text"
                                 }
                               },
                               "ignore_above": 1024,
@@ -264,8 +263,7 @@
                         "path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -277,8 +275,7 @@
                         "target_path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -490,8 +487,7 @@
                         "full": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -499,8 +495,7 @@
                         "original": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -713,8 +708,7 @@
                         "name": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -955,8 +949,7 @@
                     "path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -968,8 +961,7 @@
                     "target_path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1181,8 +1173,7 @@
                     "full": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1190,8 +1181,7 @@
                     "original": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1389,8 +1379,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1409,8 +1398,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,

--- a/generated/elasticsearch/component/url.json
+++ b/generated/elasticsearch/component/url.json
@@ -23,8 +23,7 @@
             "full": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -32,8 +31,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/generated/elasticsearch/component/user.json
+++ b/generated/elasticsearch/component/user.json
@@ -21,8 +21,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -55,8 +54,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -85,8 +83,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -119,8 +116,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -139,8 +135,7 @@
             "full_name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -173,8 +168,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -197,8 +191,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -231,8 +224,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/user_agent.json
+++ b/generated/elasticsearch/component/user_agent.json
@@ -23,8 +23,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -39,8 +38,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -53,8 +51,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/vulnerability.json
+++ b/generated/elasticsearch/component/vulnerability.json
@@ -19,8 +19,7 @@
             "description": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -40,5 +40,5 @@
         Organization name.
       example: Google LLC
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -39,6 +39,7 @@
       description: >
         Organization name.
       example: Google LLC
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -51,7 +51,7 @@
 
     - name: message
       level: core
-      type: text
+      type: match_only_text
       example: "Hello World"
       short: Log message optimized for viewing in a log viewer.
       description: >

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -54,6 +54,7 @@
       type: match_only_text
       example: "Hello World"
       short: Log message optimized for viewing in a log viewer.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         For log events the message field contains the log message, optimized for
         viewing in a log viewer.

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -20,6 +20,7 @@
     - name: message
       level: core
       type: match_only_text
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         Error message.
 
@@ -39,7 +40,9 @@
     - name: stack_trace
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The stack trace of this error in plain text.
       multi_fields:

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -19,7 +19,7 @@
 
     - name: message
       level: core
-      type: text
+      type: match_only_text
       description: >
         Error message.
 
@@ -43,5 +43,5 @@
       description: >
         The stack trace of this error in plain text.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -69,7 +69,7 @@
         drive letter, when appropriate.
       example: "/home/alice/example.png"
       multi_fields:
-        - type: text
+        - type: match_only_text
           name: text
 
     - name: target_path
@@ -77,7 +77,7 @@
       type: keyword
       description: Target path for symlinks.
       multi_fields:
-        - type: text
+        - type: match_only_text
           name: text
 
     - name: extension

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -68,6 +68,7 @@
         Full path to the file, including the file name. It should include the
         drive letter, when appropriate.
       example: "/home/alice/example.png"
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
         - type: match_only_text
           name: text
@@ -76,6 +77,7 @@
       level: extended
       type: keyword
       description: Target path for symlinks.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
         - type: match_only_text
           name: text

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -41,7 +41,7 @@
       description: >
         Operating system name, without the version.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full
@@ -51,7 +51,7 @@
       description: >
         Operating system name, including the version or code name.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: family

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -40,6 +40,7 @@
       example: "Mac OS X"
       description: >
         Operating system name, without the version.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -50,6 +51,7 @@
       example: "Mac OS Mojave"
       description: >
         Operating system name, including the version or code name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -52,6 +52,7 @@
 
         Sometimes called program name or similar.
       example: ssh
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -74,7 +75,9 @@
     - name: command_line
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       short: Full command line that started the process.
       description: >
         Full command line that started the process, including the absolute path
@@ -116,6 +119,7 @@
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -129,6 +133,7 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -168,6 +173,7 @@
       example: /home/alice
       description: >
         The working directory of the process.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -53,7 +53,7 @@
         Sometimes called program name or similar.
       example: ssh
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: ppid
@@ -83,7 +83,7 @@
         Some arguments may be filtered to protect sensitive information.
       example: "/usr/bin/ssh -l user 10.0.0.16"
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: args
@@ -117,7 +117,7 @@
         Absolute path to the process executable.
       example: /usr/bin/ssh
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: title
@@ -130,7 +130,7 @@
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: thread.id
@@ -169,7 +169,7 @@
       description: >
         The working directory of the process.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: exit_code

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -575,7 +575,7 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Threat technique name.
       description: >
@@ -614,7 +614,7 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Threat subtechnique name.
       description: >

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -574,6 +574,7 @@
     - name: technique.name
       level: extended
       type: keyword
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -617,6 +618,7 @@
       - type: match_only_text
         name: text
       short: Threat subtechnique name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
           The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
           (ex. https://attack.mitre.org/techniques/T1059/001/)

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -20,7 +20,9 @@
     - name: original
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
@@ -39,7 +41,9 @@
     - name: full
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta
       short: Full unparsed URL.
       description: >
         If full URLs are important to your use case, they should be stored in

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -33,7 +33,7 @@
       example: >
         https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full
@@ -47,7 +47,7 @@
         event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: scheme

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -42,6 +42,7 @@
       example: albert
       description: >
         Short name or login of the user.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -52,6 +53,7 @@
       example: Albert Einstein
       description: >
         User's full name, if available.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -43,7 +43,7 @@
       description: >
         Short name or login of the user.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full_name
@@ -53,7 +53,7 @@
       description: >
         User's full name, if available.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: email

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -14,7 +14,7 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       description: >
         Unparsed user_agent string.

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -16,6 +16,7 @@
       multi_fields:
       - type: match_only_text
         name: text
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         Unparsed user_agent string.
       example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -114,7 +114,7 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Description of the vulnerability.
       description: >

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -117,6 +117,7 @@
       - type: match_only_text
         name: text
       short: Description of the vulnerability.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         The description of the vulnerability that provides additional context of the
         vulnerability.


### PR DESCRIPTION
Implement the stage 2 changes from the `match_only_text` fields RFC [0023](https://github.com/elastic/ecs/blob/master/rfcs/text/0023-match_only_text-data-type.md): #1522

This change adds two versions of the `beta` tooltip text depending on the field.

1. If the `beta` attribute applies only to the multi-field `.text` type change:

<img width="780" alt="Screen Shot 2021-07-21 at 3 10 51 PM" src="https://user-images.githubusercontent.com/7226265/126553521-fa610838-6cb0-4994-b37f-ee2a8d7dc8c8.png">

2. If the `beta` attribute needs to describe both the `wildcard` ([RFC 0001](https://github.com/elastic/ecs/blob/master/rfcs/text/0001-wildcard-data-type.md)) and the `match_only_text` changes for a single field:

<img width="791" alt="Screen Shot 2021-07-21 at 3 11 23 PM" src="https://user-images.githubusercontent.com/7226265/126553582-89123c9e-fcad-4a2a-bb26-73086fea70cd.png">
