### PR TITLE
Remove `process.ppid` field

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,7 @@ Thanks, you're awesome :-) -->
 * Remove deprecation notice on `http.request.method`. #1443
 * Migrate `log.origin.file.line` from `integer` to `long`. #1533
 * Remove `log.original` field. #1580
+* Remove `process.ppid` field. #1596
 
 #### Bugfixes
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -6405,22 +6405,6 @@ example: `4242`
 // ===============================================================
 
 |
-[[field-process-ppid]]
-<<field-process-ppid, process.ppid>>
-
-| Parent process' pid.
-
-type: long
-
-
-
-example: `4241`
-
-| extended
-
-// ===============================================================
-
-|
 [[field-process-start]]
 <<field-process-start, process.start>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5919,13 +5919,6 @@
       description: Process id.
       example: 4242
       default_field: false
-    - name: parent.ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
-      default_field: false
     - name: parent.start
       level: extended
       type: date
@@ -6248,12 +6241,6 @@
       format: string
       description: Process id.
       example: 4242
-    - name: ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
     - name: start
       level: extended
       type: date
@@ -7277,13 +7264,6 @@
       description: Process id.
       example: 4242
       default_field: false
-    - name: target.parent.ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
-      default_field: false
     - name: target.parent.start
       level: extended
       type: date
@@ -7607,13 +7587,6 @@
       format: string
       description: Process id.
       example: 4242
-      default_field: false
-    - name: target.ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
       default_field: false
     - name: target.start
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -665,7 +665,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.parent.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 8.0.0-dev+exp,true,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev+exp,true,process,process.parent.pid,long,core,,4242,Process id.
-8.0.0-dev+exp,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev+exp,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev+exp,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
@@ -714,7 +713,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 8.0.0-dev+exp,true,process,process.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev+exp,true,process,process.pid,long,core,,4242,Process id.
-8.0.0-dev+exp,true,process,process.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev+exp,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev+exp,true,process,process.target.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.0.0-dev+exp,true,process,process.target.args_count,long,extended,,4,Length of the process.args array.
@@ -864,7 +862,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.parent.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 8.0.0-dev+exp,true,process,process.target.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev+exp,true,process,process.target.parent.pid,long,core,,4242,Process id.
-8.0.0-dev+exp,true,process,process.target.parent.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev+exp,true,process,process.target.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev+exp,true,process,process.target.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.target.parent.thread.name,keyword,extended,,thread-0,Thread name.
@@ -913,7 +910,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,process,process.target.pe.sections.virtual_address,long,extended,,8192,Virtual address available to the file.
 8.0.0-dev+exp,true,process,process.target.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev+exp,true,process,process.target.pid,long,core,,4242,Process id.
-8.0.0-dev+exp,true,process,process.target.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev+exp,true,process,process.target.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev+exp,true,process,process.target.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev+exp,true,process,process.target.thread.name,keyword,extended,,thread-0,Thread name.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8463,18 +8463,6 @@ process.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
-process.parent.ppid:
-  dashed_name: process-parent-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.parent.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  original_fieldset: process
-  short: Parent process' pid.
-  type: long
 process.parent.start:
   dashed_name: process-parent-start
   description: The time the process started.
@@ -9034,17 +9022,6 @@ process.pid:
   name: pid
   normalize: []
   short: Process id.
-  type: long
-process.ppid:
-  dashed_name: process-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  short: Parent process' pid.
   type: long
 process.start:
   dashed_name: process-start
@@ -10810,18 +10787,6 @@ process.target.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
-process.target.parent.ppid:
-  dashed_name: process-target-parent-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.target.parent.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  original_fieldset: process
-  short: Parent process' pid.
-  type: long
 process.target.parent.start:
   dashed_name: process-target-parent-start
   description: The time the process started.
@@ -11383,18 +11348,6 @@ process.target.pid:
   normalize: []
   original_fieldset: process
   short: Process id.
-  type: long
-process.target.ppid:
-  dashed_name: process-target-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.target.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  original_fieldset: process
-  short: Parent process' pid.
   type: long
 process.target.start:
   dashed_name: process-target-start

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10389,18 +10389,6 @@ process:
       original_fieldset: process
       short: Process id.
       type: long
-    process.parent.ppid:
-      dashed_name: process-parent-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.parent.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      original_fieldset: process
-      short: Parent process' pid.
-      type: long
     process.parent.start:
       dashed_name: process-parent-start
       description: The time the process started.
@@ -10961,17 +10949,6 @@ process:
       name: pid
       normalize: []
       short: Process id.
-      type: long
-    process.ppid:
-      dashed_name: process-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      short: Parent process' pid.
       type: long
     process.start:
       dashed_name: process-start
@@ -12738,18 +12715,6 @@ process:
       original_fieldset: process
       short: Process id.
       type: long
-    process.target.parent.ppid:
-      dashed_name: process-target-parent-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.target.parent.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      original_fieldset: process
-      short: Parent process' pid.
-      type: long
     process.target.parent.start:
       dashed_name: process-target-parent-start
       description: The time the process started.
@@ -13312,18 +13277,6 @@ process:
       normalize: []
       original_fieldset: process
       short: Process id.
-      type: long
-    process.target.ppid:
-      dashed_name: process-target-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.target.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      original_fieldset: process
-      short: Parent process' pid.
       type: long
     process.target.start:
       dashed_name: process-target-start

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -3025,9 +3025,6 @@
               "pid": {
                 "type": "long"
               },
-              "ppid": {
-                "type": "long"
-              },
               "start": {
                 "type": "date"
               },
@@ -3237,9 +3234,6 @@
             "type": "long"
           },
           "pid": {
-            "type": "long"
-          },
-          "ppid": {
             "type": "long"
           },
           "start": {
@@ -3863,9 +3857,6 @@
                   "pid": {
                     "type": "long"
                   },
-                  "ppid": {
-                    "type": "long"
-                  },
                   "start": {
                     "type": "date"
                   },
@@ -4075,9 +4066,6 @@
                 "type": "long"
               },
               "pid": {
-                "type": "long"
-              },
-              "ppid": {
                 "type": "long"
               },
               "start": {

--- a/experimental/generated/elasticsearch/component/process.json
+++ b/experimental/generated/elasticsearch/component/process.json
@@ -624,9 +624,6 @@
                 "pid": {
                   "type": "long"
                 },
-                "ppid": {
-                  "type": "long"
-                },
                 "start": {
                   "type": "date"
                 },
@@ -836,9 +833,6 @@
               "type": "long"
             },
             "pid": {
-              "type": "long"
-            },
-            "ppid": {
               "type": "long"
             },
             "start": {
@@ -1462,9 +1456,6 @@
                     "pid": {
                       "type": "long"
                     },
-                    "ppid": {
-                      "type": "long"
-                    },
                     "start": {
                       "type": "date"
                     },
@@ -1674,9 +1665,6 @@
                   "type": "long"
                 },
                 "pid": {
-                  "type": "long"
-                },
-                "ppid": {
                   "type": "long"
                 },
                 "start": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4871,13 +4871,6 @@
       description: Process id.
       example: 4242
       default_field: false
-    - name: parent.ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
-      default_field: false
     - name: parent.start
       level: extended
       type: date
@@ -4990,12 +4983,6 @@
       format: string
       description: Process id.
       example: 4242
-    - name: ppid
-      level: extended
-      type: long
-      format: string
-      description: Parent process' pid.
-      example: 4241
     - name: start
       level: extended
       type: date

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -544,7 +544,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 8.0.0-dev,true,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev,true,process,process.parent.pid,long,core,,4242,Process id.
-8.0.0-dev,true,process,process.parent.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
@@ -562,7 +561,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,process,process.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
 8.0.0-dev,true,process,process.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
 8.0.0-dev,true,process,process.pid,long,core,,4242,Process id.
-8.0.0-dev,true,process,process.ppid,long,extended,,4241,Parent process' pid.
 8.0.0-dev,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.0.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
 8.0.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7042,18 +7042,6 @@ process.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
-process.parent.ppid:
-  dashed_name: process-parent-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.parent.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  original_fieldset: process
-  short: Parent process' pid.
-  type: long
 process.parent.start:
   dashed_name: process-parent-start
   description: The time the process started.
@@ -7242,17 +7230,6 @@ process.pid:
   name: pid
   normalize: []
   short: Process id.
-  type: long
-process.ppid:
-  dashed_name: process-ppid
-  description: Parent process' pid.
-  example: 4241
-  flat_name: process.ppid
-  format: string
-  level: extended
-  name: ppid
-  normalize: []
-  short: Parent process' pid.
   type: long
 process.start:
   dashed_name: process-start

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8609,18 +8609,6 @@ process:
       original_fieldset: process
       short: Process id.
       type: long
-    process.parent.ppid:
-      dashed_name: process-parent-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.parent.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      original_fieldset: process
-      short: Parent process' pid.
-      type: long
     process.parent.start:
       dashed_name: process-parent-start
       description: The time the process started.
@@ -8809,17 +8797,6 @@ process:
       name: pid
       normalize: []
       short: Process id.
-      type: long
-    process.ppid:
-      dashed_name: process-ppid
-      description: Parent process' pid.
-      example: 4241
-      flat_name: process.ppid
-      format: string
-      level: extended
-      name: ppid
-      normalize: []
-      short: Parent process' pid.
       type: long
     process.start:
       dashed_name: process-start

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -2501,9 +2501,6 @@
                 "pid": {
                   "type": "long"
                 },
-                "ppid": {
-                  "type": "long"
-                },
                 "start": {
                   "type": "date"
                 },
@@ -2579,9 +2576,6 @@
               "type": "long"
             },
             "pid": {
-              "type": "long"
-            },
-            "ppid": {
               "type": "long"
             },
             "start": {

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -2466,9 +2466,6 @@
               "pid": {
                 "type": "long"
               },
-              "ppid": {
-                "type": "long"
-              },
               "start": {
                 "type": "date"
               },
@@ -2542,9 +2539,6 @@
             "type": "long"
           },
           "pid": {
-            "type": "long"
-          },
-          "ppid": {
             "type": "long"
           },
           "start": {

--- a/generated/elasticsearch/component/process.json
+++ b/generated/elasticsearch/component/process.json
@@ -488,9 +488,6 @@
                 "pid": {
                   "type": "long"
                 },
-                "ppid": {
-                  "type": "long"
-                },
                 "start": {
                   "type": "date"
                 },
@@ -564,9 +561,6 @@
               "type": "long"
             },
             "pid": {
-              "type": "long"
-            },
-            "ppid": {
               "type": "long"
             },
             "start": {

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -56,14 +56,6 @@
       - type: match_only_text
         name: text
 
-    - name: ppid
-      format: string
-      level: extended
-      type: long
-      description: >
-        Parent process' pid.
-      example: 4241
-
     - name: pgid
       format: string
       level: extended


### PR DESCRIPTION
Remove the `process.ppid` field as proposed in [RFC 0022](https://github.com/elastic/ecs/blob/master/rfcs/text/0022-remove-process-ppid.md) (#1592).

This change will also remove `parent.process.ppid`.
