### PR TITLE
Stage 3 changes for RFC 0018 - extend `threat.*` field set

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -13,6 +13,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `service.address` field. #1537
+* Promote `threat.software.*` and `threat.group.*` fields to GA. #1540
 
 ### Tooling and Artifact Changes
 

--- a/code/go/ecs/threat.go
+++ b/code/go/ecs/threat.go
@@ -43,23 +43,23 @@ type Threat struct {
 	Framework string `ecs:"framework"`
 
 	// The alias(es) of the group for a set of related intrusion activity that
-	// are tracked by a common name in the security community. While not
-	// required, you can use a MITRE ATT&CK® group alias(es).
+	// are tracked by a common name in the security community.
+	// While not required, you can use a MITRE ATT&CK® group alias(es).
 	GroupAlias string `ecs:"group.alias"`
 
 	// The id of the group for a set of related intrusion activity that are
-	// tracked by a common name in the security community. While not required,
-	// you can use a MITRE ATT&CK® group id.
+	// tracked by a common name in the security community.
+	// While not required, you can use a MITRE ATT&CK® group id.
 	GroupID string `ecs:"group.id"`
 
 	// The name of the group for a set of related intrusion activity that are
-	// tracked by a common name in the security community. While not required,
-	// you can use a MITRE ATT&CK® group name.
+	// tracked by a common name in the security community.
+	// While not required, you can use a MITRE ATT&CK® group name.
 	GroupName string `ecs:"group.name"`
 
 	// The reference URL of the group for a set of related intrusion activity
-	// that are tracked by a common name in the security community. While not
-	// required, you can use a MITRE ATT&CK® group reference URL.
+	// that are tracked by a common name in the security community.
+	// While not required, you can use a MITRE ATT&CK® group reference URL.
 	GroupReference string `ecs:"group.reference"`
 
 	// The date and time when intelligence source first reported sighting this
@@ -142,18 +142,23 @@ type Threat struct {
 	IndicatorProvider string `ecs:"indicator.provider"`
 
 	// The id of the software used by this threat to conduct behavior commonly
-	// modeled using MITRE ATT&CK®. While not required, you can use a MITRE
-	// ATT&CK® software id.
+	// modeled using MITRE ATT&CK®.
+	// While not required, you can use a MITRE ATT&CK® software id.
 	SoftwareID string `ecs:"software.id"`
 
 	// The name of the software used by this threat to conduct behavior
-	// commonly modeled using MITRE ATT&CK®. While not required, you can use a
-	// MITRE ATT&CK® software name.
+	// commonly modeled using MITRE ATT&CK®.
+	// While not required, you can use a MITRE ATT&CK® software name.
 	SoftwareName string `ecs:"software.name"`
 
+	// The alias(es) of the software for a set of related intrusion activity
+	// that are tracked by a common name in the security community.
+	// While not required, you can use a MITRE ATT&CK® associated software
+	// description.
+	SoftwareAlias string `ecs:"software.alias"`
+
 	// The platforms of the software used by this threat to conduct behavior
-	// commonly modeled using MITRE ATT&CK®. While not required, you can use a
-	// MITRE ATT&CK® software platforms.
+	// commonly modeled using MITRE ATT&CK®.
 	// Recommended Values:
 	//   * AWS
 	//   * Azure
@@ -165,19 +170,22 @@ type Threat struct {
 	//   * Office 365
 	//   * SaaS
 	//   * Windows
+	//
+	// While not required, you can use a MITRE ATT&CK® software platforms.
 	SoftwarePlatforms string `ecs:"software.platforms"`
 
 	// The reference URL of the software used by this threat to conduct
-	// behavior commonly modeled using MITRE ATT&CK®. While not required, you
-	// can use a MITRE ATT&CK® software reference URL.
+	// behavior commonly modeled using MITRE ATT&CK®.
+	// While not required, you can use a MITRE ATT&CK® software reference URL.
 	SoftwareReference string `ecs:"software.reference"`
 
 	// The type of software used by this threat to conduct behavior commonly
-	// modeled using MITRE ATT&CK®. While not required, you can use a MITRE
-	// ATT&CK® software type.
+	// modeled using MITRE ATT&CK®.
 	// Recommended values
 	//   * Malware
 	//   * Tool
+	//
+	//  While not required, you can use a MITRE ATT&CK® software type.
 	SoftwareType string `ecs:"software.type"`
 
 	// The id of tactic used by this threat. You can use a MITRE ATT&CK®

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -8589,8 +8589,11 @@ While not required, you can use a MITRE ATT&CK® associated software description
 type: keyword
 
 
+Note: this field should contain an array of values.
 
 
+
+example: `[ "X-Agent" ]`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -8197,9 +8197,9 @@ example: `MITRE ATT&CK`
 [[field-threat-group-alias]]
 <<field-threat-group-alias, threat.group.alias>>
 
-| beta:[ This field is beta and subject to change. ]
+| The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
-The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group alias(es).
+While not required, you can use a MITRE ATT&CK® group alias(es).
 
 type: keyword
 
@@ -8218,9 +8218,9 @@ example: `[ "Magecart Group 6" ]`
 [[field-threat-group-id]]
 <<field-threat-group-id, threat.group.id>>
 
-| beta:[ This field is beta and subject to change. ]
+| The id of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
-The id of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group id.
+While not required, you can use a MITRE ATT&CK® group id.
 
 type: keyword
 
@@ -8236,9 +8236,9 @@ example: `G0037`
 [[field-threat-group-name]]
 <<field-threat-group-name, threat.group.name>>
 
-| beta:[ This field is beta and subject to change. ]
+| The name of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
-The name of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group name.
+While not required, you can use a MITRE ATT&CK® group name.
 
 type: keyword
 
@@ -8254,9 +8254,9 @@ example: `FIN6`
 [[field-threat-group-reference]]
 <<field-threat-group-reference, threat.group.reference>>
 
-| beta:[ This field is beta and subject to change. ]
+| The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
-The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group reference URL.
+While not required, you can use a MITRE ATT&CK® group reference URL.
 
 type: keyword
 
@@ -8579,12 +8579,30 @@ example: `ipv4-addr`
 // ===============================================================
 
 |
+[[field-threat-software-alias]]
+<<field-threat-software-alias, threat.software.alias>>
+
+| The alias(es) of the software for a set of related intrusion activity that are tracked by a common name in the security community.
+
+While not required, you can use a MITRE ATT&CK® associated software description.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-threat-software-id]]
 <<field-threat-software-id, threat.software.id>>
 
-| beta:[ This field is beta and subject to change. ]
+| The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software id.
+While not required, you can use a MITRE ATT&CK® software id.
 
 type: keyword
 
@@ -8600,9 +8618,9 @@ example: `S0552`
 [[field-threat-software-name]]
 <<field-threat-software-name, threat.software.name>>
 
-| beta:[ This field is beta and subject to change. ]
+| The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software name.
+While not required, you can use a MITRE ATT&CK® software name.
 
 type: keyword
 
@@ -8618,9 +8636,7 @@ example: `AdFind`
 [[field-threat-software-platforms]]
 <<field-threat-software-platforms, threat.software.platforms>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software platforms.
+| The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
 Recommended Values:
 
@@ -8644,6 +8660,10 @@ Recommended Values:
 
   * Windows
 
+
+
+While not required, you can use a MITRE ATT&CK® software platforms.
+
 type: keyword
 
 
@@ -8661,9 +8681,9 @@ example: `[ "Windows" ]`
 [[field-threat-software-reference]]
 <<field-threat-software-reference, threat.software.reference>>
 
-| beta:[ This field is beta and subject to change. ]
+| The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software reference URL.
+While not required, you can use a MITRE ATT&CK® software reference URL.
 
 type: keyword
 
@@ -8679,15 +8699,17 @@ example: `https://attack.mitre.org/software/S0552/`
 [[field-threat-software-type]]
 <<field-threat-software-type, threat.software.type>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software type.
+| The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
 Recommended values
 
   * Malware
 
   * Tool
+
+
+
+ While not required, you can use a MITRE ATT&CK® software type.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -10958,6 +10958,7 @@
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
         \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      example: '[ "X-Agent" ]'
       default_field: false
     - name: software.id
       level: extended

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -9614,8 +9614,8 @@
       type: keyword
       ignore_above: 1024
       description: "The alias(es) of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       default_field: false
     - name: group.id
@@ -9623,7 +9623,7 @@
       type: keyword
       ignore_above: 1024
       description: "The id of the group for a set of related intrusion activity that\
-        \ are tracked by a common name in the security community. While not required,\
+        \ are tracked by a common name in the security community.\nWhile not required,\
         \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       default_field: false
@@ -9632,8 +9632,8 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group name."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       default_field: false
     - name: group.reference
@@ -9641,8 +9641,8 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the group for a set of related intrusion\
-        \ activity that are tracked by a common name in the security community. While\
-        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        \ activity that are tracked by a common name in the security community.\n\
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       default_field: false
     - name: indicator.as.number
@@ -10951,12 +10951,20 @@
       description: Version of x509 format.
       example: 3
       default_field: false
+    - name: software.alias
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The alias(es) of the software for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      default_field: false
     - name: software.id
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software id."
       example: S0552
       default_field: false
@@ -10965,7 +10973,7 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       default_field: false
@@ -10974,10 +10982,10 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
-        \ a MITRE ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n \
-        \ * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-        \ 365\n  * SaaS\n  * Windows"
+        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
+        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
+        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software platforms."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -10985,7 +10993,7 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
         \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       default_field: false
@@ -10994,8 +11002,8 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-        \ ATT&CK\xAE software type.\nRecommended values\n  * Malware\n  * Tool"
+        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+        \n While not required, you can use a MITRE ATT&CK\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1360,7 +1360,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 8.0.0-dev+exp,true,threat,threat.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 8.0.0-dev+exp,true,threat,threat.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
-8.0.0-dev+exp,true,threat,threat.software.alias,keyword,extended,,,Alias of the software
+8.0.0-dev+exp,true,threat,threat.software.alias,keyword,extended,array,"[ ""X-Agent"" ]",Alias of the software
 8.0.0-dev+exp,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
 8.0.0-dev+exp,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
 8.0.0-dev+exp,true,threat,threat.software.platforms,keyword,extended,array,"[ ""Windows"" ]",Platforms of the software.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1360,6 +1360,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 8.0.0-dev+exp,true,threat,threat.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 8.0.0-dev+exp,true,threat,threat.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
+8.0.0-dev+exp,true,threat,threat.software.alias,keyword,extended,,,Alias of the software
 8.0.0-dev+exp,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
 8.0.0-dev+exp,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
 8.0.0-dev+exp,true,threat,threat.software.platforms,keyword,extended,array,"[ ""Windows"" ]",Platforms of the software.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -17022,11 +17022,13 @@ threat.software.alias:
   description: "The alias(es) of the software for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE associated software description."
+  example: '[ "X-Agent" ]'
   flat_name: threat.software.alias
   ignore_above: 1024
   level: extended
   name: software.alias
-  normalize: []
+  normalize:
+  - array
   short: Alias of the software
   type: keyword
 threat.software.id:

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -14753,10 +14753,9 @@ threat.framework:
   short: Threat classification framework.
   type: keyword
 threat.group.alias:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-alias
   description: "The alias(es) of the group for a set of related intrusion activity\
-    \ that are tracked by a common name in the security community. While not required,\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group alias(es)."
   example: '[ "Magecart Group 6" ]'
   flat_name: threat.group.alias
@@ -14768,10 +14767,9 @@ threat.group.alias:
   short: Alias of the group.
   type: keyword
 threat.group.id:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-id
   description: "The id of the group for a set of related intrusion activity that are\
-    \ tracked by a common name in the security community. While not required, you\
+    \ tracked by a common name in the security community.\nWhile not required, you\
     \ can use a MITRE ATT&CK\xAE group id."
   example: G0037
   flat_name: threat.group.id
@@ -14782,10 +14780,9 @@ threat.group.id:
   short: ID of the group.
   type: keyword
 threat.group.name:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-name
   description: "The name of the group for a set of related intrusion activity that\
-    \ are tracked by a common name in the security community. While not required,\
+    \ are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group name."
   example: FIN6
   flat_name: threat.group.name
@@ -14796,10 +14793,9 @@ threat.group.name:
   short: Name of the group.
   type: keyword
 threat.group.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-reference
   description: "The reference URL of the group for a set of related intrusion activity\
-    \ that are tracked by a common name in the security community. While not required,\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group reference URL."
   example: https://attack.mitre.org/groups/G0037/
   flat_name: threat.group.reference
@@ -17021,11 +17017,22 @@ threat.indicator.x509.version_number:
   original_fieldset: x509
   short: Version of x509 format.
   type: keyword
+threat.software.alias:
+  dashed_name: threat-software-alias
+  description: "The alias(es) of the software for a set of related intrusion activity\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
+    \ you can use a MITRE ATT&CK\xAE associated software description."
+  flat_name: threat.software.alias
+  ignore_above: 1024
+  level: extended
+  name: software.alias
+  normalize: []
+  short: Alias of the software
+  type: keyword
 threat.software.id:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-id
   description: "The id of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
     \ software id."
   example: S0552
   flat_name: threat.software.id
@@ -17036,10 +17043,9 @@ threat.software.id:
   short: ID of the software
   type: keyword
 threat.software.name:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-name
   description: "The name of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
     \ software name."
   example: AdFind
   flat_name: threat.software.name
@@ -17050,13 +17056,12 @@ threat.software.name:
   short: Name of the software.
   type: keyword
 threat.software.platforms:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-    \ ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n  * Azure\n  *\
-    \ Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office 365\n  * SaaS\n\
-    \  * Windows"
+    \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n  *\
+    \ Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
+    \ 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software platforms."
   example: '[ "Windows" ]'
   flat_name: threat.software.platforms
   ignore_above: 1024
@@ -17067,11 +17072,10 @@ threat.software.platforms:
   short: Platforms of the software.
   type: keyword
 threat.software.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-reference
   description: "The reference URL of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-    \ ATT&CK\xAE software reference URL."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a\
+    \ MITRE ATT&CK\xAE software reference URL."
   example: https://attack.mitre.org/software/S0552/
   flat_name: threat.software.reference
   ignore_above: 1024
@@ -17081,11 +17085,10 @@ threat.software.reference:
   short: Software reference URL.
   type: keyword
 threat.software.type:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
-    \ software type.\nRecommended values\n  * Malware\n  * Tool"
+    \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+    \n While not required, you can use a MITRE ATT&CK\xAE software type."
   example: Tool
   flat_name: threat.software.type
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -19105,11 +19105,13 @@ threat:
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
         \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      example: '[ "X-Agent" ]'
       flat_name: threat.software.alias
       ignore_above: 1024
       level: extended
       name: software.alias
-      normalize: []
+      normalize:
+      - array
       short: Alias of the software
       type: keyword
     threat.software.id:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -16831,11 +16831,10 @@ threat:
       short: Threat classification framework.
       type: keyword
     threat.group.alias:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-alias
       description: "The alias(es) of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       flat_name: threat.group.alias
       ignore_above: 1024
@@ -16846,10 +16845,9 @@ threat:
       short: Alias of the group.
       type: keyword
     threat.group.id:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-id
       description: "The id of the group for a set of related intrusion activity that\
-        \ are tracked by a common name in the security community. While not required,\
+        \ are tracked by a common name in the security community.\nWhile not required,\
         \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       flat_name: threat.group.id
@@ -16860,11 +16858,10 @@ threat:
       short: ID of the group.
       type: keyword
     threat.group.name:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-name
       description: "The name of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group name."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       flat_name: threat.group.name
       ignore_above: 1024
@@ -16874,11 +16871,10 @@ threat:
       short: Name of the group.
       type: keyword
     threat.group.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-reference
       description: "The reference URL of the group for a set of related intrusion\
-        \ activity that are tracked by a common name in the security community. While\
-        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        \ activity that are tracked by a common name in the security community.\n\
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       flat_name: threat.group.reference
       ignore_above: 1024
@@ -19104,11 +19100,22 @@ threat:
       original_fieldset: x509
       short: Version of x509 format.
       type: keyword
+    threat.software.alias:
+      dashed_name: threat-software-alias
+      description: "The alias(es) of the software for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      flat_name: threat.software.alias
+      ignore_above: 1024
+      level: extended
+      name: software.alias
+      normalize: []
+      short: Alias of the software
+      type: keyword
     threat.software.id:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-id
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software id."
       example: S0552
       flat_name: threat.software.id
@@ -19119,10 +19126,9 @@ threat:
       short: ID of the software
       type: keyword
     threat.software.name:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-name
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       flat_name: threat.software.name
@@ -19133,13 +19139,12 @@ threat:
       short: Name of the software.
       type: keyword
     threat.software.platforms:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
-        \ a MITRE ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n \
-        \ * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-        \ 365\n  * SaaS\n  * Windows"
+        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
+        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
+        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software platforms."
       example: '[ "Windows" ]'
       flat_name: threat.software.platforms
       ignore_above: 1024
@@ -19150,10 +19155,9 @@ threat:
       short: Platforms of the software.
       type: keyword
     threat.software.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-reference
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
         \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       flat_name: threat.software.reference
@@ -19164,11 +19168,10 @@ threat:
       short: Software reference URL.
       type: keyword
     threat.software.type:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-        \ ATT&CK\xAE software type.\nRecommended values\n  * Malware\n  * Tool"
+        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+        \n While not required, you can use a MITRE ATT&CK\xAE software type."
       example: Tool
       flat_name: threat.software.type
       ignore_above: 1024

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -6052,6 +6052,10 @@
           },
           "software": {
             "properties": {
+              "alias": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "id": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -1604,6 +1604,10 @@
             },
             "software": {
               "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -8128,6 +8128,7 @@
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
         \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      example: '[ "X-Agent" ]'
       default_field: false
     - name: software.id
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -6994,8 +6994,8 @@
       type: keyword
       ignore_above: 1024
       description: "The alias(es) of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       default_field: false
     - name: group.id
@@ -7003,7 +7003,7 @@
       type: keyword
       ignore_above: 1024
       description: "The id of the group for a set of related intrusion activity that\
-        \ are tracked by a common name in the security community. While not required,\
+        \ are tracked by a common name in the security community.\nWhile not required,\
         \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       default_field: false
@@ -7012,8 +7012,8 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group name."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       default_field: false
     - name: group.reference
@@ -7021,8 +7021,8 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the group for a set of related intrusion\
-        \ activity that are tracked by a common name in the security community. While\
-        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        \ activity that are tracked by a common name in the security community.\n\
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       default_field: false
     - name: indicator.as.number
@@ -8121,12 +8121,20 @@
       description: Version of x509 format.
       example: 3
       default_field: false
+    - name: software.alias
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The alias(es) of the software for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      default_field: false
     - name: software.id
       level: extended
       type: keyword
       ignore_above: 1024
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software id."
       example: S0552
       default_field: false
@@ -8135,7 +8143,7 @@
       type: keyword
       ignore_above: 1024
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       default_field: false
@@ -8144,10 +8152,10 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
-        \ a MITRE ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n \
-        \ * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-        \ 365\n  * SaaS\n  * Windows"
+        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
+        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
+        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software platforms."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -8155,7 +8163,7 @@
       type: keyword
       ignore_above: 1024
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
         \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       default_field: false
@@ -8164,8 +8172,8 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-        \ ATT&CK\xAE software type.\nRecommended values\n  * Malware\n  * Tool"
+        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+        \n While not required, you can use a MITRE ATT&CK\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -974,6 +974,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 8.0.0-dev,true,threat,threat.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 8.0.0-dev,true,threat,threat.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
+8.0.0-dev,true,threat,threat.software.alias,keyword,extended,,,Alias of the software
 8.0.0-dev,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
 8.0.0-dev,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
 8.0.0-dev,true,threat,threat.software.platforms,keyword,extended,array,"[ ""Windows"" ]",Platforms of the software.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -974,7 +974,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
 8.0.0-dev,true,threat,threat.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
 8.0.0-dev,true,threat,threat.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
-8.0.0-dev,true,threat,threat.software.alias,keyword,extended,,,Alias of the software
+8.0.0-dev,true,threat,threat.software.alias,keyword,extended,array,"[ ""X-Agent"" ]",Alias of the software
 8.0.0-dev,true,threat,threat.software.id,keyword,extended,,S0552,ID of the software
 8.0.0-dev,true,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
 8.0.0-dev,true,threat,threat.software.platforms,keyword,extended,array,"[ ""Windows"" ]",Platforms of the software.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -10532,10 +10532,9 @@ threat.framework:
   short: Threat classification framework.
   type: keyword
 threat.group.alias:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-alias
   description: "The alias(es) of the group for a set of related intrusion activity\
-    \ that are tracked by a common name in the security community. While not required,\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group alias(es)."
   example: '[ "Magecart Group 6" ]'
   flat_name: threat.group.alias
@@ -10547,10 +10546,9 @@ threat.group.alias:
   short: Alias of the group.
   type: keyword
 threat.group.id:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-id
   description: "The id of the group for a set of related intrusion activity that are\
-    \ tracked by a common name in the security community. While not required, you\
+    \ tracked by a common name in the security community.\nWhile not required, you\
     \ can use a MITRE ATT&CK\xAE group id."
   example: G0037
   flat_name: threat.group.id
@@ -10561,10 +10559,9 @@ threat.group.id:
   short: ID of the group.
   type: keyword
 threat.group.name:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-name
   description: "The name of the group for a set of related intrusion activity that\
-    \ are tracked by a common name in the security community. While not required,\
+    \ are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group name."
   example: FIN6
   flat_name: threat.group.name
@@ -10575,10 +10572,9 @@ threat.group.name:
   short: Name of the group.
   type: keyword
 threat.group.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-group-reference
   description: "The reference URL of the group for a set of related intrusion activity\
-    \ that are tracked by a common name in the security community. While not required,\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE group reference URL."
   example: https://attack.mitre.org/groups/G0037/
   flat_name: threat.group.reference
@@ -12429,11 +12425,22 @@ threat.indicator.x509.version_number:
   original_fieldset: x509
   short: Version of x509 format.
   type: keyword
+threat.software.alias:
+  dashed_name: threat-software-alias
+  description: "The alias(es) of the software for a set of related intrusion activity\
+    \ that are tracked by a common name in the security community.\nWhile not required,\
+    \ you can use a MITRE ATT&CK\xAE associated software description."
+  flat_name: threat.software.alias
+  ignore_above: 1024
+  level: extended
+  name: software.alias
+  normalize: []
+  short: Alias of the software
+  type: keyword
 threat.software.id:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-id
   description: "The id of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
     \ software id."
   example: S0552
   flat_name: threat.software.id
@@ -12444,10 +12451,9 @@ threat.software.id:
   short: ID of the software
   type: keyword
 threat.software.name:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-name
   description: "The name of the software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
     \ software name."
   example: AdFind
   flat_name: threat.software.name
@@ -12458,13 +12464,12 @@ threat.software.name:
   short: Name of the software.
   type: keyword
 threat.software.platforms:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-    \ ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n  * Azure\n  *\
-    \ Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office 365\n  * SaaS\n\
-    \  * Windows"
+    \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n  *\
+    \ Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
+    \ 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software platforms."
   example: '[ "Windows" ]'
   flat_name: threat.software.platforms
   ignore_above: 1024
@@ -12475,11 +12480,10 @@ threat.software.platforms:
   short: Platforms of the software.
   type: keyword
 threat.software.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-reference
   description: "The reference URL of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-    \ ATT&CK\xAE software reference URL."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a\
+    \ MITRE ATT&CK\xAE software reference URL."
   example: https://attack.mitre.org/software/S0552/
   flat_name: threat.software.reference
   ignore_above: 1024
@@ -12489,11 +12493,10 @@ threat.software.reference:
   short: Software reference URL.
   type: keyword
 threat.software.type:
-  beta: This field is beta and subject to change.
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE ATT&CK\xAE\
-    \ software type.\nRecommended values\n  * Malware\n  * Tool"
+    \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+    \n While not required, you can use a MITRE ATT&CK\xAE software type."
   example: Tool
   flat_name: threat.software.type
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -12430,11 +12430,13 @@ threat.software.alias:
   description: "The alias(es) of the software for a set of related intrusion activity\
     \ that are tracked by a common name in the security community.\nWhile not required,\
     \ you can use a MITRE ATT&CK\xAE associated software description."
+  example: '[ "X-Agent" ]'
   flat_name: threat.software.alias
   ignore_above: 1024
   level: extended
   name: software.alias
-  normalize: []
+  normalize:
+  - array
   short: Alias of the software
   type: keyword
 threat.software.id:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -12248,11 +12248,10 @@ threat:
       short: Threat classification framework.
       type: keyword
     threat.group.alias:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-alias
       description: "The alias(es) of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group alias(es)."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group alias(es)."
       example: '[ "Magecart Group 6" ]'
       flat_name: threat.group.alias
       ignore_above: 1024
@@ -12263,10 +12262,9 @@ threat:
       short: Alias of the group.
       type: keyword
     threat.group.id:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-id
       description: "The id of the group for a set of related intrusion activity that\
-        \ are tracked by a common name in the security community. While not required,\
+        \ are tracked by a common name in the security community.\nWhile not required,\
         \ you can use a MITRE ATT&CK\xAE group id."
       example: G0037
       flat_name: threat.group.id
@@ -12277,11 +12275,10 @@ threat:
       short: ID of the group.
       type: keyword
     threat.group.name:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-name
       description: "The name of the group for a set of related intrusion activity\
-        \ that are tracked by a common name in the security community. While not required,\
-        \ you can use a MITRE ATT&CK\xAE group name."
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE group name."
       example: FIN6
       flat_name: threat.group.name
       ignore_above: 1024
@@ -12291,11 +12288,10 @@ threat:
       short: Name of the group.
       type: keyword
     threat.group.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-group-reference
       description: "The reference URL of the group for a set of related intrusion\
-        \ activity that are tracked by a common name in the security community. While\
-        \ not required, you can use a MITRE ATT&CK\xAE group reference URL."
+        \ activity that are tracked by a common name in the security community.\n\
+        While not required, you can use a MITRE ATT&CK\xAE group reference URL."
       example: https://attack.mitre.org/groups/G0037/
       flat_name: threat.group.reference
       ignore_above: 1024
@@ -14149,11 +14145,22 @@ threat:
       original_fieldset: x509
       short: Version of x509 format.
       type: keyword
+    threat.software.alias:
+      dashed_name: threat-software-alias
+      description: "The alias(es) of the software for a set of related intrusion activity\
+        \ that are tracked by a common name in the security community.\nWhile not\
+        \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      flat_name: threat.software.alias
+      ignore_above: 1024
+      level: extended
+      name: software.alias
+      normalize: []
+      short: Alias of the software
+      type: keyword
     threat.software.id:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-id
       description: "The id of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software id."
       example: S0552
       flat_name: threat.software.id
@@ -14164,10 +14171,9 @@ threat:
       short: ID of the software
       type: keyword
     threat.software.name:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-name
       description: "The name of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
         \ a MITRE ATT&CK\xAE software name."
       example: AdFind
       flat_name: threat.software.name
@@ -14178,13 +14184,12 @@ threat:
       short: Name of the software.
       type: keyword
     threat.software.platforms:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE. While not required, you can use\
-        \ a MITRE ATT&CK\xAE software platforms.\nRecommended Values:\n  * AWS\n \
-        \ * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-        \ 365\n  * SaaS\n  * Windows"
+        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
+        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
+        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software platforms."
       example: '[ "Windows" ]'
       flat_name: threat.software.platforms
       ignore_above: 1024
@@ -14195,10 +14200,9 @@ threat:
       short: Platforms of the software.
       type: keyword
     threat.software.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-reference
       description: "The reference URL of the software used by this threat to conduct\
-        \ behavior commonly modeled using MITRE ATT&CK\xAE. While not required, you\
+        \ behavior commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you\
         \ can use a MITRE ATT&CK\xAE software reference URL."
       example: https://attack.mitre.org/software/S0552/
       flat_name: threat.software.reference
@@ -14209,11 +14213,10 @@ threat:
       short: Software reference URL.
       type: keyword
     threat.software.type:
-      beta: This field is beta and subject to change.
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE. While not required, you can use a MITRE\
-        \ ATT&CK\xAE software type.\nRecommended values\n  * Malware\n  * Tool"
+        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
+        \n While not required, you can use a MITRE ATT&CK\xAE software type."
       example: Tool
       flat_name: threat.software.type
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -14150,11 +14150,13 @@ threat:
       description: "The alias(es) of the software for a set of related intrusion activity\
         \ that are tracked by a common name in the security community.\nWhile not\
         \ required, you can use a MITRE ATT&CK\xAE associated software description."
+      example: '[ "X-Agent" ]'
       flat_name: threat.software.alias
       ignore_above: 1024
       level: extended
       name: software.alias
-      normalize: []
+      normalize:
+      - array
       short: Alias of the software
       type: keyword
     threat.software.id:

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -4445,6 +4445,10 @@
             },
             "software": {
               "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -4384,6 +4384,10 @@
           },
           "software": {
             "properties": {
+              "alias": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "id": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -1332,6 +1332,10 @@
             },
             "software": {
               "properties": {
+                "alias": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "id": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -482,6 +482,9 @@
         security community.
 
         While not required, you can use a MITRE ATT&CK® associated software description.
+      example: '[ "X-Agent" ]'
+      normalize:
+        - array
 
     - name: software.platforms
       level: extended

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -245,7 +245,6 @@
       level: extended
       type: keyword
       short: Alias of the group.
-      beta: This field is beta and subject to change.
       description: >
         The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group alias(es).
 
@@ -257,7 +256,6 @@
       level: extended
       type: keyword
       short: ID of the group.
-      beta: This field is beta and subject to change.
       description: >
         The id of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group id.
 
@@ -267,7 +265,6 @@
       level: extended
       type: keyword
       short: Name of the group.
-      beta: This field is beta and subject to change.
       description: >
         The name of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group name.
 
@@ -277,7 +274,6 @@
       level: extended
       type: keyword
       short: Reference URL of the group.
-      beta: This field is beta and subject to change.
       description: >
         The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group reference URL.
 
@@ -457,7 +453,6 @@
       level: extended
       type: keyword
       short: ID of the software
-      beta: This field is beta and subject to change.
       description: >
         The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software id.
 
@@ -467,17 +462,25 @@
       level: extended
       type: keyword
       short: Name of the software.
-      beta: This field is beta and subject to change.
       description: >
         The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software name.
 
       example: "AdFind"
 
+    - name: software.alias
+      level: extended
+      type: keyword
+      short: Alias of the software
+      description: >
+        The alias(es) of the software for a set of related intrusion activity that are tracked by a common name in the
+        security community.
+
+        While not required, you can use a MITRE ATT&CK® associated software description.
+
     - name: software.platforms
       level: extended
       type: keyword
       short: Platforms of the software.
-      beta: This field is beta and subject to change.
       description: >
         The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software platforms.
 
@@ -501,7 +504,6 @@
       level: extended
       type: keyword
       short: Software reference URL.
-      beta: This field is beta and subject to change.
       description: >
         The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software reference URL.
 
@@ -511,7 +513,6 @@
       level: extended
       type: keyword
       short: Software type.
-      beta: This field is beta and subject to change.
       description: >
         The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software type.
 

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -246,8 +246,9 @@
       type: keyword
       short: Alias of the group.
       description: >
-        The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group alias(es).
+        The alias(es) of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
+        While not required, you can use a MITRE ATT&CK® group alias(es).
       example: '[ "Magecart Group 6" ]'
       normalize:
         - array
@@ -257,8 +258,9 @@
       type: keyword
       short: ID of the group.
       description: >
-        The id of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group id.
+        The id of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
+        While not required, you can use a MITRE ATT&CK® group id.
       example: "G0037"
 
     - name: group.name
@@ -266,8 +268,9 @@
       type: keyword
       short: Name of the group.
       description: >
-        The name of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group name.
+        The name of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
+        While not required, you can use a MITRE ATT&CK® group name.
       example: "FIN6"
 
     - name: group.reference
@@ -275,8 +278,9 @@
       type: keyword
       short: Reference URL of the group.
       description: >
-        The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community. While not required, you can use a MITRE ATT&CK® group reference URL.
+        The reference URL of the group for a set of related intrusion activity that are tracked by a common name in the security community.
 
+        While not required, you can use a MITRE ATT&CK® group reference URL.
       example: "https://attack.mitre.org/groups/G0037/"
 
     - name: indicator.first_seen
@@ -454,8 +458,9 @@
       type: keyword
       short: ID of the software
       description: >
-        The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software id.
+        The id of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
+        While not required, you can use a MITRE ATT&CK® software id.
       example: "S0552"
 
     - name: software.name
@@ -463,8 +468,9 @@
       type: keyword
       short: Name of the software.
       description: >
-        The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software name.
+        The name of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
+        While not required, you can use a MITRE ATT&CK® software name.
       example: "AdFind"
 
     - name: software.alias
@@ -482,7 +488,7 @@
       type: keyword
       short: Platforms of the software.
       description: >
-        The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software platforms.
+        The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
         Recommended Values:
           * AWS
@@ -496,6 +502,7 @@
           * SaaS
           * Windows
 
+        While not required, you can use a MITRE ATT&CK® software platforms.
       example: '[ "Windows" ]'
       normalize:
         - array
@@ -505,8 +512,9 @@
       type: keyword
       short: Software reference URL.
       description: >
-        The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software reference URL.
+        The reference URL of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
+        While not required, you can use a MITRE ATT&CK® software reference URL.
       example: "https://attack.mitre.org/software/S0552/"
 
     - name: software.type
@@ -514,12 +522,13 @@
       type: keyword
       short: Software type.
       description: >
-        The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. While not required, you can use a MITRE ATT&CK® software type.
+        The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
         Recommended values
           * Malware
           * Tool
 
+         While not required, you can use a MITRE ATT&CK® software type.
       example: "Tool"
 
     - name: tactic.id


### PR DESCRIPTION
Advance fields proposed in [RFC 0018](https://github.com/elastic/ecs/blob/master/rfcs/text/0018-extend-threat-group-software.md) from beta to GA.

Adding `threat.software.alias` was also part of the stage 3 changes.