### PR TITLE
RFC 0001 `wildcard` type field migration - stage 3 changes

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -23,6 +23,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Wildcard type field migration GA. #1582
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -2496,7 +2496,7 @@ type: match_only_text
 [[field-error-stack-trace]]
 <<field-error-stack-trace, error.stack_trace>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta.. ]
 
 The stack trace of this error in plain text.
 
@@ -4345,7 +4345,7 @@ example: `887`
 [[field-http-request-body-content]]
 <<field-http-request-body-content, http.request.body.content>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
 The full HTTP request body.
 
@@ -4471,7 +4471,7 @@ example: `887`
 [[field-http-response-body-content]]
 <<field-http-response-body-content, http.response.body.content>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
 The full HTTP response body.
 
@@ -6274,7 +6274,7 @@ example: `4`
 [[field-process-command-line]]
 <<field-process-command-line, process.command_line>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
 Full command line that started the process, including the absolute path to the executable, and all arguments.
 
@@ -6663,9 +6663,7 @@ example: `ZQBuAC0AVQBTAAAAZQBuAAAAAAA=`
 [[field-registry-data-strings]]
 <<field-registry-data-strings, registry.data.strings>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
-
-Content when writing string types.
+| Content when writing string types.
 
 Populated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `"1"`).
 
@@ -9782,7 +9780,7 @@ type: keyword
 [[field-url-full]]
 <<field-url-full, url.full>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta.a ]
 
 If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
 
@@ -9806,7 +9804,7 @@ example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 [[field-url-original]]
 <<field-url-original, url.original>>
 
-| beta:[ Use of `wildcard` as the primary type and `match_only_type` as the `.text` multi-field type are both currently beta. ]
+| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
 
 Unmodified original url as seen in the event source.
 
@@ -9850,9 +9848,7 @@ type: keyword
 [[field-url-path]]
 <<field-url-path, url.path>>
 
-| beta:[ Use of the `wildcard` data type for this field is currently beta. ]
-
-Path of the request, such as "/search".
+| Path of the request, such as "/search".
 
 type: wildcard
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2536,8 +2536,7 @@ error.message:
   short: Error message.
   type: match_only_text
 error.stack_trace:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta..
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -5391,8 +5390,7 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -5484,8 +5482,7 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -6905,8 +6902,7 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7541,8 +7537,7 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -9262,8 +9257,7 @@ process.target.code_signature.valid:
     content.
   type: boolean
 process.target.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-target-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -9904,8 +9898,7 @@ process.target.parent.code_signature.valid:
     content.
   type: boolean
 process.target.parent.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-target-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -11630,7 +11623,6 @@ registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: registry-data-strings
   description: 'Content when writing string types.
 
@@ -14575,7 +14567,6 @@ threat.enrichments.indicator.registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 threat.enrichments.indicator.registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-registry-data-strings
   description: 'Content when writing string types.
 
@@ -14746,8 +14737,7 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -14764,8 +14754,7 @@ threat.enrichments.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -14797,7 +14786,6 @@ threat.enrichments.indicator.url.password:
   short: Password of the request.
   type: keyword
 threat.enrichments.indicator.url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.enrichments.indicator.url.path
@@ -16943,7 +16931,6 @@ threat.indicator.registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 threat.indicator.registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-indicator-registry-data-strings
   description: 'Content when writing string types.
 
@@ -17114,8 +17101,7 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -17132,8 +17118,7 @@ threat.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -17165,7 +17150,6 @@ threat.indicator.url.password:
   short: Password of the request.
   type: keyword
 threat.indicator.url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.indicator.url.path
@@ -18850,8 +18834,7 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -18867,8 +18850,7 @@ url.full:
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -18898,7 +18880,6 @@ url.password:
   short: Password of the request.
   type: keyword
 url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3333,8 +3333,7 @@ error:
       short: Error message.
       type: match_only_text
     error.stack_trace:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta..
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -6587,8 +6586,7 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -6681,8 +6679,7 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -8841,8 +8838,7 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9477,8 +9473,7 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -11200,8 +11195,7 @@ process:
         content.
       type: boolean
     process.target.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-target-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -11842,8 +11836,7 @@ process:
         content.
       type: boolean
     process.target.parent.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-target-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -13623,7 +13616,6 @@ registry:
       short: Original bytes written with base64 encoding.
       type: keyword
     registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: registry-data-strings
       description: 'Content when writing string types.
 
@@ -16690,7 +16682,6 @@ threat:
       short: Original bytes written with base64 encoding.
       type: keyword
     threat.enrichments.indicator.registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-registry-data-strings
       description: 'Content when writing string types.
 
@@ -16862,8 +16853,7 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -16881,8 +16871,7 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -16914,7 +16903,6 @@ threat:
       short: Password of the request.
       type: keyword
     threat.enrichments.indicator.url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-path
       description: Path of the request, such as "/search".
       flat_name: threat.enrichments.indicator.url.path
@@ -19063,7 +19051,6 @@ threat:
       short: Original bytes written with base64 encoding.
       type: keyword
     threat.indicator.registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-indicator-registry-data-strings
       description: 'Content when writing string types.
 
@@ -19235,8 +19222,7 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -19254,8 +19240,7 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -19287,7 +19272,6 @@ threat:
       short: Password of the request.
       type: keyword
     threat.indicator.url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-indicator-url-path
       description: Path of the request, such as "/search".
       flat_name: threat.indicator.url.path
@@ -21123,8 +21107,7 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -21141,8 +21124,7 @@ url:
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -21172,7 +21154,6 @@ url:
       short: Password of the request.
       type: keyword
     url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: url-path
       description: Path of the request, such as "/search".
       flat_name: url.path

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1857,8 +1857,7 @@ error.message:
   short: Error message.
   type: match_only_text
 error.stack_trace:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta..
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -4341,8 +4340,7 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -4434,8 +4432,7 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -5855,8 +5852,7 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6491,8 +6487,7 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7398,7 +7393,6 @@ registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: registry-data-strings
   description: 'Content when writing string types.
 
@@ -9972,7 +9966,6 @@ threat.enrichments.indicator.registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 threat.enrichments.indicator.registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-registry-data-strings
   description: 'Content when writing string types.
 
@@ -10143,8 +10136,7 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -10161,8 +10153,7 @@ threat.enrichments.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -10194,7 +10185,6 @@ threat.enrichments.indicator.url.password:
   short: Password of the request.
   type: keyword
 threat.enrichments.indicator.url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.enrichments.indicator.url.path
@@ -11969,7 +11959,6 @@ threat.indicator.registry.data.bytes:
   short: Original bytes written with base64 encoding.
   type: keyword
 threat.indicator.registry.data.strings:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-indicator-registry-data-strings
   description: 'Content when writing string types.
 
@@ -12140,8 +12129,7 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -12158,8 +12146,7 @@ threat.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -12191,7 +12178,6 @@ threat.indicator.url.password:
   short: Password of the request.
   type: keyword
 threat.indicator.url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: threat-indicator-url-path
   description: Path of the request, such as "/search".
   flat_name: threat.indicator.url.path
@@ -13876,8 +13862,7 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta
+  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -13893,8 +13878,7 @@ url.full:
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-    multi-field type are both currently beta.
+  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -13924,7 +13908,6 @@ url.password:
   short: Password of the request.
   type: keyword
 url.path:
-  beta: Use of the `wildcard` data type for this field is currently beta.
   dashed_name: url-path
   description: Path of the request, such as "/search".
   flat_name: url.path

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2638,8 +2638,7 @@ error:
       short: Error message.
       type: match_only_text
     error.stack_trace:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta..
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -5520,8 +5519,7 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -5614,8 +5612,7 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -7433,8 +7430,7 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -8069,8 +8065,7 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9015,7 +9010,6 @@ registry:
       short: Original bytes written with base64 encoding.
       type: keyword
     registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: registry-data-strings
       description: 'Content when writing string types.
 
@@ -11710,7 +11704,6 @@ threat:
       short: Original bytes written with base64 encoding.
       type: keyword
     threat.enrichments.indicator.registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-registry-data-strings
       description: 'Content when writing string types.
 
@@ -11882,8 +11875,7 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11901,8 +11893,7 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -11934,7 +11925,6 @@ threat:
       short: Password of the request.
       type: keyword
     threat.enrichments.indicator.url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-path
       description: Path of the request, such as "/search".
       flat_name: threat.enrichments.indicator.url.path
@@ -13711,7 +13701,6 @@ threat:
       short: Original bytes written with base64 encoding.
       type: keyword
     threat.indicator.registry.data.strings:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-indicator-registry-data-strings
       description: 'Content when writing string types.
 
@@ -13883,8 +13872,7 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -13902,8 +13890,7 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -13935,7 +13922,6 @@ threat:
       short: Password of the request.
       type: keyword
     threat.indicator.url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: threat-indicator-url-path
       description: Path of the request, such as "/search".
       flat_name: threat.indicator.url.path
@@ -15771,8 +15757,7 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -15789,8 +15774,7 @@ url:
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of `wildcard` as the primary type and `match_only_type` as the `.text`
-        multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -15820,7 +15804,6 @@ url:
       short: Password of the request.
       type: keyword
     url.path:
-      beta: Use of the `wildcard` data type for this field is currently beta.
       dashed_name: url-path
       description: Path of the request, such as "/search".
       flat_name: url.path

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -40,9 +40,7 @@
     - name: stack_trace
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta..
       description: >
         The stack trace of this error in plain text.
       multi_fields:

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -51,9 +51,7 @@
     - name: request.body.content
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         The full HTTP request body.
       example: Hello world
@@ -93,9 +91,7 @@
     - name: response.body.content
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         The full HTTP response body.
       example: Hello world

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -75,9 +75,7 @@
     - name: command_line
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       short: Full command line that started the process.
       description: >
         Full command line that started the process, including the absolute path

--- a/schemas/registry.yml
+++ b/schemas/registry.yml
@@ -48,7 +48,6 @@
     - name: data.strings
       level: core
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
       short: List of strings representing what was written to the registry.
       example: '["C:\rta\red_ttp\bin\myapp.exe"]'
       description: >

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -20,9 +20,7 @@
     - name: original
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta.
+      beta: Use of the `match_only_text` type for this field is currently beta.
       short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
@@ -41,9 +39,7 @@
     - name: full
       level: extended
       type: wildcard
-      beta: >
-        Use of `wildcard` as the primary type and `match_only_type` as
-        the `.text` multi-field type are both currently beta
+      beta: Use of the `match_only_text` type for this field is currently beta.a
       short: Full unparsed URL.
       description: >
         If full URLs are important to your use case, they should be stored in
@@ -132,7 +128,6 @@
     - name: path
       level: extended
       type: wildcard
-      beta: Use of the `wildcard` data type for this field is currently beta.
       description: >
         Path of the request, such as "/search".
 


### PR DESCRIPTION
Remove the `beta` attribute to promote these uses of `type: wildcard` as GA changes.

Proposal: [RFC 0001](https://github.com/elastic/ecs/blob/master/rfcs/text/0001-wildcard-data-type.md)
Stage 3 PR: https://github.com/elastic/ecs/pull/1530
