### PR TITLE
Add `code_signature.digest_algorithm` and `code_signature.timestamp` fields

### DIFF
--- a/code/go/ecs/code_signature.go
+++ b/code/go/ecs/code_signature.go
@@ -19,6 +19,10 @@
 
 package ecs
 
+import (
+	"time"
+)
+
 // These fields contain information about binary code signatures.
 type CodeSignature struct {
 	// Boolean to capture if a signature is present.
@@ -53,4 +57,12 @@ type CodeSignature struct {
 	// This is used to identify the application manufactured by a software
 	// vendor. The field is relevant to Apple *OS only.
 	SigningID string `ecs:"signing_id"`
+
+	// The hashing algorithm used to sign the process.
+	// This value can distinguish signatures when a file is signed multiple
+	// times by the same signer but with a different digest algorithm.
+	DigestAlgorithm string `ecs:"digest_algorithm"`
+
+	// Timestamp of when the code signature was generated and signed.
+	Timestamp time.Time `ecs:"timestamp"`
 }

--- a/code/go/ecs/code_signature.go
+++ b/code/go/ecs/code_signature.go
@@ -63,6 +63,6 @@ type CodeSignature struct {
 	// times by the same signer but with a different digest algorithm.
 	DigestAlgorithm string `ecs:"digest_algorithm"`
 
-	// Timestamp of when the code signature was generated and signed.
+	// Date and time when the code signature was generated and signed.
 	Timestamp time.Time `ecs:"timestamp"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -901,7 +901,7 @@ type: date
 
 
 
-
+example: `2021-01-01T12:10:30Z`
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -788,6 +788,24 @@ These fields contain information about binary code signatures.
 // ===============================================================
 
 |
+[[field-code-signature-digest-algorithm]]
+<<field-code-signature-digest-algorithm, code_signature.digest_algorithm>>
+
+| The hashing algorithm used to sign the process.
+
+This value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.
+
+type: keyword
+
+
+
+example: `sha256`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-code-signature-exists]]
 <<field-code-signature-exists, code_signature.exists>>
 
@@ -868,6 +886,22 @@ type: keyword
 
 
 example: `EQHXZ8M8AV`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-code-signature-timestamp]]
+<<field-code-signature-timestamp, code_signature.timestamp>>
+
+| Timestamp of when the code signature was generated and signed.
+
+type: date
+
+
+
+
 
 | extended
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -895,7 +895,7 @@ example: `EQHXZ8M8AV`
 [[field-code-signature-timestamp]]
 <<field-code-signature-timestamp, code_signature.timestamp>>
 
-| Timestamp of when the code signature was generated and signed.
+| Date and time when the code signature was generated and signed.
 
 type: date
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -585,7 +585,7 @@
     - name: timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
@@ -1085,7 +1085,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -2237,7 +2237,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -4832,7 +4832,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -5199,7 +5199,7 @@
     - name: parent.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
@@ -6186,7 +6186,7 @@
     - name: target.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.code_signature.trusted
@@ -6557,7 +6557,7 @@
     - name: target.parent.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.parent.code_signature.trusted
@@ -8558,7 +8558,7 @@
     - name: enrichments.indicator.file.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
@@ -9963,7 +9963,7 @@
     - name: indicator.file.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -586,6 +586,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
       level: extended
@@ -1085,6 +1086,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -2236,6 +2238,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4830,6 +4833,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -5196,6 +5200,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -6182,6 +6187,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.code_signature.trusted
       level: extended
@@ -6552,6 +6558,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.parent.code_signature.trusted
       level: extended
@@ -8552,6 +8559,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -9956,6 +9964,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -528,6 +528,16 @@
     description: These fields contain information about binary code signatures.
     type: group
     fields:
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: exists
       level: core
       type: boolean
@@ -571,6 +581,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: trusted
       level: extended
@@ -1012,6 +1027,16 @@
       * Dynamic library (`.dylib`) commonly used on macOS'
     type: group
     fields:
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1055,6 +1080,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -2148,6 +2178,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -2191,6 +2231,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4727,6 +4772,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -4770,6 +4825,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -5078,6 +5138,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: parent.code_signature.exists
       level: core
       type: boolean
@@ -5121,6 +5191,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -6049,6 +6124,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: target.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: target.code_signature.exists
       level: core
       type: boolean
@@ -6092,6 +6177,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: target.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: target.code_signature.trusted
       level: extended
@@ -6404,6 +6494,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: target.parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: target.parent.code_signature.exists
       level: core
       type: boolean
@@ -6447,6 +6547,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: target.parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: target.parent.code_signature.trusted
       level: extended
@@ -8389,6 +8494,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: enrichments.indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: enrichments.indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -8432,6 +8547,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -9778,6 +9898,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -9821,6 +9951,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -117,7 +117,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,dll,dll.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,dll,dll.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -224,7 +224,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,file,file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,file,file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,file,file.created,date,extended,,,File creation time.
@@ -504,7 +504,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,process,process.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -558,7 +558,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,process,process.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -703,7 +703,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.target.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.target.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,process,process.target.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,process,process.target.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -757,7 +757,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,process,process.target.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,process,process.target.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -1031,7 +1031,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -1221,7 +1221,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -111,11 +111,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+8.0.0-dev+exp,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,dll,dll.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -216,11 +218,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 8.0.0-dev+exp,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev+exp,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,file,file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,file,file.created,date,extended,,,File creation time.
@@ -494,11 +498,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,package,package.version,keyword,extended,,1.12.9,Package version
 8.0.0-dev+exp,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev+exp,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,process,process.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -546,11 +552,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev+exp,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,process,process.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -689,11 +697,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev+exp,true,process,process.target.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.target.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev+exp,true,process,process.target.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,process,process.target.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,process,process.target.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,process,process.target.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.target.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.target.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,process,process.target.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -741,11 +751,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev+exp,true,process,process.target.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.target.parent.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev+exp,true,process,process.target.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,process,process.target.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -1013,11 +1025,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -1201,11 +1215,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev+exp,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev+exp,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev+exp,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev+exp,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1414,6 +1414,7 @@ dll.code_signature.team_id:
 dll.code_signature.timestamp:
   dashed_name: dll-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: dll.code_signature.timestamp
   level: extended
   name: timestamp
@@ -3227,6 +3228,7 @@ file.code_signature.team_id:
 file.code_signature.timestamp:
   dashed_name: file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: file.code_signature.timestamp
   level: extended
   name: timestamp
@@ -6641,6 +6643,7 @@ process.code_signature.team_id:
 process.code_signature.timestamp:
   dashed_name: process-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.code_signature.timestamp
   level: extended
   name: timestamp
@@ -7276,6 +7279,7 @@ process.parent.code_signature.team_id:
 process.parent.code_signature.timestamp:
   dashed_name: process-parent-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.parent.code_signature.timestamp
   level: extended
   name: timestamp
@@ -8996,6 +9000,7 @@ process.target.code_signature.team_id:
 process.target.code_signature.timestamp:
   dashed_name: process-target-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.target.code_signature.timestamp
   level: extended
   name: timestamp
@@ -9637,6 +9642,7 @@ process.target.parent.code_signature.team_id:
 process.target.parent.code_signature.timestamp:
   dashed_name: process-target-parent-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.target.parent.code_signature.timestamp
   level: extended
   name: timestamp
@@ -12938,6 +12944,7 @@ threat.enrichments.indicator.file.code_signature.team_id:
 threat.enrichments.indicator.file.code_signature.timestamp:
   dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: threat.enrichments.indicator.file.code_signature.timestamp
   level: extended
   name: timestamp
@@ -15305,6 +15312,7 @@ threat.indicator.file.code_signature.team_id:
 threat.indicator.file.code_signature.timestamp:
   dashed_name: threat-indicator-file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: threat.indicator.file.code_signature.timestamp
   level: extended
   name: timestamp

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1413,7 +1413,7 @@ dll.code_signature.team_id:
   type: keyword
 dll.code_signature.timestamp:
   dashed_name: dll-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: dll.code_signature.timestamp
   level: extended
@@ -3227,7 +3227,7 @@ file.code_signature.team_id:
   type: keyword
 file.code_signature.timestamp:
   dashed_name: file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: file.code_signature.timestamp
   level: extended
@@ -6642,7 +6642,7 @@ process.code_signature.team_id:
   type: keyword
 process.code_signature.timestamp:
   dashed_name: process-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.code_signature.timestamp
   level: extended
@@ -7278,7 +7278,7 @@ process.parent.code_signature.team_id:
   type: keyword
 process.parent.code_signature.timestamp:
   dashed_name: process-parent-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.parent.code_signature.timestamp
   level: extended
@@ -8999,7 +8999,7 @@ process.target.code_signature.team_id:
   type: keyword
 process.target.code_signature.timestamp:
   dashed_name: process-target-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.target.code_signature.timestamp
   level: extended
@@ -9641,7 +9641,7 @@ process.target.parent.code_signature.team_id:
   type: keyword
 process.target.parent.code_signature.timestamp:
   dashed_name: process-target-parent-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.target.parent.code_signature.timestamp
   level: extended
@@ -12943,7 +12943,7 @@ threat.enrichments.indicator.file.code_signature.team_id:
   type: keyword
 threat.enrichments.indicator.file.code_signature.timestamp:
   dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: threat.enrichments.indicator.file.code_signature.timestamp
   level: extended
@@ -15311,7 +15311,7 @@ threat.indicator.file.code_signature.team_id:
   type: keyword
 threat.indicator.file.code_signature.timestamp:
   dashed_name: threat-indicator-file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: threat.indicator.file.code_signature.timestamp
   level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1327,6 +1327,21 @@ destination.user.roles:
   original_fieldset: user
   short: Array of user roles at the time of the event.
   type: keyword
+dll.code_signature.digest_algorithm:
+  dashed_name: dll-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: dll.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -1396,6 +1411,16 @@ dll.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+dll.code_signature.timestamp:
+  dashed_name: dll-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: dll.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -3115,6 +3140,21 @@ file.attributes:
   - array
   short: Array of file attributes.
   type: keyword
+file.code_signature.digest_algorithm:
+  dashed_name: file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 file.code_signature.exists:
   dashed_name: file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -3184,6 +3224,16 @@ file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+file.code_signature.timestamp:
+  dashed_name: file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -6504,6 +6554,21 @@ process.args_count:
   normalize: []
   short: Length of the process.args array.
   type: long
+process.code_signature.digest_algorithm:
+  dashed_name: process-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -6573,6 +6638,16 @@ process.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.code_signature.timestamp:
+  dashed_name: process-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -7114,6 +7189,21 @@ process.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.parent.code_signature.digest_algorithm:
+  dashed_name: process-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.parent.code_signature.exists:
   dashed_name: process-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -7183,6 +7273,16 @@ process.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.parent.code_signature.timestamp:
+  dashed_name: process-parent-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -8809,6 +8909,21 @@ process.target.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.target.code_signature.digest_algorithm:
+  dashed_name: process-target-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.target.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.target.code_signature.exists:
   dashed_name: process-target-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -8878,6 +8993,16 @@ process.target.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.target.code_signature.timestamp:
+  dashed_name: process-target-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.target.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.target.code_signature.trusted:
   dashed_name: process-target-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -9425,6 +9550,21 @@ process.target.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.target.parent.code_signature.digest_algorithm:
+  dashed_name: process-target-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.target.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.target.parent.code_signature.exists:
   dashed_name: process-target-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -9494,6 +9634,16 @@ process.target.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.target.parent.code_signature.timestamp:
+  dashed_name: process-target-parent-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.target.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.target.parent.code_signature.trusted:
   dashed_name: process-target-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -12701,6 +12851,21 @@ threat.enrichments.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.enrichments.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.enrichments.indicator.file.code_signature.exists:
   dashed_name: threat-enrichments-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -12770,6 +12935,16 @@ threat.enrichments.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.enrichments.indicator.file.code_signature.timestamp:
+  dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.enrichments.indicator.file.code_signature.trusted:
   dashed_name: threat-enrichments-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -15043,6 +15218,21 @@ threat.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.indicator.file.code_signature.exists:
   dashed_name: threat-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -15112,6 +15302,16 @@ threat.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.indicator.file.code_signature.timestamp:
+  dashed_name: threat-indicator-file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: threat.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.indicator.file.code_signature.trusted:
   dashed_name: threat-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -972,6 +972,7 @@ code_signature:
     code_signature.timestamp:
       dashed_name: code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: code_signature.timestamp
       level: extended
       name: timestamp
@@ -1822,6 +1823,7 @@ dll:
     dll.code_signature.timestamp:
       dashed_name: dll-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: dll.code_signature.timestamp
       level: extended
       name: timestamp
@@ -4059,6 +4061,7 @@ file:
     file.code_signature.timestamp:
       dashed_name: file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: file.code_signature.timestamp
       level: extended
       name: timestamp
@@ -8561,6 +8564,7 @@ process:
     process.code_signature.timestamp:
       dashed_name: process-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.code_signature.timestamp
       level: extended
       name: timestamp
@@ -9196,6 +9200,7 @@ process:
     process.parent.code_signature.timestamp:
       dashed_name: process-parent-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.parent.code_signature.timestamp
       level: extended
       name: timestamp
@@ -10918,6 +10923,7 @@ process:
     process.target.code_signature.timestamp:
       dashed_name: process-target-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.target.code_signature.timestamp
       level: extended
       name: timestamp
@@ -11559,6 +11565,7 @@ process:
     process.target.parent.code_signature.timestamp:
       dashed_name: process-target-parent-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.target.parent.code_signature.timestamp
       level: extended
       name: timestamp
@@ -15034,6 +15041,7 @@ threat:
     threat.enrichments.indicator.file.code_signature.timestamp:
       dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: threat.enrichments.indicator.file.code_signature.timestamp
       level: extended
       name: timestamp
@@ -17406,6 +17414,7 @@ threat:
     threat.indicator.file.code_signature.timestamp:
       dashed_name: threat-indicator-file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: threat.indicator.file.code_signature.timestamp
       level: extended
       name: timestamp

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -971,7 +971,7 @@ code_signature:
       type: keyword
     code_signature.timestamp:
       dashed_name: code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: code_signature.timestamp
       level: extended
@@ -1822,7 +1822,7 @@ dll:
       type: keyword
     dll.code_signature.timestamp:
       dashed_name: dll-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: dll.code_signature.timestamp
       level: extended
@@ -4060,7 +4060,7 @@ file:
       type: keyword
     file.code_signature.timestamp:
       dashed_name: file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: file.code_signature.timestamp
       level: extended
@@ -8563,7 +8563,7 @@ process:
       type: keyword
     process.code_signature.timestamp:
       dashed_name: process-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.code_signature.timestamp
       level: extended
@@ -9199,7 +9199,7 @@ process:
       type: keyword
     process.parent.code_signature.timestamp:
       dashed_name: process-parent-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.parent.code_signature.timestamp
       level: extended
@@ -10922,7 +10922,7 @@ process:
       type: keyword
     process.target.code_signature.timestamp:
       dashed_name: process-target-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.target.code_signature.timestamp
       level: extended
@@ -11564,7 +11564,7 @@ process:
       type: keyword
     process.target.parent.code_signature.timestamp:
       dashed_name: process-target-parent-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.target.parent.code_signature.timestamp
       level: extended
@@ -15040,7 +15040,7 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.code_signature.timestamp:
       dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: threat.enrichments.indicator.file.code_signature.timestamp
       level: extended
@@ -17413,7 +17413,7 @@ threat:
       type: keyword
     threat.indicator.file.code_signature.timestamp:
       dashed_name: threat-indicator-file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: threat.indicator.file.code_signature.timestamp
       level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -891,6 +891,20 @@ cloud:
 code_signature:
   description: These fields contain information about binary code signatures.
   fields:
+    code_signature.digest_algorithm:
+      dashed_name: code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     code_signature.exists:
       dashed_name: code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -955,6 +969,15 @@ code_signature:
       normalize: []
       short: The team identifier used to sign the process.
       type: keyword
+    code_signature.timestamp:
+      dashed_name: code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      short: When the signature was generated and signed.
+      type: date
     code_signature.trusted:
       dashed_name: code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -1712,6 +1735,21 @@ dll:
 
     * Dynamic library (`.dylib`) commonly used on macOS'
   fields:
+    dll.code_signature.digest_algorithm:
+      dashed_name: dll-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: dll.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     dll.code_signature.exists:
       dashed_name: dll-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -1781,6 +1819,16 @@ dll:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    dll.code_signature.timestamp:
+      dashed_name: dll-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: dll.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -3924,6 +3972,21 @@ file:
       - array
       short: Array of file attributes.
       type: keyword
+    file.code_signature.digest_algorithm:
+      dashed_name: file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     file.code_signature.exists:
       dashed_name: file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -3993,6 +4056,16 @@ file:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    file.code_signature.timestamp:
+      dashed_name: file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -8401,6 +8474,21 @@ process:
       normalize: []
       short: Length of the process.args array.
       type: long
+    process.code_signature.digest_algorithm:
+      dashed_name: process-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.code_signature.exists:
       dashed_name: process-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -8470,6 +8558,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.code_signature.timestamp:
+      dashed_name: process-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -9011,6 +9109,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.parent.code_signature.digest_algorithm:
+      dashed_name: process-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.parent.code_signature.exists:
       dashed_name: process-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -9080,6 +9193,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.parent.code_signature.timestamp:
+      dashed_name: process-parent-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -10708,6 +10831,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.target.code_signature.digest_algorithm:
+      dashed_name: process-target-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.target.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.target.code_signature.exists:
       dashed_name: process-target-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -10777,6 +10915,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.target.code_signature.timestamp:
+      dashed_name: process-target-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.target.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.target.code_signature.trusted:
       dashed_name: process-target-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -11324,6 +11472,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.target.parent.code_signature.digest_algorithm:
+      dashed_name: process-target-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.target.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.target.parent.code_signature.exists:
       dashed_name: process-target-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -11393,6 +11556,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.target.parent.code_signature.timestamp:
+      dashed_name: process-target-parent-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.target.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.target.parent.code_signature.trusted:
       dashed_name: process-target-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -14774,6 +14947,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.enrichments.indicator.file.code_signature.exists:
       dashed_name: threat-enrichments-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -14843,6 +15031,16 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.timestamp:
+      dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.enrichments.indicator.file.code_signature.trusted:
       dashed_name: threat-enrichments-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -17121,6 +17319,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.indicator.file.code_signature.exists:
       dashed_name: threat-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -17190,6 +17403,16 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.indicator.file.code_signature.timestamp:
+      dashed_name: threat-indicator-file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: threat.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.indicator.file.code_signature.trusted:
       dashed_name: threat-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -572,6 +572,10 @@
         "properties": {
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -590,6 +594,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -1026,6 +1033,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -1044,6 +1055,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2313,6 +2327,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -2331,6 +2349,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2528,6 +2549,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -2546,6 +2571,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3137,6 +3165,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -3155,6 +3187,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3352,6 +3387,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -3370,6 +3409,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"
@@ -4575,6 +4617,10 @@
                       },
                       "code_signature": {
                         "properties": {
+                          "digest_algorithm": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "exists": {
                             "type": "boolean"
                           },
@@ -4593,6 +4639,9 @@
                           "team_id": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "timestamp": {
+                            "type": "date"
                           },
                           "trusted": {
                             "type": "boolean"
@@ -5397,6 +5446,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -5415,6 +5468,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"

--- a/experimental/generated/elasticsearch/component/dll.json
+++ b/experimental/generated/elasticsearch/component/dll.json
@@ -10,6 +10,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -28,6 +32,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -232,6 +239,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -250,6 +261,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -841,6 +855,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -859,6 +877,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -1056,6 +1077,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -1074,6 +1099,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -59,6 +59,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -77,6 +81,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -881,6 +888,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -899,6 +910,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -585,7 +585,7 @@
     - name: timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
@@ -1047,7 +1047,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -1989,7 +1989,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -4164,7 +4164,7 @@
     - name: code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
@@ -4531,7 +4531,7 @@
     - name: parent.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
@@ -6066,7 +6066,7 @@
     - name: enrichments.indicator.file.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
@@ -7261,7 +7261,7 @@
     - name: indicator.file.code_signature.timestamp
       level: extended
       type: date
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -528,6 +528,16 @@
     description: These fields contain information about binary code signatures.
     type: group
     fields:
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: exists
       level: core
       type: boolean
@@ -571,6 +581,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: trusted
       level: extended
@@ -974,6 +989,16 @@
       * Dynamic library (`.dylib`) commonly used on macOS'
     type: group
     fields:
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1017,6 +1042,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -1900,6 +1930,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1943,6 +1983,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4059,6 +4104,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -4102,6 +4157,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4410,6 +4470,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: parent.code_signature.exists
       level: core
       type: boolean
@@ -4453,6 +4523,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -5929,6 +6004,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: enrichments.indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: enrichments.indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -5972,6 +6057,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -7108,6 +7198,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -7151,6 +7251,11 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Timestamp of when the code signature was generated and signed.
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -586,6 +586,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
       level: extended
@@ -1047,6 +1048,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -1988,6 +1990,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4162,6 +4165,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4528,6 +4532,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -6062,6 +6067,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -7256,6 +7262,7 @@
       level: extended
       type: date
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -111,7 +111,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,dll,dll.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,dll,dll.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -187,7 +187,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,file,file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,file,file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,file,file.created,date,extended,,,File creation time.
@@ -436,7 +436,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,process,process.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -490,7 +490,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,process,process.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -695,7 +695,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -854,7 +854,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
-8.0.0-dev,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
+8.0.0-dev,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -105,11 +105,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 8.0.0-dev,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 8.0.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+8.0.0-dev,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,dll,dll.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -179,11 +181,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 8.0.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,file,file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,file,file.created,date,extended,,,File creation time.
@@ -426,11 +430,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,package,package.version,keyword,extended,,1.12.9,Package version
 8.0.0-dev,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,process,process.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -478,11 +484,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.0.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
+8.0.0-dev,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,process,process.parent.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -681,11 +689,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -838,11 +848,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+8.0.0-dev,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+8.0.0-dev,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,,When the signature was generated and signed.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 8.0.0-dev,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 8.0.0-dev,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1351,7 +1351,7 @@ dll.code_signature.team_id:
   type: keyword
 dll.code_signature.timestamp:
   dashed_name: dll-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: dll.code_signature.timestamp
   level: extended
@@ -2794,7 +2794,7 @@ file.code_signature.team_id:
   type: keyword
 file.code_signature.timestamp:
   dashed_name: file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: file.code_signature.timestamp
   level: extended
@@ -5838,7 +5838,7 @@ process.code_signature.team_id:
   type: keyword
 process.code_signature.timestamp:
   dashed_name: process-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.code_signature.timestamp
   level: extended
@@ -6474,7 +6474,7 @@ process.parent.code_signature.team_id:
   type: keyword
 process.parent.code_signature.timestamp:
   dashed_name: process-parent-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: process.parent.code_signature.timestamp
   level: extended
@@ -8957,7 +8957,7 @@ threat.enrichments.indicator.file.code_signature.team_id:
   type: keyword
 threat.enrichments.indicator.file.code_signature.timestamp:
   dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: threat.enrichments.indicator.file.code_signature.timestamp
   level: extended
@@ -10954,7 +10954,7 @@ threat.indicator.file.code_signature.team_id:
   type: keyword
 threat.indicator.file.code_signature.timestamp:
   dashed_name: threat-indicator-file-code-signature-timestamp
-  description: Timestamp of when the code signature was generated and signed.
+  description: Date and time when the code signature was generated and signed.
   example: '2021-01-01T12:10:30Z'
   flat_name: threat.indicator.file.code_signature.timestamp
   level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1352,6 +1352,7 @@ dll.code_signature.team_id:
 dll.code_signature.timestamp:
   dashed_name: dll-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: dll.code_signature.timestamp
   level: extended
   name: timestamp
@@ -2794,6 +2795,7 @@ file.code_signature.team_id:
 file.code_signature.timestamp:
   dashed_name: file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: file.code_signature.timestamp
   level: extended
   name: timestamp
@@ -5837,6 +5839,7 @@ process.code_signature.team_id:
 process.code_signature.timestamp:
   dashed_name: process-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.code_signature.timestamp
   level: extended
   name: timestamp
@@ -6472,6 +6475,7 @@ process.parent.code_signature.team_id:
 process.parent.code_signature.timestamp:
   dashed_name: process-parent-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: process.parent.code_signature.timestamp
   level: extended
   name: timestamp
@@ -8954,6 +8958,7 @@ threat.enrichments.indicator.file.code_signature.team_id:
 threat.enrichments.indicator.file.code_signature.timestamp:
   dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: threat.enrichments.indicator.file.code_signature.timestamp
   level: extended
   name: timestamp
@@ -10950,6 +10955,7 @@ threat.indicator.file.code_signature.team_id:
 threat.indicator.file.code_signature.timestamp:
   dashed_name: threat-indicator-file-code-signature-timestamp
   description: Timestamp of when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
   flat_name: threat.indicator.file.code_signature.timestamp
   level: extended
   name: timestamp

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1265,6 +1265,21 @@ destination.user.roles:
   original_fieldset: user
   short: Array of user roles at the time of the event.
   type: keyword
+dll.code_signature.digest_algorithm:
+  dashed_name: dll-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: dll.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -1334,6 +1349,16 @@ dll.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+dll.code_signature.timestamp:
+  dashed_name: dll-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: dll.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -2682,6 +2707,21 @@ file.attributes:
   - array
   short: Array of file attributes.
   type: keyword
+file.code_signature.digest_algorithm:
+  dashed_name: file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 file.code_signature.exists:
   dashed_name: file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -2751,6 +2791,16 @@ file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+file.code_signature.timestamp:
+  dashed_name: file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -5700,6 +5750,21 @@ process.args_count:
   normalize: []
   short: Length of the process.args array.
   type: long
+process.code_signature.digest_algorithm:
+  dashed_name: process-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -5769,6 +5834,16 @@ process.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.code_signature.timestamp:
+  dashed_name: process-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -6310,6 +6385,21 @@ process.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.parent.code_signature.digest_algorithm:
+  dashed_name: process-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.parent.code_signature.exists:
   dashed_name: process-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -6379,6 +6469,16 @@ process.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.parent.code_signature.timestamp:
+  dashed_name: process-parent-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: process.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -8767,6 +8867,21 @@ threat.enrichments.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.enrichments.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.enrichments.indicator.file.code_signature.exists:
   dashed_name: threat-enrichments-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -8836,6 +8951,16 @@ threat.enrichments.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.enrichments.indicator.file.code_signature.timestamp:
+  dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.enrichments.indicator.file.code_signature.trusted:
   dashed_name: threat-enrichments-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -10738,6 +10863,21 @@ threat.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.indicator.file.code_signature.exists:
   dashed_name: threat-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -10807,6 +10947,16 @@ threat.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.indicator.file.code_signature.timestamp:
+  dashed_name: threat-indicator-file-code-signature-timestamp
+  description: Timestamp of when the code signature was generated and signed.
+  flat_name: threat.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.indicator.file.code_signature.trusted:
   dashed_name: threat-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -971,7 +971,7 @@ code_signature:
       type: keyword
     code_signature.timestamp:
       dashed_name: code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: code_signature.timestamp
       level: extended
@@ -1760,7 +1760,7 @@ dll:
       type: keyword
     dll.code_signature.timestamp:
       dashed_name: dll-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: dll.code_signature.timestamp
       level: extended
@@ -3626,7 +3626,7 @@ file:
       type: keyword
     file.code_signature.timestamp:
       dashed_name: file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: file.code_signature.timestamp
       level: extended
@@ -7416,7 +7416,7 @@ process:
       type: keyword
     process.code_signature.timestamp:
       dashed_name: process-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.code_signature.timestamp
       level: extended
@@ -8052,7 +8052,7 @@ process:
       type: keyword
     process.parent.code_signature.timestamp:
       dashed_name: process-parent-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: process.parent.code_signature.timestamp
       level: extended
@@ -10693,7 +10693,7 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.code_signature.timestamp:
       dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: threat.enrichments.indicator.file.code_signature.timestamp
       level: extended
@@ -12694,7 +12694,7 @@ threat:
       type: keyword
     threat.indicator.file.code_signature.timestamp:
       dashed_name: threat-indicator-file-code-signature-timestamp
-      description: Timestamp of when the code signature was generated and signed.
+      description: Date and time when the code signature was generated and signed.
       example: '2021-01-01T12:10:30Z'
       flat_name: threat.indicator.file.code_signature.timestamp
       level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -891,6 +891,20 @@ cloud:
 code_signature:
   description: These fields contain information about binary code signatures.
   fields:
+    code_signature.digest_algorithm:
+      dashed_name: code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     code_signature.exists:
       dashed_name: code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -955,6 +969,15 @@ code_signature:
       normalize: []
       short: The team identifier used to sign the process.
       type: keyword
+    code_signature.timestamp:
+      dashed_name: code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      short: When the signature was generated and signed.
+      type: date
     code_signature.trusted:
       dashed_name: code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -1650,6 +1673,21 @@ dll:
 
     * Dynamic library (`.dylib`) commonly used on macOS'
   fields:
+    dll.code_signature.digest_algorithm:
+      dashed_name: dll-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: dll.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     dll.code_signature.exists:
       dashed_name: dll-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -1719,6 +1757,16 @@ dll:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    dll.code_signature.timestamp:
+      dashed_name: dll-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: dll.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -3490,6 +3538,21 @@ file:
       - array
       short: Array of file attributes.
       type: keyword
+    file.code_signature.digest_algorithm:
+      dashed_name: file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     file.code_signature.exists:
       dashed_name: file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -3559,6 +3622,16 @@ file:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    file.code_signature.timestamp:
+      dashed_name: file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -7254,6 +7327,21 @@ process:
       normalize: []
       short: Length of the process.args array.
       type: long
+    process.code_signature.digest_algorithm:
+      dashed_name: process-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.code_signature.exists:
       dashed_name: process-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -7323,6 +7411,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.code_signature.timestamp:
+      dashed_name: process-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -7864,6 +7962,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.parent.code_signature.digest_algorithm:
+      dashed_name: process-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.parent.code_signature.exists:
       dashed_name: process-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -7933,6 +8046,16 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.parent.code_signature.timestamp:
+      dashed_name: process-parent-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: process.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -10479,6 +10602,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.enrichments.indicator.file.code_signature.exists:
       dashed_name: threat-enrichments-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -10548,6 +10686,16 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.timestamp:
+      dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.enrichments.indicator.file.code_signature.trusted:
       dashed_name: threat-enrichments-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -12454,6 +12602,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.indicator.file.code_signature.exists:
       dashed_name: threat-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -12523,6 +12686,16 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.indicator.file.code_signature.timestamp:
+      dashed_name: threat-indicator-file-code-signature-timestamp
+      description: Timestamp of when the code signature was generated and signed.
+      flat_name: threat.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.indicator.file.code_signature.trusted:
       dashed_name: threat-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -972,6 +972,7 @@ code_signature:
     code_signature.timestamp:
       dashed_name: code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: code_signature.timestamp
       level: extended
       name: timestamp
@@ -1760,6 +1761,7 @@ dll:
     dll.code_signature.timestamp:
       dashed_name: dll-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: dll.code_signature.timestamp
       level: extended
       name: timestamp
@@ -3625,6 +3627,7 @@ file:
     file.code_signature.timestamp:
       dashed_name: file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: file.code_signature.timestamp
       level: extended
       name: timestamp
@@ -7414,6 +7417,7 @@ process:
     process.code_signature.timestamp:
       dashed_name: process-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.code_signature.timestamp
       level: extended
       name: timestamp
@@ -8049,6 +8053,7 @@ process:
     process.parent.code_signature.timestamp:
       dashed_name: process-parent-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: process.parent.code_signature.timestamp
       level: extended
       name: timestamp
@@ -10689,6 +10694,7 @@ threat:
     threat.enrichments.indicator.file.code_signature.timestamp:
       dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: threat.enrichments.indicator.file.code_signature.timestamp
       level: extended
       name: timestamp
@@ -12689,6 +12695,7 @@ threat:
     threat.indicator.file.code_signature.timestamp:
       dashed_name: threat-indicator-file-code-signature-timestamp
       description: Timestamp of when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       flat_name: threat.indicator.file.code_signature.timestamp
       level: extended
       name: timestamp

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -530,6 +530,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -548,6 +552,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -853,6 +860,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -871,6 +882,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -2013,6 +2027,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -2031,6 +2049,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -2232,6 +2253,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -2250,6 +2275,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -3165,6 +3193,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -3183,6 +3215,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -3860,6 +3895,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -3878,6 +3917,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -520,6 +520,10 @@
         "properties": {
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -538,6 +542,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -838,6 +845,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -856,6 +867,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -1989,6 +2003,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -2007,6 +2025,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2204,6 +2225,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -2222,6 +2247,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3121,6 +3149,10 @@
                       },
                       "code_signature": {
                         "properties": {
+                          "digest_algorithm": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "exists": {
                             "type": "boolean"
                           },
@@ -3139,6 +3171,9 @@
                           "team_id": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "timestamp": {
+                            "type": "date"
                           },
                           "trusted": {
                             "type": "boolean"
@@ -3807,6 +3842,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -3825,6 +3864,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -10,6 +10,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -28,6 +32,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -232,6 +239,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -250,6 +261,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -59,6 +59,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -77,6 +81,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -745,6 +752,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -763,6 +774,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -57,7 +57,7 @@
         This is useful for logging cryptographic errors with the certificate validity or trust status.
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
-      
+
     - name: team_id
       level: extended
       type: keyword
@@ -68,7 +68,7 @@
         This is used to identify the team or vendor of a software product.
         The field is relevant to Apple *OS only.
       example: EQHXZ8M8AV
-      
+
     - name: signing_id
       level: extended
       type: keyword
@@ -79,3 +79,21 @@
         This is used to identify the application manufactured by a software vendor.
         The field is relevant to Apple *OS only.
       example: com.apple.xpc.proxy
+
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      short: Hashing algorithm used to sign the process.
+      description: >
+        The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.
+      example: sha256
+
+    - name: timestamp
+      level: extended
+      type: date
+      short: When the signature was generated and signed.
+      description: >
+        Timestamp of when the code signature was generated and signed.

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -97,3 +97,4 @@
       short: When the signature was generated and signed.
       description: >
         Timestamp of when the code signature was generated and signed.
+      example: "2021-01-01T12:10:30Z"

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -96,5 +96,5 @@
       type: date
       short: When the signature was generated and signed.
       description: >
-        Timestamp of when the code signature was generated and signed.
+        Date and time when the code signature was generated and signed.
       example: "2021-01-01T12:10:30Z"


### PR DESCRIPTION
Introduces two new fields to the `code_signature.*` field set:

* `code_signature.digest_algorithm` - Hashing algorithm used to sign the process.
* `code_signature.timestamp` - When the signature was generated and signed.:w

Closes #1524 