### PR TITLE
Update `log.origin.file.line` from `integer` to `long`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,7 @@ Thanks, you're awesome :-) -->
 * Removing use-cases directory #1405
 * Remove `host.user.*` field reuse. #1439
 * Remove deprecation notice on `http.request.method`. #1443
+* Migrate `log.origin.file.line` from `integer` to `long`. #1533
 
 #### Bugfixes
 

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -40,7 +40,7 @@ type Log struct {
 	FilePath string `ecs:"file.path"`
 
 	// Deprecated for removal in next major version release. This field is
-	// superseded by  `event.original`.
+	// superseded by `event.original`.
 	// This is the original log message and contains the full log message
 	// before splitting it up in multiple parts.
 	// In contrast to the `message` field which can contain an extracted part
@@ -63,7 +63,7 @@ type Log struct {
 
 	// The line number of the file containing the source code which originated
 	// the log event.
-	OriginFileLine int32 `ecs:"origin.file.line"`
+	OriginFileLine int64 `ecs:"origin.file.line"`
 
 	// The name of the function or method which originated the log event.
 	OriginFunction string `ecs:"origin.function"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4673,7 +4673,7 @@ example: `org.elasticsearch.bootstrap.Bootstrap`
 
 | The line number of the file containing the source code which originated the log event.
 
-type: integer
+type: long
 
 
 
@@ -4721,7 +4721,7 @@ example: `init`
 [[field-log-original]]
 <<field-log-original, log.original>>
 
-| Deprecated for removal in next major version release. This field is superseded by  `event.original`.
+| Deprecated for removal in next major version release. This field is superseded by `event.original`.
 
 This is the original log message and contains the full log message before splitting it up in multiple parts.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3583,7 +3583,7 @@
       example: org.elasticsearch.bootstrap.Bootstrap
     - name: origin.file.line
       level: extended
-      type: integer
+      type: long
       description: The line number of the file containing the source code which originated
         the log event.
       example: 42
@@ -3607,7 +3607,7 @@
       level: core
       type: keyword
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `event.original`.
+        is superseded by `event.original`.
 
         This is the original log message and contains the full log message before
         splitting it up in multiple parts.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -392,7 +392,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 8.0.0-dev+exp,true,log,log.level,keyword,core,,error,Log level of the log event.
 8.0.0-dev+exp,true,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
-8.0.0-dev+exp,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
+8.0.0-dev+exp,true,log,log.origin.file.line,long,extended,,42,The line number of the file which originated the log event.
 8.0.0-dev+exp,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.0.0-dev+exp,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.0.0-dev+exp,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5226,7 +5226,7 @@ log.origin.file.line:
   name: origin.file.line
   normalize: []
   short: The line number of the file which originated the log event.
-  type: integer
+  type: long
 log.origin.file.name:
   dashed_name: log-origin-file-name
   description: 'The name of the file containing the source code which originated the
@@ -5256,7 +5256,7 @@ log.origin.function:
 log.original:
   dashed_name: log-original
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `event.original`.
+    superseded by `event.original`.
 
     This is the original log message and contains the full log message before splitting
     it up in multiple parts.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6441,7 +6441,7 @@ log:
       name: origin.file.line
       normalize: []
       short: The line number of the file which originated the log event.
-      type: integer
+      type: long
     log.origin.file.name:
       dashed_name: log-origin-file-name
       description: 'The name of the file containing the source code which originated
@@ -6471,7 +6471,7 @@ log:
     log.original:
       dashed_name: log-original
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `event.original`.
+        is superseded by `event.original`.
 
         This is the original log message and contains the full log message before
         splitting it up in multiple parts.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1812,7 +1812,7 @@
               "file": {
                 "properties": {
                   "line": {
-                    "type": "integer"
+                    "type": "long"
                   },
                   "name": {
                     "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/log.json
+++ b/experimental/generated/elasticsearch/component/log.json
@@ -29,7 +29,7 @@
                 "file": {
                   "properties": {
                     "line": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "name": {
                       "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3163,7 +3163,7 @@
       example: org.elasticsearch.bootstrap.Bootstrap
     - name: origin.file.line
       level: extended
-      type: integer
+      type: long
       description: The line number of the file containing the source code which originated
         the log event.
       example: 42
@@ -3187,7 +3187,7 @@
       level: core
       type: keyword
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `event.original`.
+        is superseded by `event.original`.
 
         This is the original log message and contains the full log message before
         splitting it up in multiple parts.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -330,7 +330,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
 8.0.0-dev,true,log,log.level,keyword,core,,error,Log level of the log event.
 8.0.0-dev,true,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
-8.0.0-dev,true,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
+8.0.0-dev,true,log,log.origin.file.line,long,extended,,42,The line number of the file which originated the log event.
 8.0.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.0.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.0.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4484,7 +4484,7 @@ log.origin.file.line:
   name: origin.file.line
   normalize: []
   short: The line number of the file which originated the log event.
-  type: integer
+  type: long
 log.origin.file.name:
   dashed_name: log-origin-file-name
   description: 'The name of the file containing the source code which originated the
@@ -4514,7 +4514,7 @@ log.origin.function:
 log.original:
   dashed_name: log-original
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `event.original`.
+    superseded by `event.original`.
 
     This is the original log message and contains the full log message before splitting
     it up in multiple parts.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5697,7 +5697,7 @@ log:
       name: origin.file.line
       normalize: []
       short: The line number of the file which originated the log event.
-      type: integer
+      type: long
     log.origin.file.name:
       dashed_name: log-origin-file-name
       description: 'The name of the file containing the source code which originated
@@ -5727,7 +5727,7 @@ log:
     log.original:
       dashed_name: log-original
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `event.original`.
+        is superseded by `event.original`.
 
         This is the original log message and contains the full log message before
         splitting it up in multiple parts.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1549,7 +1549,7 @@
                 "file": {
                   "properties": {
                     "line": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "name": {
                       "ignore_above": 1024,

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1540,7 +1540,7 @@
               "file": {
                 "properties": {
                   "line": {
-                    "type": "integer"
+                    "type": "long"
                   },
                   "name": {
                     "ignore_above": 1024,

--- a/generated/elasticsearch/component/log.json
+++ b/generated/elasticsearch/component/log.json
@@ -29,7 +29,7 @@
                 "file": {
                   "properties": {
                     "line": {
-                      "type": "integer"
+                      "type": "long"
                     },
                     "name": {
                       "ignore_above": 1024,

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -49,7 +49,7 @@
       doc_values: false
       short: Deprecated original log message with light interpretation only (encoding, newlines).
       description: >
-        Deprecated for removal in next major version release. This field is superseded by 
+        Deprecated for removal in next major version release. This field is superseded by
         `event.original`.
 
         This is the original log message and contains the full log message
@@ -85,7 +85,7 @@
 
     - name: origin.file.line
       level: extended
-      type: integer
+      type: long
       example: 42
       short: The line number of the file which originated the log event.
       description: >


### PR DESCRIPTION
Migrate `log.origin.file.line` from an `integer` type to a `long` type.

This is considered a breaking change in ECS, but may not affect many users. The index templates generated by Beats and Agent already use `long` for `log.origin.file.line`.