### PR TITLE
Adjust breaking changes entires in CHANGELOG.next

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -12,6 +12,10 @@ Thanks, you're awesome :-) -->
 
 #### Breaking changes
 
+* Remove `host.user.*` field reuse. #1439
+* Remove deprecation notice on `http.request.method`. #1443
+* Migrate `log.origin.file.line` from `integer` to `long`. #1533
+
 #### Bugfixes
 
 #### Added
@@ -22,13 +26,10 @@ Thanks, you're awesome :-) -->
 
 ### Tooling and Artifact Changes
 
-### Breaking Changes
+#### Breaking Changes
 
 * Removing deprecated --oss from generator #1404
 * Removing use-cases directory #1405
-* Remove `host.user.*` field reuse. #1439
-* Remove deprecation notice on `http.request.method`. #1443
-* Migrate `log.origin.file.line` from `integer` to `long`. #1533
 
 #### Bugfixes
 


### PR DESCRIPTION
Correct the breaking changes entries in CHANGELOG.next carried forward from past releases.
