### PR TITLE
[1.x] RFC 0010 Stage 1 - Add `email.*` fields to experimental schema (#1569)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,7 @@ Thanks, you're awesome :-) -->
 * Added `process.end` field. #1544
 * Introduce container metric fields into experimental schema. #1546
 * Update `user.name` and `user.id` examples for clarity. #1566
+* Add `email.*` field set in the experimental fields. #1569
 
 ### Tooling and Artifact Changes
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1789,6 +1789,176 @@
       ignore_above: 1024
       description: telfhash symbol hash for ELF file.
       default_field: false
+  - name: email
+    title: Email
+    group: 2
+    description: 'Fields relating to an email transaction.
+
+      This field set focuses on the email message header, body, and attachments. Network
+      protocols that send and receive email messages such as SMTP are outside the
+      scope of the `email.*` fields.'
+    type: group
+    fields:
+    - name: attachments
+      level: extended
+      type: nested
+      description: A list of attachment files sent along with an email message.
+      default_field: false
+    - name: attachments.file.extension
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Attachment file extension, excluding the leading dot.
+      example: txt
+      default_field: false
+    - name: attachments.file.mime_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The MIME media type of the attachment.
+
+        This value will typically be extracted from the `Content-Type` MIME header
+        field.'
+      example: text/plain
+      default_field: false
+    - name: attachments.file.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the attachment file including the file extension.
+      example: attachment.txt
+      default_field: false
+    - name: attachments.file.size
+      level: extended
+      type: long
+      description: Attachment file size in bytes.
+      example: 64329
+      default_field: false
+    - name: attachments.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash of the attachment file.
+      example: e25f1c98ffdacf611473af364362ec48
+      default_field: false
+    - name: attachments.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA-1 hash of the attachment file.
+      example: 8c1cd40f17109b427e61d4e72ca6d9a4fc8175f3
+      default_field: false
+    - name: attachments.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA-256 hash of the attachment file.
+      example: f0366b3559f577d8732f7e9cc343a4960d202e8137dcc42f9783f3963f6abc6a
+      default_field: false
+    - name: bcc
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The email address(es) of the blind carbon carbon (BCC) recipients.
+      example: '[''bcc.user1@example.com'', ''bcc.user2@example.com'']'
+      default_field: false
+    - name: cc
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The email address(es) of the carbon carbon (BCC) recipients.
+      example: '[''cc.user1@example.com'', ''cc.user2@example.com'']'
+      default_field: false
+    - name: content_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Information about how the message is to be displayed.
+
+        Typically a MIME type.'
+      example: text/plain
+      default_field: false
+    - name: delivery_timestamp
+      level: extended
+      type: date
+      description: The date and time when the email message was received by the service
+        or client.
+      example: '2020-11-10T22:12:34.8196921Z'
+      default_field: false
+    - name: direction
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The direction of the message based on the sending and receiving
+        domains.
+      example: inbound
+      default_field: false
+    - name: from
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The email address of the sender, typically from the RFC 5322 `From:`
+        header field.
+      example: sender@example.com
+      default_field: false
+    - name: local_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier given to the email by the source that created
+        the event.
+
+        Identifier is not persistent across hops.'
+      example: c26dbea0-80d5-463b-b93c-4e8b708219ce
+      default_field: false
+    - name: message_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Identifier from the RFC 5322 `Message-ID:` email header that refers
+        to a particular email message.
+      example: <81ce15$8r2j59@mail01.example.com>
+      default_field: false
+    - name: origination_timestamp
+      level: extended
+      type: date
+      description: The date and time the email message was composed. Many email clients
+        will fill in this value automatically when the message is sent by a user.
+      example: '2020-11-10T22:12:34.8196921Z'
+      default_field: false
+    - name: reply_to
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The address that replies should be delivered to based on the value
+        in the RFC 5322 `Reply-To:` header.
+      example: reply.here@example.com
+      default_field: false
+    - name: subject
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: match_only_text
+      description: A brief summary of the topic of the message.
+      example: Please see this important message.
+      default_field: false
+    - name: to
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The email address(es) of the message recipients.
+      example: '[''user1@example.com'', ''user2@example.com'']'
+      default_field: false
+    - name: x_mailer
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of the application that was used to draft and send the
+        original email message.
+      example: Spambot v2.5
+      default_field: false
   - name: error
     title: Error
     group: 2

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -184,6 +184,28 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,dns,dns.response_code,keyword,extended,,NOERROR,The DNS response code.
 1.12.0-dev+exp,true,dns,dns.type,keyword,extended,,answer,"The type of DNS event captured, query or answer."
 1.12.0-dev+exp,true,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
+1.12.0-dev+exp,true,email,email.attachments,nested,extended,,,List of objects describing the attachments.
+1.12.0-dev+exp,true,email,email.attachments.file.extension,keyword,extended,,txt,Attachment file extension.
+1.12.0-dev+exp,true,email,email.attachments.file.mime_type,keyword,extended,,text/plain,MIME type of the attachment file.
+1.12.0-dev+exp,true,email,email.attachments.file.name,keyword,extended,,attachment.txt,Name of the attachment file.
+1.12.0-dev+exp,true,email,email.attachments.file.size,long,extended,,64329,Attachment file size.
+1.12.0-dev+exp,true,email,email.attachments.hash.md5,keyword,extended,,e25f1c98ffdacf611473af364362ec48,MD5 hash of the attachment.
+1.12.0-dev+exp,true,email,email.attachments.hash.sha1,keyword,extended,,8c1cd40f17109b427e61d4e72ca6d9a4fc8175f3,SHA-1 hash of the attachment.
+1.12.0-dev+exp,true,email,email.attachments.hash.sha256,keyword,extended,,f0366b3559f577d8732f7e9cc343a4960d202e8137dcc42f9783f3963f6abc6a,SHA-256 hash of the attachment.
+1.12.0-dev+exp,true,email,email.bcc,keyword,extended,array,"['bcc.user1@example.com', 'bcc.user2@example.com']",Email address(es) of BCC recipients
+1.12.0-dev+exp,true,email,email.cc,keyword,extended,array,"['cc.user1@example.com', 'cc.user2@example.com']",Email address(es) of CC recipients
+1.12.0-dev+exp,true,email,email.content_type,keyword,extended,,text/plain,MIME type of the email message.
+1.12.0-dev+exp,true,email,email.delivery_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time when message was delivered.
+1.12.0-dev+exp,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
+1.12.0-dev+exp,true,email,email.from,keyword,extended,,sender@example.com,The sender's email address.
+1.12.0-dev+exp,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
+1.12.0-dev+exp,true,email,email.message_id,keyword,extended,,<81ce15$8r2j59@mail01.example.com>,Value from the Message-ID header.
+1.12.0-dev+exp,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
+1.12.0-dev+exp,true,email,email.reply_to,keyword,extended,,reply.here@example.com,Address replies should be delivered to.
+1.12.0-dev+exp,true,email,email.subject,keyword,extended,,Please see this important message.,The subject of the email message.
+1.12.0-dev+exp,true,email,email.subject.text,match_only_text,extended,,Please see this important message.,The subject of the email message.
+1.12.0-dev+exp,true,email,email.to,keyword,extended,array,"['user1@example.com', 'user2@example.com']",Email address(es) of the recipients.
+1.12.0-dev+exp,true,email,email.x_mailer,keyword,extended,,Spambot v2.5,Application that drafted email.
 1.12.0-dev+exp,true,error,error.code,keyword,core,,,Error code describing the error.
 1.12.0-dev+exp,true,error,error.id,keyword,core,,,Unique identifier for the error.
 1.12.0-dev+exp,true,error,error.message,match_only_text,core,,,Error message.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2259,6 +2259,252 @@ ecs.version:
   required: true
   short: ECS version this event conforms to.
   type: keyword
+email.attachments:
+  dashed_name: email-attachments
+  description: A list of attachment files sent along with an email message.
+  flat_name: email.attachments
+  level: extended
+  name: attachments
+  normalize: []
+  short: List of objects describing the attachments.
+  type: nested
+email.attachments.file.extension:
+  dashed_name: email-attachments-file-extension
+  description: Attachment file extension, excluding the leading dot.
+  example: txt
+  flat_name: email.attachments.file.extension
+  ignore_above: 1024
+  level: extended
+  name: attachments.file.extension
+  normalize: []
+  short: Attachment file extension.
+  type: keyword
+email.attachments.file.mime_type:
+  dashed_name: email-attachments-file-mime-type
+  description: 'The MIME media type of the attachment.
+
+    This value will typically be extracted from the `Content-Type` MIME header field.'
+  example: text/plain
+  flat_name: email.attachments.file.mime_type
+  ignore_above: 1024
+  level: extended
+  name: attachments.file.mime_type
+  normalize: []
+  short: MIME type of the attachment file.
+  type: keyword
+email.attachments.file.name:
+  dashed_name: email-attachments-file-name
+  description: Name of the attachment file including the file extension.
+  example: attachment.txt
+  flat_name: email.attachments.file.name
+  ignore_above: 1024
+  level: extended
+  name: attachments.file.name
+  normalize: []
+  short: Name of the attachment file.
+  type: keyword
+email.attachments.file.size:
+  dashed_name: email-attachments-file-size
+  description: Attachment file size in bytes.
+  example: 64329
+  flat_name: email.attachments.file.size
+  level: extended
+  name: attachments.file.size
+  normalize: []
+  short: Attachment file size.
+  type: long
+email.attachments.hash.md5:
+  dashed_name: email-attachments-hash-md5
+  description: MD5 hash of the attachment file.
+  example: e25f1c98ffdacf611473af364362ec48
+  flat_name: email.attachments.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: attachments.hash.md5
+  normalize: []
+  short: MD5 hash of the attachment.
+  type: keyword
+email.attachments.hash.sha1:
+  dashed_name: email-attachments-hash-sha1
+  description: SHA-1 hash of the attachment file.
+  example: 8c1cd40f17109b427e61d4e72ca6d9a4fc8175f3
+  flat_name: email.attachments.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: attachments.hash.sha1
+  normalize: []
+  short: SHA-1 hash of the attachment.
+  type: keyword
+email.attachments.hash.sha256:
+  dashed_name: email-attachments-hash-sha256
+  description: SHA-256 hash of the attachment file.
+  example: f0366b3559f577d8732f7e9cc343a4960d202e8137dcc42f9783f3963f6abc6a
+  flat_name: email.attachments.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: attachments.hash.sha256
+  normalize: []
+  short: SHA-256 hash of the attachment.
+  type: keyword
+email.bcc:
+  dashed_name: email-bcc
+  description: The email address(es) of the blind carbon carbon (BCC) recipients.
+  example: '[''bcc.user1@example.com'', ''bcc.user2@example.com'']'
+  flat_name: email.bcc
+  ignore_above: 1024
+  level: extended
+  name: bcc
+  normalize:
+  - array
+  short: Email address(es) of BCC recipients
+  type: keyword
+email.cc:
+  dashed_name: email-cc
+  description: The email address(es) of the carbon carbon (BCC) recipients.
+  example: '[''cc.user1@example.com'', ''cc.user2@example.com'']'
+  flat_name: email.cc
+  ignore_above: 1024
+  level: extended
+  name: cc
+  normalize:
+  - array
+  short: Email address(es) of CC recipients
+  type: keyword
+email.content_type:
+  dashed_name: email-content-type
+  description: 'Information about how the message is to be displayed.
+
+    Typically a MIME type.'
+  example: text/plain
+  flat_name: email.content_type
+  ignore_above: 1024
+  level: extended
+  name: content_type
+  normalize: []
+  short: MIME type of the email message.
+  type: keyword
+email.delivery_timestamp:
+  dashed_name: email-delivery-timestamp
+  description: The date and time when the email message was received by the service
+    or client.
+  example: '2020-11-10T22:12:34.8196921Z'
+  flat_name: email.delivery_timestamp
+  level: extended
+  name: delivery_timestamp
+  normalize: []
+  short: Date and time when message was delivered.
+  type: date
+email.direction:
+  dashed_name: email-direction
+  description: The direction of the message based on the sending and receiving domains.
+  example: inbound
+  flat_name: email.direction
+  ignore_above: 1024
+  level: extended
+  name: direction
+  normalize: []
+  short: Direction of the message.
+  type: keyword
+email.from:
+  dashed_name: email-from
+  description: The email address of the sender, typically from the RFC 5322 `From:`
+    header field.
+  example: sender@example.com
+  flat_name: email.from
+  ignore_above: 1024
+  level: extended
+  name: from
+  normalize: []
+  short: The sender's email address.
+  type: keyword
+email.local_id:
+  dashed_name: email-local-id
+  description: 'Unique identifier given to the email by the source that created the
+    event.
+
+    Identifier is not persistent across hops.'
+  example: c26dbea0-80d5-463b-b93c-4e8b708219ce
+  flat_name: email.local_id
+  ignore_above: 1024
+  level: extended
+  name: local_id
+  normalize: []
+  short: Unique identifier given by the source.
+  type: keyword
+email.message_id:
+  dashed_name: email-message-id
+  description: Identifier from the RFC 5322 `Message-ID:` email header that refers
+    to a particular email message.
+  example: <81ce15$8r2j59@mail01.example.com>
+  flat_name: email.message_id
+  ignore_above: 1024
+  level: extended
+  name: message_id
+  normalize: []
+  short: Value from the Message-ID header.
+  type: keyword
+email.origination_timestamp:
+  dashed_name: email-origination-timestamp
+  description: The date and time the email message was composed. Many email clients
+    will fill in this value automatically when the message is sent by a user.
+  example: '2020-11-10T22:12:34.8196921Z'
+  flat_name: email.origination_timestamp
+  level: extended
+  name: origination_timestamp
+  normalize: []
+  short: Date and time the email was composed.
+  type: date
+email.reply_to:
+  dashed_name: email-reply-to
+  description: The address that replies should be delivered to based on the value
+    in the RFC 5322 `Reply-To:` header.
+  example: reply.here@example.com
+  flat_name: email.reply_to
+  ignore_above: 1024
+  level: extended
+  name: reply_to
+  normalize: []
+  short: Address replies should be delivered to.
+  type: keyword
+email.subject:
+  dashed_name: email-subject
+  description: A brief summary of the topic of the message.
+  example: Please see this important message.
+  flat_name: email.subject
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: email.subject.text
+    name: text
+    type: match_only_text
+  name: subject
+  normalize: []
+  short: The subject of the email message.
+  type: keyword
+email.to:
+  dashed_name: email-to
+  description: The email address(es) of the message recipients.
+  example: '[''user1@example.com'', ''user2@example.com'']'
+  flat_name: email.to
+  ignore_above: 1024
+  level: extended
+  name: to
+  normalize:
+  - array
+  short: Email address(es) of the recipients.
+  type: keyword
+email.x_mailer:
+  dashed_name: email-x-mailer
+  description: The name of the application that was used to draft and send the original
+    email message.
+  example: Spambot v2.5
+  flat_name: email.x_mailer
+  ignore_above: 1024
+  level: extended
+  name: x_mailer
+  normalize: []
+  short: Application that drafted email.
+  type: keyword
 error.code:
   dashed_name: error-code
   description: Error code describing the error.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3035,6 +3035,267 @@ elf:
   short: These fields contain Linux Executable Linkable Format (ELF) metadata.
   title: ELF Header
   type: group
+email:
+  description: 'Fields relating to an email transaction.
+
+    This field set focuses on the email message header, body, and attachments. Network
+    protocols that send and receive email messages such as SMTP are outside the scope
+    of the `email.*` fields.'
+  fields:
+    email.attachments:
+      dashed_name: email-attachments
+      description: A list of attachment files sent along with an email message.
+      flat_name: email.attachments
+      level: extended
+      name: attachments
+      normalize: []
+      short: List of objects describing the attachments.
+      type: nested
+    email.attachments.file.extension:
+      dashed_name: email-attachments-file-extension
+      description: Attachment file extension, excluding the leading dot.
+      example: txt
+      flat_name: email.attachments.file.extension
+      ignore_above: 1024
+      level: extended
+      name: attachments.file.extension
+      normalize: []
+      short: Attachment file extension.
+      type: keyword
+    email.attachments.file.mime_type:
+      dashed_name: email-attachments-file-mime-type
+      description: 'The MIME media type of the attachment.
+
+        This value will typically be extracted from the `Content-Type` MIME header
+        field.'
+      example: text/plain
+      flat_name: email.attachments.file.mime_type
+      ignore_above: 1024
+      level: extended
+      name: attachments.file.mime_type
+      normalize: []
+      short: MIME type of the attachment file.
+      type: keyword
+    email.attachments.file.name:
+      dashed_name: email-attachments-file-name
+      description: Name of the attachment file including the file extension.
+      example: attachment.txt
+      flat_name: email.attachments.file.name
+      ignore_above: 1024
+      level: extended
+      name: attachments.file.name
+      normalize: []
+      short: Name of the attachment file.
+      type: keyword
+    email.attachments.file.size:
+      dashed_name: email-attachments-file-size
+      description: Attachment file size in bytes.
+      example: 64329
+      flat_name: email.attachments.file.size
+      level: extended
+      name: attachments.file.size
+      normalize: []
+      short: Attachment file size.
+      type: long
+    email.attachments.hash.md5:
+      dashed_name: email-attachments-hash-md5
+      description: MD5 hash of the attachment file.
+      example: e25f1c98ffdacf611473af364362ec48
+      flat_name: email.attachments.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: attachments.hash.md5
+      normalize: []
+      short: MD5 hash of the attachment.
+      type: keyword
+    email.attachments.hash.sha1:
+      dashed_name: email-attachments-hash-sha1
+      description: SHA-1 hash of the attachment file.
+      example: 8c1cd40f17109b427e61d4e72ca6d9a4fc8175f3
+      flat_name: email.attachments.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: attachments.hash.sha1
+      normalize: []
+      short: SHA-1 hash of the attachment.
+      type: keyword
+    email.attachments.hash.sha256:
+      dashed_name: email-attachments-hash-sha256
+      description: SHA-256 hash of the attachment file.
+      example: f0366b3559f577d8732f7e9cc343a4960d202e8137dcc42f9783f3963f6abc6a
+      flat_name: email.attachments.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: attachments.hash.sha256
+      normalize: []
+      short: SHA-256 hash of the attachment.
+      type: keyword
+    email.bcc:
+      dashed_name: email-bcc
+      description: The email address(es) of the blind carbon carbon (BCC) recipients.
+      example: '[''bcc.user1@example.com'', ''bcc.user2@example.com'']'
+      flat_name: email.bcc
+      ignore_above: 1024
+      level: extended
+      name: bcc
+      normalize:
+      - array
+      short: Email address(es) of BCC recipients
+      type: keyword
+    email.cc:
+      dashed_name: email-cc
+      description: The email address(es) of the carbon carbon (BCC) recipients.
+      example: '[''cc.user1@example.com'', ''cc.user2@example.com'']'
+      flat_name: email.cc
+      ignore_above: 1024
+      level: extended
+      name: cc
+      normalize:
+      - array
+      short: Email address(es) of CC recipients
+      type: keyword
+    email.content_type:
+      dashed_name: email-content-type
+      description: 'Information about how the message is to be displayed.
+
+        Typically a MIME type.'
+      example: text/plain
+      flat_name: email.content_type
+      ignore_above: 1024
+      level: extended
+      name: content_type
+      normalize: []
+      short: MIME type of the email message.
+      type: keyword
+    email.delivery_timestamp:
+      dashed_name: email-delivery-timestamp
+      description: The date and time when the email message was received by the service
+        or client.
+      example: '2020-11-10T22:12:34.8196921Z'
+      flat_name: email.delivery_timestamp
+      level: extended
+      name: delivery_timestamp
+      normalize: []
+      short: Date and time when message was delivered.
+      type: date
+    email.direction:
+      dashed_name: email-direction
+      description: The direction of the message based on the sending and receiving
+        domains.
+      example: inbound
+      flat_name: email.direction
+      ignore_above: 1024
+      level: extended
+      name: direction
+      normalize: []
+      short: Direction of the message.
+      type: keyword
+    email.from:
+      dashed_name: email-from
+      description: The email address of the sender, typically from the RFC 5322 `From:`
+        header field.
+      example: sender@example.com
+      flat_name: email.from
+      ignore_above: 1024
+      level: extended
+      name: from
+      normalize: []
+      short: The sender's email address.
+      type: keyword
+    email.local_id:
+      dashed_name: email-local-id
+      description: 'Unique identifier given to the email by the source that created
+        the event.
+
+        Identifier is not persistent across hops.'
+      example: c26dbea0-80d5-463b-b93c-4e8b708219ce
+      flat_name: email.local_id
+      ignore_above: 1024
+      level: extended
+      name: local_id
+      normalize: []
+      short: Unique identifier given by the source.
+      type: keyword
+    email.message_id:
+      dashed_name: email-message-id
+      description: Identifier from the RFC 5322 `Message-ID:` email header that refers
+        to a particular email message.
+      example: <81ce15$8r2j59@mail01.example.com>
+      flat_name: email.message_id
+      ignore_above: 1024
+      level: extended
+      name: message_id
+      normalize: []
+      short: Value from the Message-ID header.
+      type: keyword
+    email.origination_timestamp:
+      dashed_name: email-origination-timestamp
+      description: The date and time the email message was composed. Many email clients
+        will fill in this value automatically when the message is sent by a user.
+      example: '2020-11-10T22:12:34.8196921Z'
+      flat_name: email.origination_timestamp
+      level: extended
+      name: origination_timestamp
+      normalize: []
+      short: Date and time the email was composed.
+      type: date
+    email.reply_to:
+      dashed_name: email-reply-to
+      description: The address that replies should be delivered to based on the value
+        in the RFC 5322 `Reply-To:` header.
+      example: reply.here@example.com
+      flat_name: email.reply_to
+      ignore_above: 1024
+      level: extended
+      name: reply_to
+      normalize: []
+      short: Address replies should be delivered to.
+      type: keyword
+    email.subject:
+      dashed_name: email-subject
+      description: A brief summary of the topic of the message.
+      example: Please see this important message.
+      flat_name: email.subject
+      ignore_above: 1024
+      level: extended
+      multi_fields:
+      - flat_name: email.subject.text
+        name: text
+        type: match_only_text
+      name: subject
+      normalize: []
+      short: The subject of the email message.
+      type: keyword
+    email.to:
+      dashed_name: email-to
+      description: The email address(es) of the message recipients.
+      example: '[''user1@example.com'', ''user2@example.com'']'
+      flat_name: email.to
+      ignore_above: 1024
+      level: extended
+      name: to
+      normalize:
+      - array
+      short: Email address(es) of the recipients.
+      type: keyword
+    email.x_mailer:
+      dashed_name: email-x-mailer
+      description: The name of the application that was used to draft and send the
+        original email message.
+      example: Spambot v2.5
+      flat_name: email.x_mailer
+      ignore_above: 1024
+      level: extended
+      name: x_mailer
+      normalize: []
+      short: Application that drafted email.
+      type: keyword
+  group: 2
+  name: email
+  prefix: email.
+  short: Fields describing an email transaction.
+  title: Email
+  type: group
 error:
   description: 'These fields can represent errors of any kind.
 

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -895,6 +895,105 @@
           }
         }
       },
+      "email": {
+        "properties": {
+          "attachments": {
+            "properties": {
+              "file": {
+                "properties": {
+                  "extension": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "mime_type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "size": {
+                    "type": "long"
+                  }
+                }
+              },
+              "hash": {
+                "properties": {
+                  "md5": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha1": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha256": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              }
+            },
+            "type": "nested"
+          },
+          "bcc": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "cc": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "content_type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "delivery_timestamp": {
+            "type": "date"
+          },
+          "direction": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "from": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "local_id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "message_id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "origination_timestamp": {
+            "type": "date"
+          },
+          "reply_to": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "subject": {
+            "fields": {
+              "text": {
+                "type": "match_only_text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "to": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "x_mailer": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
       "error": {
         "properties": {
           "code": {

--- a/experimental/generated/elasticsearch/component/email.json
+++ b/experimental/generated/elasticsearch/component/email.json
@@ -1,0 +1,111 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-email.html",
+    "ecs_version": "1.12.0-dev+exp"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "email": {
+          "properties": {
+            "attachments": {
+              "properties": {
+                "file": {
+                  "properties": {
+                    "extension": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "mime_type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "size": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "hash": {
+                  "properties": {
+                    "md5": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha1": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "sha256": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              },
+              "type": "nested"
+            },
+            "bcc": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "cc": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "content_type": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "delivery_timestamp": {
+              "type": "date"
+            },
+            "direction": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "from": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "local_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "message_id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "origination_timestamp": {
+              "type": "date"
+            },
+            "reply_to": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "subject": {
+              "fields": {
+                "text": {
+                  "type": "match_only_text"
+                }
+              },
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "to": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "x_mailer": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experimental/generated/elasticsearch/template.json
+++ b/experimental/generated/elasticsearch/template.json
@@ -39,7 +39,8 @@
     "ecs_1.12.0-dev-exp_url",
     "ecs_1.12.0-dev-exp_user",
     "ecs_1.12.0-dev-exp_user_agent",
-    "ecs_1.12.0-dev-exp_vulnerability"
+    "ecs_1.12.0-dev-exp_vulnerability",
+    "ecs_1.12.0-dev-exp_email"
   ],
   "index_patterns": [
     "try-ecs-*"

--- a/experimental/schemas/email.yml
+++ b/experimental/schemas/email.yml
@@ -1,0 +1,198 @@
+- name: email
+  title: Email
+  group: 2
+  short: Fields describing an email transaction.
+  description: >
+    Fields relating to an email transaction.
+
+    This field set focuses on the email message header, body, and attachments. Network protocols that send and receive
+    email messages such as SMTP are outside the scope of the `email.*` fields.
+  type: group
+  fields:
+
+    - name: attachments
+      level: extended
+      type: nested
+      short: List of objects describing the attachments.
+      description: >
+        A list of attachment files sent along with an email message.
+
+    - name: attachments.file.extension
+      level: extended
+      type: keyword
+      short: Attachment file extension.
+      description: >
+        Attachment file extension, excluding the leading dot.
+      example: "txt"
+
+    - name: attachments.file.mime_type
+      level: extended
+      type: keyword
+      short: MIME type of the attachment file.
+      description: >
+        The MIME media type of the attachment.
+
+        This value will typically be extracted from the `Content-Type` MIME header field.
+      example: "text/plain"
+
+    - name: attachments.file.name
+      level: extended
+      type: keyword
+      short: Name of the attachment file.
+      description: >
+        Name of the attachment file including the file extension.
+      example: "attachment.txt"
+
+    - name: attachments.file.size
+      level: extended
+      type: long
+      short: Attachment file size.
+      description: >
+        Attachment file size in bytes.
+      example: 64329
+
+    - name: attachments.hash.md5
+      level: extended
+      type: keyword
+      short: MD5 hash of the attachment.
+      description: >
+        MD5 hash of the attachment file.
+      example: "e25f1c98ffdacf611473af364362ec48"
+
+    - name: attachments.hash.sha1
+      level: extended
+      type: keyword
+      short: SHA-1 hash of the attachment.
+      description: >
+        SHA-1 hash of the attachment file.
+      example: "8c1cd40f17109b427e61d4e72ca6d9a4fc8175f3"
+
+    - name: attachments.hash.sha256
+      level: extended
+      type: keyword
+      short: SHA-256 hash of the attachment.
+      description: >
+        SHA-256 hash of the attachment file.
+      example: "f0366b3559f577d8732f7e9cc343a4960d202e8137dcc42f9783f3963f6abc6a"
+
+    - name: bcc
+      level: extended
+      type: keyword
+      short: Email address(es) of BCC recipients
+      description: >
+        The email address(es) of the blind carbon carbon (BCC) recipients.
+      example: "['bcc.user1@example.com', 'bcc.user2@example.com']"
+
+      normalize:
+        - array
+
+    - name: cc
+      level: extended
+      type: keyword
+      short: Email address(es) of CC recipients
+      description: >
+        The email address(es) of the carbon carbon (BCC) recipients.
+      example: "['cc.user1@example.com', 'cc.user2@example.com']"
+
+      normalize:
+        - array
+
+    - name: content_type
+      level: extended
+      type: keyword
+      short: MIME type of the email message.
+      description: >
+        Information about how the message is to be displayed.
+
+        Typically a MIME type.
+      example: "text/plain"
+
+    - name: delivery_timestamp
+      level: extended
+      type: date
+      short: Date and time when message was delivered.
+      description: >
+        The date and time when the email message was received by the service or client.
+      example: "2020-11-10T22:12:34.8196921Z"
+
+    - name: direction
+      level: extended
+      type: keyword
+      short: Direction of the message.
+      description: >
+        The direction of the message based on the sending and receiving domains.
+      example: inbound
+
+    - name: from
+      level: extended
+      type: keyword
+      short: The sender's email address.
+      description: >
+        The email address of the sender, typically from the RFC 5322 `From:` header field.
+      example: "sender@example.com"
+
+    - name: local_id
+      level: extended
+      type: keyword
+      short: Unique identifier given by the source.
+      description: >
+        Unique identifier given to the email by the source that created the event.
+
+        Identifier is not persistent across hops.
+      example: "c26dbea0-80d5-463b-b93c-4e8b708219ce"
+
+    - name: message_id
+      level: extended
+      type: keyword
+      short: Value from the Message-ID header.
+      description: >
+        Identifier from the RFC 5322 `Message-ID:` email header that refers to a particular email
+        message.
+      example: "<81ce15$8r2j59@mail01.example.com>"
+
+    - name: origination_timestamp
+      level: extended
+      type: date
+      short: Date and time the email was composed.
+      description: >
+        The date and time the email message was composed. Many email clients will fill in this value
+        automatically when the message is sent by a user.
+      example: "2020-11-10T22:12:34.8196921Z"
+
+    - name: reply_to
+      level: extended
+      type: keyword
+      short: Address replies should be delivered to.
+      description: >
+        The address that replies should be delivered to based on the value in the RFC 5322 `Reply-To:` header.
+      example: "reply.here@example.com"
+
+    - name: subject
+      level: extended
+      type: keyword
+      short: The subject of the email message.
+      description: >
+        A brief summary of the topic of the message.
+      example: "Please see this important message."
+      multi_fields:
+      - type: match_only_text
+        name: text
+
+    - name: to
+      level: extended
+      type: keyword
+      short: Email address(es) of the recipients.
+      description: >
+        The email address(es) of the message recipients.
+      example: "['user1@example.com', 'user2@example.com']"
+
+      normalize:
+        - array
+
+    - name: x_mailer
+      level: extended
+      type: keyword
+      short: Application that drafted email.
+      description: >
+        The name of the application that was used to draft and send the original email message.
+      example: "Spambot v2.5"


### PR DESCRIPTION
Backports the following commits to 1.x:
 - RFC 0010 Stage 1 - Add `email.*` fields to experimental schema (#1569)