### PR TITLE
RFC 0023 `match_only_text` type field migration - stage 3 changes

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -24,6 +24,7 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Wildcard type field migration GA. #1582
+* `match_only_text` type field migration GA. #1584
 
 #### Deprecated
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -58,9 +58,7 @@ example: `{"application": "foo-bar", "env": "production"}`
 [[field-message]]
 <<field-message, message>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-For log events the message field contains the log message, optimized for viewing in a log viewer.
+| For log events the message field contains the log message, optimized for viewing in a log viewer.
 
 For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event.
 
@@ -257,9 +255,7 @@ example: `15169`
 [[field-as-organization-name]]
 <<field-as-organization-name, as.organization.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Organization name.
+| Organization name.
 
 type: keyword
 
@@ -2478,9 +2474,7 @@ type: keyword
 [[field-error-message]]
 <<field-error-message, error.message>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-Error message.
+| Error message.
 
 type: match_only_text
 
@@ -2496,9 +2490,7 @@ type: match_only_text
 [[field-error-stack-trace]]
 <<field-error-stack-trace, error.stack_trace>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta.. ]
-
-The stack trace of this error in plain text.
+| The stack trace of this error in plain text.
 
 type: wildcard
 
@@ -3389,9 +3381,7 @@ example: `alice`
 [[field-file-path]]
 <<field-file-path, file.path>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Full path to the file, including the file name. It should include the drive letter, when appropriate.
+| Full path to the file, including the file name. It should include the drive letter, when appropriate.
 
 type: keyword
 
@@ -3431,9 +3421,7 @@ example: `16384`
 [[field-file-target-path]]
 <<field-file-target-path, file.target_path>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Target path for symlinks.
+| Target path for symlinks.
 
 type: keyword
 
@@ -4345,9 +4333,7 @@ example: `887`
 [[field-http-request-body-content]]
 <<field-http-request-body-content, http.request.body.content>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-The full HTTP request body.
+| The full HTTP request body.
 
 type: wildcard
 
@@ -4471,9 +4457,7 @@ example: `887`
 [[field-http-response-body-content]]
 <<field-http-response-body-content, http.response.body.content>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-The full HTTP response body.
+| The full HTTP response body.
 
 type: wildcard
 
@@ -5645,9 +5629,7 @@ type: keyword
 [[field-organization-name]]
 <<field-organization-name, organization.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Organization name.
+| Organization name.
 
 type: keyword
 
@@ -5701,9 +5683,7 @@ example: `debian`
 [[field-os-full]]
 <<field-os-full, os.full>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Operating system name, including the version or code name.
+| Operating system name, including the version or code name.
 
 type: keyword
 
@@ -5741,9 +5721,7 @@ example: `4.4.0-112-generic`
 [[field-os-name]]
 <<field-os-name, os.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Operating system name, without the version.
+| Operating system name, without the version.
 
 type: keyword
 
@@ -6274,9 +6252,7 @@ example: `4`
 [[field-process-command-line]]
 <<field-process-command-line, process.command_line>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-Full command line that started the process, including the absolute path to the executable, and all arguments.
+| Full command line that started the process, including the absolute path to the executable, and all arguments.
 
 Some arguments may be filtered to protect sensitive information.
 
@@ -6336,9 +6312,7 @@ example: `c2c455d9f99375d`
 [[field-process-executable]]
 <<field-process-executable, process.executable>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Absolute path to the process executable.
+| Absolute path to the process executable.
 
 type: keyword
 
@@ -6378,9 +6352,7 @@ example: `137`
 [[field-process-name]]
 <<field-process-name, process.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Process name.
+| Process name.
 
 Sometimes called program name or similar.
 
@@ -6500,9 +6472,7 @@ example: `thread-0`
 [[field-process-title]]
 <<field-process-title, process.title>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Process title.
+| Process title.
 
 The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.
 
@@ -6542,9 +6512,7 @@ example: `1325`
 [[field-process-working-directory]]
 <<field-process-working-directory, process.working_directory>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-The working directory of the process.
+| The working directory of the process.
 
 type: keyword
 
@@ -8852,9 +8820,7 @@ example: `T1059`
 [[field-threat-technique-name]]
 <<field-threat-technique-name, threat.technique.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
+| The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)
 
 type: keyword
 
@@ -8917,9 +8883,7 @@ example: `T1059.001`
 [[field-threat-technique-subtechnique-name]]
 <<field-threat-technique-subtechnique-name, threat.technique.subtechnique.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
+| The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)
 
 type: keyword
 
@@ -9780,9 +9744,7 @@ type: keyword
 [[field-url-full]]
 <<field-url-full, url.full>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta.a ]
-
-If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
+| If full URLs are important to your use case, they should be stored in `url.full`, whether this field is reconstructed or present in the event source.
 
 type: wildcard
 
@@ -9804,9 +9766,7 @@ example: `https://www.elastic.co:443/search?q=elasticsearch#top`
 [[field-url-original]]
 <<field-url-original, url.original>>
 
-| beta:[ Use of the `match_only_text` type for this field is currently beta. ]
-
-Unmodified original url as seen in the event source.
+| Unmodified original url as seen in the event source.
 
 Note that in network monitoring, the observed URL may be a full URL, whereas in access logs, the URL is often just represented as a path.
 
@@ -10056,9 +10016,7 @@ type: keyword
 [[field-user-full-name]]
 <<field-user-full-name, user.full_name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-User's full name, if available.
+| User's full name, if available.
 
 type: keyword
 
@@ -10114,9 +10072,7 @@ example: `S-1-5-21-202424912787-2692429404-2351956786-1000`
 [[field-user-name]]
 <<field-user-name, user.name>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Short name or login of the user.
+| Short name or login of the user.
 
 type: keyword
 
@@ -10283,9 +10239,7 @@ example: `Safari`
 [[field-user-agent-original]]
 <<field-user-agent-original, user_agent.original>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-Unparsed user_agent string.
+| Unparsed user_agent string.
 
 type: keyword
 
@@ -10476,9 +10430,7 @@ example: `CVSS`
 [[field-vulnerability-description]]
 <<field-vulnerability-description, vulnerability.description>>
 
-| beta:[ Use of the `match_only_text` type in the `.text` multi-field is currently beta. ]
-
-The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
+| The description of the vulnerability that provides additional context of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common Vulnerabilities and Exposure CVE description])
 
 type: keyword
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -129,8 +129,6 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -453,8 +451,6 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -533,8 +529,6 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -896,8 +890,6 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -1219,8 +1211,6 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1299,8 +1289,6 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -2526,7 +2514,6 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
@@ -2536,7 +2523,6 @@ error.message:
   short: Error message.
   type: match_only_text
 error.stack_trace:
-  beta: Use of the `match_only_text` type for this field is currently beta..
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -4082,8 +4068,6 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -4571,8 +4555,6 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -5265,8 +5247,6 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -5295,8 +5275,6 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -5390,7 +5368,6 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -5482,7 +5459,6 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -5721,7 +5697,6 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -6331,8 +6306,6 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -6361,8 +6334,6 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -6584,8 +6555,6 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -6902,7 +6871,6 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7278,8 +7246,6 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -7363,8 +7329,6 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -7537,7 +7501,6 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -7916,8 +7879,6 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -8003,8 +7964,6 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -8552,8 +8511,6 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -8583,8 +8540,6 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -9257,7 +9212,6 @@ process.target.code_signature.valid:
     content.
   type: boolean
 process.target.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-target-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -9636,8 +9590,6 @@ process.target.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -9723,8 +9675,6 @@ process.target.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-name
   description: 'Process name.
 
@@ -9898,7 +9848,6 @@ process.target.parent.code_signature.valid:
     content.
   type: boolean
 process.target.parent.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-target-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -10277,8 +10226,6 @@ process.target.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.target.parent.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -10364,8 +10311,6 @@ process.target.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.target.parent.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-parent-name
   description: 'Process name.
 
@@ -10913,8 +10858,6 @@ process.target.parent.thread.name:
   short: Thread name.
   type: keyword
 process.target.parent.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-parent-title
   description: 'Process title.
 
@@ -10944,8 +10887,6 @@ process.target.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.parent.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11491,8 +11432,6 @@ process.target.thread.name:
   short: Thread name.
   type: keyword
 process.target.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-title
   description: 'Process title.
 
@@ -11522,8 +11461,6 @@ process.target.uptime:
   short: Seconds the process has been up.
   type: long
 process.target.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-target-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11562,8 +11499,6 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -11591,8 +11526,6 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -11891,8 +11824,6 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -12215,8 +12146,6 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -12295,8 +12224,6 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -12495,8 +12422,6 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -12819,8 +12744,6 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -12899,8 +12822,6 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -12989,8 +12910,6 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -13729,8 +13648,6 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -13761,8 +13678,6 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -14737,7 +14652,6 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -14754,7 +14668,6 @@ threat.enrichments.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -15353,8 +15266,6 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -16093,8 +16004,6 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -16125,8 +16034,6 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -17101,7 +17008,6 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -17118,7 +17024,6 @@ threat.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -17710,8 +17615,6 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -17755,8 +17658,6 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -18834,7 +18735,6 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -18850,7 +18750,6 @@ url.full:
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -19015,8 +18914,6 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -19095,8 +18992,6 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: a.einstein
@@ -19162,8 +19057,6 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -19242,8 +19135,6 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: a.einstein
@@ -19283,8 +19174,6 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -19360,8 +19249,6 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -19413,8 +19300,6 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -19493,8 +19378,6 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: a.einstein
@@ -19546,8 +19429,6 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -19576,8 +19457,6 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -19606,8 +19485,6 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -19707,8 +19584,6 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -119,8 +119,6 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -204,7 +202,6 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -284,8 +281,6 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -609,8 +604,6 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -689,8 +682,6 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -1270,8 +1261,6 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1594,8 +1583,6 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1674,8 +1661,6 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -3323,7 +3308,6 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
@@ -3333,7 +3317,6 @@ error:
       short: Error message.
       type: match_only_text
     error.stack_trace:
-      beta: Use of the `match_only_text` type for this field is currently beta..
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -4930,8 +4913,6 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -5420,8 +5401,6 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -6439,8 +6418,6 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6469,8 +6446,6 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6586,7 +6561,6 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -6679,7 +6653,6 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -7620,8 +7593,6 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7650,8 +7621,6 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7924,8 +7893,6 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -7960,8 +7927,6 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -7988,8 +7953,6 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -8838,7 +8801,6 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9214,8 +9176,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -9299,8 +9259,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -9473,7 +9431,6 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -9852,8 +9809,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -9939,8 +9894,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -10489,8 +10442,6 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -10520,8 +10471,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -11195,7 +11144,6 @@ process:
         content.
       type: boolean
     process.target.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-target-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -11574,8 +11522,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -11661,8 +11607,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-name
       description: 'Process name.
 
@@ -11836,7 +11780,6 @@ process:
         content.
       type: boolean
     process.target.parent.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-target-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -12215,8 +12158,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.target.parent.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -12302,8 +12243,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.target.parent.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-parent-name
       description: 'Process name.
 
@@ -12852,8 +12791,6 @@ process:
       short: Thread name.
       type: keyword
     process.target.parent.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-parent-title
       description: 'Process title.
 
@@ -12883,8 +12820,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.parent.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -13431,8 +13366,6 @@ process:
       short: Thread name.
       type: keyword
     process.target.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-title
       description: 'Process title.
 
@@ -13462,8 +13395,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.target.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-target-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -13502,8 +13433,6 @@ process:
       short: Thread name.
       type: keyword
     process.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -13531,8 +13460,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -13954,8 +13881,6 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14279,8 +14204,6 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -14359,8 +14282,6 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -14603,8 +14524,6 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -14928,8 +14847,6 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -15008,8 +14925,6 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -15101,8 +15016,6 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -15841,8 +15754,6 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -15873,8 +15784,6 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -16853,7 +16762,6 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -16871,7 +16779,6 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -17470,8 +17377,6 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -18210,8 +18115,6 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -18242,8 +18145,6 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -19222,7 +19123,6 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -19240,7 +19140,6 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -19832,8 +19731,6 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -19877,8 +19774,6 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -21107,7 +21002,6 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -21124,7 +21018,6 @@ url:
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -21313,8 +21206,6 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21393,8 +21284,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: a.einstein
@@ -21460,8 +21349,6 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21540,8 +21427,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: a.einstein
@@ -21581,8 +21466,6 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21658,8 +21541,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -21711,8 +21592,6 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -21791,8 +21670,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: a.einstein
@@ -21900,8 +21777,6 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -21930,8 +21805,6 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -21960,8 +21833,6 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -22139,8 +22010,6 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -129,8 +129,6 @@ client.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 client.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -453,8 +451,6 @@ client.user.email:
   short: User email address.
   type: keyword
 client.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -533,8 +529,6 @@ client.user.id:
   short: Unique identifier of the user.
   type: keyword
 client.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: client-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -834,8 +828,6 @@ destination.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 destination.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -1157,8 +1149,6 @@ destination.user.email:
   short: User email address.
   type: keyword
 destination.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -1237,8 +1227,6 @@ destination.user.id:
   short: Unique identifier of the user.
   type: keyword
 destination.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: destination-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -1847,7 +1835,6 @@ error.id:
   short: Unique identifier for the error.
   type: keyword
 error.message:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: error-message
   description: Error message.
   flat_name: error.message
@@ -1857,7 +1844,6 @@ error.message:
   short: Error message.
   type: match_only_text
 error.stack_trace:
-  beta: Use of the `match_only_text` type for this field is currently beta..
   dashed_name: error-stack-trace
   description: The stack trace of this error in plain text.
   flat_name: error.stack_trace
@@ -3403,8 +3389,6 @@ file.owner:
   short: File owner's username.
   type: keyword
 file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -3521,8 +3505,6 @@ file.size:
   short: File size in bytes.
   type: long
 file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: file-target-path
   description: Target path for symlinks.
   flat_name: file.target_path
@@ -4215,8 +4197,6 @@ host.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 host.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: host-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -4245,8 +4225,6 @@ host.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 host.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: host-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -4340,7 +4318,6 @@ http.request.body.bytes:
   short: Size in bytes of the request body.
   type: long
 http.request.body.content:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-request-body-content
   description: The full HTTP request body.
   example: Hello world
@@ -4432,7 +4409,6 @@ http.response.body.bytes:
   short: Size in bytes of the response body.
   type: long
 http.response.body.content:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: http-response-body-content
   description: The full HTTP response body.
   example: Hello world
@@ -4671,7 +4647,6 @@ log.syslog.severity.name:
   short: Syslog text-based severity of the event.
   type: keyword
 message:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
     for viewing in a log viewer.
@@ -5281,8 +5256,6 @@ observer.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 observer.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: observer-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -5311,8 +5284,6 @@ observer.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 observer.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: observer-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -5534,8 +5505,6 @@ organization.id:
   short: Unique identifier for the organization.
   type: keyword
 organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: organization-name
   description: Organization name.
   flat_name: organization.name
@@ -5852,7 +5821,6 @@ process.code_signature.valid:
     content.
   type: boolean
 process.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6228,8 +6196,6 @@ process.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6313,8 +6279,6 @@ process.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-name
   description: 'Process name.
 
@@ -6487,7 +6451,6 @@ process.parent.code_signature.valid:
     content.
   type: boolean
 process.parent.command_line:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: process-parent-command-line
   description: 'Full command line that started the process, including the absolute
     path to the executable, and all arguments.
@@ -6866,8 +6829,6 @@ process.parent.entity_id:
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-executable
   description: Absolute path to the process executable.
   example: /usr/bin/ssh
@@ -6953,8 +6914,6 @@ process.parent.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 process.parent.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-name
   description: 'Process name.
 
@@ -7131,8 +7090,6 @@ process.parent.thread.name:
   short: Thread name.
   type: keyword
 process.parent.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-title
   description: 'Process title.
 
@@ -7162,8 +7119,6 @@ process.parent.uptime:
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-parent-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7332,8 +7287,6 @@ process.thread.name:
   short: Thread name.
   type: keyword
 process.title:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-title
   description: 'Process title.
 
@@ -7361,8 +7314,6 @@ process.uptime:
   short: Seconds the process has been up.
   type: long
 process.working_directory:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: process-working-directory
   description: The working directory of the process.
   example: /home/alice
@@ -7661,8 +7612,6 @@ server.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 server.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -7985,8 +7934,6 @@ server.user.email:
   short: User email address.
   type: keyword
 server.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8065,8 +8012,6 @@ server.user.id:
   short: Unique identifier of the user.
   type: keyword
 server.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: server-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -8265,8 +8210,6 @@ source.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 source.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -8589,8 +8532,6 @@ source.user.email:
   short: User email address.
   type: keyword
 source.user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -8669,8 +8610,6 @@ source.user.id:
   short: Unique identifier of the user.
   type: keyword
 source.user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: source-user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -8759,8 +8698,6 @@ threat.enrichments.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.enrichments.indicator.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -9499,8 +9436,6 @@ threat.enrichments.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.enrichments.indicator.file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -9531,8 +9466,6 @@ threat.enrichments.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.enrichments.indicator.file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-enrichments-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.enrichments.indicator.file.target_path
@@ -10136,7 +10069,6 @@ threat.enrichments.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.enrichments.indicator.url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-enrichments-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -10153,7 +10085,6 @@ threat.enrichments.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.enrichments.indicator.url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-enrichments-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -10752,8 +10683,6 @@ threat.indicator.as.number:
   short: Unique number allocated to the autonomous system.
   type: long
 threat.indicator.as.organization.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-as-organization-name
   description: Organization name.
   example: Google LLC
@@ -11492,8 +11421,6 @@ threat.indicator.file.owner:
   short: File owner's username.
   type: keyword
 threat.indicator.file.path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-file-path
   description: Full path to the file, including the file name. It should include the
     drive letter, when appropriate.
@@ -11524,8 +11451,6 @@ threat.indicator.file.size:
   short: File size in bytes.
   type: long
 threat.indicator.file.target_path:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-indicator-file-target-path
   description: Target path for symlinks.
   flat_name: threat.indicator.file.target_path
@@ -12129,7 +12054,6 @@ threat.indicator.url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 threat.indicator.url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: threat-indicator-url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -12146,7 +12070,6 @@ threat.indicator.url.full:
   short: Full unparsed URL.
   type: wildcard
 threat.indicator.url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: threat-indicator-url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -12738,8 +12661,6 @@ threat.technique.id:
   short: Threat technique id.
   type: keyword
 threat.technique.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-technique-name
   description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
     \ technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -12783,8 +12704,6 @@ threat.technique.subtechnique.id:
   short: Threat subtechnique id.
   type: keyword
 threat.technique.subtechnique.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: threat-technique-subtechnique-name
   description: "The name of subtechnique used by this threat. You can use a MITRE\
     \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -13862,7 +13781,6 @@ url.fragment:
   short: Portion of the url after the `#`.
   type: keyword
 url.full:
-  beta: Use of the `match_only_text` type for this field is currently beta.a
   dashed_name: url-full
   description: If full URLs are important to your use case, they should be stored
     in `url.full`, whether this field is reconstructed or present in the event source.
@@ -13878,7 +13796,6 @@ url.full:
   short: Full unparsed URL.
   type: wildcard
 url.original:
-  beta: Use of the `match_only_text` type for this field is currently beta.
   dashed_name: url-original
   description: 'Unmodified original url as seen in the event source.
 
@@ -14043,8 +13960,6 @@ user.changes.email:
   short: User email address.
   type: keyword
 user.changes.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-changes-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14123,8 +14038,6 @@ user.changes.id:
   short: Unique identifier of the user.
   type: keyword
 user.changes.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-changes-name
   description: Short name or login of the user.
   example: a.einstein
@@ -14190,8 +14103,6 @@ user.effective.email:
   short: User email address.
   type: keyword
 user.effective.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-effective-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14270,8 +14181,6 @@ user.effective.id:
   short: Unique identifier of the user.
   type: keyword
 user.effective.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-effective-name
   description: Short name or login of the user.
   example: a.einstein
@@ -14311,8 +14220,6 @@ user.email:
   short: User email address.
   type: keyword
 user.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14388,8 +14295,6 @@ user.id:
   short: Unique identifier of the user.
   type: keyword
 user.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-name
   description: Short name or login of the user.
   example: a.einstein
@@ -14441,8 +14346,6 @@ user.target.email:
   short: User email address.
   type: keyword
 user.target.full_name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-target-full-name
   description: User's full name, if available.
   example: Albert Einstein
@@ -14521,8 +14424,6 @@ user.target.id:
   short: Unique identifier of the user.
   type: keyword
 user.target.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-target-name
   description: Short name or login of the user.
   example: a.einstein
@@ -14574,8 +14475,6 @@ user_agent.name:
   short: Name of the user agent.
   type: keyword
 user_agent.original:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-original
   description: Unparsed user_agent string.
   example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -14604,8 +14503,6 @@ user_agent.os.family:
   short: OS family (such as redhat, debian, freebsd, windows).
   type: keyword
 user_agent.os.full:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-os-full
   description: Operating system name, including the version or code name.
   example: Mac OS Mojave
@@ -14634,8 +14531,6 @@ user_agent.os.kernel:
   short: Operating system kernel version as a raw string.
   type: keyword
 user_agent.os.name:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: user-agent-os-name
   description: Operating system name, without the version.
   example: Mac OS X
@@ -14735,8 +14630,6 @@ vulnerability.classification:
   short: Classification of the vulnerability.
   type: keyword
 vulnerability.description:
-  beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-    beta.
   dashed_name: vulnerability-description
   description: The description of the vulnerability that provides additional context
     of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -119,8 +119,6 @@ as:
       short: Unique number allocated to the autonomous system.
       type: long
     as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: as-organization-name
       description: Organization name.
       example: Google LLC
@@ -204,7 +202,6 @@ base:
       short: Custom key/value pairs.
       type: object
     message:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: message
       description: 'For log events the message field contains the log message, optimized
         for viewing in a log viewer.
@@ -284,8 +281,6 @@ client:
       short: Unique number allocated to the autonomous system.
       type: long
     client.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -609,8 +604,6 @@ client:
       short: User email address.
       type: keyword
     client.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -689,8 +682,6 @@ client:
       short: Unique identifier of the user.
       type: keyword
     client.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: client-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -1208,8 +1199,6 @@ destination:
       short: Unique number allocated to the autonomous system.
       type: long
     destination.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -1532,8 +1521,6 @@ destination:
       short: User email address.
       type: keyword
     destination.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -1612,8 +1599,6 @@ destination:
       short: Unique identifier of the user.
       type: keyword
     destination.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: destination-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -2628,7 +2613,6 @@ error:
       short: Unique identifier for the error.
       type: keyword
     error.message:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: error-message
       description: Error message.
       flat_name: error.message
@@ -2638,7 +2622,6 @@ error:
       short: Error message.
       type: match_only_text
     error.stack_trace:
-      beta: Use of the `match_only_text` type for this field is currently beta..
       dashed_name: error-stack-trace
       description: The stack trace of this error in plain text.
       flat_name: error.stack_trace
@@ -4235,8 +4218,6 @@ file:
       short: File owner's username.
       type: keyword
     file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -4353,8 +4334,6 @@ file:
       short: File size in bytes.
       type: long
     file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: file-target-path
       description: Target path for symlinks.
       flat_name: file.target_path
@@ -5372,8 +5351,6 @@ host:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     host.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: host-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -5402,8 +5379,6 @@ host:
       short: Operating system kernel version as a raw string.
       type: keyword
     host.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: host-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -5519,7 +5494,6 @@ http:
       short: Size in bytes of the request body.
       type: long
     http.request.body.content:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-request-body-content
       description: The full HTTP request body.
       example: Hello world
@@ -5612,7 +5586,6 @@ http:
       short: Size in bytes of the response body.
       type: long
     http.response.body.content:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: http-response-body-content
       description: The full HTTP response body.
       example: Hello world
@@ -6553,8 +6526,6 @@ observer:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     observer.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: observer-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6583,8 +6554,6 @@ observer:
       short: Operating system kernel version as a raw string.
       type: keyword
     observer.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: observer-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -6857,8 +6826,6 @@ organization:
       short: Unique identifier for the organization.
       type: keyword
     organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: organization-name
       description: Organization name.
       flat_name: organization.name
@@ -6893,8 +6860,6 @@ os:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -6921,8 +6886,6 @@ os:
       short: Operating system kernel version as a raw string.
       type: keyword
     os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -7430,7 +7393,6 @@ process:
         content.
       type: boolean
     process.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -7806,8 +7768,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -7891,8 +7851,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-name
       description: 'Process name.
 
@@ -8065,7 +8023,6 @@ process:
         content.
       type: boolean
     process.parent.command_line:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: process-parent-command-line
       description: 'Full command line that started the process, including the absolute
         path to the executable, and all arguments.
@@ -8444,8 +8401,6 @@ process:
       short: Unique identifier for the process.
       type: keyword
     process.parent.executable:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-executable
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
@@ -8531,8 +8486,6 @@ process:
       short: SSDEEP hash.
       type: keyword
     process.parent.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-name
       description: 'Process name.
 
@@ -8709,8 +8662,6 @@ process:
       short: Thread name.
       type: keyword
     process.parent.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-title
       description: 'Process title.
 
@@ -8740,8 +8691,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.parent.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-parent-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -8910,8 +8859,6 @@ process:
       short: Thread name.
       type: keyword
     process.title:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-title
       description: 'Process title.
 
@@ -8939,8 +8886,6 @@ process:
       short: Seconds the process has been up.
       type: long
     process.working_directory:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: process-working-directory
       description: The working directory of the process.
       example: /home/alice
@@ -9348,8 +9293,6 @@ server:
       short: Unique number allocated to the autonomous system.
       type: long
     server.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -9673,8 +9616,6 @@ server:
       short: User email address.
       type: keyword
     server.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -9753,8 +9694,6 @@ server:
       short: Unique identifier of the user.
       type: keyword
     server.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: server-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -9997,8 +9936,6 @@ source:
       short: Unique number allocated to the autonomous system.
       type: long
     source.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -10322,8 +10259,6 @@ source:
       short: User email address.
       type: keyword
     source.user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -10402,8 +10337,6 @@ source:
       short: Unique identifier of the user.
       type: keyword
     source.user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: source-user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -10495,8 +10428,6 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.enrichments.indicator.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -11235,8 +11166,6 @@ threat:
       short: File owner's username.
       type: keyword
     threat.enrichments.indicator.file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -11267,8 +11196,6 @@ threat:
       short: File size in bytes.
       type: long
     threat.enrichments.indicator.file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-enrichments-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.enrichments.indicator.file.target_path
@@ -11875,7 +11802,6 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.enrichments.indicator.url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-enrichments-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -11893,7 +11819,6 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.enrichments.indicator.url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-enrichments-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -12492,8 +12417,6 @@ threat:
       short: Unique number allocated to the autonomous system.
       type: long
     threat.indicator.as.organization.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-as-organization-name
       description: Organization name.
       example: Google LLC
@@ -13232,8 +13155,6 @@ threat:
       short: File owner's username.
       type: keyword
     threat.indicator.file.path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-file-path
       description: Full path to the file, including the file name. It should include
         the drive letter, when appropriate.
@@ -13264,8 +13185,6 @@ threat:
       short: File size in bytes.
       type: long
     threat.indicator.file.target_path:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-indicator-file-target-path
       description: Target path for symlinks.
       flat_name: threat.indicator.file.target_path
@@ -13872,7 +13791,6 @@ threat:
       short: Portion of the url after the `#`.
       type: keyword
     threat.indicator.url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: threat-indicator-url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -13890,7 +13808,6 @@ threat:
       short: Full unparsed URL.
       type: wildcard
     threat.indicator.url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: threat-indicator-url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -14482,8 +14399,6 @@ threat:
       short: Threat technique id.
       type: keyword
     threat.technique.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-technique-name
       description: "The name of technique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1059/)"
@@ -14527,8 +14442,6 @@ threat:
       short: Threat subtechnique id.
       type: keyword
     threat.technique.subtechnique.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: threat-technique-subtechnique-name
       description: "The name of subtechnique used by this threat. You can use a MITRE\
         \ ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
@@ -15757,7 +15670,6 @@ url:
       short: Portion of the url after the `#`.
       type: keyword
     url.full:
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       dashed_name: url-full
       description: If full URLs are important to your use case, they should be stored
         in `url.full`, whether this field is reconstructed or present in the event
@@ -15774,7 +15686,6 @@ url:
       short: Full unparsed URL.
       type: wildcard
     url.original:
-      beta: Use of the `match_only_text` type for this field is currently beta.
       dashed_name: url-original
       description: 'Unmodified original url as seen in the event source.
 
@@ -15963,8 +15874,6 @@ user:
       short: User email address.
       type: keyword
     user.changes.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-changes-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16043,8 +15952,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.changes.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-changes-name
       description: Short name or login of the user.
       example: a.einstein
@@ -16110,8 +16017,6 @@ user:
       short: User email address.
       type: keyword
     user.effective.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-effective-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16190,8 +16095,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.effective.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-effective-name
       description: Short name or login of the user.
       example: a.einstein
@@ -16231,8 +16134,6 @@ user:
       short: User email address.
       type: keyword
     user.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16308,8 +16209,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-name
       description: Short name or login of the user.
       example: a.einstein
@@ -16361,8 +16260,6 @@ user:
       short: User email address.
       type: keyword
     user.target.full_name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-target-full-name
       description: User's full name, if available.
       example: Albert Einstein
@@ -16441,8 +16338,6 @@ user:
       short: Unique identifier of the user.
       type: keyword
     user.target.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-target-name
       description: Short name or login of the user.
       example: a.einstein
@@ -16550,8 +16445,6 @@ user_agent:
       short: Name of the user agent.
       type: keyword
     user_agent.original:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-original
       description: Unparsed user_agent string.
       example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15
@@ -16580,8 +16473,6 @@ user_agent:
       short: OS family (such as redhat, debian, freebsd, windows).
       type: keyword
     user_agent.os.full:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-os-full
       description: Operating system name, including the version or code name.
       example: Mac OS Mojave
@@ -16610,8 +16501,6 @@ user_agent:
       short: Operating system kernel version as a raw string.
       type: keyword
     user_agent.os.name:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: user-agent-os-name
       description: Operating system name, without the version.
       example: Mac OS X
@@ -16789,8 +16678,6 @@ vulnerability:
       short: Classification of the vulnerability.
       type: keyword
     vulnerability.description:
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently
-        beta.
       dashed_name: vulnerability-description
       description: The description of the vulnerability that provides additional context
         of the vulnerability. For example (https://cve.mitre.org/about/faqs.html#cve_entry_descriptions_created[Common

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -39,7 +39,6 @@
       description: >
         Organization name.
       example: Google LLC
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/base.yml
+++ b/schemas/base.yml
@@ -54,7 +54,6 @@
       type: match_only_text
       example: "Hello World"
       short: Log message optimized for viewing in a log viewer.
-      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         For log events the message field contains the log message, optimized for
         viewing in a log viewer.

--- a/schemas/error.yml
+++ b/schemas/error.yml
@@ -20,7 +20,6 @@
     - name: message
       level: core
       type: match_only_text
-      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         Error message.
 
@@ -40,7 +39,6 @@
     - name: stack_trace
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta..
       description: >
         The stack trace of this error in plain text.
       multi_fields:

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -68,7 +68,6 @@
         Full path to the file, including the file name. It should include the
         drive letter, when appropriate.
       example: "/home/alice/example.png"
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
         - type: match_only_text
           name: text
@@ -77,7 +76,6 @@
       level: extended
       type: keyword
       description: Target path for symlinks.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
         - type: match_only_text
           name: text

--- a/schemas/http.yml
+++ b/schemas/http.yml
@@ -51,7 +51,6 @@
     - name: request.body.content
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         The full HTTP request body.
       example: Hello world
@@ -91,7 +90,6 @@
     - name: response.body.content
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta.
       description: >
         The full HTTP response body.
       example: Hello world

--- a/schemas/organization.yml
+++ b/schemas/organization.yml
@@ -17,7 +17,6 @@
       type: keyword
       description: >
         Organization name.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -40,7 +40,6 @@
       example: "Mac OS X"
       description: >
         Operating system name, without the version.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -51,7 +50,6 @@
       example: "Mac OS Mojave"
       description: >
         Operating system name, including the version or code name.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -52,7 +52,6 @@
 
         Sometimes called program name or similar.
       example: ssh
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -75,7 +74,6 @@
     - name: command_line
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta.
       short: Full command line that started the process.
       description: >
         Full command line that started the process, including the absolute path
@@ -117,7 +115,6 @@
       description: >
         Absolute path to the process executable.
       example: /usr/bin/ssh
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -131,7 +128,6 @@
 
         The proctitle, some times the same as process name. Can also be different:
         for example a browser setting its title to the web page currently opened.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -171,7 +167,6 @@
       example: /home/alice
       description: >
         The working directory of the process.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -587,7 +587,6 @@
     - name: technique.name
       level: extended
       type: keyword
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -631,7 +630,6 @@
       - type: match_only_text
         name: text
       short: Threat subtechnique name.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
           The name of subtechnique used by this threat. You can use a MITRE ATT&CK® subtechnique, for example.
           (ex. https://attack.mitre.org/techniques/T1059/001/)

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -20,7 +20,6 @@
     - name: original
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta.
       short: Unmodified original url as seen in the event source.
       description: >
         Unmodified original url as seen in the event source.
@@ -39,7 +38,6 @@
     - name: full
       level: extended
       type: wildcard
-      beta: Use of the `match_only_text` type for this field is currently beta.a
       short: Full unparsed URL.
       description: >
         If full URLs are important to your use case, they should be stored in

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -43,7 +43,6 @@
       example: a.einstein
       description: >
         Short name or login of the user.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text
@@ -54,7 +53,6 @@
       example: Albert Einstein
       description: >
         User's full name, if available.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       multi_fields:
       - type: match_only_text
         name: text

--- a/schemas/user_agent.yml
+++ b/schemas/user_agent.yml
@@ -16,7 +16,6 @@
       multi_fields:
       - type: match_only_text
         name: text
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         Unparsed user_agent string.
       example: "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -117,7 +117,6 @@
       - type: match_only_text
         name: text
       short: Description of the vulnerability.
-      beta: Use of the `match_only_text` type in the `.text` multi-field is currently beta.
       description: >
         The description of the vulnerability that provides additional context of the
         vulnerability.


### PR DESCRIPTION
Remove the `beta` attribute to promote these uses of `type: match_only-text` as GA changes.

Proposal: [RFC 0023](https://github.com/elastic/ecs/blob/master/rfcs/text/0023-match_only_text-data-type.md)
Stage 3 PR: https://github.com/elastic/ecs/pull/1560