### PR TITLE
RFC 0022 remove `process.ppid` - stage 3

### DIFF
--- a/rfcs/text/0022-remove-process-ppid.md
+++ b/rfcs/text/0022-remove-process-ppid.md
@@ -2,7 +2,7 @@
 <!-- Leave this ID at 0000. The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC. -->
 
 - Stage: **3 (finished)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
-- Date: **TBD** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
+- Date: **2021-08-26** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
 
 <!--
 As you work on your RFC, use the "Stage N" comments to guide you in what you should focus on, for the stage you're targeting.


### PR DESCRIPTION
Advancing the proposal to remove `process.ppid` to Stage 3 (finished)

[Preview of the RFC proposal](https://github.com/ebeahan/ecs/blob/rfc/0022/stage-3/rfcs/text/0022-remove-process-ppid.md)

Criteria for Stage 3

- [x] Opened pull request for this candidate revising the existing candidate
- [x] Included multiple real-world example source documents
- [x] Existing or newly raised questions and concerns are addressed
- [x] No objections from sponsor, ECS team, or subject matter experts