### PR TITLE
[1.x] Add `code_signature.digest_algorithm` and `code_signature.timestamp` fields (#1557)

### DIFF
--- a/code/go/ecs/code_signature.go
+++ b/code/go/ecs/code_signature.go
@@ -19,6 +19,10 @@
 
 package ecs
 
+import (
+	"time"
+)
+
 // These fields contain information about binary code signatures.
 type CodeSignature struct {
 	// Boolean to capture if a signature is present.
@@ -53,4 +57,12 @@ type CodeSignature struct {
 	// This is used to identify the application manufactured by a software
 	// vendor. The field is relevant to Apple *OS only.
 	SigningID string `ecs:"signing_id"`
+
+	// The hashing algorithm used to sign the process.
+	// This value can distinguish signatures when a file is signed multiple
+	// times by the same signer but with a different digest algorithm.
+	DigestAlgorithm string `ecs:"digest_algorithm"`
+
+	// Date and time when the code signature was generated and signed.
+	Timestamp time.Time `ecs:"timestamp"`
 }

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -788,6 +788,24 @@ These fields contain information about binary code signatures.
 // ===============================================================
 
 |
+[[field-code-signature-digest-algorithm]]
+<<field-code-signature-digest-algorithm, code_signature.digest_algorithm>>
+
+| The hashing algorithm used to sign the process.
+
+This value can distinguish signatures when a file is signed multiple times by the same signer but with a different digest algorithm.
+
+type: keyword
+
+
+
+example: `sha256`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-code-signature-exists]]
 <<field-code-signature-exists, code_signature.exists>>
 
@@ -868,6 +886,22 @@ type: keyword
 
 
 example: `EQHXZ8M8AV`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-code-signature-timestamp]]
+<<field-code-signature-timestamp, code_signature.timestamp>>
+
+| Date and time when the code signature was generated and signed.
+
+type: date
+
+
+
+example: `2021-01-01T12:10:30Z`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -528,6 +528,16 @@
     description: These fields contain information about binary code signatures.
     type: group
     fields:
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: exists
       level: core
       type: boolean
@@ -571,6 +581,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
       level: extended
@@ -1012,6 +1028,16 @@
       * Dynamic library (`.dylib`) commonly used on macOS'
     type: group
     fields:
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1055,6 +1081,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -2148,6 +2180,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -2191,6 +2233,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4802,6 +4850,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -4845,6 +4903,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -5153,6 +5217,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: parent.code_signature.exists
       level: core
       type: boolean
@@ -5196,6 +5270,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -6124,6 +6204,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: target.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: target.code_signature.exists
       level: core
       type: boolean
@@ -6167,6 +6257,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: target.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.code_signature.trusted
       level: extended
@@ -6479,6 +6575,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: target.parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: target.parent.code_signature.exists
       level: core
       type: boolean
@@ -6522,6 +6628,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: target.parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: target.parent.code_signature.trusted
       level: extended
@@ -8464,6 +8576,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: enrichments.indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: enrichments.indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -8507,6 +8629,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -9853,6 +9981,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -9896,6 +10034,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -111,11 +111,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.12.0-dev+exp,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,dll,dll.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -216,11 +218,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 1.12.0-dev+exp,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev+exp,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,file,file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,file,file.created,date,extended,,,File creation time.
@@ -506,11 +510,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,package,package.version,keyword,extended,,1.12.9,Package version
 1.12.0-dev+exp,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev+exp,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -558,11 +564,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev+exp,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -701,11 +709,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 1.12.0-dev+exp,true,process,process.target.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.target.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev+exp,true,process,process.target.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,process,process.target.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,process,process.target.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,process,process.target.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,process,process.target.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,process,process.target.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,process,process.target.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,process,process.target.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.target.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.target.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -753,11 +763,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,process,process.target.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev+exp,true,process,process.target.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev+exp,true,process,process.target.parent.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev+exp,true,process,process.target.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,process,process.target.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,process,process.target.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,process,process.target.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -1025,11 +1037,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -1213,11 +1227,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 1.12.0-dev+exp,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev+exp,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev+exp,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev+exp,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1327,6 +1327,21 @@ destination.user.roles:
   original_fieldset: user
   short: Array of user roles at the time of the event.
   type: keyword
+dll.code_signature.digest_algorithm:
+  dashed_name: dll-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: dll.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -1396,6 +1411,17 @@ dll.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+dll.code_signature.timestamp:
+  dashed_name: dll-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: dll.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -3115,6 +3141,21 @@ file.attributes:
   - array
   short: Array of file attributes.
   type: keyword
+file.code_signature.digest_algorithm:
+  dashed_name: file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 file.code_signature.exists:
   dashed_name: file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -3184,6 +3225,17 @@ file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+file.code_signature.timestamp:
+  dashed_name: file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -6642,6 +6694,21 @@ process.args_count:
   normalize: []
   short: Length of the process.args array.
   type: long
+process.code_signature.digest_algorithm:
+  dashed_name: process-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -6711,6 +6778,17 @@ process.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.code_signature.timestamp:
+  dashed_name: process-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -7252,6 +7330,21 @@ process.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.parent.code_signature.digest_algorithm:
+  dashed_name: process-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.parent.code_signature.exists:
   dashed_name: process-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -7321,6 +7414,17 @@ process.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.parent.code_signature.timestamp:
+  dashed_name: process-parent-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -8947,6 +9051,21 @@ process.target.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.target.code_signature.digest_algorithm:
+  dashed_name: process-target-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.target.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.target.code_signature.exists:
   dashed_name: process-target-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -9016,6 +9135,17 @@ process.target.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.target.code_signature.timestamp:
+  dashed_name: process-target-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.target.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.target.code_signature.trusted:
   dashed_name: process-target-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -9563,6 +9693,21 @@ process.target.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.target.parent.code_signature.digest_algorithm:
+  dashed_name: process-target-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.target.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.target.parent.code_signature.exists:
   dashed_name: process-target-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -9632,6 +9777,17 @@ process.target.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.target.parent.code_signature.timestamp:
+  dashed_name: process-target-parent-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.target.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.target.parent.code_signature.trusted:
   dashed_name: process-target-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -12839,6 +12995,21 @@ threat.enrichments.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.enrichments.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.enrichments.indicator.file.code_signature.exists:
   dashed_name: threat-enrichments-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -12908,6 +13079,17 @@ threat.enrichments.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.enrichments.indicator.file.code_signature.timestamp:
+  dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.enrichments.indicator.file.code_signature.trusted:
   dashed_name: threat-enrichments-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -15181,6 +15363,21 @@ threat.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.indicator.file.code_signature.exists:
   dashed_name: threat-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -15250,6 +15447,17 @@ threat.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.indicator.file.code_signature.timestamp:
+  dashed_name: threat-indicator-file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: threat.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.indicator.file.code_signature.trusted:
   dashed_name: threat-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -891,6 +891,20 @@ cloud:
 code_signature:
   description: These fields contain information about binary code signatures.
   fields:
+    code_signature.digest_algorithm:
+      dashed_name: code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     code_signature.exists:
       dashed_name: code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -955,6 +969,16 @@ code_signature:
       normalize: []
       short: The team identifier used to sign the process.
       type: keyword
+    code_signature.timestamp:
+      dashed_name: code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      short: When the signature was generated and signed.
+      type: date
     code_signature.trusted:
       dashed_name: code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -1712,6 +1736,21 @@ dll:
 
     * Dynamic library (`.dylib`) commonly used on macOS'
   fields:
+    dll.code_signature.digest_algorithm:
+      dashed_name: dll-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: dll.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     dll.code_signature.exists:
       dashed_name: dll-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -1781,6 +1820,17 @@ dll:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    dll.code_signature.timestamp:
+      dashed_name: dll-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: dll.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -3924,6 +3974,21 @@ file:
       - array
       short: Array of file attributes.
       type: keyword
+    file.code_signature.digest_algorithm:
+      dashed_name: file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     file.code_signature.exists:
       dashed_name: file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -3993,6 +4058,17 @@ file:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    file.code_signature.timestamp:
+      dashed_name: file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -8544,6 +8620,21 @@ process:
       normalize: []
       short: Length of the process.args array.
       type: long
+    process.code_signature.digest_algorithm:
+      dashed_name: process-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.code_signature.exists:
       dashed_name: process-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -8613,6 +8704,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.code_signature.timestamp:
+      dashed_name: process-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -9154,6 +9256,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.parent.code_signature.digest_algorithm:
+      dashed_name: process-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.parent.code_signature.exists:
       dashed_name: process-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -9223,6 +9340,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.parent.code_signature.timestamp:
+      dashed_name: process-parent-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -10851,6 +10979,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.target.code_signature.digest_algorithm:
+      dashed_name: process-target-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.target.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.target.code_signature.exists:
       dashed_name: process-target-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -10920,6 +11063,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.target.code_signature.timestamp:
+      dashed_name: process-target-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.target.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.target.code_signature.trusted:
       dashed_name: process-target-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -11467,6 +11621,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.target.parent.code_signature.digest_algorithm:
+      dashed_name: process-target-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.target.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.target.parent.code_signature.exists:
       dashed_name: process-target-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -11536,6 +11705,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.target.parent.code_signature.timestamp:
+      dashed_name: process-target-parent-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.target.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.target.parent.code_signature.trusted:
       dashed_name: process-target-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -14917,6 +15097,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.enrichments.indicator.file.code_signature.exists:
       dashed_name: threat-enrichments-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -14986,6 +15181,17 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.timestamp:
+      dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.enrichments.indicator.file.code_signature.trusted:
       dashed_name: threat-enrichments-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -17264,6 +17470,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.indicator.file.code_signature.exists:
       dashed_name: threat-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -17333,6 +17554,17 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.indicator.file.code_signature.timestamp:
+      dashed_name: threat-indicator-file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: threat.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.indicator.file.code_signature.trusted:
       dashed_name: threat-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -572,6 +572,10 @@
         "properties": {
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -590,6 +594,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -1026,6 +1033,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -1044,6 +1055,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2371,6 +2385,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -2389,6 +2407,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2586,6 +2607,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -2604,6 +2629,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3195,6 +3223,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -3213,6 +3245,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3410,6 +3445,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -3428,6 +3467,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"
@@ -4633,6 +4675,10 @@
                       },
                       "code_signature": {
                         "properties": {
+                          "digest_algorithm": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "exists": {
                             "type": "boolean"
                           },
@@ -4651,6 +4697,9 @@
                           "team_id": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "timestamp": {
+                            "type": "date"
                           },
                           "trusted": {
                             "type": "boolean"
@@ -5455,6 +5504,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -5473,6 +5526,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"

--- a/experimental/generated/elasticsearch/component/dll.json
+++ b/experimental/generated/elasticsearch/component/dll.json
@@ -10,6 +10,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -28,6 +32,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/experimental/generated/elasticsearch/component/file.json
+++ b/experimental/generated/elasticsearch/component/file.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -232,6 +239,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -250,6 +261,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -841,6 +855,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -859,6 +877,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -1056,6 +1077,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -1074,6 +1099,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -59,6 +59,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -77,6 +81,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -881,6 +888,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -899,6 +910,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -528,6 +528,16 @@
     description: These fields contain information about binary code signatures.
     type: group
     fields:
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: exists
       level: core
       type: boolean
@@ -571,6 +581,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: trusted
       level: extended
@@ -974,6 +990,16 @@
       * Dynamic library (`.dylib`) commonly used on macOS'
     type: group
     fields:
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1017,6 +1043,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -1900,6 +1932,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -1943,6 +1985,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4134,6 +4182,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean
@@ -4177,6 +4235,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: code_signature.trusted
       level: extended
@@ -4485,6 +4549,16 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: parent.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: parent.code_signature.exists
       level: core
       type: boolean
@@ -4528,6 +4602,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: parent.code_signature.trusted
       level: extended
@@ -6004,6 +6084,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: enrichments.indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: enrichments.indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -6047,6 +6137,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: enrichments.indicator.file.code_signature.trusted
       level: extended
@@ -7183,6 +7279,16 @@
         execute, hidden, read, readonly, system, write.'
       example: '["readonly", "system"]'
       default_field: false
+    - name: indicator.file.code_signature.digest_algorithm
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      default_field: false
     - name: indicator.file.code_signature.exists
       level: core
       type: boolean
@@ -7226,6 +7332,12 @@
         This is used to identify the team or vendor of a software product. The field
         is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
+      default_field: false
+    - name: indicator.file.code_signature.timestamp
+      level: extended
+      type: date
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
       default_field: false
     - name: indicator.file.code_signature.trusted
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -105,11 +105,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
 1.12.0-dev,true,destination,destination.user.name.text,match_only_text,core,,albert,Short name or login of the user.
 1.12.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.12.0-dev,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,dll,dll.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,dll,dll.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,dll,dll.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
@@ -179,11 +181,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 1.12.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,file,file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,file,file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,file,file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,file,file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,file,file.created,date,extended,,,File creation time.
@@ -438,11 +442,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,package,package.version,keyword,extended,,1.12.9,Package version
 1.12.0-dev,true,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev,true,process,process.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev,true,process,process.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,process,process.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,process,process.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,process,process.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,process,process.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,process,process.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -490,11 +496,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 1.12.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 1.12.0-dev,true,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
+1.12.0-dev,true,process,process.parent.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,process,process.parent.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,process,process.parent.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,process,process.parent.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,process,process.parent.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,process,process.parent.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
@@ -693,11 +701,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
@@ -850,11 +860,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 1.12.0-dev,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.
 1.12.0-dev,true,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.12.0-dev,true,threat,threat.indicator.file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.12.0-dev,true,threat,threat.indicator.file.code_signature.timestamp,date,extended,,2021-01-01T12:10:30Z,When the signature was generated and signed.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,true,Stores the trust status of the certificate chain.
 1.12.0-dev,true,threat,threat.indicator.file.code_signature.valid,boolean,extended,,true,Boolean to capture if the digital signature is verified against the binary content.
 1.12.0-dev,true,threat,threat.indicator.file.created,date,extended,,,File creation time.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1265,6 +1265,21 @@ destination.user.roles:
   original_fieldset: user
   short: Array of user roles at the time of the event.
   type: keyword
+dll.code_signature.digest_algorithm:
+  dashed_name: dll-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: dll.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -1334,6 +1349,17 @@ dll.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+dll.code_signature.timestamp:
+  dashed_name: dll-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: dll.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 dll.code_signature.trusted:
   dashed_name: dll-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -2682,6 +2708,21 @@ file.attributes:
   - array
   short: Array of file attributes.
   type: keyword
+file.code_signature.digest_algorithm:
+  dashed_name: file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 file.code_signature.exists:
   dashed_name: file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -2751,6 +2792,17 @@ file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+file.code_signature.timestamp:
+  dashed_name: file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 file.code_signature.trusted:
   dashed_name: file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -5838,6 +5890,21 @@ process.args_count:
   normalize: []
   short: Length of the process.args array.
   type: long
+process.code_signature.digest_algorithm:
+  dashed_name: process-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -5907,6 +5974,17 @@ process.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.code_signature.timestamp:
+  dashed_name: process-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.code_signature.trusted:
   dashed_name: process-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -6448,6 +6526,21 @@ process.parent.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.parent.code_signature.digest_algorithm:
+  dashed_name: process-parent-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: process.parent.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 process.parent.code_signature.exists:
   dashed_name: process-parent-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -6517,6 +6610,17 @@ process.parent.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+process.parent.code_signature.timestamp:
+  dashed_name: process-parent-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: process.parent.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 process.parent.code_signature.trusted:
   dashed_name: process-parent-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -8905,6 +9009,21 @@ threat.enrichments.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.enrichments.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.enrichments.indicator.file.code_signature.exists:
   dashed_name: threat-enrichments-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -8974,6 +9093,17 @@ threat.enrichments.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.enrichments.indicator.file.code_signature.timestamp:
+  dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.enrichments.indicator.file.code_signature.trusted:
   dashed_name: threat-enrichments-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.
@@ -10876,6 +11006,21 @@ threat.indicator.file.attributes:
   original_fieldset: file
   short: Array of file attributes.
   type: keyword
+threat.indicator.file.code_signature.digest_algorithm:
+  dashed_name: threat-indicator-file-code-signature-digest-algorithm
+  description: 'The hashing algorithm used to sign the process.
+
+    This value can distinguish signatures when a file is signed multiple times by
+    the same signer but with a different digest algorithm.'
+  example: sha256
+  flat_name: threat.indicator.file.code_signature.digest_algorithm
+  ignore_above: 1024
+  level: extended
+  name: digest_algorithm
+  normalize: []
+  original_fieldset: code_signature
+  short: Hashing algorithm used to sign the process.
+  type: keyword
 threat.indicator.file.code_signature.exists:
   dashed_name: threat-indicator-file-code-signature-exists
   description: Boolean to capture if a signature is present.
@@ -10945,6 +11090,17 @@ threat.indicator.file.code_signature.team_id:
   original_fieldset: code_signature
   short: The team identifier used to sign the process.
   type: keyword
+threat.indicator.file.code_signature.timestamp:
+  dashed_name: threat-indicator-file-code-signature-timestamp
+  description: Date and time when the code signature was generated and signed.
+  example: '2021-01-01T12:10:30Z'
+  flat_name: threat.indicator.file.code_signature.timestamp
+  level: extended
+  name: timestamp
+  normalize: []
+  original_fieldset: code_signature
+  short: When the signature was generated and signed.
+  type: date
 threat.indicator.file.code_signature.trusted:
   dashed_name: threat-indicator-file-code-signature-trusted
   description: 'Stores the trust status of the certificate chain.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -891,6 +891,20 @@ cloud:
 code_signature:
   description: These fields contain information about binary code signatures.
   fields:
+    code_signature.digest_algorithm:
+      dashed_name: code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     code_signature.exists:
       dashed_name: code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -955,6 +969,16 @@ code_signature:
       normalize: []
       short: The team identifier used to sign the process.
       type: keyword
+    code_signature.timestamp:
+      dashed_name: code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      short: When the signature was generated and signed.
+      type: date
     code_signature.trusted:
       dashed_name: code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -1650,6 +1674,21 @@ dll:
 
     * Dynamic library (`.dylib`) commonly used on macOS'
   fields:
+    dll.code_signature.digest_algorithm:
+      dashed_name: dll-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: dll.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     dll.code_signature.exists:
       dashed_name: dll-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -1719,6 +1758,17 @@ dll:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    dll.code_signature.timestamp:
+      dashed_name: dll-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: dll.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     dll.code_signature.trusted:
       dashed_name: dll-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -3490,6 +3540,21 @@ file:
       - array
       short: Array of file attributes.
       type: keyword
+    file.code_signature.digest_algorithm:
+      dashed_name: file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     file.code_signature.exists:
       dashed_name: file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -3559,6 +3624,17 @@ file:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    file.code_signature.timestamp:
+      dashed_name: file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     file.code_signature.trusted:
       dashed_name: file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -7397,6 +7473,21 @@ process:
       normalize: []
       short: Length of the process.args array.
       type: long
+    process.code_signature.digest_algorithm:
+      dashed_name: process-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.code_signature.exists:
       dashed_name: process-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -7466,6 +7557,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.code_signature.timestamp:
+      dashed_name: process-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.code_signature.trusted:
       dashed_name: process-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -8007,6 +8109,21 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.parent.code_signature.digest_algorithm:
+      dashed_name: process-parent-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: process.parent.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     process.parent.code_signature.exists:
       dashed_name: process-parent-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -8076,6 +8193,17 @@ process:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    process.parent.code_signature.timestamp:
+      dashed_name: process-parent-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: process.parent.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     process.parent.code_signature.trusted:
       dashed_name: process-parent-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -10622,6 +10750,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-enrichments-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.enrichments.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.enrichments.indicator.file.code_signature.exists:
       dashed_name: threat-enrichments-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -10691,6 +10834,17 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.enrichments.indicator.file.code_signature.timestamp:
+      dashed_name: threat-enrichments-indicator-file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: threat.enrichments.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.enrichments.indicator.file.code_signature.trusted:
       dashed_name: threat-enrichments-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.
@@ -12597,6 +12751,21 @@ threat:
       original_fieldset: file
       short: Array of file attributes.
       type: keyword
+    threat.indicator.file.code_signature.digest_algorithm:
+      dashed_name: threat-indicator-file-code-signature-digest-algorithm
+      description: 'The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.'
+      example: sha256
+      flat_name: threat.indicator.file.code_signature.digest_algorithm
+      ignore_above: 1024
+      level: extended
+      name: digest_algorithm
+      normalize: []
+      original_fieldset: code_signature
+      short: Hashing algorithm used to sign the process.
+      type: keyword
     threat.indicator.file.code_signature.exists:
       dashed_name: threat-indicator-file-code-signature-exists
       description: Boolean to capture if a signature is present.
@@ -12666,6 +12835,17 @@ threat:
       original_fieldset: code_signature
       short: The team identifier used to sign the process.
       type: keyword
+    threat.indicator.file.code_signature.timestamp:
+      dashed_name: threat-indicator-file-code-signature-timestamp
+      description: Date and time when the code signature was generated and signed.
+      example: '2021-01-01T12:10:30Z'
+      flat_name: threat.indicator.file.code_signature.timestamp
+      level: extended
+      name: timestamp
+      normalize: []
+      original_fieldset: code_signature
+      short: When the signature was generated and signed.
+      type: date
     threat.indicator.file.code_signature.trusted:
       dashed_name: threat-indicator-file-code-signature-trusted
       description: 'Stores the trust status of the certificate chain.

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -530,6 +530,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -548,6 +552,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -853,6 +860,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -871,6 +882,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -2073,6 +2087,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -2091,6 +2109,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -2292,6 +2313,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -2310,6 +2335,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"
@@ -3225,6 +3253,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -3243,6 +3275,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -3920,6 +3955,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -3938,6 +3977,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -520,6 +520,10 @@
         "properties": {
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -538,6 +542,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -838,6 +845,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -856,6 +867,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2047,6 +2061,10 @@
           },
           "code_signature": {
             "properties": {
+              "digest_algorithm": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "exists": {
                 "type": "boolean"
               },
@@ -2065,6 +2083,9 @@
               "team_id": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "timestamp": {
+                "type": "date"
               },
               "trusted": {
                 "type": "boolean"
@@ -2262,6 +2283,10 @@
               },
               "code_signature": {
                 "properties": {
+                  "digest_algorithm": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "exists": {
                     "type": "boolean"
                   },
@@ -2280,6 +2305,9 @@
                   "team_id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "timestamp": {
+                    "type": "date"
                   },
                   "trusted": {
                     "type": "boolean"
@@ -3179,6 +3207,10 @@
                       },
                       "code_signature": {
                         "properties": {
+                          "digest_algorithm": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "exists": {
                             "type": "boolean"
                           },
@@ -3197,6 +3229,9 @@
                           "team_id": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "timestamp": {
+                            "type": "date"
                           },
                           "trusted": {
                             "type": "boolean"
@@ -3865,6 +3900,10 @@
                   },
                   "code_signature": {
                     "properties": {
+                      "digest_algorithm": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "exists": {
                         "type": "boolean"
                       },
@@ -3883,6 +3922,9 @@
                       "team_id": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "timestamp": {
+                        "type": "date"
                       },
                       "trusted": {
                         "type": "boolean"

--- a/generated/elasticsearch/component/dll.json
+++ b/generated/elasticsearch/component/dll.json
@@ -10,6 +10,10 @@
           "properties": {
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -28,6 +32,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/generated/elasticsearch/component/file.json
+++ b/generated/elasticsearch/component/file.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -17,6 +17,10 @@
             },
             "code_signature": {
               "properties": {
+                "digest_algorithm": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "exists": {
                   "type": "boolean"
                 },
@@ -35,6 +39,9 @@
                 "team_id": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "timestamp": {
+                  "type": "date"
                 },
                 "trusted": {
                   "type": "boolean"
@@ -232,6 +239,10 @@
                 },
                 "code_signature": {
                   "properties": {
+                    "digest_algorithm": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "exists": {
                       "type": "boolean"
                     },
@@ -250,6 +261,9 @@
                     "team_id": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "timestamp": {
+                      "type": "date"
                     },
                     "trusted": {
                       "type": "boolean"

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -59,6 +59,10 @@
                         },
                         "code_signature": {
                           "properties": {
+                            "digest_algorithm": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "exists": {
                               "type": "boolean"
                             },
@@ -77,6 +81,9 @@
                             "team_id": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "timestamp": {
+                              "type": "date"
                             },
                             "trusted": {
                               "type": "boolean"
@@ -745,6 +752,10 @@
                     },
                     "code_signature": {
                       "properties": {
+                        "digest_algorithm": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "exists": {
                           "type": "boolean"
                         },
@@ -763,6 +774,9 @@
                         "team_id": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "timestamp": {
+                          "type": "date"
                         },
                         "trusted": {
                           "type": "boolean"

--- a/schemas/code_signature.yml
+++ b/schemas/code_signature.yml
@@ -57,7 +57,7 @@
         This is useful for logging cryptographic errors with the certificate validity or trust status.
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
-      
+
     - name: team_id
       level: extended
       type: keyword
@@ -68,7 +68,7 @@
         This is used to identify the team or vendor of a software product.
         The field is relevant to Apple *OS only.
       example: EQHXZ8M8AV
-      
+
     - name: signing_id
       level: extended
       type: keyword
@@ -79,3 +79,22 @@
         This is used to identify the application manufactured by a software vendor.
         The field is relevant to Apple *OS only.
       example: com.apple.xpc.proxy
+
+    - name: digest_algorithm
+      level: extended
+      type: keyword
+      short: Hashing algorithm used to sign the process.
+      description: >
+        The hashing algorithm used to sign the process.
+
+        This value can distinguish signatures when a file is signed multiple times
+        by the same signer but with a different digest algorithm.
+      example: sha256
+
+    - name: timestamp
+      level: extended
+      type: date
+      short: When the signature was generated and signed.
+      description: >
+        Date and time when the code signature was generated and signed.
+      example: "2021-01-01T12:10:30Z"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - Add `code_signature.digest_algorithm` and `code_signature.timestamp` fields (#1557)