### PR TITLE
Introduce usage section for `threat.*` field set

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -9615,8 +9615,6 @@ These fields contain x509 certificate metadata.
 |=====
 
 
-<<<<<<< HEAD:docs/fields/field-details.asciidoc
-=======
 
 [discrete]
 ==== Threat Field Usage
@@ -9625,7 +9623,7 @@ For usage and examples of the threat fields, please see the <<ecs-threat-usage, 
 
 include::usage/threat.asciidoc[]
 
->>>>>>> 42476f30 (frame out new threat usage section):docs/field-details.asciidoc
+
 [[ecs-tls]]
 === TLS Fields
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -9615,6 +9615,17 @@ These fields contain x509 certificate metadata.
 |=====
 
 
+<<<<<<< HEAD:docs/fields/field-details.asciidoc
+=======
+
+[discrete]
+==== Threat Field Usage
+
+For usage and examples of the threat fields, please see the <<ecs-threat-usage, Threat Fields Usage and Examples>> section.
+
+include::usage/threat.asciidoc[]
+
+>>>>>>> 42476f30 (frame out new threat usage section):docs/field-details.asciidoc
 [[ecs-tls]]
 === TLS Fields
 

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -1,0 +1,13 @@
+[[ecs-threat-usage]]
+==== Threat Fields Usage and Examples
+
+* <<ecs-threat-usage-indicators>>
+* <<ecs-threat-usage-enrichments>>
+
+[discrete]
+[[ecs-threat-usage-indicators]]
+===== Indicators
+
+[discrete]
+[[ecs-threat-usage-enrichments]]
+===== Enrichments

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -12,15 +12,14 @@ Threat intelligence indicators come from many sources in different types and
 formats. The ECS `threat.indicator.*` fields normalizes indicators to a common
 format and enables consistent querying and use with indicator match rules.
 
-[discrete]
-[[ecs-threat-usage-indicators-network-example]]
-===== URL Abuse Network Indicator Example
+This sample mapping contains several network indicators from a known malware URL
+ingested from an online database.
 
 ```JSON
 {
     "@timestamp": "2019-08-10T11:09:23.000Z",
-    "event": { <1>
-        "kind": "enrichment",
+    "event": {
+        "kind": "enrichment", <1>
         "category": "threat", <2>
         "type": "indicator", <3>
         "severity": 7,
@@ -40,7 +39,7 @@ format and enables consistent querying and use with indicator match rules.
             ],
             "description": "Email address, domain, port, and IP address observed during an Angler EK campaign.",
             "provider": "Abuse.ch",
-            "reference": "https://urlhaus.abuse.ch/url/1292596/",
+            "reference": "https://urlhaus.abuse.ch/url/abcdefg/",
             "confidence": "High",
             "ip": 1.2.3.4,
             "domain": "malicious.evil",
@@ -54,7 +53,7 @@ format and enables consistent querying and use with indicator match rules.
     },
     "related": { <5>
         "hosts": [
-            "nefarious.evil"
+            "malicious.evil"
         ],
         "ip": [
             1.2.3.4
@@ -62,15 +61,13 @@ format and enables consistent querying and use with indicator match rules.
     }
 }
 ```
-<1> Metadata about the indicator event.
-<2> Using the `enrichment` value for `event.kind`.
-<3> Using the `threat` value for `event.category`.
-<4> Metadata about the indicator data.
-<5> Any indicators should also be copied to relevant related.* fields.
+<1> Using the `enrichment` value for `event.kind`.
+<2> Using the `threat` value for `event.category`.
+<3> The event type is set to `indicator`.
+<4> Indicator details are captured at `threat.indicator.*`.
+<5> Any indicators should also be copied to relevant `related.*` fields.
 
-[discrete]
-[[ecs-threat-usage-indicators-file-example]]
-===== File Example
+This next example maps a file-based indicator.
 
 ```JSON
 {
@@ -125,6 +122,8 @@ format and enables consistent querying and use with indicator match rules.
 [[ecs-threat-usage-enrichments]]
 ===== Enrichments
 
+Events can be enriched if the original event's contents is associated with any known threat indicators.
+
 ```JSON
 {
   "process": {
@@ -144,9 +143,9 @@ format and enables consistent querying and use with indicator match rules.
     }
   },
   "threat": {
-    "enrichments": [
+    "enrichments": [ <1>
       {
-        "indicator": { <1>
+        "indicator": {
           "marking": {
             "tlp": "WHITE"
           },
@@ -182,5 +181,5 @@ format and enables consistent querying and use with indicator match rules.
   }
 }
 ```
-<1> Each enrichment is added as a nested object under `threat.enrichments.*` Copy all the object indicators under `indicator.*`, providing full context.
-<2> `matched` will provide context about which of the indicators above matched on the particular enrichment. If multiple matches for this indicator object, this could be a list.
+<1> Each enrichment is added as a nested object under `threat.enrichments.*`.
+<2> The `matched` object provides context about which of the included indicators matched a value in this event.

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -1,6 +1,9 @@
 [[ecs-threat-usage]]
 ==== Threat Fields Usage and Examples
 
+Threat data can be mapped under the `threat.*` field set for detecting malicious
+events and traffic through indicator match rules or enriching incoming events.
+
 [discrete]
 [[ecs-threat-usage-indicators]]
 ===== Indicators

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -10,7 +10,7 @@ malicious events with indicator match rules and enrichment.
 
 Threat intelligence indicators come from many sources in different structures.
 Normalize these indicators using the ECS threat.indicator.* fields.  Once
-normalized, consistently query indicators from different sources and build
+normalized, consistently query indicators from various sources and build
 indicator match rules.
 
 The below example is from an online database. It contains several network

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -1,12 +1,6 @@
 [[ecs-threat-usage]]
 ==== Threat Fields Usage and Examples
 
-* <<ecs-threat-usage-indicators>>
-** <<ecs-threat-usage-indicators-network-example>>
-** <<ecs-threat-usage-indicators-file-example>>
-
-* <<ecs-threat-usage-enrichments>>
-
 [discrete]
 [[ecs-threat-usage-indicators]]
 ===== Indicators

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -1,8 +1,8 @@
 [[ecs-threat-usage]]
 ==== Threat Fields Usage and Examples
 
-Threat data can be mapped under the `threat.*` field set for detecting malicious
-events and traffic through indicator match rules or enriching incoming events.
+The `threat.*` fields map threat indicator data to ECS. The data helps detect
+malicious events with indicator match rules and enrichment.
 
 [discrete]
 [[ecs-threat-usage-indicators]]

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -1,7 +1,7 @@
 [[ecs-threat-usage]]
 ==== Threat Fields Usage and Examples
 
-The `threat.*` fields map threat indicator data to ECS. The data helps detect
+The `threat.*` fields map threat indicators to ECS. The data helps detect
 malicious events with indicator match rules and enrichment.
 
 [discrete]

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -8,12 +8,13 @@ malicious events with indicator match rules and enrichment.
 [[ecs-threat-usage-indicators]]
 ===== Indicators
 
-Threat intelligence indicators come from many sources in different types and
-formats. The ECS `threat.indicator.*` fields normalizes indicators to a common
-format and enables consistent querying and use with indicator match rules.
+Threat intelligence indicators come from many sources in different structures.
+Normalize these indicators using the ECS threat.indicator.* fields.  Once
+normalized, consistently query indicators from different sources and build
+indicator match rules.
 
-This sample mapping contains several network indicators from a known malware URL
-ingested from an online database.
+The below example is from an online database. It contains several network
+indicators from a known malware site.
 
 ```JSON
 {
@@ -64,10 +65,10 @@ ingested from an online database.
 <1> Using the `enrichment` value for `event.kind`.
 <2> Using the `threat` value for `event.category`.
 <3> The event type is set to `indicator`.
-<4> Indicator details are captured at `threat.indicator.*`.
-<5> Any indicators should also be copied to relevant `related.*` fields.
+<4> Capture indicator details at `threat.indicator.*`.
+<5> Copy indicators to the relevant `related.*` fields.
 
-This next example maps a file-based indicator.
+The next example maps a file-based indicator.
 
 ```JSON
 {
@@ -115,14 +116,14 @@ This next example maps a file-based indicator.
 }
 ```
 <1> Using the `file` value for `threat.indicator.type`.
-<2> Attributes of the file are defined at `threat.indicator.file.*`
-<3> Also populate the `related.hash` field with the file hashes.
+<2> Capture file attributes at `threat.indicator.file.*`.
+<3> Again, populate the `related.hash` field with the file hashes.
 
 [discrete]
 [[ecs-threat-usage-enrichments]]
 ===== Enrichments
 
-Events can be enriched if the original event's contents is associated with any known threat indicators.
+Event enrichment searches for known threats using an event's values and, if found, adds those associated details.
 
 ```JSON
 {
@@ -181,5 +182,5 @@ Events can be enriched if the original event's contents is associated with any k
   }
 }
 ```
-<1> Each enrichment is added as a nested object under `threat.enrichments.*`.
-<2> The `matched` object provides context about which of the included indicators matched a value in this event.
+<1> Add each enrichment to a nested object under `threat.enrichments.*`.
+<2> The `matched` object provides context about the indicators this event matched on.

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -2,11 +2,130 @@
 ==== Threat Fields Usage and Examples
 
 * <<ecs-threat-usage-indicators>>
+** <<ecs-threat-usage-indicators-network-example>>
+** <<ecs-threat-usage-indicators-file-example>>
+
 * <<ecs-threat-usage-enrichments>>
 
 [discrete]
 [[ecs-threat-usage-indicators]]
 ===== Indicators
+
+Threat intelligence indicators come from many sources in different types and
+formats. The ECS `threat.indicator.*` fields normalizes indicators to a common
+format and enables consistent querying and use with indicator match rules.
+
+Once collected, the threat intelligence data can be stored in a dedicated index
+using the `threat.indicator.*` fields.
+
+[discrete]
+[[ecs-threat-usage-indicators-network-example]]
+===== URL Abuse Network Indicator Example
+
+```JSON
+{
+    "@timestamp": "2019-08-10T11:09:23.000Z",
+    "event": { <1>
+        "kind": "enrichment",
+        "category": "threat", <2>
+        "type": "indicator", <3>
+        "severity": 7,
+        "risk_score": 10.0,
+    },
+    "threat: {
+        indicator": { <4>
+            "first_seen": "2020-11-05T17:25:47.000Z",
+            "last_seen": "2020-11-05T17:25:47.000Z",
+            "modified_at": "2020-11-05T17:25:47.000Z",
+            "sightings": 10,
+            "type": [
+                "ipv4-addr",
+                "port",
+                "domain-name",
+                "email-addr"
+            ],
+            "description": "Email address, domain, port, and IP address observed during an Angler EK campaign.",
+            "provider": "Abuse.ch",
+            "reference": "https://urlhaus.abuse.ch/url/1292596/",
+            "confidence": "High",
+            "ip": 1.2.3.4,
+            "domain": "malicious.evil",
+            "port": 443,
+            "email.address": "phish@malicious.evil",
+            "marking: {
+                tlp": "WHITE"
+            },
+            "scanner_stats": 4
+        }
+    },
+    "related": { <5>
+        "hosts": [
+            "nefarious.evil"
+        ],
+        "ip": [
+            1.2.3.4
+        ]
+    }
+}
+```
+<1> Metadata about the indicator event.
+<2> Using the `enrichment` value for `event.kind`.
+<3> Using the `threat` value for `event.category`.
+<4> Metadata about the indicator data.
+<5> Any indicators should also be copied to relevant related.* fields.
+
+[discrete]
+[[ecs-threat-usage-indicators-file-example]]
+===== File Example
+
+```JSON
+{
+    "@timestamp": "2019-08-10T11:09:23.000Z",
+    "event": {
+        "kind": "enrichment",
+        "category": "threat",
+        "type": "indicator",
+        "severity": 7,
+        "risk_score": 10,
+        },
+    "threat": {
+        "indicator": {
+            "first_seen": "2020-11-05T17:25:47.000Z",
+            "last_seen": "2020-11-05T17:25:47.000Z",
+            "modified_at": "2020-11-05T17:25:47.000Z",
+            "sightings": 10,
+            "type": [
+                "file" <1>
+            ],
+            "description": "Implant used during an Angler EK campaign.",
+            "provider": "Abuse.ch",
+            "reference": "https://bazaar.abuse.ch/sample/f3ec9a2f2766c6bcf8c2894a9927c227649249ac146aabfe8d26b259be7d7055",
+            "confidence": "High",
+            "file": { <2>
+                "hash": {
+                    "sha256": "0c415dd718e3b3728707d579cf8214f54c2942e964975a5f925e0b82fea644b4",
+                     "md5": "1eee2bf3f56d8abed72da2bc523e7431"
+                },
+                "size": 656896,
+                "name": "invoice.doc"
+                },
+            "marking": {
+                "tlp": "WHITE"
+            },
+            "scanner_stats": 4
+        }
+    },
+    "related": { <3>
+        "hash": [
+            "1eee2bf3f56d8abed72da2bc523e7431",
+            "0c415dd718e3b3728707d579cf8214f54c2942e964975a5f925e0b82fea644b4"
+        ]
+    }
+}
+```
+<1> Using the `file` value for `threat.indicator.type`.
+<2> Attributes of the file are defined at `threat.indicator.file.*`
+<3> Also populate the `related.hash` field with the file hashes.
 
 [discrete]
 [[ecs-threat-usage-enrichments]]

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -130,3 +130,63 @@ using the `threat.indicator.*` fields.
 [discrete]
 [[ecs-threat-usage-enrichments]]
 ===== Enrichments
+
+```JSON
+{
+  "process": {
+    "name": "svchost.exe",
+    "pid": 1644,
+    "entity_id": "MDgyOWFiYTYtMzRkYi1kZTM2LTFkNDItMzBlYWM3NDVlOTgwLTE2NDQtMTMyNDk3MTA2OTcuNDc1OTExNTAw",
+    "executable": "C:\\Windows\\System32\\svchost.exe"
+  },
+  "message": "Endpoint file event",
+  "@timestamp": "2020-11-17T19:07:46.0956672Z",
+  "file": {
+    "path": "C:\\Windows\\Prefetch\\SVCHOST.EXE-AE7DB802.pf",
+    "extension": "pf",
+    "name": "SVCHOST.EXE-AE7DB802.pf",
+    "hash": {
+      "sha256": "0c415dd718e3b3728707d579cf8214f54c2942e964975a5f925e0b82fea644b4"
+    }
+  },
+  "threat": {
+    "enrichments": [
+      {
+        "indicator": { <1>
+          "marking": {
+            "tlp": "WHITE"
+          },
+          "first_seen": "2020-11-17T19:07:46.0956672Z",
+          "file": {
+            "hash": {
+              "sha256": "0c415dd718e3b3728707d579cf8214f54c2942e964975a5f925e0b82fea644b4",
+              "md5": "1eee2bf3f56d8abed72da2bc523e7431"
+            },
+            "size": 656896,
+            "name": "invoice.doc"
+          },
+          "last_seen": "2020-11-17T19:07:46.0956672Z",
+          "reference": "https://system.example.com/event/#0001234",
+          "sightings": 4,
+          "type": [
+              "sha256",
+              "md5",
+              "file_name",
+              "file_size"
+        ],
+          "description": "file last associated with delivering Angler EK"
+        },
+        "matched": { <2>
+          "atomic": "0c415dd718e3b3728707d579cf8214f54c2942e964975a5f925e0b82fea644b4",
+          "field": "file.hash.sha256",
+          "id": "abc123f03",
+          "index": "threat-indicators-index-000001",
+          "type": "indicator_match_rule"
+        }
+      }
+    ]
+  }
+}
+```
+<1> Each enrichment is added as a nested object under `threat.enrichments.*` Copy all the object indicators under `indicator.*`, providing full context.
+<2> `matched` will provide context about which of the indicators above matched on the particular enrichment. If multiple matches for this indicator object, this could be a list.

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -62,13 +62,13 @@ indicators from a known malware site.
     }
 }
 ```
-<1> Using the `enrichment` value for `event.kind`.
-<2> Using the `threat` value for `event.category`.
+<1> Use the `enrichment` value for `event.kind`.
+<2> Use the `threat` value for `event.category`.
 <3> The event type is set to `indicator`.
 <4> Capture indicator details at `threat.indicator.*`.
 <5> Copy indicators to the relevant `related.*` fields.
 
-The next example maps a file-based indicator.
+The following example maps a file-based indicator.
 
 ```JSON
 {
@@ -115,7 +115,7 @@ The next example maps a file-based indicator.
     }
 }
 ```
-<1> Using the `file` value for `threat.indicator.type`.
+<1> Use the `file` value for `threat.indicator.type`.
 <2> Capture file attributes at `threat.indicator.file.*`.
 <3> Again, populate the `related.hash` field with the file hashes.
 

--- a/docs/fields/usage/threat.asciidoc
+++ b/docs/fields/usage/threat.asciidoc
@@ -12,9 +12,6 @@ Threat intelligence indicators come from many sources in different types and
 formats. The ECS `threat.indicator.*` fields normalizes indicators to a common
 format and enables consistent querying and use with indicator match rules.
 
-Once collected, the threat intelligence data can be stored in a dedicated index
-using the `threat.indicator.*` fields.
-
 [discrete]
 [[ecs-threat-usage-indicators-network-example]]
 ===== URL Abuse Network Indicator Example


### PR DESCRIPTION
### Summary

Add a [usage doc](https://github.com/elastic/ecs/blob/master/docs/usage/README.md) for the `threat.*` field set.

Details the threat intelligence indicator and enrichment use cases detailed in [RFC 0008](https://github.com/elastic/ecs/blob/master/rfcs/text/0008-threat-intel.md) and [RFC 0021](https://github.com/elastic/ecs/blob/master/rfcs/text/0021-threat-enrichment.md). The goal is to give users complete mapping examples using the `threat.*` fields.

[Usage doc preview](https://ecs_1597.docs-preview.app.elstc.co/guide/en/ecs/master/ecs-threat-usage.html)