### PR TITLE
[1.x] [RFC] `match_only_text` stage 2 - additional changes (#1571)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -34,7 +34,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532
+* Beta migration of `text` and `.text` multi-fields to `match_only_text`. #1532, #1571
 #### Deprecated
 
 <!-- All empty sections:

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4352,7 +4352,7 @@ example: `887`
 [[field-http-request-body-content]]
 <<field-http-request-body-content, http.request.body.content>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The full HTTP request body.
 
@@ -4360,7 +4360,7 @@ type: wildcard
 
 Multi-fields:
 
-* http.request.body.content.text (type: text)
+* http.request.body.content.text (type: match_only_text)
 
 
 
@@ -4482,7 +4482,7 @@ example: `887`
 [[field-http-response-body-content]]
 <<field-http-response-body-content, http.response.body.content>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
+| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
 
 The full HTTP response body.
 
@@ -4490,7 +4490,7 @@ type: wildcard
 
 Multi-fields:
 
-* http.response.body.content.text (type: text)
+* http.response.body.content.text (type: match_only_text)
 
 
 
@@ -5678,13 +5678,15 @@ type: keyword
 [[field-organization-name]]
 <<field-organization-name, organization.name>>
 
-| Organization name.
+| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
+
+Organization name.
 
 type: keyword
 
 Multi-fields:
 
-* organization.name.text (type: text)
+* organization.name.text (type: match_only_text)
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3728,8 +3728,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP request body.
       example: Hello world
@@ -3793,8 +3792,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP response body.
       example: Hello world
@@ -4558,8 +4556,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
   - name: os

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -420,7 +420,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev+exp,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 1.12.0-dev+exp,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
-1.12.0-dev+exp,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+1.12.0-dev+exp,true,http,http.request.body.content.text,match_only_text,extended,,Hello world,The full HTTP request body.
 1.12.0-dev+exp,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 1.12.0-dev+exp,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 1.12.0-dev+exp,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
@@ -428,7 +428,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 1.12.0-dev+exp,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
 1.12.0-dev+exp,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
-1.12.0-dev+exp,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+1.12.0-dev+exp,true,http,http.response.body.content.text,match_only_text,extended,,Hello world,The full HTTP response body.
 1.12.0-dev+exp,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 1.12.0-dev+exp,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 1.12.0-dev+exp,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -516,7 +516,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 1.12.0-dev+exp,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 1.12.0-dev+exp,true,organization,organization.name,keyword,extended,,,Organization name.
-1.12.0-dev+exp,true,organization,organization.name.text,text,extended,,,Organization name.
+1.12.0-dev+exp,true,organization,organization.name.text,match_only_text,extended,,,Organization name.
 1.12.0-dev+exp,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 1.12.0-dev+exp,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
 1.12.0-dev+exp,true,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5526,7 +5526,8 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -5535,8 +5536,7 @@ http.request.body.content:
   multi_fields:
   - flat_name: http.request.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
@@ -5623,7 +5623,8 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -5632,8 +5633,7 @@ http.response.body.content:
   multi_fields:
   - flat_name: http.response.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
@@ -6751,6 +6751,8 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -6759,8 +6761,7 @@ organization.name:
   multi_fields:
   - flat_name: organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Organization name.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6726,7 +6726,8 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -6735,8 +6736,7 @@ http:
       multi_fields:
       - flat_name: http.request.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
@@ -6825,7 +6825,8 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -6834,8 +6835,7 @@ http:
       multi_fields:
       - flat_name: http.response.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: response.body.content
       normalize: []
       short: The full HTTP response body.
@@ -8096,6 +8096,8 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -8104,8 +8106,7 @@ organization:
       multi_fields:
       - flat_name: organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Organization name.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1932,8 +1932,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1971,8 +1970,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -2410,8 +2408,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/http.json
+++ b/experimental/generated/elasticsearch/component/http.json
@@ -18,8 +18,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -57,8 +56,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"

--- a/experimental/generated/elasticsearch/component/organization.json
+++ b/experimental/generated/elasticsearch/component/organization.json
@@ -15,8 +15,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3100,8 +3100,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP request body.
       example: Hello world
@@ -3165,8 +3164,7 @@
       type: wildcard
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: The full HTTP response body.
       example: Hello world
@@ -3930,8 +3928,7 @@
       ignore_above: 1024
       multi_fields:
       - name: text
-        type: text
-        norms: false
+        type: match_only_text
         default_field: false
       description: Organization name.
   - name: os

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -330,7 +330,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 1.12.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
 1.12.0-dev,true,http,http.request.body.content,wildcard,extended,,Hello world,The full HTTP request body.
-1.12.0-dev,true,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+1.12.0-dev,true,http,http.request.body.content.text,match_only_text,extended,,Hello world,The full HTTP request body.
 1.12.0-dev,true,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
 1.12.0-dev,true,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
 1.12.0-dev,true,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
@@ -338,7 +338,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
 1.12.0-dev,true,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
 1.12.0-dev,true,http,http.response.body.content,wildcard,extended,,Hello world,The full HTTP response body.
-1.12.0-dev,true,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+1.12.0-dev,true,http,http.response.body.content.text,match_only_text,extended,,Hello world,The full HTTP response body.
 1.12.0-dev,true,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
 1.12.0-dev,true,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
 1.12.0-dev,true,http,http.response.status_code,long,extended,,404,HTTP response status code.
@@ -426,7 +426,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 1.12.0-dev,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
 1.12.0-dev,true,organization,organization.name,keyword,extended,,,Organization name.
-1.12.0-dev,true,organization,organization.name.text,text,extended,,,Organization name.
+1.12.0-dev,true,organization,organization.name.text,match_only_text,extended,,,Organization name.
 1.12.0-dev,true,package,package.architecture,keyword,extended,,x86_64,Package architecture.
 1.12.0-dev,true,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
 1.12.0-dev,true,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4476,7 +4476,8 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -4485,8 +4486,7 @@ http.request.body.content:
   multi_fields:
   - flat_name: http.request.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: request.body.content
   normalize: []
   short: The full HTTP request body.
@@ -4573,7 +4573,8 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `wildcard` data type for this field is currently beta.
+  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+    multi-field type are both currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -4582,8 +4583,7 @@ http.response.body.content:
   multi_fields:
   - flat_name: http.response.body.content.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: response.body.content
   normalize: []
   short: The full HTTP response body.
@@ -5701,6 +5701,8 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
+  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -5709,8 +5711,7 @@ organization.name:
   multi_fields:
   - flat_name: organization.name.text
     name: text
-    norms: false
-    type: text
+    type: match_only_text
   name: name
   normalize: []
   short: Organization name.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5659,7 +5659,8 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -5668,8 +5669,7 @@ http:
       multi_fields:
       - flat_name: http.request.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: request.body.content
       normalize: []
       short: The full HTTP request body.
@@ -5758,7 +5758,8 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
+        multi-field type are both currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -5767,8 +5768,7 @@ http:
       multi_fields:
       - flat_name: http.response.body.content.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: response.body.content
       normalize: []
       short: The full HTTP response body.
@@ -7029,6 +7029,8 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
+        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -7037,8 +7039,7 @@ organization:
       multi_fields:
       - flat_name: organization.name.text
         name: text
-        norms: false
-        type: text
+        type: match_only_text
       name: name
       normalize: []
       short: Organization name.

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1509,8 +1509,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1548,8 +1547,7 @@
                   "content": {
                     "fields": {
                       "text": {
-                        "norms": false,
-                        "type": "text"
+                        "type": "match_only_text"
                       }
                     },
                     "type": "wildcard"
@@ -1987,8 +1985,7 @@
           "name": {
             "fields": {
               "text": {
-                "norms": false,
-                "type": "text"
+                "type": "match_only_text"
               }
             },
             "ignore_above": 1024,

--- a/generated/elasticsearch/component/http.json
+++ b/generated/elasticsearch/component/http.json
@@ -18,8 +18,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"
@@ -57,8 +56,7 @@
                     "content": {
                       "fields": {
                         "text": {
-                          "norms": false,
-                          "type": "text"
+                          "type": "match_only_text"
                         }
                       },
                       "type": "wildcard"

--- a/generated/elasticsearch/component/organization.json
+++ b/generated/elasticsearch/component/organization.json
@@ -15,8 +15,7 @@
             "name": {
               "fields": {
                 "text": {
-                  "norms": false,
-                  "type": "text"
+                  "type": "match_only_text"
                 }
               },
               "ignore_above": 1024,

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -56,12 +56,14 @@
     - name: request.body.content
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The full HTTP request body.
       example: Hello world
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: request.referrer
@@ -96,12 +98,14 @@
     - name: response.body.content
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
+      beta: >
+        Use of `wildcard` as the primary type and `match_only_type` as
+        the `.text` multi-field type are both currently beta.
       description: >
         The full HTTP response body.
       example: Hello world
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: version

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -17,8 +17,9 @@
       type: keyword
       description: >
         Organization name.
+      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
-      - type: text
+      - type: match_only_text
         name: text
 
     - name: id


### PR DESCRIPTION
Backports the following commits to 1.x:
 - [RFC] `match_only_text` stage 2 - additional changes (#1571)