### PR TITLE
[1.12] fix breaking changes and their sections now that CHANGELOG.next is pointing to 8.0 (#1577)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -12,6 +12,10 @@ Thanks, you're awesome :-) -->
 
 #### Breaking changes
 
+* Remove `host.user.*` field reuse. #1439
+* Remove deprecation notice on `http.request.method`. #1443
+* Migrate `log.origin.file.line` from `integer` to `long`. #1533
+
 #### Bugfixes
 
 #### Added
@@ -22,7 +26,10 @@ Thanks, you're awesome :-) -->
 
 ### Tooling and Artifact Changes
 
-#### Breaking changes
+#### Breaking Changes
+
+* Removing deprecated --oss from generator #1404
+* Removing use-cases directory #1405
 
 #### Bugfixes
 


### PR DESCRIPTION
Backports the following commits to 1.12:
 - fix breaking changes and their sections now that CHANGELOG.next is pointing to 8.0 (#1577)