### PR TITLE
[RFC] `match_only_text` stage 2 - additional changes

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,7 +40,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532
+* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532, #1571
 #### Deprecated
 
 <!-- All empty sections:

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4345,7 +4345,7 @@ example: `887`
 [[field-http-request-body-content]]
 <<field-http-request-body-content, http.request.body.content>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The full HTTP request body.
 
@@ -4353,7 +4353,7 @@ type: wildcard
 
 Multi-fields:
 
-* http.request.body.content.text (type: text)
+* http.request.body.content.text (type: match_only_text)
 
 
 
@@ -4471,7 +4471,7 @@ example: `887`
 [[field-http-response-body-content]]
 <<field-http-response-body-content, http.response.body.content>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The full HTTP response body.
 
@@ -4479,7 +4479,7 @@ type: wildcard
 
 Multi-fields:
 
-* http.response.body.content.text (type: text)
+* http.response.body.content.text (type: match_only_text)
 
 
 
@@ -5667,13 +5667,15 @@ type: keyword
 [[field-organization-name]]
 <<field-organization-name, organization.name>>
 
-| Organization name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Organization name.
 
 type: keyword
 
 Multi-fields:
 
-* organization.name.text (type: text)
+* organization.name.text (type: match_only_text)
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3657,8 +3657,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP request body.
       example: Hello world
@@ -3717,8 +3716,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP response body.
       example: Hello world
@@ -4482,8 +4480,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
   - name: os

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -408,7 +408,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 8.0.0-dev+exp,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 8.0.0-dev+exp,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
-8.0.0-dev+exp,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+8.0.0-dev+exp,true,http,http.request.body.content.text,match_only_text,extended,,Hello world,The full HTTP request body.
 8.0.0-dev+exp,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 8.0.0-dev+exp,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 8.0.0-dev+exp,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
@@ -416,7 +416,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 8.0.0-dev+exp,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
 8.0.0-dev+exp,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
-8.0.0-dev+exp,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+8.0.0-dev+exp,true,http,http.response.body.content.text,match_only_text,extended,,Hello world,The full HTTP response body.
 8.0.0-dev+exp,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 8.0.0-dev+exp,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 8.0.0-dev+exp,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -504,7 +504,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 8.0.0-dev+exp,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 8.0.0-dev+exp,true,organization,organization.name,keyword,extended,,,Organization name.
-8.0.0-dev+exp,true,organization,organization.name.text,text,extended,,,Organization name.
+8.0.0-dev+exp,true,organization,organization.name.text,match_only_text,extended,,,Organization name.
 8.0.0-dev+exp,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 8.0.0-dev+exp,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
 8.0.0-dev+exp,true,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5391,7 +5391,8 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -5400,8 +5401,7 @@ http.request.body.content:
   multi_fields:
   - flat_name: http.request.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
@@ -5484,7 +5484,8 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -5493,8 +5494,7 @@ http.response.body.content:
   multi_fields:
   - flat_name: http.response.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
@@ -6612,6 +6612,8 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -6620,8 +6622,7 @@ organization.name:
   multi_fields:
   - flat_name: organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Organization name.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6587,7 +6587,8 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -6596,8 +6597,7 @@ http:
       multi_fields:
       - flat_name: http.request.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
@@ -6681,7 +6681,8 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -6690,8 +6691,7 @@ http:
       multi_fields:
       - flat_name: http.response.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: response.body.content
       normalize: []
       short: The full HTTP response body.
@@ -7952,6 +7952,8 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -7960,8 +7962,7 @@ organization:
       multi_fields:
       - flat_name: organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Organization name.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1874,8 +1874,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1913,8 +1912,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -2352,8 +2350,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/http.json
+++ b/experimental/generated/elasticsearch/component/http.json
@@ -18,8 +18,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -57,8 +56,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/organization.json
+++ b/experimental/generated/elasticsearch/component/organization.json
@@ -15,8 +15,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3029,8 +3029,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP request body.
       example: Hello world
@@ -3089,8 +3088,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP response body.
       example: Hello world
@@ -3854,8 +3852,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
   - name: os

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -318,7 +318,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 8.0.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 8.0.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
-8.0.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+8.0.0-dev,true,http,http.request.body.content.text,match_only_text,extended,,Hello world,The full HTTP request body.
 8.0.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 8.0.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 8.0.0-dev,true,http,http.request.method,keyword,extended,,POST,HTTP request method.
@@ -326,7 +326,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 8.0.0-dev,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
 8.0.0-dev,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
-8.0.0-dev,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+8.0.0-dev,true,http,http.response.body.content.text,match_only_text,extended,,Hello world,The full HTTP response body.
 8.0.0-dev,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 8.0.0-dev,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 8.0.0-dev,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -414,7 +414,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 8.0.0-dev,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 8.0.0-dev,true,organization,organization.name,keyword,extended,,,Organization name.
-8.0.0-dev,true,organization,organization.name.text,text,extended,,,Organization name.
+8.0.0-dev,true,organization,organization.name.text,match_only_text,extended,,,Organization name.
 8.0.0-dev,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 8.0.0-dev,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
 8.0.0-dev,true,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4341,7 +4341,8 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -4350,8 +4351,7 @@ http.request.body.content:
   multi_fields:
   - flat_name: http.request.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
@@ -4434,7 +4434,8 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -4443,8 +4444,7 @@ http.response.body.content:
   multi_fields:
   - flat_name: http.response.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
@@ -5562,6 +5562,8 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -5570,8 +5572,7 @@ organization.name:
   multi_fields:
   - flat_name: organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Organization name.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5520,7 +5520,8 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -5529,8 +5530,7 @@ http:
       multi_fields:
       - flat_name: http.request.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
@@ -5614,7 +5614,8 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -5623,8 +5624,7 @@ http:
       multi_fields:
       - flat_name: http.response.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: response.body.content
       normalize: []
       short: The full HTTP response body.
@@ -6885,6 +6885,8 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -6893,8 +6895,7 @@ organization:
       multi_fields:
       - flat_name: organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Organization name.

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1451,8 +1451,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1490,8 +1489,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1929,8 +1927,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -18,8 +18,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -57,8 +56,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"

--- a/generated/elasticsearch/component/organization.json
+++ b/generated/elasticsearch/component/organization.json
@@ -15,8 +15,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -51,12 +51,14 @@
     - name: request.body.content
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The full HTTP request body.
       example: Hello world
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: request.referrer
@@ -91,12 +93,14 @@
     - name: response.body.content
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The full HTTP response body.
       example: Hello world
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: version

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -17,8 +17,9 @@
       type: keyword
       description: >
         Organization name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: id


### PR DESCRIPTION
While auditing changes implemented in #1532, discovered several `http.*` and `organization.*` fields were missed in the original PR.

Also migrating these multi-fields to `match_only_text`:

* `http.request.body.content.text`
* `http.response.body.content.text`
* `organization.name.text`