### PR TITLE
Stage 2 changes for RFC 0002 - `service.environment`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -13,6 +13,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `service.address` field. #1537
+* Added `service.environment` as a beta field. #1541
 
 ### Tooling and Artifact Changes
 

--- a/code/go/ecs/service.go
+++ b/code/go/ecs/service.go
@@ -24,6 +24,13 @@ package ecs
 // These fields help you find and correlate logs for a specific service and
 // version.
 type Service struct {
+	// Identifies the environment where the service is running.
+	// If the same service runs in different environments (production, staging,
+	// QA, development, etc.), the environment can identify other instances of
+	// the same service. Can also group services and applications from the same
+	// environment.
+	Environment string `ecs:"environment"`
+
 	// Unique identifier of the running service. If the service is comprised of
 	// many nodes, the `service.id` should be the same for all nodes.
 	// This id should uniquely identify the service. This makes it possible to

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -7332,6 +7332,24 @@ example: `172.26.0.2:5432`
 // ===============================================================
 
 |
+[[field-service-environment]]
+<<field-service-environment, service.environment>>
+
+| Identifies the environment where the service is running.
+
+If the same service runs in different environments (production, staging, QA, development, etc.), the environment can identify other instances of the same service. Can also group services and applications from the same environment.
+
+type: keyword
+
+
+
+example: `production`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-service-ephemeral-id]]
 <<field-service-ephemeral-id, service.ephemeral_id>>
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -7335,7 +7335,9 @@ example: `172.26.0.2:5432`
 [[field-service-environment]]
 <<field-service-environment, service.environment>>
 
-| Identifies the environment where the service is running.
+| beta:[ This field is beta and subject to change. ]
+
+Identifies the environment where the service is running.
 
 If the same service runs in different environments (production, staging, QA, development, etc.), the environment can identify other instances of the same service. Can also group services and applications from the same environment.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -7879,6 +7879,17 @@
         path (sockets).'
       example: 172.26.0.2:5432
       default_field: false
+    - name: environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
     - name: ephemeral_id
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -946,6 +946,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev+exp,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev+exp,true,service,service.environment,keyword,extended,,production,Environment of the service.
 8.0.0-dev+exp,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.0.0-dev+exp,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.0.0-dev+exp,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11843,6 +11843,21 @@ service.address:
   normalize: []
   short: Address of this service.
   type: keyword
+service.environment:
+  dashed_name: service-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  short: Environment of the service.
+  type: keyword
 service.ephemeral_id:
   dashed_name: service-ephemeral-id
   description: 'Ephemeral identifier of this service (if one exists).

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11844,6 +11844,7 @@ service.address:
   short: Address of this service.
   type: keyword
 service.environment:
+  beta: This field is beta and subject to change.
   dashed_name: service-environment
   description: 'Identifies the environment where the service is running.
 

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13894,6 +13894,21 @@ service:
       normalize: []
       short: Address of this service.
       type: keyword
+    service.environment:
+      dashed_name: service-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      short: Environment of the service.
+      type: keyword
     service.ephemeral_id:
       dashed_name: service-ephemeral-id
       description: 'Ephemeral identifier of this service (if one exists).

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13895,6 +13895,7 @@ service:
       short: Address of this service.
       type: keyword
     service.environment:
+      beta: This field is beta and subject to change.
       dashed_name: service-environment
       description: 'Identifies the environment where the service is running.
 

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -4233,6 +4233,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "environment": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "ephemeral_id": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/experimental/generated/elasticsearch/component/service.json
+++ b/experimental/generated/elasticsearch/component/service.json
@@ -12,6 +12,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "environment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ephemeral_id": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5469,6 +5469,17 @@
         path (sockets).'
       example: 172.26.0.2:5432
       default_field: false
+    - name: environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
     - name: ephemeral_id
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -622,6 +622,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,server,server.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.0.0-dev,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev,true,service,service.environment,keyword,extended,,production,Environment of the service.
 8.0.0-dev,true,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.0.0-dev,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.0.0-dev,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7994,6 +7994,7 @@ service.address:
   short: Address of this service.
   type: keyword
 service.environment:
+  beta: This field is beta and subject to change.
   dashed_name: service-environment
   description: 'Identifies the environment where the service is running.
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7993,6 +7993,21 @@ service.address:
   normalize: []
   short: Address of this service.
   type: keyword
+service.environment:
+  dashed_name: service-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  short: Environment of the service.
+  type: keyword
 service.ephemeral_id:
   dashed_name: service-ephemeral-id
   description: 'Ephemeral identifier of this service (if one exists).

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9684,6 +9684,7 @@ service:
       short: Address of this service.
       type: keyword
     service.environment:
+      beta: This field is beta and subject to change.
       dashed_name: service-environment
       description: 'Identifies the environment where the service is running.
 

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9683,6 +9683,21 @@ service:
       normalize: []
       short: Address of this service.
       type: keyword
+    service.environment:
+      dashed_name: service-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      short: Environment of the service.
+      type: keyword
     service.ephemeral_id:
       dashed_name: service-ephemeral-id
       description: 'Ephemeral identifier of this service (if one exists).

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2877,6 +2877,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "environment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ephemeral_id": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2837,6 +2837,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "environment": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "ephemeral_id": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/elasticsearch/component/service.json
+++ b/generated/elasticsearch/component/service.json
@@ -12,6 +12,10 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "environment": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "ephemeral_id": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -18,11 +18,10 @@
       description: >
         Identifies the environment where the service is running.
 
-        The environment field can group services and applications from
-        the same environment. If service runs in different
-        environments (production, staging, QA, or development) under the
-        same name, `service.environment` can identify the instance of that
-        service.
+        If the same service runs in different environments
+        (production, staging, QA, development, etc.), the environment
+        can identify other instances of the same service. Can also
+        group services and applications from the same environment.
 
       example: production
 

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -11,6 +11,21 @@
   type: group
   fields:
 
+    - name: environment
+      level: extended
+      type: keyword
+      short: Environment of the service.
+      description: >
+        Identifies the environment where the service is running.
+
+        The environment field can group services and applications from
+        the same environment. If service runs in different
+        environments (production, staging, QA, or development) under the
+        same name, `service.environment` can identify the instance of that
+        service.
+
+      example: production
+
     - name: id
       level: core
       type: keyword
@@ -110,7 +125,7 @@
       level: extended
       type: keyword
       short: Address of this service.
-      description: > 
+      description: >
         Address where data about this service was collected from.
 
         This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource path (sockets).

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -15,6 +15,7 @@
       level: extended
       type: keyword
       short: Environment of the service.
+      beta: This field is beta and subject to change.
       description: >
         Identifies the environment where the service is running.
 


### PR DESCRIPTION
Adding `service.environment` field as beta to the schema: [RFC 0002](https://github.com/elastic/ecs/blob/master/rfcs/text/0002-rfc-environment.md).

[Docs preview](https://ecs_1541.docs-preview.app.elstc.co/guide/en/ecs/master/ecs-service.html#field-service-environment)