### PR TITLE
Stage 1 changes for RFC 0025 - container metric fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,7 @@ Thanks, you're awesome :-) -->
 * Added `service.address` field. #1537
 * Promote `threat.software.*` and `threat.group.*` fields to GA. #1540
 * Added `service.environment` as a beta field. #1541
+* Introduce container metric fields into experimental schema. #1546
 
 ### Tooling and Artifact Changes
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -599,6 +599,25 @@
       These fields help correlate data based containers from any runtime.'
     type: group
     fields:
+    - name: cpu.usage
+      level: extended
+      type: scaled_float
+      description: 'Percent CPU used which is normalized by the number of CPU cores
+        and it ranges from 0 to 1. Scaling factor: 1000.'
+      scaling_factor: 1000
+      default_field: false
+    - name: disk.read.bytes
+      level: extended
+      type: long
+      description: The total number of bytes (gauge) read successfully (aggregated
+        from all disks) since the last metric collection.
+      default_field: false
+    - name: disk.write.bytes
+      level: extended
+      type: long
+      description: The total number of bytes (gauge) written successfully (aggregated
+        from all disks) since the last metric collection.
+      default_field: false
     - name: id
       level: core
       type: keyword
@@ -619,11 +638,30 @@
       type: object
       object_type: keyword
       description: Image labels.
+    - name: memory.usage
+      level: extended
+      type: scaled_float
+      description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
+        1000.'
+      scaling_factor: 1000
+      default_field: false
     - name: name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Container name.
+    - name: network.egress.bytes
+      level: extended
+      type: long
+      description: The number of bytes (gauge) sent out on all network interfaces
+        by the container since the last metric collection.
+      default_field: false
+    - name: network.ingress.bytes
+      level: extended
+      type: long
+      description: The number of bytes received (gauge) on all network interfaces
+        by the container since the last metric collection.
+      default_field: false
     - name: runtime
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -58,11 +58,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 8.0.0-dev+exp,true,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
 8.0.0-dev+exp,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
+8.0.0-dev+exp,true,container,container.cpu.usage,scaled_float,extended,,,"Percent CPU used, between 0 and 1."
+8.0.0-dev+exp,true,container,container.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
+8.0.0-dev+exp,true,container,container.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
 8.0.0-dev+exp,true,container,container.id,keyword,core,,,Unique container id.
 8.0.0-dev+exp,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 8.0.0-dev+exp,true,container,container.image.tag,keyword,extended,array,,Container image tags.
 8.0.0-dev+exp,true,container,container.labels,object,extended,,,Image labels.
+8.0.0-dev+exp,true,container,container.memory.usage,scaled_float,extended,,,"Percent memory used, between 0 and 1."
 8.0.0-dev+exp,true,container,container.name,keyword,extended,,,Container name.
+8.0.0-dev+exp,true,container,container.network.egress.bytes,long,extended,,,The number of bytes sent on all network interfaces.
+8.0.0-dev+exp,true,container,container.network.ingress.bytes,long,extended,,,The number of bytes received on all network interfaces.
 8.0.0-dev+exp,true,container,container.runtime,keyword,extended,,docker,Runtime managing this container.
 8.0.0-dev+exp,true,data_stream,data_stream.dataset,constant_keyword,extended,,nginx.access,The field can contain anything that makes sense to signify the source of the data.
 8.0.0-dev+exp,true,data_stream,data_stream.namespace,constant_keyword,extended,,production,A user defined namespace. Namespaces are useful to allow grouping of data.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -697,6 +697,37 @@ cloud.service.name:
   normalize: []
   short: The cloud service name.
   type: keyword
+container.cpu.usage:
+  dashed_name: container-cpu-usage
+  description: 'Percent CPU used which is normalized by the number of CPU cores and
+    it ranges from 0 to 1. Scaling factor: 1000.'
+  flat_name: container.cpu.usage
+  level: extended
+  name: cpu.usage
+  normalize: []
+  scaling_factor: 1000
+  short: Percent CPU used, between 0 and 1.
+  type: scaled_float
+container.disk.read.bytes:
+  dashed_name: container-disk-read-bytes
+  description: The total number of bytes (gauge) read successfully (aggregated from
+    all disks) since the last metric collection.
+  flat_name: container.disk.read.bytes
+  level: extended
+  name: disk.read.bytes
+  normalize: []
+  short: The number of bytes read by all disks.
+  type: long
+container.disk.write.bytes:
+  dashed_name: container-disk-write-bytes
+  description: The total number of bytes (gauge) written successfully (aggregated
+    from all disks) since the last metric collection.
+  flat_name: container.disk.write.bytes
+  level: extended
+  name: disk.write.bytes
+  normalize: []
+  short: The number of bytes written on all disks.
+  type: long
 container.id:
   dashed_name: container-id
   description: Unique container id.
@@ -738,6 +769,17 @@ container.labels:
   object_type: keyword
   short: Image labels.
   type: object
+container.memory.usage:
+  dashed_name: container-memory-usage
+  description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
+    1000.'
+  flat_name: container.memory.usage
+  level: extended
+  name: memory.usage
+  normalize: []
+  scaling_factor: 1000
+  short: Percent memory used, between 0 and 1.
+  type: scaled_float
 container.name:
   dashed_name: container-name
   description: Container name.
@@ -748,6 +790,26 @@ container.name:
   normalize: []
   short: Container name.
   type: keyword
+container.network.egress.bytes:
+  dashed_name: container-network-egress-bytes
+  description: The number of bytes (gauge) sent out on all network interfaces by the
+    container since the last metric collection.
+  flat_name: container.network.egress.bytes
+  level: extended
+  name: network.egress.bytes
+  normalize: []
+  short: The number of bytes sent on all network interfaces.
+  type: long
+container.network.ingress.bytes:
+  dashed_name: container-network-ingress-bytes
+  description: The number of bytes received (gauge) on all network interfaces by the
+    container since the last metric collection.
+  flat_name: container.network.ingress.bytes
+  level: extended
+  name: network.ingress.bytes
+  normalize: []
+  short: The number of bytes received on all network interfaces.
+  type: long
 container.runtime:
   dashed_name: container-runtime
   description: Runtime managing this container.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1006,6 +1006,37 @@ container:
 
     These fields help correlate data based containers from any runtime.'
   fields:
+    container.cpu.usage:
+      dashed_name: container-cpu-usage
+      description: 'Percent CPU used which is normalized by the number of CPU cores
+        and it ranges from 0 to 1. Scaling factor: 1000.'
+      flat_name: container.cpu.usage
+      level: extended
+      name: cpu.usage
+      normalize: []
+      scaling_factor: 1000
+      short: Percent CPU used, between 0 and 1.
+      type: scaled_float
+    container.disk.read.bytes:
+      dashed_name: container-disk-read-bytes
+      description: The total number of bytes (gauge) read successfully (aggregated
+        from all disks) since the last metric collection.
+      flat_name: container.disk.read.bytes
+      level: extended
+      name: disk.read.bytes
+      normalize: []
+      short: The number of bytes read by all disks.
+      type: long
+    container.disk.write.bytes:
+      dashed_name: container-disk-write-bytes
+      description: The total number of bytes (gauge) written successfully (aggregated
+        from all disks) since the last metric collection.
+      flat_name: container.disk.write.bytes
+      level: extended
+      name: disk.write.bytes
+      normalize: []
+      short: The number of bytes written on all disks.
+      type: long
     container.id:
       dashed_name: container-id
       description: Unique container id.
@@ -1047,6 +1078,17 @@ container:
       object_type: keyword
       short: Image labels.
       type: object
+    container.memory.usage:
+      dashed_name: container-memory-usage
+      description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
+        1000.'
+      flat_name: container.memory.usage
+      level: extended
+      name: memory.usage
+      normalize: []
+      scaling_factor: 1000
+      short: Percent memory used, between 0 and 1.
+      type: scaled_float
     container.name:
       dashed_name: container-name
       description: Container name.
@@ -1057,6 +1099,26 @@ container:
       normalize: []
       short: Container name.
       type: keyword
+    container.network.egress.bytes:
+      dashed_name: container-network-egress-bytes
+      description: The number of bytes (gauge) sent out on all network interfaces
+        by the container since the last metric collection.
+      flat_name: container.network.egress.bytes
+      level: extended
+      name: network.egress.bytes
+      normalize: []
+      short: The number of bytes sent on all network interfaces.
+      type: long
+    container.network.ingress.bytes:
+      dashed_name: container-network-ingress-bytes
+      description: The number of bytes received (gauge) on all network interfaces
+        by the container since the last metric collection.
+      flat_name: container.network.ingress.bytes
+      level: extended
+      name: network.ingress.bytes
+      normalize: []
+      short: The number of bytes received on all network interfaces.
+      type: long
     container.runtime:
       dashed_name: container-runtime
       description: Runtime managing this container.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -299,6 +299,32 @@
       },
       "container": {
         "properties": {
+          "cpu": {
+            "properties": {
+              "usage": {
+                "scaling_factor": 1000,
+                "type": "scaled_float"
+              }
+            }
+          },
+          "disk": {
+            "properties": {
+              "read": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              },
+              "write": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              }
+            }
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -318,9 +344,35 @@
           "labels": {
             "type": "object"
           },
+          "memory": {
+            "properties": {
+              "usage": {
+                "scaling_factor": 1000,
+                "type": "scaled_float"
+              }
+            }
+          },
           "name": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "network": {
+            "properties": {
+              "egress": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              },
+              "ingress": {
+                "properties": {
+                  "bytes": {
+                    "type": "long"
+                  }
+                }
+              }
+            }
           },
           "runtime": {
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/container.json
+++ b/experimental/generated/elasticsearch/component/container.json
@@ -8,6 +8,32 @@
       "properties": {
         "container": {
           "properties": {
+            "cpu": {
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "disk": {
+              "properties": {
+                "read": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "write": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
+            },
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -27,9 +53,35 @@
             "labels": {
               "type": "object"
             },
+            "memory": {
+              "properties": {
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
             "name": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "network": {
+              "properties": {
+                "egress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "ingress": {
+                  "properties": {
+                    "bytes": {
+                      "type": "long"
+                    }
+                  }
+                }
+              }
             },
             "runtime": {
               "ignore_above": 1024,

--- a/experimental/schemas/container.yml
+++ b/experimental/schemas/container.yml
@@ -1,0 +1,50 @@
+- name: container
+  fields:
+    - name: cpu.usage
+      type: scaled_float
+      scaling_factor: 1000
+      level: extended
+      short: Percent CPU used, between 0 and 1.
+      description: >
+        Percent CPU used which is normalized by the number of CPU cores and it
+        ranges from 0 to 1. Scaling factor: 1000.
+
+    - name: memory.usage
+      type: scaled_float
+      scaling_factor: 1000
+      level: extended
+      short: Percent memory used, between 0 and 1.
+      description: >
+        Memory usage percentage and it ranges from 0 to 1. Scaling factor: 1000.
+
+    - name: network.ingress.bytes
+      type: long
+      level: extended
+      short: The number of bytes received on all network interfaces.
+      description: >
+        The number of bytes received (gauge) on all network interfaces by the
+        container since the last metric collection.
+
+    - name: network.egress.bytes
+      type: long
+      level: extended
+      short: The number of bytes sent on all network interfaces.
+      description: >
+        The number of bytes (gauge) sent out on all network interfaces by the
+        container since the last metric collection.
+
+    - name: disk.read.bytes
+      type: long
+      level: extended
+      short: The number of bytes read by all disks.
+      description: >
+        The total number of bytes (gauge) read successfully (aggregated from all
+        disks) since the last metric collection.
+
+    - name: disk.write.bytes
+      type: long
+      level: extended
+      short: The number of bytes written on all disks.
+      description: >
+        The total number of bytes (gauge) written successfully (aggregated from
+        all disks) since the last metric collection.


### PR DESCRIPTION
Introduce additional `container.*` metric fields proposed in [RFC 0025](https://github.com/elastic/ecs/blob/master/rfcs/text/0025-container-metric-fields.md) (#1529) to the `experimental` schema.
