### PR TITLE
Remove remaining golang dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,6 @@ jobs:
     name: Unit Tests
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.15.x'
       - uses: actions/setup-python@v2
         with:
           python-version: '3.x'

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -42,6 +42,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Remove remaining Go deps after removing Go code generator. #1585
+
 #### Deprecated
 
 ## 1.12.0 (Feature Freeze)

--- a/Makefile
+++ b/Makefile
@@ -68,10 +68,10 @@ makelint:
 .PHONY: misspell
 misspell:
 	@if [ ! -d $(PWD)/build/misspell ]; then \
-	    mkdir -p ./build/misspell ; \
-	    curl -L -o ./build/mispell/install-misspell.sh https://git.io/misspell ; \
-		chmod +x ./build/install-misspell.sh ; \
-		./build/misspell/install-misspell.sh -b ./build/misspell ; \
+	    mkdir -p ./build/misspell/bin ; \
+	    curl -sLo ./build/misspell/install-misspell.sh https://git.io/misspell ; \
+		chmod +x ./build/misspell/install-misspell.sh ; \
+		./build/misspell/install-misspell.sh -b ./build/misspell/bin >> /dev/null 2>&1 ; \
 	fi
 	./build/misspell/bin/misspell -error README.md CONTRIBUTING.md schemas/* docs/* experimental/schemas/*
 

--- a/Makefile
+++ b/Makefile
@@ -18,17 +18,11 @@ all: generate experimental
 # Check verifies that all of the committed files that are generated are
 # up-to-date.
 .PHONY: check
-check: generate experimental test fmt misspell makelint check-license-headers
+check: generate experimental test fmt misspell makelint
 	# Check if diff is empty.
 	git diff | cat
 	git update-index --refresh
 	git diff-index --exit-code HEAD --
-
-# Check license headers on files (currently .go files only).
-.PHONY: check-license-headers
-check-license-headers:
-	go get github.com/elastic/go-licenser
-	go-licenser -d
 
 # Clean deletes all temporary and generated content.
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,13 @@ makelint:
 # Check for basic misspellings.
 .PHONY: misspell
 misspell:
-	go get github.com/client9/misspell/cmd/misspell
-	misspell README.md CONTRIBUTING.md schemas/*
+	@if [ ! -d $(PWD)/build/misspell ]; then \
+	    mkdir -p ./build/misspell ; \
+	    curl -L -o ./build/mispell/install-misspell.sh https://git.io/misspell ; \
+		chmod +x ./build/install-misspell.sh ; \
+		./build/misspell/install-misspell.sh -b ./build/misspell ; \
+	fi
+	./build/misspell/bin/misspell -error README.md CONTRIBUTING.md schemas/* docs/* experimental/schemas/*
 
 .PHONY: reload_docs
 reload_docs: generator docs


### PR DESCRIPTION
This PR removes the remaining golang dependencies in the project `Makefile`.

### check-license-header

Remove `check-license-header` rule from `Makefile` since `check-license-header` only works with `.go` source files.

### misspell

* Install the `misspell` binary instead of `go get`
* Add `-error` flag to throw a non-zero exit code for CI
* Include `docs/*` and `experimental/schema/*` directives in the `misspell` check.

### GitHub workflow

Remove the `setup-go` step since golang is no longer a required dependency for testing. 

Closes #630 