### PR TITLE
[1.x] [RFC] `match_only_text` - stage 2 beta changes (#1532)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -28,6 +28,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532
 #### Deprecated
 
 ## 1.11.0 (Feature Freeze)

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -58,13 +58,15 @@ example: `{"application": "foo-bar", "env": "production"}`
 [[field-message]]
 <<field-message, message>>
 
-| For log events the message field contains the log message, optimized for viewing in a log viewer.
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
+
+For log events the message field contains the log message, optimized for viewing in a log viewer.
 
 For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
 
 If multiple messages exist, they can be combined into one message.
 
-type: text
+type: match_only_text
 
 
 
@@ -255,13 +257,15 @@ example: `15169`
 [[field-as-organization-name]]
 <<field-as-organization-name, as.organization.name>>
 
-| Organization name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Organization name.
 
 type: keyword
 
 Multi-fields:
 
-* as.organization.name.text (type: text)
+* as.organization.name.text (type: match_only_text)
 
 
 
@@ -2440,9 +2444,11 @@ type: keyword
 [[field-error-message]]
 <<field-error-message, error.message>>
 
-| Error message.
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
-type: text
+Error message.
+
+type: match_only_text
 
 
 
@@ -2456,7 +2462,7 @@ type: text
 [[field-error-stack-trace]]
 <<field-error-stack-trace, error.stack_trace>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The stack trace of this error in plain text.
 
@@ -2464,7 +2470,7 @@ type: wildcard
 
 Multi-fields:
 
-* error.stack_trace.text (type: text)
+* error.stack_trace.text (type: match_only_text)
 
 
 
@@ -3349,13 +3355,15 @@ example: `alice`
 [[field-file-path]]
 <<field-file-path, file.path>>
 
-| Full path to the file, including the file name. It should include the drive letter, when appropriate.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Full path to the file, including the file name. It should include the drive letter, when appropriate.
 
 type: keyword
 
 Multi-fields:
 
-* file.path.text (type: text)
+* file.path.text (type: match_only_text)
 
 
 
@@ -3389,13 +3397,15 @@ example: `16384`
 [[field-file-target-path]]
 <<field-file-target-path, file.target_path>>
 
-| Target path for symlinks.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Target path for symlinks.
 
 type: keyword
 
 Multi-fields:
 
-* file.target_path.text (type: text)
+* file.target_path.text (type: match_only_text)
 
 
 
@@ -5688,13 +5698,15 @@ example: `debian`
 [[field-os-full]]
 <<field-os-full, os.full>>
 
-| Operating system name, including the version or code name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Operating system name, including the version or code name.
 
 type: keyword
 
 Multi-fields:
 
-* os.full.text (type: text)
+* os.full.text (type: match_only_text)
 
 
 
@@ -5726,13 +5738,15 @@ example: `4.4.0-112-generic`
 [[field-os-name]]
 <<field-os-name, os.name>>
 
-| Operating system name, without the version.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Operating system name, without the version.
 
 type: keyword
 
 Multi-fields:
 
-* os.name.text (type: text)
+* os.name.text (type: match_only_text)
 
 
 
@@ -6257,7 +6271,7 @@ example: `4`
 [[field-process-command-line]]
 <<field-process-command-line, process.command_line>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 Full command line that started the process, including the absolute path to the executable, and all arguments.
 
@@ -6267,7 +6281,7 @@ type: wildcard
 
 Multi-fields:
 
-* process.command_line.text (type: text)
+* process.command_line.text (type: match_only_text)
 
 
 
@@ -6303,13 +6317,15 @@ example: `c2c455d9f99375d`
 [[field-process-executable]]
 <<field-process-executable, process.executable>>
 
-| Absolute path to the process executable.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Absolute path to the process executable.
 
 type: keyword
 
 Multi-fields:
 
-* process.executable.text (type: text)
+* process.executable.text (type: match_only_text)
 
 
 
@@ -6343,7 +6359,9 @@ example: `137`
 [[field-process-name]]
 <<field-process-name, process.name>>
 
-| Process name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Process name.
 
 Sometimes called program name or similar.
 
@@ -6351,7 +6369,7 @@ type: keyword
 
 Multi-fields:
 
-* process.name.text (type: text)
+* process.name.text (type: match_only_text)
 
 
 
@@ -6463,7 +6481,9 @@ example: `thread-0`
 [[field-process-title]]
 <<field-process-title, process.title>>
 
-| Process title.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Process title.
 
 The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
 
@@ -6471,7 +6491,7 @@ type: keyword
 
 Multi-fields:
 
-* process.title.text (type: text)
+* process.title.text (type: match_only_text)
 
 
 
@@ -6503,13 +6523,15 @@ example: `1325`
 [[field-process-working-directory]]
 <<field-process-working-directory, process.working_directory>>
 
-| The working directory of the process.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The working directory of the process.
 
 type: keyword
 
 Multi-fields:
 
-* process.working_directory.text (type: text)
+* process.working_directory.text (type: match_only_text)
 
 
 
@@ -8768,13 +8790,15 @@ example: `T1059`
 [[field-threat-technique-name]]
 <<field-threat-technique-name, threat.technique.name>>
 
-| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
 Multi-fields:
 
-* threat.technique.name.text (type: text)
+* threat.technique.name.text (type: match_only_text)
 
 
 
@@ -8831,13 +8855,15 @@ example: `T1059.001`
 [[field-threat-technique-subtechnique-name]]
 <<field-threat-technique-subtechnique-name, threat.technique.subtechnique.name>>
 
-| The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
 
 type: keyword
 
 Multi-fields:
 
-* threat.technique.subtechnique.name.text (type: text)
+* threat.technique.subtechnique.name.text (type: match_only_text)
 
 
 
@@ -9692,7 +9718,7 @@ type: keyword
 [[field-url-full]]
 <<field-url-full, url.full>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta ]
 
 If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
 
@@ -9700,7 +9726,7 @@ type: wildcard
 
 Multi-fields:
 
-* url.full.text (type: text)
+* url.full.text (type: match_only_text)
 
 
 
@@ -9716,7 +9742,7 @@ example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 [[field-url-original]]
 <<field-url-original, url.original>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 Unmodified original url as seen in the event source.
 
@@ -9728,7 +9754,7 @@ type: wildcard
 
 Multi-fields:
 
-* url.original.text (type: text)
+* url.original.text (type: match_only_text)
 
 
 
@@ -9970,13 +9996,15 @@ type: keyword
 [[field-user-full-name]]
 <<field-user-full-name, user.full_name>>
 
-| User's full name, if available.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+User's full name, if available.
 
 type: keyword
 
 Multi-fields:
 
-* user.full_name.text (type: text)
+* user.full_name.text (type: match_only_text)
 
 
 
@@ -10026,13 +10054,15 @@ type: keyword
 [[field-user-name]]
 <<field-user-name, user.name>>
 
-| Short name or login of the user.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Short name or login of the user.
 
 type: keyword
 
 Multi-fields:
 
-* user.name.text (type: text)
+* user.name.text (type: match_only_text)
 
 
 
@@ -10195,13 +10225,15 @@ example: `Safari`
 [[field-user-agent-original]]
 <<field-user-agent-original, user_agent.original>>
 
-| Unparsed user_agent string.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Unparsed user_agent string.
 
 type: keyword
 
 Multi-fields:
 
-* user_agent.original.text (type: text)
+* user_agent.original.text (type: match_only_text)
 
 
 
@@ -10386,13 +10418,15 @@ example: `CVSS`
 [[field-vulnerability-description]]
 <<field-vulnerability-description, vulnerability.description>>
 
-| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
 
 type: keyword
 
 Multi-fields:
 
-* vulnerability.description.text (type: text)
+* vulnerability.description.text (type: match_only_text)
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -33,7 +33,7 @@
     example: '{"application": "foo-bar", "env": "production"}'
   - name: message
     level: core
-    type: text
+    type: match_only_text
     description: 'For log events the message field contains the log message, optimized
       for viewing in a log viewer.
 
@@ -140,8 +140,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -187,8 +186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -376,8 +374,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -418,8 +415,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -722,8 +718,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -910,8 +905,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -952,8 +946,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -1745,15 +1738,14 @@
       description: Unique identifier for the error.
     - name: message
       level: core
-      type: text
+      type: match_only_text
       description: Error message.
     - name: stack_trace
       level: extended
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The stack trace of this error in plain text.
     - name: type
@@ -2504,8 +2496,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -2786,8 +2777,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Target path for symlinks.
     - name: type
@@ -3330,8 +3320,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3347,8 +3336,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -3411,8 +3399,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -3453,8 +3440,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -4146,8 +4132,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -4163,8 +4148,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4337,8 +4321,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -4354,8 +4337,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4849,8 +4831,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -5057,8 +5038,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -5103,8 +5083,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process name.
 
@@ -5197,8 +5176,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -5405,8 +5383,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -5455,8 +5432,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -5771,8 +5747,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -5790,8 +5765,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -6167,8 +6141,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -6375,8 +6348,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -6425,8 +6397,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -6519,8 +6490,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -6727,8 +6697,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -6777,8 +6746,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -7093,8 +7061,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -7112,8 +7079,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -7426,8 +7392,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -7445,8 +7410,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -7468,8 +7432,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process title.
 
@@ -7486,8 +7449,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The working directory of the process.
       example: /home/alice
@@ -7733,8 +7695,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -7922,8 +7883,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -7964,8 +7924,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -8109,8 +8068,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -8298,8 +8256,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -8340,8 +8297,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -8388,8 +8344,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -8808,8 +8763,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -8828,8 +8782,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: enrichments.indicator.file.type
@@ -9407,8 +9360,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -9419,8 +9371,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -9782,8 +9733,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -10202,8 +10152,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -10222,8 +10171,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: indicator.file.type
@@ -10801,8 +10749,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -10813,8 +10760,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -11162,8 +11108,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -11189,8 +11134,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
@@ -11861,8 +11805,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11873,8 +11816,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Unmodified original url as seen in the event source.
 
@@ -11990,8 +11932,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -12037,8 +11978,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -12076,8 +12016,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -12123,8 +12062,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -12146,8 +12084,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -12188,8 +12125,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -12220,8 +12156,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -12267,8 +12202,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -12305,8 +12239,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
@@ -12322,8 +12255,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -12339,8 +12271,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -12445,8 +12376,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 1.12.0-dev+exp,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-1.12.0-dev+exp,true,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
+1.12.0-dev+exp,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 1.12.0-dev+exp,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 1.12.0-dev+exp,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 1.12.0-dev+exp,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -12,7 +12,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,client,client.address,keyword,extended,,,Client network address.
 1.12.0-dev+exp,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 1.12.0-dev+exp,true,client,client.domain,keyword,core,,,Client domain.
 1.12.0-dev+exp,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
@@ -38,14 +38,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,client,client.user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,client,client.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,client,client.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 1.12.0-dev+exp,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -70,7 +70,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,destination,destination.address,keyword,extended,,,Destination network address.
 1.12.0-dev+exp,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 1.12.0-dev+exp,true,destination,destination.domain,keyword,core,,,Destination domain.
 1.12.0-dev+exp,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
@@ -96,14 +96,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,destination,destination.user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,destination,destination.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
@@ -178,9 +178,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
 1.12.0-dev+exp,true,error,error.code,keyword,core,,,Error code describing the error.
 1.12.0-dev+exp,true,error,error.id,keyword,core,,,Unique identifier for the error.
-1.12.0-dev+exp,true,error,error.message,text,core,,,Error message.
+1.12.0-dev+exp,true,error,error.message,match_only_text,core,,,Error message.
 1.12.0-dev+exp,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
-1.12.0-dev+exp,true,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+1.12.0-dev+exp,true,error,error.stack_trace.text,match_only_text,extended,,,The stack trace of this error in plain text.
 1.12.0-dev+exp,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 1.12.0-dev+exp,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 1.12.0-dev+exp,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -267,7 +267,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev+exp,true,file,file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev+exp,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev+exp,true,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev+exp,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev+exp,true,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev+exp,true,file,file.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 1.12.0-dev+exp,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -308,7 +308,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,file,file.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 1.12.0-dev+exp,true,file,file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev+exp,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev+exp,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev+exp,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev+exp,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev+exp,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev+exp,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
@@ -365,10 +365,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
 1.12.0-dev+exp,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev+exp,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev+exp,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev+exp,true,host,host.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev+exp,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev+exp,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev+exp,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev+exp,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev+exp,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev+exp,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev+exp,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -377,14 +377,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,host,host.user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,host,host.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,host,host.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,host,host.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,host,host.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,host,host.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,host,host.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,host,host.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,host,host.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,host,host.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,host,host.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 1.12.0-dev+exp,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
@@ -461,10 +461,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 1.12.0-dev+exp,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev+exp,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev+exp,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev+exp,true,observer,observer.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev+exp,true,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev+exp,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev+exp,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev+exp,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev+exp,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev+exp,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev+exp,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -508,7 +508,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev+exp,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev+exp,true,process,process.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev+exp,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev+exp,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -540,7 +540,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev+exp,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev+exp,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev+exp,true,process,process.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev+exp,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -548,7 +548,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev+exp,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
-1.12.0-dev+exp,true,process,process.name.text,text,extended,,ssh,Process name.
+1.12.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.12.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -559,7 +559,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev+exp,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev+exp,true,process,process.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev+exp,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev+exp,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -591,7 +591,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev+exp,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev+exp,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev+exp,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev+exp,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev+exp,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev+exp,true,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev+exp,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -599,7 +599,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev+exp,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-1.12.0-dev+exp,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+1.12.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev+exp,true,process,process.parent.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 1.12.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -645,10 +645,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev+exp,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev+exp,true,process,process.parent.title,keyword,extended,,,Process title.
-1.12.0-dev+exp,true,process,process.parent.title.text,text,extended,,,Process title.
+1.12.0-dev+exp,true,process,process.parent.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev+exp,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev+exp,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev+exp,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev+exp,true,process,process.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev+exp,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev+exp,true,process,process.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 1.12.0-dev+exp,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -701,7 +701,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev+exp,true,process,process.target.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev+exp,true,process,process.target.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev+exp,true,process,process.target.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev+exp,true,process,process.target.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev+exp,true,process,process.target.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -733,7 +733,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev+exp,true,process,process.target.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev+exp,true,process,process.target.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev+exp,true,process,process.target.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev+exp,true,process,process.target.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev+exp,true,process,process.target.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev+exp,true,process,process.target.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev+exp,true,process,process.target.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -741,7 +741,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev+exp,true,process,process.target.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,process,process.target.name,keyword,extended,,ssh,Process name.
-1.12.0-dev+exp,true,process,process.target.name.text,text,extended,,ssh,Process name.
+1.12.0-dev+exp,true,process,process.target.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.target.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.target.parent.args_count,long,extended,,4,Length of the process.args array.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -752,7 +752,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev+exp,true,process,process.target.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev+exp,true,process,process.target.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev+exp,true,process,process.target.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev+exp,true,process,process.target.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev+exp,true,process,process.target.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -784,7 +784,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev+exp,true,process,process.target.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev+exp,true,process,process.target.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev+exp,true,process,process.target.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev+exp,true,process,process.target.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev+exp,true,process,process.target.parent.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev+exp,true,process,process.target.parent.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev+exp,true,process,process.target.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -792,7 +792,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev+exp,true,process,process.target.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,process,process.target.parent.name,keyword,extended,,ssh,Process name.
-1.12.0-dev+exp,true,process,process.target.parent.name.text,text,extended,,ssh,Process name.
+1.12.0-dev+exp,true,process,process.target.parent.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.target.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev+exp,true,process,process.target.parent.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 1.12.0-dev+exp,true,process,process.target.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -838,10 +838,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.parent.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev+exp,true,process,process.target.parent.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev+exp,true,process,process.target.parent.title,keyword,extended,,,Process title.
-1.12.0-dev+exp,true,process,process.target.parent.title.text,text,extended,,,Process title.
+1.12.0-dev+exp,true,process,process.target.parent.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev+exp,true,process,process.target.parent.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev+exp,true,process,process.target.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev+exp,true,process,process.target.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev+exp,true,process,process.target.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev+exp,true,process,process.target.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev+exp,true,process,process.target.pe.authentihash,keyword,extended,,ac9555d914bbb112ecc5f15bb9887ca8371f493ab0941344e976bb8410c8aa78,Authentihash of the PE file.
 1.12.0-dev+exp,true,process,process.target.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
@@ -887,17 +887,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev+exp,true,process,process.target.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev+exp,true,process,process.target.title,keyword,extended,,,Process title.
-1.12.0-dev+exp,true,process,process.target.title.text,text,extended,,,Process title.
+1.12.0-dev+exp,true,process,process.target.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev+exp,true,process,process.target.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev+exp,true,process,process.target.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev+exp,true,process,process.target.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev+exp,true,process,process.target.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev+exp,true,process,process.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev+exp,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev+exp,true,process,process.title,keyword,extended,,,Process title.
-1.12.0-dev+exp,true,process,process.title.text,text,extended,,,Process title.
+1.12.0-dev+exp,true,process,process.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev+exp,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev+exp,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev+exp,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev+exp,true,process,process.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev+exp,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
 1.12.0-dev+exp,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 1.12.0-dev+exp,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
@@ -922,7 +922,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,server,server.address,keyword,extended,,,Server network address.
 1.12.0-dev+exp,true,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 1.12.0-dev+exp,true,server,server.domain,keyword,core,,,Server domain.
 1.12.0-dev+exp,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
@@ -948,14 +948,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,server,server.user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,server,server.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 1.12.0-dev+exp,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -968,7 +968,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,source,source.address,keyword,extended,,,Source network address.
 1.12.0-dev+exp,true,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 1.12.0-dev+exp,true,source,source.domain,keyword,core,,,Source domain.
 1.12.0-dev+exp,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
@@ -994,21 +994,21 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,source,source.user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,source,source.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,source,source.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 1.12.0-dev+exp,true,threat,threat.enrichments,nested,extended,,,List of objects containing indicators enriching the event.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator,object,extended,,,Object containing indicators enriching the event.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -1066,10 +1066,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -1148,9 +1148,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1196,7 +1196,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 1.12.0-dev+exp,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev+exp,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev+exp,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 1.12.0-dev+exp,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 1.12.0-dev+exp,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -1254,10 +1254,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev+exp,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev+exp,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev+exp,true,threat,threat.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev+exp,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev+exp,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev+exp,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev+exp,true,threat,threat.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev+exp,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev+exp,true,threat,threat.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev+exp,true,threat,threat.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev+exp,true,threat,threat.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -1336,9 +1336,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev+exp,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev+exp,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev+exp,true,threat,threat.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev+exp,true,threat,threat.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev+exp,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev+exp,true,threat,threat.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev+exp,true,threat,threat.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev+exp,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
 1.12.0-dev+exp,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev+exp,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1382,11 +1382,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
 1.12.0-dev+exp,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
 1.12.0-dev+exp,true,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
-1.12.0-dev+exp,true,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+1.12.0-dev+exp,true,threat,threat.technique.name.text,match_only_text,extended,,Command and Scripting Interpreter,Threat technique name.
 1.12.0-dev+exp,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
 1.12.0-dev+exp,true,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
 1.12.0-dev+exp,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
-1.12.0-dev+exp,true,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+1.12.0-dev+exp,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 1.12.0-dev+exp,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
 1.12.0-dev+exp,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 1.12.0-dev+exp,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
@@ -1471,9 +1471,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev+exp,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev+exp,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev+exp,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev+exp,true,url,url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev+exp,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev+exp,true,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev+exp,true,url,url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev+exp,true,url,url.password,keyword,extended,,,Password of the request.
 1.12.0-dev+exp,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev+exp,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1486,61 +1486,61 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,user,user.changes.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,user,user.changes.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,user,user.changes.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,user,user.effective.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,user,user.effective.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,user,user.effective.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,user,user.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,user,user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,user,user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,user,user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,user,user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,user,user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev+exp,true,user,user.target.email,keyword,extended,,,User email address.
 1.12.0-dev+exp,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev+exp,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev+exp,true,user,user.target.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev+exp,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev+exp,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev+exp,true,user,user.target.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev+exp,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev+exp,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev+exp,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev+exp,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev+exp,true,user,user.target.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 1.12.0-dev+exp,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 1.12.0-dev+exp,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
-1.12.0-dev+exp,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+1.12.0-dev+exp,true,user_agent,user_agent.original.text,match_only_text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 1.12.0-dev+exp,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev+exp,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev+exp,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev+exp,true,user_agent,user_agent.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev+exp,true,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev+exp,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev+exp,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev+exp,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev+exp,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev+exp,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev+exp,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -1548,7 +1548,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
 1.12.0-dev+exp,true,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
 1.12.0-dev+exp,true,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
-1.12.0-dev+exp,true,vulnerability,vulnerability.description.text,text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.12.0-dev+exp,true,vulnerability,vulnerability.description.text,match_only_text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 1.12.0-dev+exp,true,vulnerability,vulnerability.enumeration,keyword,extended,,CVE,Identifier of the vulnerability.
 1.12.0-dev+exp,true,vulnerability,vulnerability.id,keyword,extended,,CVE-2019-00001,ID of the vulnerability.
 1.12.0-dev+exp,true,vulnerability,vulnerability.reference,keyword,extended,,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -129,6 +129,8 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -138,8 +140,7 @@ client.as.organization.name:
   multi_fields:
   - flat_name: client.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -452,6 +453,8 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -461,8 +464,7 @@ client.user.full_name:
   multi_fields:
   - flat_name: client.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -530,6 +532,8 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
@@ -539,8 +543,7 @@ client.user.name:
   multi_fields:
   - flat_name: client.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -830,6 +833,8 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -839,8 +844,7 @@ destination.as.organization.name:
   multi_fields:
   - flat_name: destination.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -1152,6 +1156,8 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1161,8 +1167,7 @@ destination.user.full_name:
   multi_fields:
   - flat_name: destination.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -1230,6 +1235,8 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
@@ -1239,8 +1246,7 @@ destination.user.name:
   multi_fields:
   - flat_name: destination.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -2184,17 +2190,18 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
   level: core
   name: message
   normalize: []
-  norms: false
   short: Error message.
-  type: text
+  type: match_only_text
 error.stack_trace:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -2202,8 +2209,7 @@ error.stack_trace:
   multi_fields:
   - flat_name: error.stack_trace.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: stack_trace
   normalize: []
   short: The stack trace of this error in plain text.
@@ -3697,6 +3703,8 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -3707,8 +3715,7 @@ file.path:
   multi_fields:
   - flat_name: file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   short: Full path to the file, including the file name.
@@ -4185,6 +4192,8 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -4193,8 +4202,7 @@ file.target_path:
   multi_fields:
   - flat_name: file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   short: Target path for symlinks.
@@ -4878,6 +4886,8 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4887,8 +4897,7 @@ host.os.full:
   multi_fields:
   - flat_name: host.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -4907,6 +4916,8 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4916,8 +4927,7 @@ host.os.name:
   multi_fields:
   - flat_name: host.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -5014,6 +5024,8 @@ host.user.email:
   short: User email address.
   type: keyword
 host.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -5023,8 +5035,7 @@ host.user.full_name:
   multi_fields:
   - flat_name: host.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -5092,6 +5103,8 @@ host.user.id:
   short: Unique identifier of the user.
   type: keyword
 host.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-user-name
   description: Short name or login of the user.
   example: albert
@@ -5101,8 +5114,7 @@ host.user.name:
   multi_fields:
   - flat_name: host.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -5495,6 +5507,7 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -5508,9 +5521,8 @@ message:
   level: core
   name: message
   normalize: []
-  norms: false
   short: Log message optimized for viewing in a log viewer.
-  type: text
+  type: match_only_text
 network.application:
   dashed_name: network-application
   description: 'A name given to an application level protocol. This can be arbitrarily
@@ -6105,6 +6117,8 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -6114,8 +6128,7 @@ observer.os.full:
   multi_fields:
   - flat_name: observer.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -6134,6 +6147,8 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -6143,8 +6158,7 @@ observer.os.name:
   multi_fields:
   - flat_name: observer.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -6647,7 +6661,8 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6659,8 +6674,7 @@ process.command_line:
   multi_fields:
   - flat_name: process.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   short: Full command line that started the process.
@@ -7014,6 +7028,8 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -7023,8 +7039,7 @@ process.executable:
   multi_fields:
   - flat_name: process.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   short: Absolute path to the process executable.
@@ -7098,6 +7113,8 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -7109,8 +7126,7 @@ process.name:
   multi_fields:
   - flat_name: process.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Process name.
@@ -7245,7 +7261,8 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7257,8 +7274,7 @@ process.parent.command_line:
   multi_fields:
   - flat_name: process.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -7614,6 +7630,8 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -7623,8 +7641,7 @@ process.parent.executable:
   multi_fields:
   - flat_name: process.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -7700,6 +7717,8 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -7711,8 +7730,7 @@ process.parent.name:
   multi_fields:
   - flat_name: process.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -8248,6 +8266,8 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -8259,8 +8279,7 @@ process.parent.title:
   multi_fields:
   - flat_name: process.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -8278,6 +8297,8 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -8287,8 +8308,7 @@ process.parent.working_directory:
   multi_fields:
   - flat_name: process.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -8925,7 +8945,8 @@ process.target.code_signature.valid:
     content.
   type: boolean
 process.target.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-target-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -8937,8 +8958,7 @@ process.target.command_line:
   multi_fields:
   - flat_name: process.target.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -9294,6 +9314,8 @@ process.target.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -9303,8 +9325,7 @@ process.target.executable:
   multi_fields:
   - flat_name: process.target.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -9380,6 +9401,8 @@ process.target.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-name
   description: 'Process name.
 
@@ -9391,8 +9414,7 @@ process.target.name:
   multi_fields:
   - flat_name: process.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -9528,7 +9550,8 @@ process.target.parent.code_signature.valid:
     content.
   type: boolean
 process.target.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-target-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -9540,8 +9563,7 @@ process.target.parent.command_line:
   multi_fields:
   - flat_name: process.target.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -9897,6 +9919,8 @@ process.target.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -9906,8 +9930,7 @@ process.target.parent.executable:
   multi_fields:
   - flat_name: process.target.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -9983,6 +10006,8 @@ process.target.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-name
   description: 'Process name.
 
@@ -9994,8 +10019,7 @@ process.target.parent.name:
   multi_fields:
   - flat_name: process.target.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -10531,6 +10555,8 @@ process.target.parent.thread.name:
   short: Thread name.
   type: keyword
 process.target.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-title
   description: 'Process title.
 
@@ -10542,8 +10568,7 @@ process.target.parent.title:
   multi_fields:
   - flat_name: process.target.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -10561,6 +10586,8 @@ process.target.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -10570,8 +10597,7 @@ process.target.parent.working_directory:
   multi_fields:
   - flat_name: process.target.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -11107,6 +11133,8 @@ process.target.thread.name:
   short: Thread name.
   type: keyword
 process.target.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-title
   description: 'Process title.
 
@@ -11118,8 +11146,7 @@ process.target.title:
   multi_fields:
   - flat_name: process.target.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -11137,6 +11164,8 @@ process.target.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-target-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11146,8 +11175,7 @@ process.target.working_directory:
   multi_fields:
   - flat_name: process.target.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -11176,6 +11204,8 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -11187,8 +11217,7 @@ process.title:
   multi_fields:
   - flat_name: process.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   short: Process title.
@@ -11204,6 +11233,8 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11213,8 +11244,7 @@ process.working_directory:
   multi_fields:
   - flat_name: process.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   short: The working directory of the process.
@@ -11504,6 +11534,8 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -11513,8 +11545,7 @@ server.as.organization.name:
   multi_fields:
   - flat_name: server.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -11827,6 +11858,8 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -11836,8 +11869,7 @@ server.user.full_name:
   multi_fields:
   - flat_name: server.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -11905,6 +11937,8 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
@@ -11914,8 +11948,7 @@ server.user.name:
   multi_fields:
   - flat_name: server.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -12088,6 +12121,8 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -12097,8 +12132,7 @@ source.as.organization.name:
   multi_fields:
   - flat_name: source.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -12411,6 +12445,8 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -12420,8 +12456,7 @@ source.user.full_name:
   multi_fields:
   - flat_name: source.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -12489,6 +12524,8 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
@@ -12498,8 +12535,7 @@ source.user.name:
   multi_fields:
   - flat_name: source.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -12578,6 +12614,8 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -12587,8 +12625,7 @@ threat.enrichments.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.enrichments.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -13291,6 +13328,8 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -13301,8 +13340,7 @@ threat.enrichments.indicator.file.path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -13322,6 +13360,8 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -13330,8 +13370,7 @@ threat.enrichments.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -14298,7 +14337,8 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -14308,15 +14348,15 @@ threat.enrichments.indicator.url.full:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -14330,8 +14370,7 @@ threat.enrichments.indicator.url.original:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -14921,6 +14960,8 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -14930,8 +14971,7 @@ threat.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -15634,6 +15674,8 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -15644,8 +15686,7 @@ threat.indicator.file.path:
   multi_fields:
   - flat_name: threat.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -15665,6 +15706,8 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -15673,8 +15716,7 @@ threat.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -16641,7 +16683,8 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -16651,15 +16694,15 @@ threat.indicator.url.full:
   multi_fields:
   - flat_name: threat.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -16673,8 +16716,7 @@ threat.indicator.url.original:
   multi_fields:
   - flat_name: threat.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -17244,6 +17286,8 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -17254,8 +17298,7 @@ threat.technique.name:
   multi_fields:
   - flat_name: threat.technique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.name
   normalize:
   - array
@@ -17288,6 +17331,8 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -17298,8 +17343,7 @@ threat.technique.subtechnique.name:
   multi_fields:
   - flat_name: threat.technique.subtechnique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.subtechnique.name
   normalize:
   - array
@@ -18366,7 +18410,8 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -18376,14 +18421,14 @@ url.full:
   multi_fields:
   - flat_name: url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -18397,8 +18442,7 @@ url.original:
   multi_fields:
   - flat_name: url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unmodified original url as seen in the event source.
@@ -18550,6 +18594,8 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18559,8 +18605,7 @@ user.changes.full_name:
   multi_fields:
   - flat_name: user.changes.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -18628,6 +18673,8 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
@@ -18637,8 +18684,7 @@ user.changes.name:
   multi_fields:
   - flat_name: user.changes.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -18694,6 +18740,8 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18703,8 +18751,7 @@ user.effective.full_name:
   multi_fields:
   - flat_name: user.effective.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -18772,6 +18819,8 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
@@ -18781,8 +18830,7 @@ user.effective.name:
   multi_fields:
   - flat_name: user.effective.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -18812,6 +18860,8 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18821,8 +18871,7 @@ user.full_name:
   multi_fields:
   - flat_name: user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   short: User's full name, if available.
@@ -18887,6 +18936,8 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
@@ -18896,8 +18947,7 @@ user.name:
   multi_fields:
   - flat_name: user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Short name or login of the user.
@@ -18939,6 +18989,8 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -18948,8 +19000,7 @@ user.target.full_name:
   multi_fields:
   - flat_name: user.target.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -19017,6 +19068,8 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
@@ -19026,8 +19079,7 @@ user.target.name:
   multi_fields:
   - flat_name: user.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -19069,6 +19121,8 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -19079,8 +19133,7 @@ user_agent.original:
   multi_fields:
   - flat_name: user_agent.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unparsed user_agent string.
@@ -19098,6 +19151,8 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -19107,8 +19162,7 @@ user_agent.os.full:
   multi_fields:
   - flat_name: user_agent.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -19127,6 +19181,8 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -19136,8 +19192,7 @@ user_agent.os.name:
   multi_fields:
   - flat_name: user_agent.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -19227,6 +19282,8 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -19238,8 +19295,7 @@ vulnerability.description:
   multi_fields:
   - flat_name: vulnerability.description.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: description
   normalize: []
   short: Description of the vulnerability.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -119,6 +119,8 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -128,8 +130,7 @@ as:
       multi_fields:
       - flat_name: as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       short: Organization name.
@@ -203,6 +204,7 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -216,9 +218,8 @@ base:
       level: core
       name: message
       normalize: []
-      norms: false
       short: Log message optimized for viewing in a log viewer.
-      type: text
+      type: match_only_text
     tags:
       dashed_name: tags
       description: List of keywords used to tag each event.
@@ -283,6 +284,8 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -292,8 +295,7 @@ client:
       multi_fields:
       - flat_name: client.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -607,6 +609,8 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -616,8 +620,7 @@ client:
       multi_fields:
       - flat_name: client.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -685,6 +688,8 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
@@ -694,8 +699,7 @@ client:
       multi_fields:
       - flat_name: client.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -1179,6 +1183,8 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1188,8 +1194,7 @@ destination:
       multi_fields:
       - flat_name: destination.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -1502,6 +1507,8 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1511,8 +1518,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -1580,6 +1586,8 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
@@ -1589,8 +1597,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -2941,17 +2948,18 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
       level: core
       name: message
       normalize: []
-      norms: false
       short: Error message.
-      type: text
+      type: match_only_text
     error.stack_trace:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -2959,8 +2967,7 @@ error:
       multi_fields:
       - flat_name: error.stack_trace.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: stack_trace
       normalize: []
       short: The stack trace of this error in plain text.
@@ -4505,6 +4512,8 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -4515,8 +4524,7 @@ file:
       multi_fields:
       - flat_name: file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       short: Full path to the file, including the file name.
@@ -4994,6 +5002,8 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -5002,8 +5012,7 @@ file:
       multi_fields:
       - flat_name: file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       short: Target path for symlinks.
@@ -6012,6 +6021,8 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6021,8 +6032,7 @@ host:
       multi_fields:
       - flat_name: host.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -6041,6 +6051,8 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6050,8 +6062,7 @@ host:
       multi_fields:
       - flat_name: host.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -6150,6 +6161,8 @@ host:
       short: User email address.
       type: keyword
     host.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -6159,8 +6172,7 @@ host:
       multi_fields:
       - flat_name: host.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -6228,6 +6240,8 @@ host:
       short: Unique identifier of the user.
       type: keyword
     host.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-user-name
       description: Short name or login of the user.
       example: albert
@@ -6237,8 +6251,7 @@ host:
       multi_fields:
       - flat_name: host.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -7359,6 +7372,8 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7368,8 +7383,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -7388,6 +7402,8 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7397,8 +7413,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -7696,6 +7711,8 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7705,8 +7722,7 @@ os:
       multi_fields:
       - flat_name: os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Operating system name, including the version or code name.
@@ -7723,6 +7739,8 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7732,8 +7750,7 @@ os:
       multi_fields:
       - flat_name: os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Operating system name, without the version.
@@ -8546,7 +8563,8 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -8558,8 +8576,7 @@ process:
       multi_fields:
       - flat_name: process.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       short: Full command line that started the process.
@@ -8913,6 +8930,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -8922,8 +8941,7 @@ process:
       multi_fields:
       - flat_name: process.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       short: Absolute path to the process executable.
@@ -8997,6 +9015,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -9008,8 +9028,7 @@ process:
       multi_fields:
       - flat_name: process.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Process name.
@@ -9144,7 +9163,8 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9156,8 +9176,7 @@ process:
       multi_fields:
       - flat_name: process.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -9513,6 +9532,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -9522,8 +9543,7 @@ process:
       multi_fields:
       - flat_name: process.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -9599,6 +9619,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -9610,8 +9632,7 @@ process:
       multi_fields:
       - flat_name: process.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -10148,6 +10169,8 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -10159,8 +10182,7 @@ process:
       multi_fields:
       - flat_name: process.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -10178,6 +10200,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -10187,8 +10211,7 @@ process:
       multi_fields:
       - flat_name: process.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -10826,7 +10849,8 @@ process:
         content.
       type: boolean
     process.target.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-target-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -10838,8 +10862,7 @@ process:
       multi_fields:
       - flat_name: process.target.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -11195,6 +11218,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -11204,8 +11229,7 @@ process:
       multi_fields:
       - flat_name: process.target.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -11281,6 +11305,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-name
       description: 'Process name.
 
@@ -11292,8 +11318,7 @@ process:
       multi_fields:
       - flat_name: process.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -11429,7 +11454,8 @@ process:
         content.
       type: boolean
     process.target.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-target-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -11441,8 +11467,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -11798,6 +11823,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -11807,8 +11834,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -11884,6 +11910,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-name
       description: 'Process name.
 
@@ -11895,8 +11923,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -12433,6 +12460,8 @@ process:
       short: Thread name.
       type: keyword
     process.target.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-title
       description: 'Process title.
 
@@ -12444,8 +12473,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -12463,6 +12491,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -12472,8 +12502,7 @@ process:
       multi_fields:
       - flat_name: process.target.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -13010,6 +13039,8 @@ process:
       short: Thread name.
       type: keyword
     process.target.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-title
       description: 'Process title.
 
@@ -13021,8 +13052,7 @@ process:
       multi_fields:
       - flat_name: process.target.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -13040,6 +13070,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-target-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -13049,8 +13081,7 @@ process:
       multi_fields:
       - flat_name: process.target.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -13079,6 +13110,8 @@ process:
       short: Thread name.
       type: keyword
     process.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -13090,8 +13123,7 @@ process:
       multi_fields:
       - flat_name: process.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       short: Process title.
@@ -13107,6 +13139,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -13116,8 +13150,7 @@ process:
       multi_fields:
       - flat_name: process.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       short: The working directory of the process.
@@ -13530,6 +13563,8 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -13539,8 +13574,7 @@ server:
       multi_fields:
       - flat_name: server.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -13854,6 +13888,8 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -13863,8 +13899,7 @@ server:
       multi_fields:
       - flat_name: server.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -13932,6 +13967,8 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
@@ -13941,8 +13978,7 @@ server:
       multi_fields:
       - flat_name: server.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -14159,6 +14195,8 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14168,8 +14206,7 @@ source:
       multi_fields:
       - flat_name: source.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -14483,6 +14520,8 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -14492,8 +14531,7 @@ source:
       multi_fields:
       - flat_name: source.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -14561,6 +14599,8 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
@@ -14570,8 +14610,7 @@ source:
       multi_fields:
       - flat_name: source.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -14653,6 +14692,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14662,8 +14703,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -15366,6 +15406,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -15376,8 +15418,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -15397,6 +15438,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -15405,8 +15448,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -16377,7 +16419,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -16388,15 +16431,15 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -16410,8 +16453,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -17001,6 +17043,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -17010,8 +17054,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -17714,6 +17757,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -17724,8 +17769,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -17745,6 +17789,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -17753,8 +17799,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -18725,7 +18770,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -18736,15 +18782,15 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -18758,8 +18804,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -19329,6 +19374,8 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -19339,8 +19386,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.name
       normalize:
       - array
@@ -19373,6 +19419,8 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -19383,8 +19431,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.subtechnique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.subtechnique.name
       normalize:
       - array
@@ -20602,7 +20649,8 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -20613,14 +20661,14 @@ url:
       multi_fields:
       - flat_name: url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -20634,8 +20682,7 @@ url:
       multi_fields:
       - flat_name: url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unmodified original url as seen in the event source.
@@ -20811,6 +20858,8 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -20820,8 +20869,7 @@ user:
       multi_fields:
       - flat_name: user.changes.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -20889,6 +20937,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
@@ -20898,8 +20948,7 @@ user:
       multi_fields:
       - flat_name: user.changes.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -20955,6 +21004,8 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -20964,8 +21015,7 @@ user:
       multi_fields:
       - flat_name: user.effective.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -21033,6 +21083,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
@@ -21042,8 +21094,7 @@ user:
       multi_fields:
       - flat_name: user.effective.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -21073,6 +21124,8 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21082,8 +21135,7 @@ user:
       multi_fields:
       - flat_name: user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       short: User's full name, if available.
@@ -21148,6 +21200,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
@@ -21157,8 +21211,7 @@ user:
       multi_fields:
       - flat_name: user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Short name or login of the user.
@@ -21200,6 +21253,8 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21209,8 +21264,7 @@ user:
       multi_fields:
       - flat_name: user.target.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -21278,6 +21332,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
@@ -21287,8 +21343,7 @@ user:
       multi_fields:
       - flat_name: user.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -21391,6 +21446,8 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -21401,8 +21458,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unparsed user_agent string.
@@ -21420,6 +21476,8 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -21429,8 +21487,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -21449,6 +21506,8 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -21458,8 +21517,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -21627,6 +21685,8 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -21638,8 +21698,7 @@ vulnerability:
       multi_fields:
       - flat_name: vulnerability.description.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: description
       normalize: []
       short: Description of the vulnerability.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -70,8 +70,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -183,8 +182,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -217,8 +215,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -360,8 +357,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -473,8 +469,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -507,8 +502,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -853,14 +847,12 @@
             "type": "keyword"
           },
           "message": {
-            "norms": false,
-            "type": "text"
+            "type": "match_only_text"
           },
           "stack_trace": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -1210,8 +1202,7 @@
           "path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1391,8 +1382,7 @@
           "target_path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1665,8 +1655,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1679,8 +1668,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1720,8 +1708,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1754,8 +1741,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1924,8 +1910,7 @@
         }
       },
       "message": {
-        "norms": false,
-        "type": "text"
+        "type": "match_only_text"
       },
       "network": {
         "properties": {
@@ -2148,8 +2133,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2162,8 +2146,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2366,8 +2349,7 @@
           "command_line": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -2496,8 +2478,7 @@
           "executable": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2533,8 +2514,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2581,8 +2561,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -2711,8 +2690,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2748,8 +2726,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2949,8 +2926,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2962,8 +2938,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3192,8 +3167,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -3322,8 +3296,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3359,8 +3332,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3407,8 +3379,7 @@
                   "command_line": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -3537,8 +3508,7 @@
                   "executable": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3574,8 +3544,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3775,8 +3744,7 @@
                   "title": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3788,8 +3756,7 @@
                   "working_directory": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3991,8 +3958,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4004,8 +3970,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4027,8 +3992,7 @@
           "title": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -4040,8 +4004,7 @@
           "working_directory": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -4163,8 +4126,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4276,8 +4238,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4310,8 +4271,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4381,8 +4341,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4494,8 +4453,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4528,8 +4486,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4571,8 +4528,7 @@
                           "name": {
                             "fields": {
                               "text": {
-                                "norms": false,
-                                "type": "text"
+                                "type": "match_only_text"
                               }
                             },
                             "ignore_above": 1024,
@@ -4813,8 +4769,7 @@
                       "path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -4826,8 +4781,7 @@
                       "target_path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -5175,8 +5129,7 @@
                       "full": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -5184,8 +5137,7 @@
                       "original": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -5398,8 +5350,7 @@
                       "name": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -5640,8 +5591,7 @@
                   "path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -5653,8 +5603,7 @@
                   "target_path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -6002,8 +5951,7 @@
                   "full": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -6011,8 +5959,7 @@
                   "original": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -6210,8 +6157,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6230,8 +6176,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -6622,8 +6567,7 @@
           "full": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -6631,8 +6575,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -6688,8 +6631,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6722,8 +6664,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6752,8 +6693,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6786,8 +6726,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6806,8 +6745,7 @@
           "full_name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6840,8 +6778,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6864,8 +6801,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6898,8 +6834,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6930,8 +6865,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -6946,8 +6880,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -6960,8 +6893,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -7000,8 +6932,7 @@
           "description": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/base.json
+++ b/experimental/generated/elasticsearch/component/base.json
@@ -13,8 +13,7 @@
           "type": "object"
         },
         "message": {
-          "norms": false,
-          "type": "text"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/client.json
+++ b/experimental/generated/elasticsearch/component/client.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/destination.json
+++ b/experimental/generated/elasticsearch/component/destination.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/error.json
+++ b/experimental/generated/elasticsearch/component/error.json
@@ -17,14 +17,12 @@
               "type": "keyword"
             },
             "message": {
-              "norms": false,
-              "type": "text"
+              "type": "match_only_text"
             },
             "stack_trace": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -245,8 +245,7 @@
             "path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -426,8 +425,7 @@
             "target_path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/host.json
+++ b/experimental/generated/elasticsearch/component/host.json
@@ -141,8 +141,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -155,8 +154,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -196,8 +194,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -230,8 +227,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/observer.json
+++ b/experimental/generated/elasticsearch/component/observer.json
@@ -153,8 +153,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -167,8 +166,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -47,8 +47,7 @@
             "command_line": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -177,8 +176,7 @@
             "executable": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -214,8 +212,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -262,8 +259,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -392,8 +388,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -429,8 +424,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -630,8 +624,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -643,8 +636,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -873,8 +865,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -1003,8 +994,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1040,8 +1030,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1088,8 +1077,7 @@
                     "command_line": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1218,8 +1206,7 @@
                     "executable": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1255,8 +1242,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1456,8 +1442,7 @@
                     "title": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1469,8 +1454,7 @@
                     "working_directory": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1672,8 +1656,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1685,8 +1668,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1708,8 +1690,7 @@
             "title": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -1721,8 +1702,7 @@
             "working_directory": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/server.json
+++ b/experimental/generated/elasticsearch/component/server.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/source.json
+++ b/experimental/generated/elasticsearch/component/source.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -22,8 +22,7 @@
                             "name": {
                               "fields": {
                                 "text": {
-                                  "norms": false,
-                                  "type": "text"
+                                  "type": "match_only_text"
                                 }
                               },
                               "ignore_above": 1024,
@@ -264,8 +263,7 @@
                         "path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -277,8 +275,7 @@
                         "target_path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -626,8 +623,7 @@
                         "full": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -635,8 +631,7 @@
                         "original": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -849,8 +844,7 @@
                         "name": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -1091,8 +1085,7 @@
                     "path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1104,8 +1097,7 @@
                     "target_path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1453,8 +1445,7 @@
                     "full": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1462,8 +1453,7 @@
                     "original": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1661,8 +1651,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1681,8 +1670,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/url.json
+++ b/experimental/generated/elasticsearch/component/url.json
@@ -23,8 +23,7 @@
             "full": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -32,8 +31,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/user.json
+++ b/experimental/generated/elasticsearch/component/user.json
@@ -21,8 +21,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -55,8 +54,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -85,8 +83,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -119,8 +116,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -139,8 +135,7 @@
             "full_name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -173,8 +168,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -197,8 +191,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -231,8 +224,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/user_agent.json
+++ b/experimental/generated/elasticsearch/component/user_agent.json
@@ -23,8 +23,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -39,8 +38,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -53,8 +51,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/vulnerability.json
+++ b/experimental/generated/elasticsearch/component/vulnerability.json
@@ -19,8 +19,7 @@
             "description": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -33,7 +33,7 @@
     example: '{"application": "foo-bar", "env": "production"}'
   - name: message
     level: core
-    type: text
+    type: match_only_text
     description: 'For log events the message field contains the log message, optimized
       for viewing in a log viewer.
 
@@ -140,8 +140,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -187,8 +186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -376,8 +374,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -418,8 +415,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -722,8 +718,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -910,8 +905,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -952,8 +946,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -1535,15 +1528,14 @@
       description: Unique identifier for the error.
     - name: message
       level: core
-      type: text
+      type: match_only_text
       description: Error message.
     - name: stack_trace
       level: extended
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The stack trace of this error in plain text.
     - name: type
@@ -2294,8 +2286,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -2366,8 +2357,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Target path for symlinks.
     - name: type
@@ -2910,8 +2900,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -2927,8 +2916,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -2991,8 +2979,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -3033,8 +3020,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -3726,8 +3712,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3743,8 +3728,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -3917,8 +3901,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -3934,8 +3917,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -4219,8 +4201,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -4427,8 +4408,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -4473,8 +4453,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process name.
 
@@ -4567,8 +4546,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
 
@@ -4775,8 +4753,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
@@ -4825,8 +4802,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process name.
 
         Sometimes called program name or similar.'
@@ -4931,8 +4907,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Process title.
 
         The proctitle, some times the same as process name. Can also be different:
@@ -4950,8 +4925,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The working directory of the process.
       example: /home/alice
       default_field: false
@@ -5048,8 +5022,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Process title.
 
@@ -5066,8 +5039,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The working directory of the process.
       example: /home/alice
@@ -5313,8 +5285,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -5502,8 +5473,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -5544,8 +5514,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -5689,8 +5658,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
       example: Google LLC
@@ -5878,8 +5846,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -5920,8 +5887,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -5968,8 +5934,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -6388,8 +6353,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -6408,8 +6372,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: enrichments.indicator.file.type
@@ -6777,8 +6740,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -6789,8 +6751,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -7152,8 +7113,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Organization name.
       example: Google LLC
       default_field: false
@@ -7572,8 +7532,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
       example: /home/alice/example.png
@@ -7592,8 +7551,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Target path for symlinks.
       default_field: false
     - name: indicator.file.type
@@ -7961,8 +7919,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
         source.
@@ -7973,8 +7930,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: 'Unmodified original url as seen in the event source.
 
         Note that in network monitoring, the observed URL may be a full URL, whereas
@@ -8322,8 +8278,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -8349,8 +8304,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: PowerShell
@@ -9021,8 +8975,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -9033,8 +8986,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: 'Unmodified original url as seen in the event source.
 
@@ -9150,8 +9102,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9197,8 +9148,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9236,8 +9186,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9283,8 +9232,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9306,8 +9254,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: User's full name, if available.
       example: Albert Einstein
@@ -9348,8 +9295,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Short name or login of the user.
       example: albert
@@ -9380,8 +9326,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: User's full name, if available.
       example: Albert Einstein
       default_field: false
@@ -9427,8 +9372,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Short name or login of the user.
       example: albert
       default_field: false
@@ -9465,8 +9409,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
         (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
@@ -9482,8 +9425,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -9499,8 +9441,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Operating system name, without the version.
       example: Mac OS X
@@ -9605,8 +9546,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
         Vulnerabilities and Exposure CVE description])

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1,7 +1,7 @@
 ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
 1.12.0-dev,true,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
-1.12.0-dev,true,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
+1.12.0-dev,true,base,message,match_only_text,core,,Hello World,Log message optimized for viewing in a log viewer.
 1.12.0-dev,true,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
 1.12.0-dev,true,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
 1.12.0-dev,true,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
@@ -12,7 +12,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,client,client.address,keyword,extended,,,Client network address.
 1.12.0-dev,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
 1.12.0-dev,true,client,client.domain,keyword,core,,,Client domain.
 1.12.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
@@ -38,14 +38,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,client,client.user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,client,client.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,client,client.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,client,client.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,client,client.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,client,client.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 1.12.0-dev,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -70,7 +70,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,destination,destination.address,keyword,extended,,,Destination network address.
 1.12.0-dev,true,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
 1.12.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
 1.12.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
@@ -96,14 +96,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,destination,destination.user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,destination,destination.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,destination,destination.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
@@ -147,9 +147,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
 1.12.0-dev,true,error,error.code,keyword,core,,,Error code describing the error.
 1.12.0-dev,true,error,error.id,keyword,core,,,Unique identifier for the error.
-1.12.0-dev,true,error,error.message,text,core,,,Error message.
+1.12.0-dev,true,error,error.message,match_only_text,core,,,Error message.
 1.12.0-dev,true,error,error.stack_trace,wildcard,extended,,,The stack trace of this error in plain text.
-1.12.0-dev,true,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+1.12.0-dev,true,error,error.stack_trace.text,match_only_text,extended,,,The stack trace of this error in plain text.
 1.12.0-dev,true,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
 1.12.0-dev,true,event,event.action,keyword,core,,user-password-change,The action captured by the event.
 1.12.0-dev,true,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
@@ -236,7 +236,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev,true,file,file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev,true,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev,true,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev,true,file,file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev,true,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 1.12.0-dev,true,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -246,7 +246,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,file,file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 1.12.0-dev,true,file,file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev,true,file,file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev,true,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev,true,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev,true,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
@@ -303,10 +303,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
 1.12.0-dev,true,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev,true,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev,true,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev,true,host,host.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev,true,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev,true,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -315,14 +315,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,host,host.user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,host,host.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,host,host.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,host,host.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,host,host.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,host,host.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,host,host.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,host,host.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,host,host.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,host,host.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,host,host.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 1.12.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
@@ -399,10 +399,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
 1.12.0-dev,true,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev,true,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev,true,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev,true,observer,observer.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev,true,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev,true,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -446,7 +446,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev,true,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev,true,process,process.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev,true,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev,true,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -478,7 +478,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev,true,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev,true,process,process.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev,true,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -486,7 +486,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
-1.12.0-dev,true,process,process.name.text,text,extended,,ssh,Process name.
+1.12.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
 1.12.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -497,7 +497,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
-1.12.0-dev,true,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.12.0-dev,true,process,process.parent.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 1.12.0-dev,true,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
 1.12.0-dev,true,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
 1.12.0-dev,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
@@ -529,7 +529,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
 1.12.0-dev,true,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 1.12.0-dev,true,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
-1.12.0-dev,true,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.12.0-dev,true,process,process.parent.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 1.12.0-dev,true,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
 1.12.0-dev,true,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
 1.12.0-dev,true,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
@@ -537,7 +537,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
 1.12.0-dev,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
-1.12.0-dev,true,process,process.parent.name.text,text,extended,,ssh,Process name.
+1.12.0-dev,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 1.12.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -552,10 +552,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev,true,process,process.parent.title,keyword,extended,,,Process title.
-1.12.0-dev,true,process,process.parent.title.text,text,extended,,,Process title.
+1.12.0-dev,true,process,process.parent.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev,true,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev,true,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev,true,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev,true,process,process.parent.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev,true,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 1.12.0-dev,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 1.12.0-dev,true,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
@@ -570,10 +570,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
 1.12.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 1.12.0-dev,true,process,process.title,keyword,extended,,,Process title.
-1.12.0-dev,true,process,process.title.text,text,extended,,,Process title.
+1.12.0-dev,true,process,process.title.text,match_only_text,extended,,,Process title.
 1.12.0-dev,true,process,process.uptime,long,extended,,1325,Seconds the process has been up.
 1.12.0-dev,true,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
-1.12.0-dev,true,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.12.0-dev,true,process,process.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
 1.12.0-dev,true,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
 1.12.0-dev,true,registry,registry.data.strings,wildcard,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
 1.12.0-dev,true,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
@@ -598,7 +598,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,server,server.address,keyword,extended,,,Server network address.
 1.12.0-dev,true,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
 1.12.0-dev,true,server,server.domain,keyword,core,,,Server domain.
 1.12.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
@@ -624,14 +624,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,server,server.user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,server,server.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,server,server.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,server,server.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,server,server.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 1.12.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -644,7 +644,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,source,source.address,keyword,extended,,,Source network address.
 1.12.0-dev,true,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
 1.12.0-dev,true,source,source.domain,keyword,core,,,Source domain.
 1.12.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
@@ -670,21 +670,21 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,source,source.user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,source,source.user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,source,source.user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,source,source.user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,source,source.user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,source,source.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 1.12.0-dev,true,threat,threat.enrichments,nested,extended,,,List of objects containing indicators enriching the event.
 1.12.0-dev,true,threat,threat.enrichments.indicator,object,extended,,,Object containing indicators enriching the event.
 1.12.0-dev,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,threat,threat.enrichments.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 1.12.0-dev,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 1.12.0-dev,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -742,10 +742,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev,true,threat,threat.enrichments.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev,true,threat,threat.enrichments.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev,true,threat,threat.enrichments.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -793,9 +793,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev,true,threat,threat.enrichments.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev,true,threat,threat.enrichments.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev,true,threat,threat.enrichments.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev,true,threat,threat.enrichments.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev,true,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -841,7 +841,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
 1.12.0-dev,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 1.12.0-dev,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
-1.12.0-dev,true,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.12.0-dev,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 1.12.0-dev,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
 1.12.0-dev,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 1.12.0-dev,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
@@ -899,10 +899,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
 1.12.0-dev,true,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
 1.12.0-dev,true,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
-1.12.0-dev,true,threat,threat.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.12.0-dev,true,threat,threat.indicator.file.path.text,match_only_text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
 1.12.0-dev,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 1.12.0-dev,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
-1.12.0-dev,true,threat,threat.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.12.0-dev,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
 1.12.0-dev,true,threat,threat.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
 1.12.0-dev,true,threat,threat.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
 1.12.0-dev,true,threat,threat.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
@@ -950,9 +950,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev,true,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev,true,threat,threat.indicator.url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev,true,threat,threat.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev,true,threat,threat.indicator.url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev,true,threat,threat.indicator.url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev,true,threat,threat.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev,true,threat,threat.indicator.url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev,true,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
 1.12.0-dev,true,threat,threat.indicator.url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev,true,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
@@ -996,11 +996,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
 1.12.0-dev,true,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
 1.12.0-dev,true,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
-1.12.0-dev,true,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+1.12.0-dev,true,threat,threat.technique.name.text,match_only_text,extended,,Command and Scripting Interpreter,Threat technique name.
 1.12.0-dev,true,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
 1.12.0-dev,true,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
 1.12.0-dev,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
-1.12.0-dev,true,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+1.12.0-dev,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 1.12.0-dev,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
 1.12.0-dev,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 1.12.0-dev,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
@@ -1085,9 +1085,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
 1.12.0-dev,true,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
 1.12.0-dev,true,url,url.full,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
-1.12.0-dev,true,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.12.0-dev,true,url,url.full.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
 1.12.0-dev,true,url,url.original,wildcard,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
-1.12.0-dev,true,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.12.0-dev,true,url,url.original.text,match_only_text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
 1.12.0-dev,true,url,url.password,keyword,extended,,,Password of the request.
 1.12.0-dev,true,url,url.path,wildcard,extended,,,"Path of the request, such as ""/search""."
 1.12.0-dev,true,url,url.port,long,extended,,443,"Port of the request, such as 443."
@@ -1100,61 +1100,61 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,user,user.changes.email,keyword,extended,,,User email address.
 1.12.0-dev,true,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,user,user.changes.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,user,user.changes.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,user,user.changes.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,user,user.changes.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,user,user.effective.email,keyword,extended,,,User email address.
 1.12.0-dev,true,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,user,user.effective.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,user,user.effective.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,user,user.effective.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,user,user.effective.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,user,user.email,keyword,extended,,,User email address.
 1.12.0-dev,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,user,user.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,user,user.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,user,user.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,user,user.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,user,user.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,user,user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 1.12.0-dev,true,user,user.target.email,keyword,extended,,,User email address.
 1.12.0-dev,true,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
-1.12.0-dev,true,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.12.0-dev,true,user,user.target.full_name.text,match_only_text,extended,,Albert Einstein,"User's full name, if available."
 1.12.0-dev,true,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
 1.12.0-dev,true,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 1.12.0-dev,true,user,user.target.group.name,keyword,extended,,,Name of the group.
 1.12.0-dev,true,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
 1.12.0-dev,true,user,user.target.id,keyword,core,,,Unique identifier of the user.
 1.12.0-dev,true,user,user.target.name,keyword,core,,albert,Short name or login of the user.
-1.12.0-dev,true,user,user.target.name.text,text,core,,albert,Short name or login of the user.
+1.12.0-dev,true,user,user.target.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 1.12.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
 1.12.0-dev,true,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
-1.12.0-dev,true,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+1.12.0-dev,true,user_agent,user_agent.original.text,match_only_text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
 1.12.0-dev,true,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
 1.12.0-dev,true,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
-1.12.0-dev,true,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.12.0-dev,true,user_agent,user_agent.os.full.text,match_only_text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
 1.12.0-dev,true,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
 1.12.0-dev,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
-1.12.0-dev,true,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.12.0-dev,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 1.12.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
 1.12.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
 1.12.0-dev,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
@@ -1162,7 +1162,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
 1.12.0-dev,true,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
 1.12.0-dev,true,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
-1.12.0-dev,true,vulnerability,vulnerability.description.text,text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.12.0-dev,true,vulnerability,vulnerability.description.text,match_only_text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
 1.12.0-dev,true,vulnerability,vulnerability.enumeration,keyword,extended,,CVE,Identifier of the vulnerability.
 1.12.0-dev,true,vulnerability,vulnerability.id,keyword,extended,,CVE-2019-00001,ID of the vulnerability.
 1.12.0-dev,true,vulnerability,vulnerability.reference,keyword,extended,,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -129,6 +129,8 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -138,8 +140,7 @@ client.as.organization.name:
   multi_fields:
   - flat_name: client.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -452,6 +453,8 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -461,8 +464,7 @@ client.user.full_name:
   multi_fields:
   - flat_name: client.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -530,6 +532,8 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: albert
@@ -539,8 +543,7 @@ client.user.name:
   multi_fields:
   - flat_name: client.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -830,6 +833,8 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -839,8 +844,7 @@ destination.as.organization.name:
   multi_fields:
   - flat_name: destination.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -1152,6 +1156,8 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1161,8 +1167,7 @@ destination.user.full_name:
   multi_fields:
   - flat_name: destination.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -1230,6 +1235,8 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: albert
@@ -1239,8 +1246,7 @@ destination.user.name:
   multi_fields:
   - flat_name: destination.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -1813,17 +1819,18 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
   level: core
   name: message
   normalize: []
-  norms: false
   short: Error message.
-  type: text
+  type: match_only_text
 error.stack_trace:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -1831,8 +1838,7 @@ error.stack_trace:
   multi_fields:
   - flat_name: error.stack_trace.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: stack_trace
   normalize: []
   short: The stack trace of this error in plain text.
@@ -3326,6 +3332,8 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -3336,8 +3344,7 @@ file.path:
   multi_fields:
   - flat_name: file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   short: Full path to the file, including the file name.
@@ -3443,6 +3450,8 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -3451,8 +3460,7 @@ file.target_path:
   multi_fields:
   - flat_name: file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   short: Target path for symlinks.
@@ -4136,6 +4144,8 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4145,8 +4155,7 @@ host.os.full:
   multi_fields:
   - flat_name: host.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -4165,6 +4174,8 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4174,8 +4185,7 @@ host.os.name:
   multi_fields:
   - flat_name: host.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -4272,6 +4282,8 @@ host.user.email:
   short: User email address.
   type: keyword
 host.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -4281,8 +4293,7 @@ host.user.full_name:
   multi_fields:
   - flat_name: host.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -4350,6 +4361,8 @@ host.user.id:
   short: Unique identifier of the user.
   type: keyword
 host.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: host-user-name
   description: Short name or login of the user.
   example: albert
@@ -4359,8 +4372,7 @@ host.user.name:
   multi_fields:
   - flat_name: host.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -4753,6 +4765,7 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -4766,9 +4779,8 @@ message:
   level: core
   name: message
   normalize: []
-  norms: false
   short: Log message optimized for viewing in a log viewer.
-  type: text
+  type: match_only_text
 network.application:
   dashed_name: network-application
   description: 'A name given to an application level protocol. This can be arbitrarily
@@ -5363,6 +5375,8 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -5372,8 +5386,7 @@ observer.os.full:
   multi_fields:
   - flat_name: observer.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -5392,6 +5405,8 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -5401,8 +5416,7 @@ observer.os.name:
   multi_fields:
   - flat_name: observer.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -5905,7 +5919,8 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -5917,8 +5932,7 @@ process.command_line:
   multi_fields:
   - flat_name: process.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   short: Full command line that started the process.
@@ -6272,6 +6286,8 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6281,8 +6297,7 @@ process.executable:
   multi_fields:
   - flat_name: process.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   short: Absolute path to the process executable.
@@ -6356,6 +6371,8 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -6367,8 +6384,7 @@ process.name:
   multi_fields:
   - flat_name: process.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Process name.
@@ -6503,7 +6519,8 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6515,8 +6532,7 @@ process.parent.command_line:
   multi_fields:
   - flat_name: process.parent.command_line.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: command_line
   normalize: []
   original_fieldset: process
@@ -6872,6 +6888,8 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6881,8 +6899,7 @@ process.parent.executable:
   multi_fields:
   - flat_name: process.parent.executable.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: executable
   normalize: []
   original_fieldset: process
@@ -6958,6 +6975,8 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -6969,8 +6988,7 @@ process.parent.name:
   multi_fields:
   - flat_name: process.parent.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: process
@@ -7135,6 +7153,8 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -7146,8 +7166,7 @@ process.parent.title:
   multi_fields:
   - flat_name: process.parent.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   original_fieldset: process
@@ -7165,6 +7184,8 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7174,8 +7195,7 @@ process.parent.working_directory:
   multi_fields:
   - flat_name: process.parent.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   original_fieldset: process
@@ -7334,6 +7354,8 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -7345,8 +7367,7 @@ process.title:
   multi_fields:
   - flat_name: process.title.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: title
   normalize: []
   short: Process title.
@@ -7362,6 +7383,8 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7371,8 +7394,7 @@ process.working_directory:
   multi_fields:
   - flat_name: process.working_directory.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: working_directory
   normalize: []
   short: The working directory of the process.
@@ -7662,6 +7684,8 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -7671,8 +7695,7 @@ server.as.organization.name:
   multi_fields:
   - flat_name: server.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -7985,6 +8008,8 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -7994,8 +8019,7 @@ server.user.full_name:
   multi_fields:
   - flat_name: server.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -8063,6 +8087,8 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: albert
@@ -8072,8 +8098,7 @@ server.user.name:
   multi_fields:
   - flat_name: server.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -8246,6 +8271,8 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -8255,8 +8282,7 @@ source.as.organization.name:
   multi_fields:
   - flat_name: source.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -8569,6 +8595,8 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8578,8 +8606,7 @@ source.user.full_name:
   multi_fields:
   - flat_name: source.user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -8647,6 +8674,8 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: albert
@@ -8656,8 +8685,7 @@ source.user.name:
   multi_fields:
   - flat_name: source.user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -8736,6 +8764,8 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -8745,8 +8775,7 @@ threat.enrichments.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.enrichments.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -9449,6 +9478,8 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -9459,8 +9490,7 @@ threat.enrichments.indicator.file.path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -9480,6 +9510,8 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -9488,8 +9520,7 @@ threat.enrichments.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.enrichments.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -10085,7 +10116,8 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -10095,15 +10127,15 @@ threat.enrichments.indicator.url.full:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -10117,8 +10149,7 @@ threat.enrichments.indicator.url.original:
   multi_fields:
   - flat_name: threat.enrichments.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -10708,6 +10739,8 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -10717,8 +10750,7 @@ threat.indicator.as.organization.name:
   multi_fields:
   - flat_name: threat.indicator.as.organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: organization.name
   normalize: []
   original_fieldset: as
@@ -11421,6 +11453,8 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -11431,8 +11465,7 @@ threat.indicator.file.path:
   multi_fields:
   - flat_name: threat.indicator.file.path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: path
   normalize: []
   original_fieldset: file
@@ -11452,6 +11485,8 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -11460,8 +11495,7 @@ threat.indicator.file.target_path:
   multi_fields:
   - flat_name: threat.indicator.file.target_path.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: target_path
   normalize: []
   original_fieldset: file
@@ -12057,7 +12091,8 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -12067,15 +12102,15 @@ threat.indicator.url.full:
   multi_fields:
   - flat_name: threat.indicator.url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: url
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -12089,8 +12124,7 @@ threat.indicator.url.original:
   multi_fields:
   - flat_name: threat.indicator.url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   original_fieldset: url
@@ -12660,6 +12694,8 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -12670,8 +12706,7 @@ threat.technique.name:
   multi_fields:
   - flat_name: threat.technique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.name
   normalize:
   - array
@@ -12704,6 +12739,8 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -12714,8 +12751,7 @@ threat.technique.subtechnique.name:
   multi_fields:
   - flat_name: threat.technique.subtechnique.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: technique.subtechnique.name
   normalize:
   - array
@@ -13782,7 +13818,8 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -13792,14 +13829,14 @@ url.full:
   multi_fields:
   - flat_name: url.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -13813,8 +13850,7 @@ url.original:
   multi_fields:
   - flat_name: url.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unmodified original url as seen in the event source.
@@ -13966,6 +14002,8 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -13975,8 +14013,7 @@ user.changes.full_name:
   multi_fields:
   - flat_name: user.changes.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -14044,6 +14081,8 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: albert
@@ -14053,8 +14092,7 @@ user.changes.name:
   multi_fields:
   - flat_name: user.changes.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -14110,6 +14148,8 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14119,8 +14159,7 @@ user.effective.full_name:
   multi_fields:
   - flat_name: user.effective.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -14188,6 +14227,8 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: albert
@@ -14197,8 +14238,7 @@ user.effective.name:
   multi_fields:
   - flat_name: user.effective.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -14228,6 +14268,8 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14237,8 +14279,7 @@ user.full_name:
   multi_fields:
   - flat_name: user.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   short: User's full name, if available.
@@ -14303,6 +14344,8 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: albert
@@ -14312,8 +14355,7 @@ user.name:
   multi_fields:
   - flat_name: user.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Short name or login of the user.
@@ -14355,6 +14397,8 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14364,8 +14408,7 @@ user.target.full_name:
   multi_fields:
   - flat_name: user.target.full_name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full_name
   normalize: []
   original_fieldset: user
@@ -14433,6 +14476,8 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: albert
@@ -14442,8 +14487,7 @@ user.target.name:
   multi_fields:
   - flat_name: user.target.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: user
@@ -14485,6 +14529,8 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -14495,8 +14541,7 @@ user_agent.original:
   multi_fields:
   - flat_name: user_agent.original.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: original
   normalize: []
   short: Unparsed user_agent string.
@@ -14514,6 +14559,8 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -14523,8 +14570,7 @@ user_agent.os.full:
   multi_fields:
   - flat_name: user_agent.os.full.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: full
   normalize: []
   original_fieldset: os
@@ -14543,6 +14589,8 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -14552,8 +14600,7 @@ user_agent.os.name:
   multi_fields:
   - flat_name: user_agent.os.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   original_fieldset: os
@@ -14643,6 +14690,8 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -14654,8 +14703,7 @@ vulnerability.description:
   multi_fields:
   - flat_name: vulnerability.description.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: description
   normalize: []
   short: Description of the vulnerability.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -119,6 +119,8 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -128,8 +130,7 @@ as:
       multi_fields:
       - flat_name: as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       short: Organization name.
@@ -203,6 +204,7 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -216,9 +218,8 @@ base:
       level: core
       name: message
       normalize: []
-      norms: false
       short: Log message optimized for viewing in a log viewer.
-      type: text
+      type: match_only_text
     tags:
       dashed_name: tags
       description: List of keywords used to tag each event.
@@ -283,6 +284,8 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -292,8 +295,7 @@ client:
       multi_fields:
       - flat_name: client.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -607,6 +609,8 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -616,8 +620,7 @@ client:
       multi_fields:
       - flat_name: client.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -685,6 +688,8 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: albert
@@ -694,8 +699,7 @@ client:
       multi_fields:
       - flat_name: client.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -1179,6 +1183,8 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1188,8 +1194,7 @@ destination:
       multi_fields:
       - flat_name: destination.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -1502,6 +1507,8 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1511,8 +1518,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -1580,6 +1586,8 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: albert
@@ -1589,8 +1597,7 @@ destination:
       multi_fields:
       - flat_name: destination.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -2569,17 +2576,18 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
       level: core
       name: message
       normalize: []
-      norms: false
       short: Error message.
-      type: text
+      type: match_only_text
     error.stack_trace:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -2587,8 +2595,7 @@ error:
       multi_fields:
       - flat_name: error.stack_trace.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: stack_trace
       normalize: []
       short: The stack trace of this error in plain text.
@@ -4133,6 +4140,8 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -4143,8 +4152,7 @@ file:
       multi_fields:
       - flat_name: file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       short: Full path to the file, including the file name.
@@ -4250,6 +4258,8 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -4258,8 +4268,7 @@ file:
       multi_fields:
       - flat_name: file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       short: Target path for symlinks.
@@ -5268,6 +5277,8 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -5277,8 +5288,7 @@ host:
       multi_fields:
       - flat_name: host.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -5297,6 +5307,8 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -5306,8 +5318,7 @@ host:
       multi_fields:
       - flat_name: host.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -5406,6 +5417,8 @@ host:
       short: User email address.
       type: keyword
     host.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -5415,8 +5428,7 @@ host:
       multi_fields:
       - flat_name: host.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -5484,6 +5496,8 @@ host:
       short: Unique identifier of the user.
       type: keyword
     host.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: host-user-name
       description: Short name or login of the user.
       example: albert
@@ -5493,8 +5507,7 @@ host:
       multi_fields:
       - flat_name: host.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -6615,6 +6628,8 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6624,8 +6639,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -6644,6 +6658,8 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6653,8 +6669,7 @@ observer:
       multi_fields:
       - flat_name: observer.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -6952,6 +6967,8 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6961,8 +6978,7 @@ os:
       multi_fields:
       - flat_name: os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Operating system name, including the version or code name.
@@ -6979,6 +6995,8 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6988,8 +7006,7 @@ os:
       multi_fields:
       - flat_name: os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Operating system name, without the version.
@@ -7461,7 +7478,8 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -7473,8 +7491,7 @@ process:
       multi_fields:
       - flat_name: process.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       short: Full command line that started the process.
@@ -7828,6 +7845,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -7837,8 +7856,7 @@ process:
       multi_fields:
       - flat_name: process.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       short: Absolute path to the process executable.
@@ -7912,6 +7930,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -7923,8 +7943,7 @@ process:
       multi_fields:
       - flat_name: process.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Process name.
@@ -8059,7 +8078,8 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -8071,8 +8091,7 @@ process:
       multi_fields:
       - flat_name: process.parent.command_line.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: command_line
       normalize: []
       original_fieldset: process
@@ -8428,6 +8447,8 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -8437,8 +8458,7 @@ process:
       multi_fields:
       - flat_name: process.parent.executable.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: executable
       normalize: []
       original_fieldset: process
@@ -8514,6 +8534,8 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -8525,8 +8547,7 @@ process:
       multi_fields:
       - flat_name: process.parent.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: process
@@ -8691,6 +8712,8 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -8702,8 +8725,7 @@ process:
       multi_fields:
       - flat_name: process.parent.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       original_fieldset: process
@@ -8721,6 +8743,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -8730,8 +8754,7 @@ process:
       multi_fields:
       - flat_name: process.parent.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       original_fieldset: process
@@ -8890,6 +8913,8 @@ process:
       short: Thread name.
       type: keyword
     process.title:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -8901,8 +8926,7 @@ process:
       multi_fields:
       - flat_name: process.title.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: title
       normalize: []
       short: Process title.
@@ -8918,6 +8942,8 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -8927,8 +8953,7 @@ process:
       multi_fields:
       - flat_name: process.working_directory.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: working_directory
       normalize: []
       short: The working directory of the process.
@@ -9327,6 +9352,8 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -9336,8 +9363,7 @@ server:
       multi_fields:
       - flat_name: server.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -9651,6 +9677,8 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -9660,8 +9688,7 @@ server:
       multi_fields:
       - flat_name: server.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -9729,6 +9756,8 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: albert
@@ -9738,8 +9767,7 @@ server:
       multi_fields:
       - flat_name: server.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -9956,6 +9984,8 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -9965,8 +9995,7 @@ source:
       multi_fields:
       - flat_name: source.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -10280,6 +10309,8 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10289,8 +10320,7 @@ source:
       multi_fields:
       - flat_name: source.user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -10358,6 +10388,8 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: albert
@@ -10367,8 +10399,7 @@ source:
       multi_fields:
       - flat_name: source.user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -10450,6 +10481,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -10459,8 +10492,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -11163,6 +11195,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -11173,8 +11207,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -11194,6 +11227,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -11202,8 +11237,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -11802,7 +11836,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11813,15 +11848,15 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -11835,8 +11870,7 @@ threat:
       multi_fields:
       - flat_name: threat.enrichments.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -12426,6 +12460,8 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -12435,8 +12471,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.as.organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: organization.name
       normalize: []
       original_fieldset: as
@@ -13139,6 +13174,8 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -13149,8 +13186,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: path
       normalize: []
       original_fieldset: file
@@ -13170,6 +13206,8 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -13178,8 +13216,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.file.target_path.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: target_path
       normalize: []
       original_fieldset: file
@@ -13778,7 +13815,8 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -13789,15 +13827,15 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: url
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -13811,8 +13849,7 @@ threat:
       multi_fields:
       - flat_name: threat.indicator.url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       original_fieldset: url
@@ -14382,6 +14419,8 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -14392,8 +14431,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.name
       normalize:
       - array
@@ -14426,6 +14464,8 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -14436,8 +14476,7 @@ threat:
       multi_fields:
       - flat_name: threat.technique.subtechnique.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: technique.subtechnique.name
       normalize:
       - array
@@ -15655,7 +15694,8 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -15666,14 +15706,14 @@ url:
       multi_fields:
       - flat_name: url.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -15687,8 +15727,7 @@ url:
       multi_fields:
       - flat_name: url.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unmodified original url as seen in the event source.
@@ -15864,6 +15903,8 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -15873,8 +15914,7 @@ user:
       multi_fields:
       - flat_name: user.changes.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -15942,6 +15982,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: albert
@@ -15951,8 +15993,7 @@ user:
       multi_fields:
       - flat_name: user.changes.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -16008,6 +16049,8 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16017,8 +16060,7 @@ user:
       multi_fields:
       - flat_name: user.effective.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -16086,6 +16128,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: albert
@@ -16095,8 +16139,7 @@ user:
       multi_fields:
       - flat_name: user.effective.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -16126,6 +16169,8 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16135,8 +16180,7 @@ user:
       multi_fields:
       - flat_name: user.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       short: User's full name, if available.
@@ -16201,6 +16245,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: albert
@@ -16210,8 +16256,7 @@ user:
       multi_fields:
       - flat_name: user.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Short name or login of the user.
@@ -16253,6 +16298,8 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16262,8 +16309,7 @@ user:
       multi_fields:
       - flat_name: user.target.full_name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full_name
       normalize: []
       original_fieldset: user
@@ -16331,6 +16377,8 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: albert
@@ -16340,8 +16388,7 @@ user:
       multi_fields:
       - flat_name: user.target.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: user
@@ -16444,6 +16491,8 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -16454,8 +16503,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.original.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: original
       normalize: []
       short: Unparsed user_agent string.
@@ -16473,6 +16521,8 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -16482,8 +16532,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.full.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: full
       normalize: []
       original_fieldset: os
@@ -16502,6 +16551,8 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -16511,8 +16562,7 @@ user_agent:
       multi_fields:
       - flat_name: user_agent.os.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       original_fieldset: os
@@ -16680,6 +16730,8 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common
@@ -16691,8 +16743,7 @@ vulnerability:
       multi_fields:
       - flat_name: vulnerability.description.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: description
       normalize: []
       short: Description of the vulnerability.

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -70,8 +70,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -183,8 +182,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -217,8 +215,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -360,8 +357,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -473,8 +469,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -507,8 +502,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -717,14 +711,12 @@
             "type": "keyword"
           },
           "message": {
-            "norms": false,
-            "type": "text"
+            "type": "match_only_text"
           },
           "stack_trace": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -1074,8 +1066,7 @@
           "path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1119,8 +1110,7 @@
           "target_path": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -1393,8 +1383,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1407,8 +1396,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1448,8 +1436,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1482,8 +1469,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1652,8 +1638,7 @@
         }
       },
       "message": {
-        "norms": false,
-        "type": "text"
+        "type": "match_only_text"
       },
       "network": {
         "properties": {
@@ -1876,8 +1861,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -1890,8 +1874,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2094,8 +2077,7 @@
           "command_line": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -2224,8 +2206,7 @@
           "executable": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2261,8 +2242,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2309,8 +2289,7 @@
               "command_line": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "type": "wildcard"
@@ -2439,8 +2418,7 @@
               "executable": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2476,8 +2454,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2541,8 +2518,7 @@
               "title": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2554,8 +2530,7 @@
               "working_directory": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2621,8 +2596,7 @@
           "title": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2634,8 +2608,7 @@
           "working_directory": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -2757,8 +2730,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -2870,8 +2842,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2904,8 +2875,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -2975,8 +2945,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -3088,8 +3057,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3122,8 +3090,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -3165,8 +3132,7 @@
                           "name": {
                             "fields": {
                               "text": {
-                                "norms": false,
-                                "type": "text"
+                                "type": "match_only_text"
                               }
                             },
                             "ignore_above": 1024,
@@ -3407,8 +3373,7 @@
                       "path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -3420,8 +3385,7 @@
                       "target_path": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -3633,8 +3597,7 @@
                       "full": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -3642,8 +3605,7 @@
                       "original": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "type": "wildcard"
@@ -3856,8 +3818,7 @@
                       "name": {
                         "fields": {
                           "text": {
-                            "norms": false,
-                            "type": "text"
+                            "type": "match_only_text"
                           }
                         },
                         "ignore_above": 1024,
@@ -4098,8 +4059,7 @@
                   "path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4111,8 +4071,7 @@
                   "target_path": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4324,8 +4283,7 @@
                   "full": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -4333,8 +4291,7 @@
                   "original": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -4532,8 +4489,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -4552,8 +4508,7 @@
                   "name": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "ignore_above": 1024,
@@ -4944,8 +4899,7 @@
           "full": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -4953,8 +4907,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "type": "wildcard"
@@ -5010,8 +4963,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5044,8 +4996,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5074,8 +5025,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5108,8 +5058,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5128,8 +5077,7 @@
           "full_name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5162,8 +5110,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5186,8 +5133,7 @@
               "full_name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5220,8 +5166,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5252,8 +5197,7 @@
           "original": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,
@@ -5268,8 +5212,7 @@
               "full": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5282,8 +5225,7 @@
               "name": {
                 "fields": {
                   "text": {
-                    "norms": false,
-                    "type": "text"
+                    "type": "match_only_text"
                   }
                 },
                 "ignore_above": 1024,
@@ -5322,8 +5264,7 @@
           "description": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/generated/elasticsearch/component/base.json
+++ b/generated/elasticsearch/component/base.json
@@ -13,8 +13,7 @@
           "type": "object"
         },
         "message": {
-          "norms": false,
-          "type": "text"
+          "type": "match_only_text"
         },
         "tags": {
           "ignore_above": 1024,

--- a/generated/elasticsearch/component/client.json
+++ b/generated/elasticsearch/component/client.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/destination.json
+++ b/generated/elasticsearch/component/destination.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/error.json
+++ b/generated/elasticsearch/component/error.json
@@ -17,14 +17,12 @@
               "type": "keyword"
             },
             "message": {
-              "norms": false,
-              "type": "text"
+              "type": "match_only_text"
             },
             "stack_trace": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -245,8 +245,7 @@
             "path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -290,8 +289,7 @@
             "target_path": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/host.json
+++ b/generated/elasticsearch/component/host.json
@@ -141,8 +141,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -155,8 +154,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -196,8 +194,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -230,8 +227,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/observer.json
+++ b/generated/elasticsearch/component/observer.json
@@ -153,8 +153,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -167,8 +166,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -47,8 +47,7 @@
             "command_line": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -177,8 +176,7 @@
             "executable": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -214,8 +212,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -262,8 +259,7 @@
                 "command_line": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "type": "wildcard"
@@ -392,8 +388,7 @@
                 "executable": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -429,8 +424,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -494,8 +488,7 @@
                 "title": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -507,8 +500,7 @@
                 "working_directory": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -574,8 +566,7 @@
             "title": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -587,8 +578,7 @@
             "working_directory": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/elasticsearch/component/server.json
+++ b/generated/elasticsearch/component/server.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/source.json
+++ b/generated/elasticsearch/component/source.json
@@ -22,8 +22,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -135,8 +134,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -169,8 +167,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -22,8 +22,7 @@
                             "name": {
                               "fields": {
                                 "text": {
-                                  "norms": false,
-                                  "type": "text"
+                                  "type": "match_only_text"
                                 }
                               },
                               "ignore_above": 1024,
@@ -264,8 +263,7 @@
                         "path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -277,8 +275,7 @@
                         "target_path": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -490,8 +487,7 @@
                         "full": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -499,8 +495,7 @@
                         "original": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "type": "wildcard"
@@ -713,8 +708,7 @@
                         "name": {
                           "fields": {
                             "text": {
-                              "norms": false,
-                              "type": "text"
+                              "type": "match_only_text"
                             }
                           },
                           "ignore_above": 1024,
@@ -955,8 +949,7 @@
                     "path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -968,8 +961,7 @@
                     "target_path": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,
@@ -1181,8 +1173,7 @@
                     "full": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1190,8 +1181,7 @@
                     "original": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -1389,8 +1379,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -1409,8 +1398,7 @@
                     "name": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "ignore_above": 1024,

--- a/generated/elasticsearch/component/url.json
+++ b/generated/elasticsearch/component/url.json
@@ -23,8 +23,7 @@
             "full": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"
@@ -32,8 +31,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "type": "wildcard"

--- a/generated/elasticsearch/component/user.json
+++ b/generated/elasticsearch/component/user.json
@@ -21,8 +21,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -55,8 +54,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -85,8 +83,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -119,8 +116,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -139,8 +135,7 @@
             "full_name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -173,8 +168,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -197,8 +191,7 @@
                 "full_name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -231,8 +224,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/user_agent.json
+++ b/generated/elasticsearch/component/user_agent.json
@@ -23,8 +23,7 @@
             "original": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,
@@ -39,8 +38,7 @@
                 "full": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,
@@ -53,8 +51,7 @@
                 "name": {
                   "fields": {
                     "text": {
-                      "norms": false,
-                      "type": "text"
+                      "type": "match_only_text"
                     }
                   },
                   "ignore_above": 1024,

--- a/generated/elasticsearch/component/vulnerability.json
+++ b/generated/elasticsearch/component/vulnerability.json
@@ -19,8 +19,7 @@
             "description": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -39,6 +39,7 @@
       description: >
         Organization name.
       example: Google LLC
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -51,9 +51,10 @@
 
     - name: message
       level: core
-      type: text
+      type: match_only_text
       example: "Hello World"
       short: Log message optimized for viewing in a log viewer.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         For log events the message field contains the log message, optimized for
         viewing in a log viewer.

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -19,7 +19,8 @@
 
     - name: message
       level: core
-      type: text
+      type: match_only_text
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         Error message.
 
@@ -39,9 +40,11 @@
     - name: stack_trace
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The stack trace of this error in plain text.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -68,16 +68,18 @@
         Full path to the file, including the file name. It should include the
         drive letter, when appropriate.
       example: "/home/alice/example.png"
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-        - type: text
+        - type: match_only_text
           name: text
 
     - name: target_path
       level: extended
       type: keyword
       description: Target path for symlinks.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-        - type: text
+        - type: match_only_text
           name: text
 
     - name: extension

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -40,8 +40,9 @@
       example: "Mac OS X"
       description: >
         Operating system name, without the version.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full
@@ -50,8 +51,9 @@
       example: "Mac OS Mojave"
       description: >
         Operating system name, including the version or code name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: family

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -52,8 +52,9 @@
 
         Sometimes called program name or similar.
       example: ssh
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: ppid
@@ -74,7 +75,9 @@
     - name: command_line
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       short: Full command line that started the process.
       description: >
         Full command line that started the process, including the absolute path
@@ -83,7 +86,7 @@
         Some arguments may be filtered to protect sensitive information.
       example: "/usr/bin/ssh -l user 10.0.0.16"
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: args
@@ -116,8 +119,9 @@
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: title
@@ -129,8 +133,9 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: thread.id
@@ -168,8 +173,9 @@
       example: /home/alice
       description: >
         The working directory of the process.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: exit_code

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -574,8 +574,9 @@
     - name: technique.name
       level: extended
       type: keyword
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Threat technique name.
       description: >
@@ -614,9 +615,10 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Threat subtechnique name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
           The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
           (ex. https://attack.mitre.org/techniques/T1059/001/)

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -20,7 +20,9 @@
     - name: original
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
@@ -33,13 +35,15 @@
       example: >
         https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta
       short: Full unparsed URL.
       description: >
         If full URLs are important to your use case, they should be stored in
@@ -47,7 +51,7 @@
         event source.
       example: https://www.elastic.co:443/search?q=elasticsearch#top
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: scheme

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -54,8 +54,9 @@
       example: albert
       description: >
         Short name or login of the user.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: full_name
@@ -64,8 +65,9 @@
       example: Albert Einstein
       description: >
         User's full name, if available.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: email

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -14,8 +14,9 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         Unparsed user_agent string.
       example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -114,9 +114,10 @@
       level: extended
       type: keyword
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
       short: Description of the vulnerability.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         The description of the vulnerability that provides additional context of the
         vulnerability.

--- a/use-cases/filebeat-apache-access.md
+++ b/use-cases/filebeat-apache-access.md
@@ -9,7 +9,7 @@ ECS fields used in Filebeat for the apache module.
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id to describe the event.* | (use case) | keyword | `8a4f500d` |
 | [@timestamp](../README.md#@timestamp)  | Timestamp of the log line after processing. | core | date | `2016-05-23T08:05:34.853Z` |
-| [message](../README.md#message)  | Log message of the event | core | text | `Hello World` |
+| [message](../README.md#message)  | Log message of the event | core | match_only_text | `Hello World` |
 | [event.module](../README.md#event.module)  | Currently fileset.module | core | keyword | `apache` |
 | [event.dataset](../README.md#event.dataset)  | Currenly fileset.name | core | keyword | `access` |
 | [source.ip](../README.md#source.ip)  | Source ip of the request. Currently apache.access.remote_ip | core | ip | `192.168.1.1` |

--- a/use-cases/logging.md
+++ b/use-cases/logging.md
@@ -9,7 +9,7 @@ ECS fields used in logging use cases.
 |---|---|---|---|---|
 | <a name="id"></a>*id* | *Unique id of the log entry.* | (use case) | keyword | `8a4f500d` |
 | <a name="timestamp"></a>*timestamp* | *Timestamp of the log line.* | (use case) | date | `2016-05-23T08:05:34.853Z` |
-| [message](../README.md#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable. | core | text | `Hello World` |
+| [message](../README.md#message)  | The log message.<br/>This can contain the full log line or based on the processing only the extracted message part. This is expected to be human readable. | core | match_only_text | `Hello World` |
 | <a name="hostname"></a>*hostname* | *Hostname extracted from the log line.* | (use case) | keyword | `www.example.com` |
 | <a name="ip"></a>*ip* | *IP Address extracted from the log line. Can be IPv4 or IPv6.* | (use case) | ip | `192.168.1.12` |
 | [log.level](../README.md#log.level)  | Log level field. Is expected to be `WARN`, `ERR`, `INFO` etc. | core | keyword | `ERR` |

--- a/use-cases/metricbeat.md
+++ b/use-cases/metricbeat.md
@@ -19,7 +19,7 @@ ECS fields used Metricbeat.
 | <a name="service.host"></a>*service.host* | *Host address that is used to connect to the service.<br/>This normally contains hostname + port.<br/>REVIEW: Should this be service.uri instead, sometimes it's more then just the host? It could also include a path or the protocol.* | (use case) | keyword | `elasticsearch:9200` |
 | <a name="request.rtt"></a>*request.rtt* | *Request round trip time.<br/>How long did the request take to fetch metrics from the service.<br/>REVIEW: THIS DOES NOT EXIST YET IN ECS.* | (use case) | long | `115` |
 | <a name="error.&ast;"></a>*error.&ast;* | *Error namespace<br/>Use for errors which can happen during fetching information for a service.<br/>* |  |  |  |
-| [error.message](../README.md#error.message)  | Error message returned by the service during fetching metrics. | core | text |  |
+| [error.message](../README.md#error.message)  | Error message returned by the service during fetching metrics. | core | match_only_text |  |
 | [error.code](../README.md#error.code)  | Error code returned by the service during fetching metrics. | core | keyword |  |
 | [host.hostname](../README.md#host.hostname)  | Hostname of the system metricbeat is running on or user defined name. | core | keyword |  |
 | <a name="host.timezone.offset.sec"></a>*host.timezone.offset.sec* | *Timezone offset of the host in seconds.* | (use case) | long |  |


### PR DESCRIPTION
Backports the following commits to 1.x:
 - [RFC] `match_only_text` - stage 2 beta changes (#1532)