### PR TITLE
[1.12] [DOCS] New FAQ section for field type families (#1591)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -69,6 +69,9 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 * Prevent failure if no files need to be deleted `find | xargs rm`. #1588
+#### Improvements
+
+* Document field type family interoperability in FAQ. #1591
 
 <!-- All empty sections:
 

--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -96,3 +96,20 @@ the ECS data itself, this is not an issue because all fields are predefined.
 
 As long as there are no conflicts, underline notation and ECS dot notation can
 coexist in the same document.
+
+[float]
+[[type-interop]]
+==== What if I want to use a different data type from the same field type family?
+
+In Elasticsearch, field types are grouped by family. Types in the same family support
+the same search functionality but may have different space usage or performance
+characteristics. For example, both `keyword` and `wildcard` types are members of the
+`keyword` family, and `text` and `match_only_text` are members of the `text` family.
+
+The field types defined in ECS provide the best default experience for most users.
+However, a different type from the same family can replace the default defined in ECS
+if required for a specific use cases. Users should understand any potential performance
+or storage differences before changing from a default field type.
+
+The Elasticsearch {ref}/mapping-types.html[mapping types] section has more information about type
+families.


### PR DESCRIPTION
Backports the following commits to 1.12:
 - [DOCS] New FAQ section for field type families (#1591)