### PR TITLE
[1.11] Update event.kind allowed value descriptions to clarify usage of "alert" and "signal" (#1548)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -41,6 +41,7 @@ Thanks, you're awesome :-) -->
 * Add --exclude flag to Generator to support field removal testing #1411
 * Explicitly include user identifiers in `relater.user` description. #1420
 * Improve descriptions for `cloud.region` and `cloud.availability` fields. #1452
+* Clarify `event.kind` descriptions for `alert` and `signal`. #1548
 
 #### Deprecated
 

--- a/docs/field-values.asciidoc
+++ b/docs/field-values.asciidoc
@@ -51,9 +51,11 @@ The value of this field can be used to inform how these kinds of events should b
 [[ecs-event-kind-alert]]
 ==== alert
 
-This value indicates an event that describes an alert or notable event, triggered by a detection rule.
+This value indicates an event such as an alert or notable event, triggered by a detection rule executing externally to the Elastic Stack.
 
 `event.kind:alert` is often populated for events coming from firewalls, intrusion detection systems, endpoint detection and response systems, and so on.
+
+This value is not used by Elastic solutions for alert documents that are created by rules executing within the Kibana alerting framework.
 
 
 
@@ -103,11 +105,9 @@ This value indicates that an error occurred during the ingestion of this event, 
 [[ecs-event-kind-signal]]
 ==== signal
 
-This value is used by the Elastic Security app to denote an Elasticsearch document that was created by a SIEM detection engine rule.
+This value is used by Elastic solutions (e.g., Security, Observability) for alert documents that are created by rules executing within the Kibana alerting framework.
 
-A signal will typically trigger a notification that something meaningful happened and should be investigated.
-
-Usage of this value is reserved, and pipelines should not populate `event.kind` with the value "signal".
+Usage of this value is reserved, and data ingestion pipelines must not populate `event.kind` with the value "signal".
 
 
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2558,11 +2558,14 @@ event.ingested:
   type: date
 event.kind:
   allowed_values:
-  - description: 'This value indicates an event that describes an alert or notable
-      event, triggered by a detection rule.
+  - description: 'This value indicates an event such as an alert or notable event,
+      triggered by a detection rule executing externally to the Elastic Stack.
 
       `event.kind:alert` is often populated for events coming from firewalls, intrusion
-      detection systems, endpoint detection and response systems, and so on.'
+      detection systems, endpoint detection and response systems, and so on.
+
+      This value is not used by Elastic solutions for alert documents that are created
+      by rules executing within the Kibana alerting framework.'
     name: alert
   - description: This value is the most general and most common value for this field.
       It is used to represent events that indicate that something happened.
@@ -2599,14 +2602,12 @@ event.kind:
       of this event, and that event data may be missing, inconsistent, or incorrect.
       `event.kind:pipeline_error` is often associated with parsing errors.
     name: pipeline_error
-  - description: 'This value is used by the Elastic Security app to denote an Elasticsearch
-      document that was created by a SIEM detection engine rule.
+  - description: 'This value is used by Elastic solutions (e.g., Security, Observability)
+      for alert documents that are created by rules executing within the Kibana alerting
+      framework.
 
-      A signal will typically trigger a notification that something meaningful happened
-      and should be investigated.
-
-      Usage of this value is reserved, and pipelines should not populate `event.kind`
-      with the value "signal".'
+      Usage of this value is reserved, and data ingestion pipelines must not populate
+      `event.kind` with the value "signal".'
     name: signal
   dashed_name: event-kind
   description: 'This is one of four ECS Categorization Fields, and indicates the highest

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3338,12 +3338,15 @@ event:
       type: date
     event.kind:
       allowed_values:
-      - description: 'This value indicates an event that describes an alert or notable
-          event, triggered by a detection rule.
+      - description: 'This value indicates an event such as an alert or notable event,
+          triggered by a detection rule executing externally to the Elastic Stack.
 
           `event.kind:alert` is often populated for events coming from firewalls,
           intrusion detection systems, endpoint detection and response systems, and
-          so on.'
+          so on.
+
+          This value is not used by Elastic solutions for alert documents that are
+          created by rules executing within the Kibana alerting framework.'
         name: alert
       - description: This value is the most general and most common value for this
           field. It is used to represent events that indicate that something happened.
@@ -3380,14 +3383,12 @@ event:
           of this event, and that event data may be missing, inconsistent, or incorrect.
           `event.kind:pipeline_error` is often associated with parsing errors.
         name: pipeline_error
-      - description: 'This value is used by the Elastic Security app to denote an
-          Elasticsearch document that was created by a SIEM detection engine rule.
+      - description: 'This value is used by Elastic solutions (e.g., Security, Observability)
+          for alert documents that are created by rules executing within the Kibana
+          alerting framework.
 
-          A signal will typically trigger a notification that something meaningful
-          happened and should be investigated.
-
-          Usage of this value is reserved, and pipelines should not populate `event.kind`
-          with the value "signal".'
+          Usage of this value is reserved, and data ingestion pipelines must not populate
+          `event.kind` with the value "signal".'
         name: signal
       dashed_name: event-kind
       description: 'This is one of four ECS Categorization Fields, and indicates the

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2208,11 +2208,14 @@ event.ingested:
   type: date
 event.kind:
   allowed_values:
-  - description: 'This value indicates an event that describes an alert or notable
-      event, triggered by a detection rule.
+  - description: 'This value indicates an event such as an alert or notable event,
+      triggered by a detection rule executing externally to the Elastic Stack.
 
       `event.kind:alert` is often populated for events coming from firewalls, intrusion
-      detection systems, endpoint detection and response systems, and so on.'
+      detection systems, endpoint detection and response systems, and so on.
+
+      This value is not used by Elastic solutions for alert documents that are created
+      by rules executing within the Kibana alerting framework.'
     name: alert
   - description: This value is the most general and most common value for this field.
       It is used to represent events that indicate that something happened.
@@ -2249,14 +2252,12 @@ event.kind:
       of this event, and that event data may be missing, inconsistent, or incorrect.
       `event.kind:pipeline_error` is often associated with parsing errors.
     name: pipeline_error
-  - description: 'This value is used by the Elastic Security app to denote an Elasticsearch
-      document that was created by a SIEM detection engine rule.
+  - description: 'This value is used by Elastic solutions (e.g., Security, Observability)
+      for alert documents that are created by rules executing within the Kibana alerting
+      framework.
 
-      A signal will typically trigger a notification that something meaningful happened
-      and should be investigated.
-
-      Usage of this value is reserved, and pipelines should not populate `event.kind`
-      with the value "signal".'
+      Usage of this value is reserved, and data ingestion pipelines must not populate
+      `event.kind` with the value "signal".'
     name: signal
   dashed_name: event-kind
   description: 'This is one of four ECS Categorization Fields, and indicates the highest

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2988,12 +2988,15 @@ event:
       type: date
     event.kind:
       allowed_values:
-      - description: 'This value indicates an event that describes an alert or notable
-          event, triggered by a detection rule.
+      - description: 'This value indicates an event such as an alert or notable event,
+          triggered by a detection rule executing externally to the Elastic Stack.
 
           `event.kind:alert` is often populated for events coming from firewalls,
           intrusion detection systems, endpoint detection and response systems, and
-          so on.'
+          so on.
+
+          This value is not used by Elastic solutions for alert documents that are
+          created by rules executing within the Kibana alerting framework.'
         name: alert
       - description: This value is the most general and most common value for this
           field. It is used to represent events that indicate that something happened.
@@ -3030,14 +3033,12 @@ event:
           of this event, and that event data may be missing, inconsistent, or incorrect.
           `event.kind:pipeline_error` is often associated with parsing errors.
         name: pipeline_error
-      - description: 'This value is used by the Elastic Security app to denote an
-          Elasticsearch document that was created by a SIEM detection engine rule.
+      - description: 'This value is used by Elastic solutions (e.g., Security, Observability)
+          for alert documents that are created by rules executing within the Kibana
+          alerting framework.
 
-          A signal will typically trigger a notification that something meaningful
-          happened and should be investigated.
-
-          Usage of this value is reserved, and pipelines should not populate `event.kind`
-          with the value "signal".'
+          Usage of this value is reserved, and data ingestion pipelines must not populate
+          `event.kind` with the value "signal".'
         name: signal
       dashed_name: event-kind
       description: 'This is one of four ECS Categorization Fields, and indicates the

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -59,11 +59,14 @@
       allowed_values:
         - name: alert
           description: >
-            This value indicates an event that describes an alert or notable event,
-            triggered by a detection rule.
+            This value indicates an event such as an alert or notable event,
+            triggered by a detection rule executing externally to the Elastic Stack.
 
             `event.kind:alert` is often populated for events coming from firewalls,
             intrusion detection systems, endpoint detection and response systems, and so on.
+
+            This value is not used by Elastic solutions for alert documents
+            that are created by rules executing within the Kibana alerting framework.
         - name: event
           description: >
             This value is the most general and most common value for this field.
@@ -104,13 +107,10 @@
             `event.kind:pipeline_error` is often associated with parsing errors.
         - name: signal
           description: >
-            This value is used by the Elastic Security app to denote an Elasticsearch
-            document that was created by a SIEM detection engine rule.
+            This value is used by Elastic solutions (e.g., Security, Observability) for alert documents
+            that are created by rules executing within the Kibana alerting framework.
 
-            A signal will typically trigger a notification that something
-            meaningful happened and should be investigated.
-
-            Usage of this value is reserved, and pipelines should not populate
+            Usage of this value is reserved, and data ingestion pipelines must not populate
             `event.kind` with the value "signal".
 
     - name: category


### PR DESCRIPTION
Backports the following commits to 1.11:
 - Update event.kind allowed value descriptions to clarify usage of "alert" and "signal" (#1548)