### PR TITLE
RFC 0017 - remove `log.original` field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,7 @@ Thanks, you're awesome :-) -->
 * Remove `host.user.*` field reuse. #1439
 * Remove deprecation notice on `http.request.method`. #1443
 * Migrate `log.origin.file.line` from `integer` to `long`. #1533
+* Remove `log.original` field. #1580
 
 #### Bugfixes
 

--- a/code/go/ecs/log.go
+++ b/code/go/ecs/log.go
@@ -39,18 +39,6 @@ type Log struct {
 	// If the event wasn't read from a log file, do not populate this field.
 	FilePath string `ecs:"file.path"`
 
-	// Deprecated for removal in next major version release. This field is
-	// superseded by `event.original`.
-	// This is the original log message and contains the full log message
-	// before splitting it up in multiple parts.
-	// In contrast to the `message` field which can contain an extracted part
-	// of the log message, this field contains the original, full log message.
-	// It can have already some modifications applied like encoding or new
-	// lines removed to clean up the log message.
-	// This field is not indexed and doc_values are disabled so it can't be
-	// queried but the value can be retrieved from `_source`.
-	Original string `ecs:"original"`
-
 	// The name of the logger inside an application. This is usually the name
 	// of the class which initialized the logger, or can be a custom name.
 	Logger string `ecs:"logger"`

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -4762,28 +4762,6 @@ example: `init`
 // ===============================================================
 
 |
-[[field-log-original]]
-<<field-log-original, log.original>>
-
-| Deprecated for removal in next major version release. This field is superseded by `event.original`.
-
-This is the original log message and contains the full log message before splitting it up in multiple parts.
-
-In contrast to the `message` field which can contain an extracted part of the log message, this field contains the original, full log message. It can have already some modifications applied like encoding or new lines removed to clean up the log message.
-
-This field is not indexed and doc_values are disabled so it can't be queried but the value can be retrieved from `_source`.
-
-type: keyword
-
-
-
-example: `Sep 19 08:26:10 localhost My log`
-
-| core
-
-// ===============================================================
-
-|
 [[field-log-syslog]]
 <<field-log-syslog, log.syslog>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3847,25 +3847,6 @@
       ignore_above: 1024
       description: The name of the function or method which originated the log event.
       example: init
-    - name: original
-      level: core
-      type: keyword
-      description: 'Deprecated for removal in next major version release. This field
-        is superseded by `event.original`.
-
-        This is the original log message and contains the full log message before
-        splitting it up in multiple parts.
-
-        In contrast to the `message` field which can contain an extracted part of
-        the log message, this field contains the original, full log message. It can
-        have already some modifications applied like encoding or new lines removed
-        to clean up the log message.
-
-        This field is not indexed and doc_values are disabled so it can''t be queried
-        but the value can be retrieved from `_source`.'
-      example: Sep 19 08:26:10 localhost My log
-      index: false
-      doc_values: false
     - name: syslog
       level: extended
       type: object

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -427,7 +427,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,log,log.origin.file.line,long,extended,,42,The line number of the file which originated the log event.
 8.0.0-dev+exp,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.0.0-dev+exp,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
-8.0.0-dev+exp,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."
 8.0.0-dev+exp,true,log,log.syslog,object,extended,,,Syslog metadata
 8.0.0-dev+exp,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.0.0-dev+exp,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5643,31 +5643,6 @@ log.origin.function:
   normalize: []
   short: The function which originated the log event.
   type: keyword
-log.original:
-  dashed_name: log-original
-  description: 'Deprecated for removal in next major version release. This field is
-    superseded by `event.original`.
-
-    This is the original log message and contains the full log message before splitting
-    it up in multiple parts.
-
-    In contrast to the `message` field which can contain an extracted part of the
-    log message, this field contains the original, full log message. It can have already
-    some modifications applied like encoding or new lines removed to clean up the
-    log message.
-
-    This field is not indexed and doc_values are disabled so it can''t be queried
-    but the value can be retrieved from `_source`.'
-  doc_values: false
-  example: Sep 19 08:26:10 localhost My log
-  flat_name: log.original
-  index: false
-  level: core
-  name: original
-  normalize: []
-  short: Deprecated original log message with light interpretation only (encoding,
-    newlines).
-  type: keyword
 log.syslog:
   dashed_name: log-syslog
   description: The Syslog metadata of the event, if the event was transmitted via

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6898,31 +6898,6 @@ log:
       normalize: []
       short: The function which originated the log event.
       type: keyword
-    log.original:
-      dashed_name: log-original
-      description: 'Deprecated for removal in next major version release. This field
-        is superseded by `event.original`.
-
-        This is the original log message and contains the full log message before
-        splitting it up in multiple parts.
-
-        In contrast to the `message` field which can contain an extracted part of
-        the log message, this field contains the original, full log message. It can
-        have already some modifications applied like encoding or new lines removed
-        to clean up the log message.
-
-        This field is not indexed and doc_values are disabled so it can''t be queried
-        but the value can be retrieved from `_source`.'
-      doc_values: false
-      example: Sep 19 08:26:10 localhost My log
-      flat_name: log.original
-      index: false
-      level: core
-      name: original
-      normalize: []
-      short: Deprecated original log message with light interpretation only (encoding,
-        newlines).
-      type: keyword
     log.syslog:
       dashed_name: log-syslog
       description: The Syslog metadata of the event, if the event was transmitted

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -1977,11 +1977,6 @@
               }
             }
           },
-          "original": {
-            "doc_values": false,
-            "index": false,
-            "type": "keyword"
-          },
           "syslog": {
             "properties": {
               "facility": {

--- a/experimental/generated/elasticsearch/component/log.json
+++ b/experimental/generated/elasticsearch/component/log.json
@@ -43,11 +43,6 @@
                 }
               }
             },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
             "syslog": {
               "properties": {
                 "facility": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3219,25 +3219,6 @@
       ignore_above: 1024
       description: The name of the function or method which originated the log event.
       example: init
-    - name: original
-      level: core
-      type: keyword
-      description: 'Deprecated for removal in next major version release. This field
-        is superseded by `event.original`.
-
-        This is the original log message and contains the full log message before
-        splitting it up in multiple parts.
-
-        In contrast to the `message` field which can contain an extracted part of
-        the log message, this field contains the original, full log message. It can
-        have already some modifications applied like encoding or new lines removed
-        to clean up the log message.
-
-        This field is not indexed and doc_values are disabled so it can''t be queried
-        but the value can be retrieved from `_source`.'
-      example: Sep 19 08:26:10 localhost My log
-      index: false
-      doc_values: false
     - name: syslog
       level: extended
       type: object

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -337,7 +337,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,log,log.origin.file.line,long,extended,,42,The line number of the file which originated the log event.
 8.0.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.0.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
-8.0.0-dev,false,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."
 8.0.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata
 8.0.0-dev,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.0.0-dev,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -4593,31 +4593,6 @@ log.origin.function:
   normalize: []
   short: The function which originated the log event.
   type: keyword
-log.original:
-  dashed_name: log-original
-  description: 'Deprecated for removal in next major version release. This field is
-    superseded by `event.original`.
-
-    This is the original log message and contains the full log message before splitting
-    it up in multiple parts.
-
-    In contrast to the `message` field which can contain an extracted part of the
-    log message, this field contains the original, full log message. It can have already
-    some modifications applied like encoding or new lines removed to clean up the
-    log message.
-
-    This field is not indexed and doc_values are disabled so it can''t be queried
-    but the value can be retrieved from `_source`.'
-  doc_values: false
-  example: Sep 19 08:26:10 localhost My log
-  flat_name: log.original
-  index: false
-  level: core
-  name: original
-  normalize: []
-  short: Deprecated original log message with light interpretation only (encoding,
-    newlines).
-  type: keyword
 log.syslog:
   dashed_name: log-syslog
   description: The Syslog metadata of the event, if the event was transmitted via

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5831,31 +5831,6 @@ log:
       normalize: []
       short: The function which originated the log event.
       type: keyword
-    log.original:
-      dashed_name: log-original
-      description: 'Deprecated for removal in next major version release. This field
-        is superseded by `event.original`.
-
-        This is the original log message and contains the full log message before
-        splitting it up in multiple parts.
-
-        In contrast to the `message` field which can contain an extracted part of
-        the log message, this field contains the original, full log message. It can
-        have already some modifications applied like encoding or new lines removed
-        to clean up the log message.
-
-        This field is not indexed and doc_values are disabled so it can''t be queried
-        but the value can be retrieved from `_source`.'
-      doc_values: false
-      example: Sep 19 08:26:10 localhost My log
-      flat_name: log.original
-      index: false
-      level: core
-      name: original
-      normalize: []
-      short: Deprecated original log message with light interpretation only (encoding,
-        newlines).
-      type: keyword
     log.syslog:
       dashed_name: log-syslog
       description: The Syslog metadata of the event, if the event was transmitted

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -1577,11 +1577,6 @@
                 }
               }
             },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
             "syslog": {
               "properties": {
                 "facility": {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -1554,11 +1554,6 @@
               }
             }
           },
-          "original": {
-            "doc_values": false,
-            "index": false,
-            "type": "keyword"
-          },
           "syslog": {
             "properties": {
               "facility": {

--- a/generated/elasticsearch/component/log.json
+++ b/generated/elasticsearch/component/log.json
@@ -43,11 +43,6 @@
                 }
               }
             },
-            "original": {
-              "doc_values": false,
-              "index": false,
-              "type": "keyword"
-            },
             "syslog": {
               "properties": {
                 "facility": {

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -40,30 +40,6 @@
         If the event wasn't read from a log file, do not populate this field.
       example: "/var/log/fun-times.log"
 
-
-    - name: original
-      level: core
-      type: keyword
-      example: "Sep 19 08:26:10 localhost My log"
-      index: false
-      doc_values: false
-      short: Deprecated original log message with light interpretation only (encoding, newlines).
-      description: >
-        Deprecated for removal in next major version release. This field is superseded by
-        `event.original`.
-
-        This is the original log message and contains the full log message
-        before splitting it up in multiple parts.
-
-        In contrast to the `message` field which can contain an extracted part
-        of the log message, this field contains the original, full log message.
-        It can have already some modifications applied like encoding or new
-        lines removed to clean up the log message.
-
-        This field is not indexed and doc_values are disabled so it can't be
-        queried but the value can be retrieved from `_source`.
-
-
     - name: logger
       level: core
       type: keyword


### PR DESCRIPTION
Remove the `log.original` field as finalized in [RFC 0017](https://github.com/elastic/ecs/blob/master/rfcs/text/0017-remove-log-original.md) (https://github.com/elastic/ecs/pull/1465).
