### PR TITLE
[1.12] Hash ordering fix (#1603)

### DIFF
--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -9088,6 +9088,36 @@
       description: Primary group name of the file.
       example: alice
       default_field: false
+    - name: enrichments.indicator.file.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: enrichments.indicator.file.inode
       level: extended
       type: keyword
@@ -10462,6 +10492,36 @@
       ignore_above: 1024
       description: Primary group name of the file.
       example: alice
+      default_field: false
+    - name: indicator.file.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: indicator.file.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: indicator.file.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: indicator.file.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: indicator.file.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
       default_field: false
     - name: indicator.file.inode
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1106,6 +1106,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.fork_name,keyword,extended,,Zone.Identifer,A fork is additional data associated with a filesystem object.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.hash.md5,keyword,extended,,,MD5 hash.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.hash.sha1,keyword,extended,,,SHA1 hash.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.hash.sha256,keyword,extended,,,SHA256 hash.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.12.0-dev+exp,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
@@ -1291,6 +1296,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev+exp,true,threat,threat.indicator.file.fork_name,keyword,extended,,Zone.Identifer,A fork is additional data associated with a filesystem object.
 1.12.0-dev+exp,true,threat,threat.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.12.0-dev+exp,true,threat,threat.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.12.0-dev+exp,true,threat,threat.indicator.file.hash.md5,keyword,extended,,,MD5 hash.
+1.12.0-dev+exp,true,threat,threat.indicator.file.hash.sha1,keyword,extended,,,SHA1 hash.
+1.12.0-dev+exp,true,threat,threat.indicator.file.hash.sha256,keyword,extended,,,SHA256 hash.
+1.12.0-dev+exp,true,threat,threat.indicator.file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.12.0-dev+exp,true,threat,threat.indicator.file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev+exp,true,threat,threat.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.12.0-dev+exp,true,threat,threat.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.12.0-dev+exp,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -13828,6 +13828,61 @@ threat.enrichments.indicator.file.group:
   original_fieldset: file
   short: Primary group name of the file.
   type: keyword
+threat.enrichments.indicator.file.hash.md5:
+  dashed_name: threat-enrichments-indicator-file-hash-md5
+  description: MD5 hash.
+  flat_name: threat.enrichments.indicator.file.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha1:
+  dashed_name: threat-enrichments-indicator-file-hash-sha1
+  description: SHA1 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha256:
+  dashed_name: threat-enrichments-indicator-file-hash-sha256
+  description: SHA256 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha512:
+  dashed_name: threat-enrichments-indicator-file-hash-sha512
+  description: SHA512 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.ssdeep:
+  dashed_name: threat-enrichments-indicator-file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: threat.enrichments.indicator.file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 threat.enrichments.indicator.file.inode:
   dashed_name: threat-enrichments-indicator-file-inode
   description: Inode representing the file in the filesystem.
@@ -16140,6 +16195,61 @@ threat.indicator.file.group:
   normalize: []
   original_fieldset: file
   short: Primary group name of the file.
+  type: keyword
+threat.indicator.file.hash.md5:
+  dashed_name: threat-indicator-file-hash-md5
+  description: MD5 hash.
+  flat_name: threat.indicator.file.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+threat.indicator.file.hash.sha1:
+  dashed_name: threat-indicator-file-hash-sha1
+  description: SHA1 hash.
+  flat_name: threat.indicator.file.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+threat.indicator.file.hash.sha256:
+  dashed_name: threat-indicator-file-hash-sha256
+  description: SHA256 hash.
+  flat_name: threat.indicator.file.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+threat.indicator.file.hash.sha512:
+  dashed_name: threat-indicator-file-hash-sha512
+  description: SHA512 hash.
+  flat_name: threat.indicator.file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+threat.indicator.file.hash.ssdeep:
+  dashed_name: threat-indicator-file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: threat.indicator.file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 threat.indicator.file.inode:
   dashed_name: threat-indicator-file-inode

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2409,15 +2409,15 @@ dll:
   - dll.pe
   prefix: dll.
   reused_here:
+  - full: dll.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: dll.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
   - full: dll.code_signature
     schema_name: code_signature
     short: These fields contain information about binary code signatures.
-  - full: dll.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   short: These fields contain information about code libraries dynamically loaded
     into processes.
   title: DLL
@@ -5785,6 +5785,9 @@ file:
       full: threat.enrichments.indicator.file
     top_level: true
   reused_here:
+  - full: file.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: file.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
@@ -5795,9 +5798,6 @@ file:
     full: file.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - full: file.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   - full: file.x509
     schema_name: x509
     short: These fields contain x509 certificate metadata.
@@ -13732,6 +13732,9 @@ process:
       full: process.target.parent
     top_level: true
   reused_here:
+  - full: process.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: process.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
@@ -13742,9 +13745,6 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - full: process.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
@@ -15928,6 +15928,61 @@ threat:
       normalize: []
       original_fieldset: file
       short: Primary group name of the file.
+      type: keyword
+    threat.enrichments.indicator.file.hash.md5:
+      dashed_name: threat-enrichments-indicator-file-hash-md5
+      description: MD5 hash.
+      flat_name: threat.enrichments.indicator.file.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha1:
+      dashed_name: threat-enrichments-indicator-file-hash-sha1
+      description: SHA1 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha256:
+      dashed_name: threat-enrichments-indicator-file-hash-sha256
+      description: SHA256 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha512:
+      dashed_name: threat-enrichments-indicator-file-hash-sha512
+      description: SHA512 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.ssdeep:
+      dashed_name: threat-enrichments-indicator-file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: threat.enrichments.indicator.file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
       type: keyword
     threat.enrichments.indicator.file.inode:
       dashed_name: threat-enrichments-indicator-file-inode
@@ -18246,6 +18301,61 @@ threat:
       normalize: []
       original_fieldset: file
       short: Primary group name of the file.
+      type: keyword
+    threat.indicator.file.hash.md5:
+      dashed_name: threat-indicator-file-hash-md5
+      description: MD5 hash.
+      flat_name: threat.indicator.file.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    threat.indicator.file.hash.sha1:
+      dashed_name: threat-indicator-file-hash-sha1
+      description: SHA1 hash.
+      flat_name: threat.indicator.file.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    threat.indicator.file.hash.sha256:
+      dashed_name: threat-indicator-file-hash-sha256
+      description: SHA256 hash.
+      flat_name: threat.indicator.file.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    threat.indicator.file.hash.sha512:
+      dashed_name: threat-indicator-file-hash-sha512
+      description: SHA512 hash.
+      flat_name: threat.indicator.file.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    threat.indicator.file.hash.ssdeep:
+      dashed_name: threat-indicator-file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: threat.indicator.file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
       type: keyword
     threat.indicator.file.inode:
       dashed_name: threat-indicator-file-inode

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -4956,6 +4956,30 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "hash": {
+                        "properties": {
+                          "md5": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha1": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha256": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha512": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "ssdeep": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
                       "inode": {
                         "ignore_above": 1024,
                         "type": "keyword"
@@ -5760,6 +5784,30 @@
                   "group": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "hash": {
+                    "properties": {
+                      "md5": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha1": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha256": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha512": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "ssdeep": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
                   },
                   "inode": {
                     "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/threat.json
+++ b/experimental/generated/elasticsearch/component/threat.json
@@ -244,6 +244,30 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "hash": {
+                          "properties": {
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
                         "inode": {
                           "ignore_above": 1024,
                           "type": "keyword"
@@ -1048,6 +1072,30 @@
                     "group": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "inode": {
                       "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -6426,6 +6426,36 @@
       description: Primary group name of the file.
       example: alice
       default_field: false
+    - name: enrichments.indicator.file.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: enrichments.indicator.file.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
     - name: enrichments.indicator.file.inode
       level: extended
       type: keyword
@@ -7590,6 +7620,36 @@
       ignore_above: 1024
       description: Primary group name of the file.
       example: alice
+      default_field: false
+    - name: indicator.file.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: indicator.file.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: indicator.file.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: indicator.file.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: indicator.file.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
       default_field: false
     - name: indicator.file.inode
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -748,6 +748,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.fork_name,keyword,extended,,Zone.Identifer,A fork is additional data associated with a filesystem object.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.hash.md5,keyword,extended,,,MD5 hash.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.hash.sha1,keyword,extended,,,SHA1 hash.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.hash.sha256,keyword,extended,,,SHA256 hash.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.12.0-dev,true,threat,threat.enrichments.indicator.file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.12.0-dev,true,threat,threat.enrichments.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.
@@ -902,6 +907,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 1.12.0-dev,true,threat,threat.indicator.file.fork_name,keyword,extended,,Zone.Identifer,A fork is additional data associated with a filesystem object.
 1.12.0-dev,true,threat,threat.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
 1.12.0-dev,true,threat,threat.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.12.0-dev,true,threat,threat.indicator.file.hash.md5,keyword,extended,,,MD5 hash.
+1.12.0-dev,true,threat,threat.indicator.file.hash.sha1,keyword,extended,,,SHA1 hash.
+1.12.0-dev,true,threat,threat.indicator.file.hash.sha256,keyword,extended,,,SHA256 hash.
+1.12.0-dev,true,threat,threat.indicator.file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.12.0-dev,true,threat,threat.indicator.file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 1.12.0-dev,true,threat,threat.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
 1.12.0-dev,true,threat,threat.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 1.12.0-dev,true,threat,threat.indicator.file.mode,keyword,extended,,0640,Mode of the file in octal representation.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -9596,6 +9596,61 @@ threat.enrichments.indicator.file.group:
   original_fieldset: file
   short: Primary group name of the file.
   type: keyword
+threat.enrichments.indicator.file.hash.md5:
+  dashed_name: threat-enrichments-indicator-file-hash-md5
+  description: MD5 hash.
+  flat_name: threat.enrichments.indicator.file.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha1:
+  dashed_name: threat-enrichments-indicator-file-hash-sha1
+  description: SHA1 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha256:
+  dashed_name: threat-enrichments-indicator-file-hash-sha256
+  description: SHA256 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.sha512:
+  dashed_name: threat-enrichments-indicator-file-hash-sha512
+  description: SHA512 hash.
+  flat_name: threat.enrichments.indicator.file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+threat.enrichments.indicator.file.hash.ssdeep:
+  dashed_name: threat-enrichments-indicator-file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: threat.enrichments.indicator.file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
 threat.enrichments.indicator.file.inode:
   dashed_name: threat-enrichments-indicator-file-inode
   description: Inode representing the file in the filesystem.
@@ -11537,6 +11592,61 @@ threat.indicator.file.group:
   normalize: []
   original_fieldset: file
   short: Primary group name of the file.
+  type: keyword
+threat.indicator.file.hash.md5:
+  dashed_name: threat-indicator-file-hash-md5
+  description: MD5 hash.
+  flat_name: threat.indicator.file.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+threat.indicator.file.hash.sha1:
+  dashed_name: threat-indicator-file-hash-sha1
+  description: SHA1 hash.
+  flat_name: threat.indicator.file.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+threat.indicator.file.hash.sha256:
+  dashed_name: threat-indicator-file-hash-sha256
+  description: SHA256 hash.
+  flat_name: threat.indicator.file.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+threat.indicator.file.hash.sha512:
+  dashed_name: threat-indicator-file-hash-sha512
+  description: SHA512 hash.
+  flat_name: threat.indicator.file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+threat.indicator.file.hash.ssdeep:
+  dashed_name: threat-indicator-file-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: threat.indicator.file.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
   type: keyword
 threat.indicator.file.inode:
   dashed_name: threat-indicator-file-inode

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1975,15 +1975,15 @@ dll:
   - dll.pe
   prefix: dll.
   reused_here:
+  - full: dll.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: dll.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
   - full: dll.code_signature
     schema_name: code_signature
     short: These fields contain information about binary code signatures.
-  - full: dll.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   short: These fields contain information about code libraries dynamically loaded
     into processes.
   title: DLL
@@ -4718,6 +4718,9 @@ file:
       full: threat.enrichments.indicator.file
     top_level: true
   reused_here:
+  - full: file.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: file.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
@@ -4728,9 +4731,6 @@ file:
     full: file.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - full: file.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   - full: file.x509
     schema_name: x509
     short: These fields contain x509 certificate metadata.
@@ -9130,6 +9130,9 @@ process:
       short_override: Information about the parent process.
     top_level: true
   reused_here:
+  - full: process.hash
+    schema_name: hash
+    short: Hashes, usually file hashes.
   - full: process.pe
     schema_name: pe
     short: These fields contain Windows Portable Executable (PE) metadata.
@@ -9140,9 +9143,6 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - full: process.hash
-    schema_name: hash
-    short: Hashes, usually file hashes.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
@@ -11321,6 +11321,61 @@ threat:
       original_fieldset: file
       short: Primary group name of the file.
       type: keyword
+    threat.enrichments.indicator.file.hash.md5:
+      dashed_name: threat-enrichments-indicator-file-hash-md5
+      description: MD5 hash.
+      flat_name: threat.enrichments.indicator.file.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha1:
+      dashed_name: threat-enrichments-indicator-file-hash-sha1
+      description: SHA1 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha256:
+      dashed_name: threat-enrichments-indicator-file-hash-sha256
+      description: SHA256 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.sha512:
+      dashed_name: threat-enrichments-indicator-file-hash-sha512
+      description: SHA512 hash.
+      flat_name: threat.enrichments.indicator.file.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    threat.enrichments.indicator.file.hash.ssdeep:
+      dashed_name: threat-enrichments-indicator-file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: threat.enrichments.indicator.file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
+      type: keyword
     threat.enrichments.indicator.file.inode:
       dashed_name: threat-enrichments-indicator-file-inode
       description: Inode representing the file in the filesystem.
@@ -13266,6 +13321,61 @@ threat:
       normalize: []
       original_fieldset: file
       short: Primary group name of the file.
+      type: keyword
+    threat.indicator.file.hash.md5:
+      dashed_name: threat-indicator-file-hash-md5
+      description: MD5 hash.
+      flat_name: threat.indicator.file.hash.md5
+      ignore_above: 1024
+      level: extended
+      name: md5
+      normalize: []
+      original_fieldset: hash
+      short: MD5 hash.
+      type: keyword
+    threat.indicator.file.hash.sha1:
+      dashed_name: threat-indicator-file-hash-sha1
+      description: SHA1 hash.
+      flat_name: threat.indicator.file.hash.sha1
+      ignore_above: 1024
+      level: extended
+      name: sha1
+      normalize: []
+      original_fieldset: hash
+      short: SHA1 hash.
+      type: keyword
+    threat.indicator.file.hash.sha256:
+      dashed_name: threat-indicator-file-hash-sha256
+      description: SHA256 hash.
+      flat_name: threat.indicator.file.hash.sha256
+      ignore_above: 1024
+      level: extended
+      name: sha256
+      normalize: []
+      original_fieldset: hash
+      short: SHA256 hash.
+      type: keyword
+    threat.indicator.file.hash.sha512:
+      dashed_name: threat-indicator-file-hash-sha512
+      description: SHA512 hash.
+      flat_name: threat.indicator.file.hash.sha512
+      ignore_above: 1024
+      level: extended
+      name: sha512
+      normalize: []
+      original_fieldset: hash
+      short: SHA512 hash.
+      type: keyword
+    threat.indicator.file.hash.ssdeep:
+      dashed_name: threat-indicator-file-hash-ssdeep
+      description: SSDEEP hash.
+      flat_name: threat.indicator.file.hash.ssdeep
+      ignore_above: 1024
+      level: extended
+      name: ssdeep
+      normalize: []
+      original_fieldset: hash
+      short: SSDEEP hash.
       type: keyword
     threat.indicator.file.inode:
       dashed_name: threat-indicator-file-inode

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -3438,6 +3438,30 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "hash": {
+                          "properties": {
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
                         "inode": {
                           "ignore_above": 1024,
                           "type": "keyword"
@@ -4115,6 +4139,30 @@
                     "group": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "inode": {
                       "ignore_above": 1024,

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -3389,6 +3389,30 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "hash": {
+                        "properties": {
+                          "md5": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha1": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha256": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "sha512": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "ssdeep": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        }
+                      },
                       "inode": {
                         "ignore_above": 1024,
                         "type": "keyword"
@@ -4057,6 +4081,30 @@
                   "group": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "hash": {
+                    "properties": {
+                      "md5": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha1": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha256": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "sha512": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "ssdeep": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
                   },
                   "inode": {
                     "ignore_above": 1024,

--- a/generated/elasticsearch/component/threat.json
+++ b/generated/elasticsearch/component/threat.json
@@ -244,6 +244,30 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "hash": {
+                          "properties": {
+                            "md5": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha1": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha256": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "sha512": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "ssdeep": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
+                        },
                         "inode": {
                           "ignore_above": 1024,
                           "type": "keyword"
@@ -912,6 +936,30 @@
                     "group": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "hash": {
+                      "properties": {
+                        "md5": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha1": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha256": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "sha512": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "ssdeep": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
                     },
                     "inode": {
                       "ignore_above": 1024,

--- a/schemas/hash.yml
+++ b/schemas/hash.yml
@@ -17,6 +17,7 @@
 
   reusable:
     top_level: false
+    order: 1
     expected:
       - file
       - process


### PR DESCRIPTION
Backports the following commits to 1.12:
 - Hash ordering fix (#1603)