### PR TITLE
RFC 0008 threat indicator fields - stage 3 changes

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -25,6 +25,7 @@ Thanks, you're awesome :-) -->
 
 * Wildcard type field migration GA. #1582
 * `match_only_text` type field migration GA. #1584
+* Threat indicator fields GA from RFC 0008. #1586
 
 #### Deprecated
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -7805,23 +7805,25 @@ type: object
 
 | beta:[ This field is beta and subject to change. ]
 
-Identifies the confidence rating assigned by the provider using STIX confidence scales. Expected values:
+Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
 
-  * Not Specified, None, Low, Medium, High
+Expected values are:
 
-  * 0-10
+  * Not Specified
 
-  * Admirality Scale (1-6)
+  * None
 
-  * DNI Scale (5-95)
+  * Low
 
-  * WEP Scale (Impossible - Certain)
+  * Medium
+
+  * High
 
 type: keyword
 
 
 
-example: `High`
+example: `Medium`
 
 | extended
 
@@ -8288,27 +8290,25 @@ example: `https://attack.mitre.org/groups/G0037/`
 [[field-threat-indicator-confidence]]
 <<field-threat-indicator-confidence, threat.indicator.confidence>>
 
-| beta:[ This field is beta and subject to change. ]
+| Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
 
-Identifies the confidence rating assigned by the provider using STIX confidence scales.
+Expected values are:
 
-Recommended values:
+  * Not Specified
 
-  * Not Specified, None, Low, Medium, High
+  * None
 
-  * 0-10
+  * Low
 
-  * Admirality Scale (1-6)
+  * Medium
 
-  * DNI Scale (5-95)
-
-  * WEP Scale (Impossible - Certain)
+  * High
 
 type: keyword
 
 
 
-example: `High`
+example: `Medium`
 
 | extended
 
@@ -8318,9 +8318,7 @@ example: `High`
 [[field-threat-indicator-description]]
 <<field-threat-indicator-description, threat.indicator.description>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Describes the type of action conducted by the threat.
+| Describes the type of action conducted by the threat.
 
 type: keyword
 
@@ -8336,9 +8334,7 @@ example: `IP x.x.x.x was observed delivering the Angler EK.`
 [[field-threat-indicator-email-address]]
 <<field-threat-indicator-email-address, threat.indicator.email.address>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Identifies a threat indicator as an email address (irrespective of direction).
+| Identifies a threat indicator as an email address (irrespective of direction).
 
 type: keyword
 
@@ -8354,9 +8350,7 @@ example: `phish@example.com`
 [[field-threat-indicator-first-seen]]
 <<field-threat-indicator-first-seen, threat.indicator.first_seen>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The date and time when intelligence source first reported sighting this indicator.
+| The date and time when intelligence source first reported sighting this indicator.
 
 type: date
 
@@ -8372,9 +8366,7 @@ example: `2020-11-05T17:25:47.000Z`
 [[field-threat-indicator-ip]]
 <<field-threat-indicator-ip, threat.indicator.ip>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Identifies a threat indicator as an IP address (irrespective of direction).
+| Identifies a threat indicator as an IP address (irrespective of direction).
 
 type: ip
 
@@ -8390,9 +8382,7 @@ example: `1.2.3.4`
 [[field-threat-indicator-last-seen]]
 <<field-threat-indicator-last-seen, threat.indicator.last_seen>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The date and time when intelligence source last reported sighting this indicator.
+| The date and time when intelligence source last reported sighting this indicator.
 
 type: date
 
@@ -8408,9 +8398,7 @@ example: `2020-11-05T17:25:47.000Z`
 [[field-threat-indicator-marking-tlp]]
 <<field-threat-indicator-marking-tlp, threat.indicator.marking.tlp>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Traffic Light Protocol sharing markings.
+| Traffic Light Protocol sharing markings.
 
 Recommended values are:
 
@@ -8436,9 +8424,7 @@ example: `WHITE`
 [[field-threat-indicator-modified-at]]
 <<field-threat-indicator-modified-at, threat.indicator.modified_at>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The date and time when intelligence source last modified information for this indicator.
+| The date and time when intelligence source last modified information for this indicator.
 
 type: date
 
@@ -8454,9 +8440,7 @@ example: `2020-11-05T17:25:47.000Z`
 [[field-threat-indicator-port]]
 <<field-threat-indicator-port, threat.indicator.port>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Identifies a threat indicator as a port number (irrespective of direction).
+| Identifies a threat indicator as a port number (irrespective of direction).
 
 type: long
 
@@ -8472,9 +8456,7 @@ example: `443`
 [[field-threat-indicator-provider]]
 <<field-threat-indicator-provider, threat.indicator.provider>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The name of the indicator's provider.
+| The name of the indicator's provider.
 
 type: keyword
 
@@ -8490,9 +8472,7 @@ example: `lrz_urlhaus`
 [[field-threat-indicator-reference]]
 <<field-threat-indicator-reference, threat.indicator.reference>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Reference URL linking to additional information about this indicator.
+| Reference URL linking to additional information about this indicator.
 
 type: keyword
 
@@ -8508,9 +8488,7 @@ example: `https://system.example.com/indicator/0001234`
 [[field-threat-indicator-scanner-stats]]
 <<field-threat-indicator-scanner-stats, threat.indicator.scanner_stats>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Count of AV/EDR vendors that successfully detected malicious file or URL.
+| Count of AV/EDR vendors that successfully detected malicious file or URL.
 
 type: long
 
@@ -8526,9 +8504,7 @@ example: `4`
 [[field-threat-indicator-sightings]]
 <<field-threat-indicator-sightings, threat.indicator.sightings>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Number of times this indicator was observed conducting threat activity.
+| Number of times this indicator was observed conducting threat activity.
 
 type: long
 
@@ -8544,9 +8520,7 @@ example: `20`
 [[field-threat-indicator-type]]
 <<field-threat-indicator-type, threat.indicator.type>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Type of indicator as represented by Cyber Observable in STIX 2.0.
+| Type of indicator as represented by Cyber Observable in STIX 2.0.
 
 Recommended values:
 
@@ -9007,65 +8981,57 @@ These fields contain x509 certificate metadata.
 
 
 | `threat.indicator.as.*`
-| <<ecs-as,as>>| beta:[ Reusing the `as` fields in this location is currently considered beta.]
-
-Fields describing an Autonomous System (Internet routing prefix).
+| <<ecs-as,as>>
+| Fields describing an Autonomous System (Internet routing prefix).
 
 // ===============================================================
 
 
 | `threat.indicator.file.*`
-| <<ecs-file,file>>| beta:[ Reusing the `file` fields in this location is currently considered beta.]
-
-Fields describing files.
+| <<ecs-file,file>>
+| Fields describing files.
 
 // ===============================================================
 
 
 | `threat.indicator.geo.*`
-| <<ecs-geo,geo>>| beta:[ Reusing the `geo` fields in this location is currently considered beta.]
-
-Fields describing a location.
+| <<ecs-geo,geo>>
+| Fields describing a location.
 
 // ===============================================================
 
 
 | `threat.indicator.hash.*`
-| <<ecs-hash,hash>>| beta:[ Reusing the `hash` fields in this location is currently considered beta.]
-
-Hashes, usually file hashes.
+| <<ecs-hash,hash>>
+| Hashes, usually file hashes.
 
 // ===============================================================
 
 
 | `threat.indicator.pe.*`
-| <<ecs-pe,pe>>| beta:[ Reusing the `pe` fields in this location is currently considered beta.]
-
-These fields contain Windows Portable Executable (PE) metadata.
+| <<ecs-pe,pe>>
+| These fields contain Windows Portable Executable (PE) metadata.
 
 // ===============================================================
 
 
 | `threat.indicator.registry.*`
-| <<ecs-registry,registry>>| beta:[ Reusing the `registry` fields in this location is currently considered beta.]
-
-Fields related to Windows Registry operations.
+| <<ecs-registry,registry>>
+| Fields related to Windows Registry operations.
 
 // ===============================================================
 
 
 | `threat.indicator.url.*`
-| <<ecs-url,url>>| beta:[ Reusing the `url` fields in this location is currently considered beta.]
-
-Fields that let you store URLs in various forms.
+| <<ecs-url,url>>
+| Fields that let you store URLs in various forms.
 
 // ===============================================================
 
 
 | `threat.indicator.x509.*`
-| <<ecs-x509,x509>>| beta:[ Reusing the `x509` fields in this location is currently considered beta.]
-
-These fields contain x509 certificate metadata.
+| <<ecs-x509,x509>>
+| These fields contain x509 certificate metadata.
 
 // ===============================================================
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -8614,11 +8614,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-        using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None,\
-        \ Low, Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       default_field: false
     - name: enrichments.indicator.description
       level: extended
@@ -10019,11 +10019,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies the confidence rating assigned by the provider using\
-        \ STIX confidence scales.\nRecommended values:\n  * Not Specified, None, Low,\
-        \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       default_field: false
     - name: indicator.description
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1041,7 +1041,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+8.0.0-dev+exp,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,Medium,Indicator confidence rating
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev+exp,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
@@ -1231,7 +1231,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev+exp,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.0.0-dev+exp,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
-8.0.0-dev+exp,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+8.0.0-dev+exp,true,threat,threat.indicator.confidence,keyword,extended,,Medium,Indicator confidence rating
 8.0.0-dev+exp,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev+exp,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev+exp,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -12928,11 +12928,11 @@ threat.enrichments.indicator.as.organization.name:
 threat.enrichments.indicator.confidence:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-confidence
-  description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-    using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None, Low,\
-    \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n \
-    \ * WEP Scale (Impossible - Certain)"
-  example: High
+  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
+    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
+    \  * None\n  * Low\n  * Medium\n  * High"
+  example: Medium
   flat_name: threat.enrichments.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -15282,13 +15282,12 @@ threat.indicator.as.organization.name:
   short: Organization name.
   type: keyword
 threat.indicator.confidence:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-confidence
-  description: "Identifies the confidence rating assigned by the provider using STIX\
-    \ confidence scales.\nRecommended values:\n  * Not Specified, None, Low, Medium,\
-    \ High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n  * WEP Scale\
-    \ (Impossible - Certain)"
-  example: High
+  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
+    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
+    \  * None\n  * Low\n  * Medium\n  * High"
+  example: Medium
   flat_name: threat.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -15297,7 +15296,6 @@ threat.indicator.confidence:
   short: Indicator confidence rating
   type: keyword
 threat.indicator.description:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-description
   description: Describes the type of action conducted by the threat.
   example: IP x.x.x.x was observed delivering the Angler EK.
@@ -15309,7 +15307,6 @@ threat.indicator.description:
   short: Indicator description
   type: keyword
 threat.indicator.email.address:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-email-address
   description: Identifies a threat indicator as an email address (irrespective of
     direction).
@@ -16073,7 +16070,6 @@ threat.indicator.file.uid:
   short: The user ID (UID) or security identifier (SID) of the file owner.
   type: keyword
 threat.indicator.first_seen:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-first-seen
   description: The date and time when intelligence source first reported sighting
     this indicator.
@@ -16280,7 +16276,6 @@ threat.indicator.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 threat.indicator.ip:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-ip
   description: Identifies a threat indicator as an IP address (irrespective of direction).
   example: 1.2.3.4
@@ -16291,7 +16286,6 @@ threat.indicator.ip:
   short: Indicator IP address
   type: ip
 threat.indicator.last_seen:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-last-seen
   description: The date and time when intelligence source last reported sighting this
     indicator.
@@ -16303,7 +16297,6 @@ threat.indicator.last_seen:
   short: Date/time indicator was last reported.
   type: date
 threat.indicator.marking.tlp:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-marking-tlp
   description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
     \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
@@ -16316,7 +16309,6 @@ threat.indicator.marking.tlp:
   short: Indicator TLP marking
   type: keyword
 threat.indicator.modified_at:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-modified-at
   description: The date and time when intelligence source last modified information
     for this indicator.
@@ -16787,7 +16779,6 @@ threat.indicator.pe.sections.virtual_address:
   short: Virtual address available to the file.
   type: long
 threat.indicator.port:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-port
   description: Identifies a threat indicator as a port number (irrespective of direction).
   example: 443
@@ -16798,7 +16789,6 @@ threat.indicator.port:
   short: Indicator port
   type: long
 threat.indicator.provider:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-provider
   description: The name of the indicator's provider.
   example: lrz_urlhaus
@@ -16810,7 +16800,6 @@ threat.indicator.provider:
   short: Indicator provider
   type: keyword
 threat.indicator.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-reference
   description: Reference URL linking to additional information about this indicator.
   example: https://system.example.com/indicator/0001234
@@ -16917,7 +16906,6 @@ threat.indicator.registry.value:
   short: Name of the value written.
   type: keyword
 threat.indicator.scanner_stats:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-scanner-stats
   description: Count of AV/EDR vendors that successfully detected malicious file or
     URL.
@@ -16929,7 +16917,6 @@ threat.indicator.scanner_stats:
   short: Scanner statistics
   type: long
 threat.indicator.sightings:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-sightings
   description: Number of times this indicator was observed conducting threat activity.
   example: 20
@@ -16940,7 +16927,6 @@ threat.indicator.sightings:
   short: Number of times indicator observed
   type: long
 threat.indicator.type:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-type
   description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
     Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  * domain-name\n\

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -152,7 +152,6 @@ as:
       full: source.as
     - as: as
       at: threat.indicator
-      beta: Reusing the `as` fields in this location is currently considered beta.
       full: threat.indicator.as
     - as: as
       at: threat.enrichments.indicator
@@ -5755,7 +5754,6 @@ file:
     expected:
     - as: file
       at: threat.indicator
-      beta: Reusing the `file` fields in this location is currently considered beta.
       full: threat.indicator.file
     - as: file
       at: threat.enrichments.indicator
@@ -5943,7 +5941,6 @@ geo:
       full: source.geo
     - as: geo
       at: threat.indicator
-      beta: Reusing the `geo` fields in this location is currently considered beta.
       full: threat.indicator.geo
     - as: geo
       at: threat.enrichments.indicator
@@ -6079,7 +6076,6 @@ hash:
       full: dll.hash
     - as: hash
       at: threat.indicator
-      beta: Reusing the `hash` fields in this location is currently considered beta.
       full: threat.indicator.hash
     - as: hash
       at: threat.enrichments.indicator
@@ -8630,7 +8626,6 @@ pe:
       full: process.pe
     - as: pe
       at: threat.indicator
-      beta: Reusing the `pe` fields in this location is currently considered beta.
       full: threat.indicator.pe
     - as: pe
       at: threat.enrichments.indicator
@@ -13622,8 +13617,6 @@ registry:
     expected:
     - as: registry
       at: threat.indicator
-      beta: Reusing the `registry` fields in this location is currently considered
-        beta.
       full: threat.indicator.registry
     - as: registry
       at: threat.enrichments.indicator
@@ -15034,11 +15027,11 @@ threat:
     threat.enrichments.indicator.confidence:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-confidence
-      description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-        using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None,\
-        \ Low, Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       flat_name: threat.enrichments.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -17393,13 +17386,12 @@ threat:
       short: Organization name.
       type: keyword
     threat.indicator.confidence:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-confidence
-      description: "Identifies the confidence rating assigned by the provider using\
-        \ STIX confidence scales.\nRecommended values:\n  * Not Specified, None, Low,\
-        \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       flat_name: threat.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -17408,7 +17400,6 @@ threat:
       short: Indicator confidence rating
       type: keyword
     threat.indicator.description:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-description
       description: Describes the type of action conducted by the threat.
       example: IP x.x.x.x was observed delivering the Angler EK.
@@ -17420,7 +17411,6 @@ threat:
       short: Indicator description
       type: keyword
     threat.indicator.email.address:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-email-address
       description: Identifies a threat indicator as an email address (irrespective
         of direction).
@@ -18184,7 +18174,6 @@ threat:
       short: The user ID (UID) or security identifier (SID) of the file owner.
       type: keyword
     threat.indicator.first_seen:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-first-seen
       description: The date and time when intelligence source first reported sighting
         this indicator.
@@ -18391,7 +18380,6 @@ threat:
       short: SSDEEP hash.
       type: keyword
     threat.indicator.ip:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-ip
       description: Identifies a threat indicator as an IP address (irrespective of
         direction).
@@ -18403,7 +18391,6 @@ threat:
       short: Indicator IP address
       type: ip
     threat.indicator.last_seen:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-last-seen
       description: The date and time when intelligence source last reported sighting
         this indicator.
@@ -18415,7 +18402,6 @@ threat:
       short: Date/time indicator was last reported.
       type: date
     threat.indicator.marking.tlp:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-marking-tlp
       description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
         \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
@@ -18428,7 +18414,6 @@ threat:
       short: Indicator TLP marking
       type: keyword
     threat.indicator.modified_at:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-modified-at
       description: The date and time when intelligence source last modified information
         for this indicator.
@@ -18900,7 +18885,6 @@ threat:
       short: Virtual address available to the file.
       type: long
     threat.indicator.port:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-port
       description: Identifies a threat indicator as a port number (irrespective of
         direction).
@@ -18912,7 +18896,6 @@ threat:
       short: Indicator port
       type: long
     threat.indicator.provider:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-provider
       description: The name of the indicator's provider.
       example: lrz_urlhaus
@@ -18924,7 +18907,6 @@ threat:
       short: Indicator provider
       type: keyword
     threat.indicator.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-reference
       description: Reference URL linking to additional information about this indicator.
       example: https://system.example.com/indicator/0001234
@@ -19031,7 +19013,6 @@ threat:
       short: Name of the value written.
       type: keyword
     threat.indicator.scanner_stats:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-scanner-stats
       description: Count of AV/EDR vendors that successfully detected malicious file
         or URL.
@@ -19043,7 +19024,6 @@ threat:
       short: Scanner statistics
       type: long
     threat.indicator.sightings:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-sightings
       description: Number of times this indicator was observed conducting threat activity.
       example: 20
@@ -19054,7 +19034,6 @@ threat:
       short: Number of times indicator observed
       type: long
     threat.indicator.type:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-type
       description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
         Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
@@ -19824,64 +19803,56 @@ threat:
   - threat.indicator.x509
   prefix: threat.
   reused_here:
-  - beta: Reusing the `as` fields in this location is currently considered beta.
-    full: threat.indicator.as
+  - full: threat.indicator.as
     schema_name: as
     short: Fields describing an Autonomous System (Internet routing prefix).
   - beta: Reusing the `as` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.as
     schema_name: as
     short: Fields describing an Autonomous System (Internet routing prefix).
-  - beta: Reusing the `file` fields in this location is currently considered beta.
-    full: threat.indicator.file
+  - full: threat.indicator.file
     schema_name: file
     short: Fields describing files.
   - beta: Reusing the `file` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.file
     schema_name: file
     short: Fields describing files.
-  - beta: Reusing the `geo` fields in this location is currently considered beta.
-    full: threat.indicator.geo
+  - full: threat.indicator.geo
     schema_name: geo
     short: Fields describing a location.
   - beta: Reusing the `geo` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.geo
     schema_name: geo
     short: Fields describing a location.
-  - beta: Reusing the `hash` fields in this location is currently considered beta.
-    full: threat.indicator.hash
+  - full: threat.indicator.hash
     schema_name: hash
     short: Hashes, usually file hashes.
   - beta: Reusing the `hash` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.hash
     schema_name: hash
     short: Hashes, usually file hashes.
-  - beta: Reusing the `pe` fields in this location is currently considered beta.
-    full: threat.indicator.pe
+  - full: threat.indicator.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
   - beta: Reusing the `pe` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
-  - beta: Reusing the `registry` fields in this location is currently considered beta.
-    full: threat.indicator.registry
+  - full: threat.indicator.registry
     schema_name: registry
     short: Fields related to Windows Registry operations.
   - beta: Reusing the `registry` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.registry
     schema_name: registry
     short: Fields related to Windows Registry operations.
-  - beta: Reusing the `url` fields in this location is currently considered beta.
-    full: threat.indicator.url
+  - full: threat.indicator.url
     schema_name: url
     short: Fields that let you store URLs in various forms.
   - beta: Reusing the `url` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.url
     schema_name: url
     short: Fields that let you store URLs in various forms.
-  - beta: Reusing the `x509` fields in this location is currently considered beta.
-    full: threat.indicator.x509
+  - full: threat.indicator.x509
     schema_name: x509
     short: These fields contain x509 certificate metadata.
   - beta: Reusing the `x509` fields in this location is currently considered beta.
@@ -21164,7 +21135,6 @@ url:
     expected:
     - as: url
       at: threat.indicator
-      beta: Reusing the `url` fields in this location is currently considered beta.
       full: threat.indicator.url
     - as: url
       at: threat.enrichments.indicator
@@ -22465,7 +22435,6 @@ x509:
       full: file.x509
     - as: x509
       at: threat.indicator
-      beta: Reusing the `x509` fields in this location is currently considered beta.
       full: threat.indicator.x509
     - as: x509
       at: threat.enrichments.indicator

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5952,11 +5952,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-        using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None,\
-        \ Low, Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       default_field: false
     - name: enrichments.indicator.description
       level: extended
@@ -7147,11 +7147,11 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies the confidence rating assigned by the provider using\
-        \ STIX confidence scales.\nRecommended values:\n  * Not Specified, None, Low,\
-        \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       default_field: false
     - name: indicator.description
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -683,7 +683,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.0.0-dev,true,threat,threat.enrichments.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
-8.0.0-dev,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+8.0.0-dev,true,threat,threat.enrichments.indicator.confidence,keyword,extended,,Medium,Indicator confidence rating
 8.0.0-dev,true,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev,true,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev,true,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
@@ -842,7 +842,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.0.0-dev,true,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.0.0-dev,true,threat,threat.indicator.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
-8.0.0-dev,true,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+8.0.0-dev,true,threat,threat.indicator.confidence,keyword,extended,,Medium,Indicator confidence rating
 8.0.0-dev,true,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
 8.0.0-dev,true,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
 8.0.0-dev,true,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8716,11 +8716,11 @@ threat.enrichments.indicator.as.organization.name:
 threat.enrichments.indicator.confidence:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-confidence
-  description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-    using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None, Low,\
-    \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n \
-    \ * WEP Scale (Impossible - Certain)"
-  example: High
+  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
+    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
+    \  * None\n  * Low\n  * Medium\n  * High"
+  example: Medium
   flat_name: threat.enrichments.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -10699,13 +10699,12 @@ threat.indicator.as.organization.name:
   short: Organization name.
   type: keyword
 threat.indicator.confidence:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-confidence
-  description: "Identifies the confidence rating assigned by the provider using STIX\
-    \ confidence scales.\nRecommended values:\n  * Not Specified, None, Low, Medium,\
-    \ High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n  * WEP Scale\
-    \ (Impossible - Certain)"
-  example: High
+  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
+    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
+    \  * None\n  * Low\n  * Medium\n  * High"
+  example: Medium
   flat_name: threat.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -10714,7 +10713,6 @@ threat.indicator.confidence:
   short: Indicator confidence rating
   type: keyword
 threat.indicator.description:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-description
   description: Describes the type of action conducted by the threat.
   example: IP x.x.x.x was observed delivering the Angler EK.
@@ -10726,7 +10724,6 @@ threat.indicator.description:
   short: Indicator description
   type: keyword
 threat.indicator.email.address:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-email-address
   description: Identifies a threat indicator as an email address (irrespective of
     direction).
@@ -11490,7 +11487,6 @@ threat.indicator.file.uid:
   short: The user ID (UID) or security identifier (SID) of the file owner.
   type: keyword
 threat.indicator.first_seen:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-first-seen
   description: The date and time when intelligence source first reported sighting
     this indicator.
@@ -11697,7 +11693,6 @@ threat.indicator.hash.ssdeep:
   short: SSDEEP hash.
   type: keyword
 threat.indicator.ip:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-ip
   description: Identifies a threat indicator as an IP address (irrespective of direction).
   example: 1.2.3.4
@@ -11708,7 +11703,6 @@ threat.indicator.ip:
   short: Indicator IP address
   type: ip
 threat.indicator.last_seen:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-last-seen
   description: The date and time when intelligence source last reported sighting this
     indicator.
@@ -11720,7 +11714,6 @@ threat.indicator.last_seen:
   short: Date/time indicator was last reported.
   type: date
 threat.indicator.marking.tlp:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-marking-tlp
   description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
     \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
@@ -11733,7 +11726,6 @@ threat.indicator.marking.tlp:
   short: Indicator TLP marking
   type: keyword
 threat.indicator.modified_at:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-modified-at
   description: The date and time when intelligence source last modified information
     for this indicator.
@@ -11833,7 +11825,6 @@ threat.indicator.pe.product:
   short: Internal product name of the file, provided at compile-time.
   type: keyword
 threat.indicator.port:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-port
   description: Identifies a threat indicator as a port number (irrespective of direction).
   example: 443
@@ -11844,7 +11835,6 @@ threat.indicator.port:
   short: Indicator port
   type: long
 threat.indicator.provider:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-provider
   description: The name of the indicator's provider.
   example: lrz_urlhaus
@@ -11856,7 +11846,6 @@ threat.indicator.provider:
   short: Indicator provider
   type: keyword
 threat.indicator.reference:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-reference
   description: Reference URL linking to additional information about this indicator.
   example: https://system.example.com/indicator/0001234
@@ -11963,7 +11952,6 @@ threat.indicator.registry.value:
   short: Name of the value written.
   type: keyword
 threat.indicator.scanner_stats:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-scanner-stats
   description: Count of AV/EDR vendors that successfully detected malicious file or
     URL.
@@ -11975,7 +11963,6 @@ threat.indicator.scanner_stats:
   short: Scanner statistics
   type: long
 threat.indicator.sightings:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-sightings
   description: Number of times this indicator was observed conducting threat activity.
   example: 20
@@ -11986,7 +11973,6 @@ threat.indicator.sightings:
   short: Number of times indicator observed
   type: long
 threat.indicator.type:
-  beta: This field is beta and subject to change.
   dashed_name: threat-indicator-type
   description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
     Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  * domain-name\n\

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -152,7 +152,6 @@ as:
       full: source.as
     - as: as
       at: threat.indicator
-      beta: Reusing the `as` fields in this location is currently considered beta.
       full: threat.indicator.as
     - as: as
       at: threat.enrichments.indicator
@@ -4688,7 +4687,6 @@ file:
     expected:
     - as: file
       at: threat.indicator
-      beta: Reusing the `file` fields in this location is currently considered beta.
       full: threat.indicator.file
     - as: file
       at: threat.enrichments.indicator
@@ -4876,7 +4874,6 @@ geo:
       full: source.geo
     - as: geo
       at: threat.indicator
-      beta: Reusing the `geo` fields in this location is currently considered beta.
       full: threat.indicator.geo
     - as: geo
       at: threat.enrichments.indicator
@@ -5012,7 +5009,6 @@ hash:
       full: dll.hash
     - as: hash
       at: threat.indicator
-      beta: Reusing the `hash` fields in this location is currently considered beta.
       full: threat.indicator.hash
     - as: hash
       at: threat.enrichments.indicator
@@ -7222,7 +7218,6 @@ pe:
       full: process.pe
     - as: pe
       at: threat.indicator
-      beta: Reusing the `pe` fields in this location is currently considered beta.
       full: threat.indicator.pe
     - as: pe
       at: threat.enrichments.indicator
@@ -9034,8 +9029,6 @@ registry:
     expected:
     - as: registry
       at: threat.indicator
-      beta: Reusing the `registry` fields in this location is currently considered
-        beta.
       full: threat.indicator.registry
     - as: registry
       at: threat.enrichments.indicator
@@ -10446,11 +10439,11 @@ threat:
     threat.enrichments.indicator.confidence:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-confidence
-      description: "Identifies\_the\_confidence\_rating\_assigned\_by\_the\_provider\_\
-        using\_STIX\_confidence scales. Expected values:\n  * Not Specified, None,\
-        \ Low, Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       flat_name: threat.enrichments.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -12433,13 +12426,12 @@ threat:
       short: Organization name.
       type: keyword
     threat.indicator.confidence:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-confidence
-      description: "Identifies the confidence rating assigned by the provider using\
-        \ STIX confidence scales.\nRecommended values:\n  * Not Specified, None, Low,\
-        \ Medium, High\n  * 0-10\n  * Admirality Scale (1-6)\n  * DNI Scale (5-95)\n\
-        \  * WEP Scale (Impossible - Certain)"
-      example: High
+      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
+        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
+        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
+        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      example: Medium
       flat_name: threat.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -12448,7 +12440,6 @@ threat:
       short: Indicator confidence rating
       type: keyword
     threat.indicator.description:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-description
       description: Describes the type of action conducted by the threat.
       example: IP x.x.x.x was observed delivering the Angler EK.
@@ -12460,7 +12451,6 @@ threat:
       short: Indicator description
       type: keyword
     threat.indicator.email.address:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-email-address
       description: Identifies a threat indicator as an email address (irrespective
         of direction).
@@ -13224,7 +13214,6 @@ threat:
       short: The user ID (UID) or security identifier (SID) of the file owner.
       type: keyword
     threat.indicator.first_seen:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-first-seen
       description: The date and time when intelligence source first reported sighting
         this indicator.
@@ -13431,7 +13420,6 @@ threat:
       short: SSDEEP hash.
       type: keyword
     threat.indicator.ip:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-ip
       description: Identifies a threat indicator as an IP address (irrespective of
         direction).
@@ -13443,7 +13431,6 @@ threat:
       short: Indicator IP address
       type: ip
     threat.indicator.last_seen:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-last-seen
       description: The date and time when intelligence source last reported sighting
         this indicator.
@@ -13455,7 +13442,6 @@ threat:
       short: Date/time indicator was last reported.
       type: date
     threat.indicator.marking.tlp:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-marking-tlp
       description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
         \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
@@ -13468,7 +13454,6 @@ threat:
       short: Indicator TLP marking
       type: keyword
     threat.indicator.modified_at:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-modified-at
       description: The date and time when intelligence source last modified information
         for this indicator.
@@ -13568,7 +13553,6 @@ threat:
       short: Internal product name of the file, provided at compile-time.
       type: keyword
     threat.indicator.port:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-port
       description: Identifies a threat indicator as a port number (irrespective of
         direction).
@@ -13580,7 +13564,6 @@ threat:
       short: Indicator port
       type: long
     threat.indicator.provider:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-provider
       description: The name of the indicator's provider.
       example: lrz_urlhaus
@@ -13592,7 +13575,6 @@ threat:
       short: Indicator provider
       type: keyword
     threat.indicator.reference:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-reference
       description: Reference URL linking to additional information about this indicator.
       example: https://system.example.com/indicator/0001234
@@ -13699,7 +13681,6 @@ threat:
       short: Name of the value written.
       type: keyword
     threat.indicator.scanner_stats:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-scanner-stats
       description: Count of AV/EDR vendors that successfully detected malicious file
         or URL.
@@ -13711,7 +13692,6 @@ threat:
       short: Scanner statistics
       type: long
     threat.indicator.sightings:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-sightings
       description: Number of times this indicator was observed conducting threat activity.
       example: 20
@@ -13722,7 +13702,6 @@ threat:
       short: Number of times indicator observed
       type: long
     threat.indicator.type:
-      beta: This field is beta and subject to change.
       dashed_name: threat-indicator-type
       description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
         Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
@@ -14492,64 +14471,56 @@ threat:
   - threat.indicator.x509
   prefix: threat.
   reused_here:
-  - beta: Reusing the `as` fields in this location is currently considered beta.
-    full: threat.indicator.as
+  - full: threat.indicator.as
     schema_name: as
     short: Fields describing an Autonomous System (Internet routing prefix).
   - beta: Reusing the `as` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.as
     schema_name: as
     short: Fields describing an Autonomous System (Internet routing prefix).
-  - beta: Reusing the `file` fields in this location is currently considered beta.
-    full: threat.indicator.file
+  - full: threat.indicator.file
     schema_name: file
     short: Fields describing files.
   - beta: Reusing the `file` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.file
     schema_name: file
     short: Fields describing files.
-  - beta: Reusing the `geo` fields in this location is currently considered beta.
-    full: threat.indicator.geo
+  - full: threat.indicator.geo
     schema_name: geo
     short: Fields describing a location.
   - beta: Reusing the `geo` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.geo
     schema_name: geo
     short: Fields describing a location.
-  - beta: Reusing the `hash` fields in this location is currently considered beta.
-    full: threat.indicator.hash
+  - full: threat.indicator.hash
     schema_name: hash
     short: Hashes, usually file hashes.
   - beta: Reusing the `hash` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.hash
     schema_name: hash
     short: Hashes, usually file hashes.
-  - beta: Reusing the `pe` fields in this location is currently considered beta.
-    full: threat.indicator.pe
+  - full: threat.indicator.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
   - beta: Reusing the `pe` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
-  - beta: Reusing the `registry` fields in this location is currently considered beta.
-    full: threat.indicator.registry
+  - full: threat.indicator.registry
     schema_name: registry
     short: Fields related to Windows Registry operations.
   - beta: Reusing the `registry` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.registry
     schema_name: registry
     short: Fields related to Windows Registry operations.
-  - beta: Reusing the `url` fields in this location is currently considered beta.
-    full: threat.indicator.url
+  - full: threat.indicator.url
     schema_name: url
     short: Fields that let you store URLs in various forms.
   - beta: Reusing the `url` fields in this location is currently considered beta.
     full: threat.enrichments.indicator.url
     schema_name: url
     short: Fields that let you store URLs in various forms.
-  - beta: Reusing the `x509` fields in this location is currently considered beta.
-    full: threat.indicator.x509
+  - full: threat.indicator.x509
     schema_name: x509
     short: These fields contain x509 certificate metadata.
   - beta: Reusing the `x509` fields in this location is currently considered beta.
@@ -15832,7 +15803,6 @@ url:
     expected:
     - as: url
       at: threat.indicator
-      beta: Reusing the `url` fields in this location is currently considered beta.
       full: threat.indicator.url
     - as: url
       at: threat.enrichments.indicator
@@ -17133,7 +17103,6 @@ x509:
       full: file.x509
     - as: x509
       at: threat.indicator
-      beta: Reusing the `x509` fields in this location is currently considered beta.
       full: threat.indicator.x509
     - as: x509
       at: threat.enrichments.indicator

--- a/schemas/as.yml
+++ b/schemas/as.yml
@@ -17,7 +17,6 @@
       - source
       - at: threat.indicator
         as: as
-        beta: Reusing the `as` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: as
         beta: Reusing the `as` fields in this location is currently considered beta.

--- a/schemas/file.yml
+++ b/schemas/file.yml
@@ -15,7 +15,6 @@
     expected:
       - at: threat.indicator
         as: file
-        beta: Reusing the `file` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: file
         beta: Reusing the `file` fields in this location is currently considered beta.

--- a/schemas/geo.yml
+++ b/schemas/geo.yml
@@ -19,7 +19,6 @@
       - source
       - at: threat.indicator
         as: geo
-        beta: Reusing the `geo` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: geo
         beta: Reusing the `geo` fields in this location is currently considered beta.

--- a/schemas/hash.yml
+++ b/schemas/hash.yml
@@ -23,7 +23,6 @@
       - dll
       - at: threat.indicator
         as: hash
-        beta: Reusing the `hash` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: hash
         beta: Reusing the `hash` fields in this location is currently considered beta.

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -12,7 +12,6 @@
       - process
       - at: threat.indicator
         as: pe
-        beta: Reusing the `pe` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: pe
         beta: Reusing the `pe` fields in this location is currently considered beta.

--- a/schemas/registry.yml
+++ b/schemas/registry.yml
@@ -9,7 +9,6 @@
     expected:
       - at: threat.indicator
         as: registry
-        beta: Reusing the `registry` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: registry
         beta: Reusing the `registry` fields in this location is currently considered beta.

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -289,7 +289,6 @@
       level: extended
       type: date
       short: Date/time indicator was first reported.
-      beta: This field is beta and subject to change.
       description: >
         The date and time when intelligence source first reported sighting this indicator.
 
@@ -299,7 +298,6 @@
       level: extended
       type: date
       short: Date/time indicator was last reported.
-      beta: This field is beta and subject to change.
       description: >
         The date and time when intelligence source last reported sighting this indicator.
 
@@ -309,7 +307,6 @@
       level: extended
       type: date
       short: Date/time indicator was last updated.
-      beta: This field is beta and subject to change.
       description: >
         The date and time when intelligence source last modified information for this indicator.
 
@@ -319,7 +316,6 @@
       level: extended
       type: long
       short: Number of times indicator observed
-      beta: This field is beta and subject to change.
       description: >
         Number of times this indicator was observed conducting threat activity.
 
@@ -329,7 +325,6 @@
       level: extended
       type: keyword
       short: Type of indicator
-      beta: This field is beta and subject to change.
       description: >
         Type of indicator as represented by Cyber Observable in STIX 2.0.
 
@@ -358,7 +353,6 @@
       level: extended
       type: keyword
       short: Indicator description
-      beta: This field is beta and subject to change.
       description: >
         Describes the type of action conducted by the threat.
 
@@ -368,7 +362,6 @@
       level: extended
       type: long
       short: Scanner statistics
-      beta: This field is beta and subject to change.
       description: >
         Count of AV/EDR vendors that successfully detected malicious file or URL.
 
@@ -378,7 +371,6 @@
       level: extended
       type: keyword
       short: Indicator confidence rating
-      beta: This field is beta and subject to change.
       description: >
         Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
         confidence scales may be added as custom fields.
@@ -395,7 +387,6 @@
       level: extended
       type: ip
       short: Indicator IP address
-      beta: This field is beta and subject to change.
       description: >
         Identifies a threat indicator as an IP address (irrespective of direction).
 
@@ -405,7 +396,6 @@
       level: extended
       type: long
       short: Indicator port
-      beta: This field is beta and subject to change.
       description: >
         Identifies a threat indicator as a port number (irrespective of direction).
 
@@ -415,7 +405,6 @@
       level: extended
       type: keyword
       short: Indicator email address
-      beta: This field is beta and subject to change.
       description: >
         Identifies a threat indicator as an email address (irrespective of direction).
 
@@ -425,7 +414,6 @@
       level: extended
       type: keyword
       short: Indicator TLP marking
-      beta: This field is beta and subject to change.
       description: >
         Traffic Light Protocol sharing markings.
 
@@ -441,7 +429,6 @@
       level: extended
       type: keyword
       short: Indicator reference URL
-      beta: This field is beta and subject to change.
       description: >
         Reference URL linking to additional information about this indicator.
       example: https://system.example.com/indicator/0001234
@@ -450,7 +437,6 @@
       level: extended
       type: keyword
       short: Indicator provider
-      beta: This field is beta and subject to change.
       description: >
         The name of the indicator's provider.
       example: lrz_urlhaus

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -118,14 +118,16 @@
       short: Indicator confidence rating
       beta: This field is beta and subject to change.
       description: >
-        Identifies the confidence rating assigned by the provider using STIX confidence scales.
-        Expected values:
-          * Not Specified, None, Low, Medium, High
-          * 0-10
-          * Admirality Scale (1-6)
-          * DNI Scale (5-95)
-          * WEP Scale (Impossible - Certain)
-      example: High
+        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
+        confidence scales may be added as custom fields.
+
+        Expected values are:
+          * Not Specified
+          * None
+          * Low
+          * Medium
+          * High
+      example: Medium
 
     - name: enrichments.indicator.ip
       level: extended
@@ -381,13 +383,12 @@
         Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
         confidence scales may be added as custom fields.
 
-        Expected values:
-
-        * Not Specified
-        * None
-        * Low
-        * Medium
-        * High
+        Expected values are:
+          * Not Specified
+          * None
+          * Low
+          * Medium
+          * High
       example: Medium
 
     - name: indicator.ip

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -378,16 +378,17 @@
       short: Indicator confidence rating
       beta: This field is beta and subject to change.
       description: >
-        Identifies the confidence rating assigned by the provider using STIX confidence scales.
+        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
+        confidence scales may be added as custom fields.
 
-        Recommended values:
-          * Not Specified, None, Low, Medium, High
-          * 0-10
-          * Admirality Scale (1-6)
-          * DNI Scale (5-95)
-          * WEP Scale (Impossible - Certain)
+        Expected values:
 
-      example: High
+        * Not Specified
+        * None
+        * Low
+        * Medium
+        * High
+      example: Medium
 
     - name: indicator.ip
       level: extended

--- a/schemas/url.yml
+++ b/schemas/url.yml
@@ -11,7 +11,6 @@
     expected:
       - at: threat.indicator
         as: url
-        beta: Reusing the `url` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: url
         beta: Reusing the `url` fields in this location is currently considered beta.

--- a/schemas/x509.yml
+++ b/schemas/x509.yml
@@ -19,7 +19,6 @@
       - file
       - at: threat.indicator
         as: x509
-        beta: Reusing the `x509` fields in this location is currently considered beta.
       - at: threat.enrichments.indicator
         as: x509
         beta: Reusing the `x509` fields in this location is currently considered beta.


### PR DESCRIPTION
Removing the `beta` attributes now that [RFC 0008](https://github.com/elastic/ecs/blob/master/rfcs/text/0008-threat-intel.md) has advanced to stage 3.

Also, adjusting the `threat.indicator.confidence` field's description.

