### PR TITLE
RFC 0027 FaaS fields -- stage 2 changes

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -792,7 +792,7 @@ Note also that the `cloud` fields may be used directly at the root of the events
 | `cloud.origin.*`
 | <<ecs-cloud,cloud>>| beta:[ Reusing the `cloud` fields in this location is currently considered beta.]
 
-Fields about the cloud resource.
+Provides the cloud information of the origin entity in case of an incoming request or event.
 
 // ===============================================================
 
@@ -800,7 +800,7 @@ Fields about the cloud resource.
 | `cloud.target.*`
 | <<ecs-cloud,cloud>>| beta:[ Reusing the `cloud` fields in this location is currently considered beta.]
 
-Fields about the cloud resource.
+Provides the cloud information of the target entity in case of an outgoing request or event.
 
 // ===============================================================
 
@@ -7603,7 +7603,7 @@ Note also that the `service` fields may be used directly at the root of the even
 | `service.origin.*`
 | <<ecs-service,service>>| beta:[ Reusing the `service` fields in this location is currently considered beta.]
 
-Fields describing the service for or from which the data was collected.
+Describes the origin service in case of an incoming request or event.
 
 // ===============================================================
 
@@ -7611,7 +7611,7 @@ Fields describing the service for or from which the data was collected.
 | `service.target.*`
 | <<ecs-service,service>>| beta:[ Reusing the `service` fields in this location is currently considered beta.]
 
-Fields describing the service for or from which the data was collected.
+Describes the target service in case of an outgoing request or event.
 
 // ===============================================================
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -765,6 +765,48 @@ example: `lambda`
 
 |=====
 
+[discrete]
+==== Field Reuse
+
+The `cloud` fields are expected to be nested at:
+
+
+* `cloud.origin`
+
+* `cloud.target`
+
+
+Note also that the `cloud` fields may be used directly at the root of the events.
+
+[[ecs-cloud-nestings]]
+[discrete]
+===== Field sets that can be nested under Cloud
+
+[options="header"]
+|=====
+| Location | Field Set | Description
+
+// ===============================================================
+
+
+| `cloud.origin.*`
+| <<ecs-cloud,cloud>>| beta:[ Reusing the `cloud` fields in this location is currently considered beta.]
+
+Fields about the cloud resource.
+
+// ===============================================================
+
+
+| `cloud.target.*`
+| <<ecs-cloud,cloud>>| beta:[ Reusing the `cloud` fields in this location is currently considered beta.]
+
+Fields about the cloud resource.
+
+// ===============================================================
+
+
+|=====
+
 
 
 [discrete]
@@ -3062,6 +3104,112 @@ type: keyword
 
 
 example: `https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe`
+
+| extended
+
+// ===============================================================
+
+|=====
+
+
+[[ecs-faas]]
+=== FaaS Fields
+
+TBD description
+
+beta::[ These fields are in beta and are subject to change.]
+
+[discrete]
+==== FaaS Field Details
+
+[options="header"]
+|=====
+| Field  | Description | Level
+
+// ===============================================================
+
+|
+[[field-faas-coldstart]]
+<<field-faas-coldstart, faas.coldstart>>
+
+| Boolean value indicating a cold start of a function.
+
+type: boolean
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-execution]]
+<<field-faas-execution, faas.execution>>
+
+| The execution ID of the current function execution.
+
+type: keyword
+
+
+
+example: `af9d5aa4-a685-4c5f-a22b-444f80b3cc28`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-trigger]]
+<<field-faas-trigger, faas.trigger>>
+
+| Details about the function trigger.
+
+type: nested
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-trigger-request-id]]
+<<field-faas-trigger-request-id, faas.trigger.request_id>>
+
+| The ID of the trigger request , message, event, etc.
+
+type: keyword
+
+
+
+example: `123456789`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-trigger-type]]
+<<field-faas-trigger-type, faas.trigger.type>>
+
+| The trigger for the cuntion execution.
+
+type: keyword
+
+
+
+
+*Important*: The field value must be one of the following:
+
+http, pubsub, datasource, timer, other
+
+To learn more about when to use which value, visit the page
+<<ecs-allowed-values-faas-trigger-type,allowed values for faas.trigger.type>>
+
 
 | extended
 
@@ -7425,6 +7573,48 @@ example: `3.2.4`
 | core
 
 // ===============================================================
+
+|=====
+
+[discrete]
+==== Field Reuse
+
+The `service` fields are expected to be nested at:
+
+
+* `service.origin`
+
+* `service.target`
+
+
+Note also that the `service` fields may be used directly at the root of the events.
+
+[[ecs-service-nestings]]
+[discrete]
+===== Field sets that can be nested under Service
+
+[options="header"]
+|=====
+| Location | Field Set | Description
+
+// ===============================================================
+
+
+| `service.origin.*`
+| <<ecs-service,service>>| beta:[ Reusing the `service` fields in this location is currently considered beta.]
+
+Fields describing the service for or from which the data was collected.
+
+// ===============================================================
+
+
+| `service.target.*`
+| <<ecs-service,service>>| beta:[ Reusing the `service` fields in this location is currently considered beta.]
+
+Fields describing the service for or from which the data was collected.
+
+// ===============================================================
+
 
 |=====
 

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -50,6 +50,8 @@ For a single page representation of all fields, please see the
 
 | <<ecs-event,Event>> | Fields breaking down the event details.
 
+| <<ecs-faas,FaaS>> | Fields describing functions as a service.
+
 | <<ecs-file,File>> | Fields describing files.
 
 | <<ecs-geo,Geo>> | Fields describing a location.

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -436,7 +436,17 @@
       from its host, the cloud info contains the data about this machine. If Metricbeat
       runs on a remote machine outside the cloud and fetches data from a service running
       in the cloud, the field contains cloud data from the machine the service is
-      running on.'
+      running on.
+
+      The cloud fields may be self-nested under cloud.origin.* and cloud.target.*  to
+      describe origin or target service''s cloud information in the context of  incoming
+      or outgoing requests, respectively. However, the fieldsets  cloud.origin.* and
+      cloud.target.* must not be confused with the root cloud  fieldset that is used
+      to describe the cloud context of the actual service  under observation. The
+      fieldset cloud.origin.* may only be used in the  context of incoming requests
+      or events to provide the originating service''s  cloud information. The fieldset
+      cloud.target.* may only be used in the  context of outgoing requests or events
+      to describe the target service''s  cloud information.'
     type: group
     fields:
     - name: account.id
@@ -8383,6 +8393,14 @@
       was collected.
 
       These fields help you find and correlate logs for a specific service and version.'
+    footnote: The service fields may be self-nested under service.origin.* and service.target.*  to
+      describe origin or target services in the context of incoming or outgoing requests,  respectively.
+      However, the fieldsets service.origin.* and service.target.* must not be confused
+      with  the root service fieldset that is used to describe the actual service
+      under observation. The fieldset service.origin.* may only be used in the context
+      of incoming requests or  events to describe the originating service of the request.
+      The fieldset service.target.*  may only be used in the context of outgoing requests
+      or events to describe the target  service of the request.
     type: group
     fields:
     - name: address

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -481,6 +481,97 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
+    - name: origin.account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      default_field: false
+    - name: origin.account.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      default_field: false
+    - name: origin.availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      default_field: false
+    - name: origin.instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      default_field: false
+    - name: origin.instance.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+      default_field: false
+    - name: origin.machine.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+      example: t2.medium
+      default_field: false
+    - name: origin.project.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      default_field: false
+    - name: origin.project.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      default_field: false
+    - name: origin.provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      default_field: false
+    - name: origin.region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      default_field: false
+    - name: origin.service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
     - name: project.id
       level: extended
       type: keyword
@@ -513,6 +604,97 @@
       description: Region in which this host, resource, or service is located.
       example: us-east-1
     - name: service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
+    - name: target.account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      default_field: false
+    - name: target.account.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      default_field: false
+    - name: target.availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      default_field: false
+    - name: target.instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      default_field: false
+    - name: target.instance.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+      default_field: false
+    - name: target.machine.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+      example: t2.medium
+      default_field: false
+    - name: target.project.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      default_field: false
+    - name: target.project.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      default_field: false
+    - name: target.provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      default_field: false
+    - name: target.region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      default_field: false
+    - name: target.service.name
       level: extended
       type: keyword
       ignore_above: 1024
@@ -2322,6 +2504,42 @@
         occurrence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      default_field: false
+  - name: faas
+    title: FaaS
+    group: 2
+    description: TBD description
+    type: group
+    fields:
+    - name: coldstart
+      level: extended
+      type: boolean
+      description: Boolean value indicating a cold start of a function.
+      default_field: false
+    - name: execution
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The execution ID of the current function execution.
+      example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+      default_field: false
+    - name: trigger
+      level: extended
+      type: nested
+      description: Details about the function trigger.
+      default_field: false
+    - name: trigger.request_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The ID of the trigger request , message, event, etc.
+      example: 123456789
+      default_field: false
+    - name: trigger.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The trigger for the cuntion execution.
       default_field: false
   - name: file
     title: File
@@ -8241,11 +8459,223 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+    - name: origin.address
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      default_field: false
+    - name: origin.environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
+    - name: origin.ephemeral_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      default_field: false
+    - name: origin.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      default_field: false
+    - name: origin.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      default_field: false
+    - name: origin.node.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      default_field: false
+    - name: origin.state
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Current state of the service.
+      default_field: false
+    - name: origin.type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      default_field: false
+    - name: origin.version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      default_field: false
     - name: state
       level: core
       type: keyword
       ignore_above: 1024
       description: Current state of the service.
+    - name: target.address
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      default_field: false
+    - name: target.environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
+    - name: target.ephemeral_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      default_field: false
+    - name: target.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      default_field: false
+    - name: target.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      default_field: false
+    - name: target.node.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      default_field: false
+    - name: target.state
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Current state of the service.
+      default_field: false
+    - name: target.type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      default_field: false
+    - name: target.version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      default_field: false
     - name: type
       level: core
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -53,11 +53,33 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 8.0.0-dev+exp,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 8.0.0-dev+exp,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.origin.account.id,keyword,extended,,666777888999,The cloud account or organization id.
+8.0.0-dev+exp,true,cloud,cloud.origin.account.name,keyword,extended,,elastic-dev,The cloud account name.
+8.0.0-dev+exp,true,cloud,cloud.origin.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
+8.0.0-dev+exp,true,cloud,cloud.origin.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.origin.instance.name,keyword,extended,,,Instance name of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.origin.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.origin.project.id,keyword,extended,,my-project,The cloud project id.
+8.0.0-dev+exp,true,cloud,cloud.origin.project.name,keyword,extended,,my project,The cloud project name.
+8.0.0-dev+exp,true,cloud,cloud.origin.provider,keyword,extended,,aws,Name of the cloud provider.
+8.0.0-dev+exp,true,cloud,cloud.origin.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
+8.0.0-dev+exp,true,cloud,cloud.origin.service.name,keyword,extended,,lambda,The cloud service name.
 8.0.0-dev+exp,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 8.0.0-dev+exp,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 8.0.0-dev+exp,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 8.0.0-dev+exp,true,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
 8.0.0-dev+exp,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
+8.0.0-dev+exp,true,cloud,cloud.target.account.id,keyword,extended,,666777888999,The cloud account or organization id.
+8.0.0-dev+exp,true,cloud,cloud.target.account.name,keyword,extended,,elastic-dev,The cloud account name.
+8.0.0-dev+exp,true,cloud,cloud.target.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
+8.0.0-dev+exp,true,cloud,cloud.target.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.target.instance.name,keyword,extended,,,Instance name of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.target.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev+exp,true,cloud,cloud.target.project.id,keyword,extended,,my-project,The cloud project id.
+8.0.0-dev+exp,true,cloud,cloud.target.project.name,keyword,extended,,my project,The cloud project name.
+8.0.0-dev+exp,true,cloud,cloud.target.provider,keyword,extended,,aws,Name of the cloud provider.
+8.0.0-dev+exp,true,cloud,cloud.target.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
+8.0.0-dev+exp,true,cloud,cloud.target.service.name,keyword,extended,,lambda,The cloud service name.
 8.0.0-dev+exp,true,container,container.cpu.usage,scaled_float,extended,,,"Percent CPU used, between 0 and 1."
 8.0.0-dev+exp,true,container,container.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
 8.0.0-dev+exp,true,container,container.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
@@ -238,6 +260,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.0.0-dev+exp,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.0.0-dev+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
+8.0.0-dev+exp,true,faas,faas.coldstart,boolean,extended,,,Boolean value indicating a cold start of a function.
+8.0.0-dev+exp,true,faas,faas.execution,keyword,extended,,af9d5aa4-a685-4c5f-a22b-444f80b3cc28,The execution ID of the current function execution.
+8.0.0-dev+exp,true,faas,faas.trigger,nested,extended,,,Details about the function trigger.
+8.0.0-dev+exp,true,faas,faas.trigger.request_id,keyword,extended,,123456789,"The ID of the trigger request , message, event, etc."
+8.0.0-dev+exp,true,faas,faas.trigger.type,keyword,extended,,,The trigger for the cuntion execution.
 8.0.0-dev+exp,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.0.0-dev+exp,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
@@ -990,7 +1017,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev+exp,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.0.0-dev+exp,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.0.0-dev+exp,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev+exp,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev+exp,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
+8.0.0-dev+exp,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
+8.0.0-dev+exp,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+8.0.0-dev+exp,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
+8.0.0-dev+exp,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev+exp,true,service,service.origin.state,keyword,core,,,Current state of the service.
+8.0.0-dev+exp,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
+8.0.0-dev+exp,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev+exp,true,service,service.state,keyword,core,,,Current state of the service.
+8.0.0-dev+exp,true,service,service.target.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev+exp,true,service,service.target.environment,keyword,extended,,production,Environment of the service.
+8.0.0-dev+exp,true,service,service.target.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
+8.0.0-dev+exp,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+8.0.0-dev+exp,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
+8.0.0-dev+exp,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev+exp,true,service,service.target.state,keyword,core,,,Current state of the service.
+8.0.0-dev+exp,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
+8.0.0-dev+exp,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev+exp,true,service,service.type,keyword,core,,elasticsearch,The type of the service.
 8.0.0-dev+exp,true,service,service.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev+exp,true,source,source.address,keyword,extended,,,Source network address.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -628,6 +628,152 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
+cloud.origin.account.id:
+  dashed_name: cloud-origin-account-id
+  description: 'The cloud account or organization id used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+  example: 666777888999
+  flat_name: cloud.origin.account.id
+  ignore_above: 1024
+  level: extended
+  name: account.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account or organization id.
+  type: keyword
+cloud.origin.account.name:
+  dashed_name: cloud-origin-account-name
+  description: 'The cloud account name or alias used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account name, Google Cloud ORG display name.'
+  example: elastic-dev
+  flat_name: cloud.origin.account.name
+  ignore_above: 1024
+  level: extended
+  name: account.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account name.
+  type: keyword
+cloud.origin.availability_zone:
+  dashed_name: cloud-origin-availability-zone
+  description: Availability zone in which this host, resource, or service is located.
+  example: us-east-1c
+  flat_name: cloud.origin.availability_zone
+  ignore_above: 1024
+  level: extended
+  name: availability_zone
+  normalize: []
+  original_fieldset: cloud
+  short: Availability zone in which this host, resource, or service is located.
+  type: keyword
+cloud.origin.instance.id:
+  dashed_name: cloud-origin-instance-id
+  description: Instance ID of the host machine.
+  example: i-1234567890abcdef0
+  flat_name: cloud.origin.instance.id
+  ignore_above: 1024
+  level: extended
+  name: instance.id
+  normalize: []
+  original_fieldset: cloud
+  short: Instance ID of the host machine.
+  type: keyword
+cloud.origin.instance.name:
+  dashed_name: cloud-origin-instance-name
+  description: Instance name of the host machine.
+  flat_name: cloud.origin.instance.name
+  ignore_above: 1024
+  level: extended
+  name: instance.name
+  normalize: []
+  original_fieldset: cloud
+  short: Instance name of the host machine.
+  type: keyword
+cloud.origin.machine.type:
+  dashed_name: cloud-origin-machine-type
+  description: Machine type of the host machine.
+  example: t2.medium
+  flat_name: cloud.origin.machine.type
+  ignore_above: 1024
+  level: extended
+  name: machine.type
+  normalize: []
+  original_fieldset: cloud
+  short: Machine type of the host machine.
+  type: keyword
+cloud.origin.project.id:
+  dashed_name: cloud-origin-project-id
+  description: 'The cloud project identifier.
+
+    Examples: Google Cloud Project id, Azure Project id.'
+  example: my-project
+  flat_name: cloud.origin.project.id
+  ignore_above: 1024
+  level: extended
+  name: project.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project id.
+  type: keyword
+cloud.origin.project.name:
+  dashed_name: cloud-origin-project-name
+  description: 'The cloud project name.
+
+    Examples: Google Cloud Project name, Azure Project name.'
+  example: my project
+  flat_name: cloud.origin.project.name
+  ignore_above: 1024
+  level: extended
+  name: project.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project name.
+  type: keyword
+cloud.origin.provider:
+  dashed_name: cloud-origin-provider
+  description: Name of the cloud provider. Example values are aws, azure, gcp, or
+    digitalocean.
+  example: aws
+  flat_name: cloud.origin.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  original_fieldset: cloud
+  short: Name of the cloud provider.
+  type: keyword
+cloud.origin.region:
+  dashed_name: cloud-origin-region
+  description: Region in which this host, resource, or service is located.
+  example: us-east-1
+  flat_name: cloud.origin.region
+  ignore_above: 1024
+  level: extended
+  name: region
+  normalize: []
+  original_fieldset: cloud
+  short: Region in which this host, resource, or service is located.
+  type: keyword
+cloud.origin.service.name:
+  dashed_name: cloud-origin-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.origin.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud service name.
+  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.
@@ -690,6 +836,152 @@ cloud.service.name:
   level: extended
   name: service.name
   normalize: []
+  short: The cloud service name.
+  type: keyword
+cloud.target.account.id:
+  dashed_name: cloud-target-account-id
+  description: 'The cloud account or organization id used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+  example: 666777888999
+  flat_name: cloud.target.account.id
+  ignore_above: 1024
+  level: extended
+  name: account.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account or organization id.
+  type: keyword
+cloud.target.account.name:
+  dashed_name: cloud-target-account-name
+  description: 'The cloud account name or alias used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account name, Google Cloud ORG display name.'
+  example: elastic-dev
+  flat_name: cloud.target.account.name
+  ignore_above: 1024
+  level: extended
+  name: account.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account name.
+  type: keyword
+cloud.target.availability_zone:
+  dashed_name: cloud-target-availability-zone
+  description: Availability zone in which this host, resource, or service is located.
+  example: us-east-1c
+  flat_name: cloud.target.availability_zone
+  ignore_above: 1024
+  level: extended
+  name: availability_zone
+  normalize: []
+  original_fieldset: cloud
+  short: Availability zone in which this host, resource, or service is located.
+  type: keyword
+cloud.target.instance.id:
+  dashed_name: cloud-target-instance-id
+  description: Instance ID of the host machine.
+  example: i-1234567890abcdef0
+  flat_name: cloud.target.instance.id
+  ignore_above: 1024
+  level: extended
+  name: instance.id
+  normalize: []
+  original_fieldset: cloud
+  short: Instance ID of the host machine.
+  type: keyword
+cloud.target.instance.name:
+  dashed_name: cloud-target-instance-name
+  description: Instance name of the host machine.
+  flat_name: cloud.target.instance.name
+  ignore_above: 1024
+  level: extended
+  name: instance.name
+  normalize: []
+  original_fieldset: cloud
+  short: Instance name of the host machine.
+  type: keyword
+cloud.target.machine.type:
+  dashed_name: cloud-target-machine-type
+  description: Machine type of the host machine.
+  example: t2.medium
+  flat_name: cloud.target.machine.type
+  ignore_above: 1024
+  level: extended
+  name: machine.type
+  normalize: []
+  original_fieldset: cloud
+  short: Machine type of the host machine.
+  type: keyword
+cloud.target.project.id:
+  dashed_name: cloud-target-project-id
+  description: 'The cloud project identifier.
+
+    Examples: Google Cloud Project id, Azure Project id.'
+  example: my-project
+  flat_name: cloud.target.project.id
+  ignore_above: 1024
+  level: extended
+  name: project.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project id.
+  type: keyword
+cloud.target.project.name:
+  dashed_name: cloud-target-project-name
+  description: 'The cloud project name.
+
+    Examples: Google Cloud Project name, Azure Project name.'
+  example: my project
+  flat_name: cloud.target.project.name
+  ignore_above: 1024
+  level: extended
+  name: project.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project name.
+  type: keyword
+cloud.target.provider:
+  dashed_name: cloud-target-provider
+  description: Name of the cloud provider. Example values are aws, azure, gcp, or
+    digitalocean.
+  example: aws
+  flat_name: cloud.target.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  original_fieldset: cloud
+  short: Name of the cloud provider.
+  type: keyword
+cloud.target.region:
+  dashed_name: cloud-target-region
+  description: Region in which this host, resource, or service is located.
+  example: us-east-1
+  flat_name: cloud.target.region
+  ignore_above: 1024
+  level: extended
+  name: region
+  normalize: []
+  original_fieldset: cloud
+  short: Region in which this host, resource, or service is located.
+  type: keyword
+cloud.target.service.name:
+  dashed_name: cloud-target-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.target.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  original_fieldset: cloud
   short: The cloud service name.
   type: keyword
 container.cpu.usage:
@@ -3346,6 +3638,62 @@ event.url:
   name: url
   normalize: []
   short: Event investigation URL
+  type: keyword
+faas.coldstart:
+  dashed_name: faas-coldstart
+  description: Boolean value indicating a cold start of a function.
+  flat_name: faas.coldstart
+  level: extended
+  name: coldstart
+  normalize: []
+  short: Boolean value indicating a cold start of a function.
+  type: boolean
+faas.execution:
+  dashed_name: faas-execution
+  description: The execution ID of the current function execution.
+  example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+  flat_name: faas.execution
+  ignore_above: 1024
+  level: extended
+  name: execution
+  normalize: []
+  short: The execution ID of the current function execution.
+  type: keyword
+faas.trigger:
+  dashed_name: faas-trigger
+  description: Details about the function trigger.
+  flat_name: faas.trigger
+  level: extended
+  name: trigger
+  normalize: []
+  short: Details about the function trigger.
+  type: nested
+faas.trigger.request_id:
+  dashed_name: faas-trigger-request-id
+  description: The ID of the trigger request , message, event, etc.
+  example: 123456789
+  flat_name: faas.trigger.request_id
+  ignore_above: 1024
+  level: extended
+  name: trigger.request_id
+  normalize: []
+  short: The ID of the trigger request , message, event, etc.
+  type: keyword
+faas.trigger.type:
+  allowed_values:
+  - name: http
+  - name: pubsub
+  - name: datasource
+  - name: timer
+  - name: other
+  dashed_name: faas-trigger-type
+  description: The trigger for the cuntion execution.
+  flat_name: faas.trigger.type
+  ignore_above: 1024
+  level: extended
+  name: trigger.type
+  normalize: []
+  short: The trigger for the cuntion execution.
   type: keyword
 file.accessed:
   dashed_name: file-accessed
@@ -12307,6 +12655,157 @@ service.node.name:
   normalize: []
   short: Name of the service node.
   type: keyword
+service.origin.address:
+  dashed_name: service-origin-address
+  description: 'Address where data about this service was collected from.
+
+    This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+    path (sockets).'
+  example: 172.26.0.2:5432
+  flat_name: service.origin.address
+  ignore_above: 1024
+  level: extended
+  name: address
+  normalize: []
+  original_fieldset: service
+  short: Address of this service.
+  type: keyword
+service.origin.environment:
+  beta: This field is beta and subject to change.
+  dashed_name: service-origin-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.origin.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  original_fieldset: service
+  short: Environment of the service.
+  type: keyword
+service.origin.ephemeral_id:
+  dashed_name: service-origin-ephemeral-id
+  description: 'Ephemeral identifier of this service (if one exists).
+
+    This id normally changes across restarts, but `service.id` does not.'
+  example: 8a4f500f
+  flat_name: service.origin.ephemeral_id
+  ignore_above: 1024
+  level: extended
+  name: ephemeral_id
+  normalize: []
+  original_fieldset: service
+  short: Ephemeral identifier of this service.
+  type: keyword
+service.origin.id:
+  dashed_name: service-origin-id
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
+
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
+
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
+  example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+  flat_name: service.origin.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: service
+  short: Unique identifier of the running service.
+  type: keyword
+service.origin.name:
+  dashed_name: service-origin-name
+  description: 'Name of the service data is collected from.
+
+    The name of the service is normally user given. This allows for distributed services
+    that run on multiple hosts to correlate the related instances based on the name.
+
+    In the case of Elasticsearch the `service.name` could contain the cluster name.
+    For Beats the `service.name` is by default a copy of the `service.type` field
+    if no name is specified.'
+  example: elasticsearch-metrics
+  flat_name: service.origin.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service.
+  type: keyword
+service.origin.node.name:
+  dashed_name: service-origin-node-name
+  description: 'Name of a service node.
+
+    This allows for two nodes of the same service running on the same host to be differentiated.
+    Therefore, `service.node.name` should typically be unique across nodes of a given
+    service.
+
+    In the case of Elasticsearch, the `service.node.name` could contain the unique
+    node name within the Elasticsearch cluster. In cases where the service doesn''t
+    have the concept of a node name, the host name or container name can be used to
+    distinguish running instances that make up this service. If those do not provide
+    uniqueness (e.g. multiple instances of the service running on the same host) -
+    the node name can be manually set.'
+  example: instance-0000000016
+  flat_name: service.origin.node.name
+  ignore_above: 1024
+  level: extended
+  name: node.name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service node.
+  type: keyword
+service.origin.state:
+  dashed_name: service-origin-state
+  description: Current state of the service.
+  flat_name: service.origin.state
+  ignore_above: 1024
+  level: core
+  name: state
+  normalize: []
+  original_fieldset: service
+  short: Current state of the service.
+  type: keyword
+service.origin.type:
+  dashed_name: service-origin-type
+  description: 'The type of the service data is collected from.
+
+    The type can be used to group and correlate logs and metrics from one service
+    type.
+
+    Example: If logs or metrics are collected from Elasticsearch, `service.type` would
+    be `elasticsearch`.'
+  example: elasticsearch
+  flat_name: service.origin.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  original_fieldset: service
+  short: The type of the service.
+  type: keyword
+service.origin.version:
+  dashed_name: service-origin-version
+  description: 'Version of the service the data was collected from.
+
+    This allows to look at a data set only for a specific version of a service.'
+  example: 3.2.4
+  flat_name: service.origin.version
+  ignore_above: 1024
+  level: core
+  name: version
+  normalize: []
+  original_fieldset: service
+  short: Version of the service.
+  type: keyword
 service.state:
   dashed_name: service-state
   description: Current state of the service.
@@ -12316,6 +12815,157 @@ service.state:
   name: state
   normalize: []
   short: Current state of the service.
+  type: keyword
+service.target.address:
+  dashed_name: service-target-address
+  description: 'Address where data about this service was collected from.
+
+    This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+    path (sockets).'
+  example: 172.26.0.2:5432
+  flat_name: service.target.address
+  ignore_above: 1024
+  level: extended
+  name: address
+  normalize: []
+  original_fieldset: service
+  short: Address of this service.
+  type: keyword
+service.target.environment:
+  beta: This field is beta and subject to change.
+  dashed_name: service-target-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.target.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  original_fieldset: service
+  short: Environment of the service.
+  type: keyword
+service.target.ephemeral_id:
+  dashed_name: service-target-ephemeral-id
+  description: 'Ephemeral identifier of this service (if one exists).
+
+    This id normally changes across restarts, but `service.id` does not.'
+  example: 8a4f500f
+  flat_name: service.target.ephemeral_id
+  ignore_above: 1024
+  level: extended
+  name: ephemeral_id
+  normalize: []
+  original_fieldset: service
+  short: Ephemeral identifier of this service.
+  type: keyword
+service.target.id:
+  dashed_name: service-target-id
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
+
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
+
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
+  example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+  flat_name: service.target.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: service
+  short: Unique identifier of the running service.
+  type: keyword
+service.target.name:
+  dashed_name: service-target-name
+  description: 'Name of the service data is collected from.
+
+    The name of the service is normally user given. This allows for distributed services
+    that run on multiple hosts to correlate the related instances based on the name.
+
+    In the case of Elasticsearch the `service.name` could contain the cluster name.
+    For Beats the `service.name` is by default a copy of the `service.type` field
+    if no name is specified.'
+  example: elasticsearch-metrics
+  flat_name: service.target.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service.
+  type: keyword
+service.target.node.name:
+  dashed_name: service-target-node-name
+  description: 'Name of a service node.
+
+    This allows for two nodes of the same service running on the same host to be differentiated.
+    Therefore, `service.node.name` should typically be unique across nodes of a given
+    service.
+
+    In the case of Elasticsearch, the `service.node.name` could contain the unique
+    node name within the Elasticsearch cluster. In cases where the service doesn''t
+    have the concept of a node name, the host name or container name can be used to
+    distinguish running instances that make up this service. If those do not provide
+    uniqueness (e.g. multiple instances of the service running on the same host) -
+    the node name can be manually set.'
+  example: instance-0000000016
+  flat_name: service.target.node.name
+  ignore_above: 1024
+  level: extended
+  name: node.name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service node.
+  type: keyword
+service.target.state:
+  dashed_name: service-target-state
+  description: Current state of the service.
+  flat_name: service.target.state
+  ignore_above: 1024
+  level: core
+  name: state
+  normalize: []
+  original_fieldset: service
+  short: Current state of the service.
+  type: keyword
+service.target.type:
+  dashed_name: service-target-type
+  description: 'The type of the service data is collected from.
+
+    The type can be used to group and correlate logs and metrics from one service
+    type.
+
+    Example: If logs or metrics are collected from Elasticsearch, `service.type` would
+    be `elasticsearch`.'
+  example: elasticsearch
+  flat_name: service.target.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  original_fieldset: service
+  short: The type of the service.
+  type: keyword
+service.target.version:
+  dashed_name: service-target-version
+  description: 'Version of the service the data was collected from.
+
+    This allows to look at a data set only for a specific version of a service.'
+  example: 3.2.4
+  flat_name: service.target.version
+  ignore_above: 1024
+  level: core
+  name: version
+  normalize: []
+  original_fieldset: service
+  short: Version of the service.
   type: keyword
 service.type:
   dashed_name: service-type

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1164,7 +1164,17 @@ cloud:
     its host, the cloud info contains the data about this machine. If Metricbeat runs
     on a remote machine outside the cloud and fetches data from a service running
     in the cloud, the field contains cloud data from the machine the service is running
-    on.'
+    on.
+
+    The cloud fields may be self-nested under cloud.origin.* and cloud.target.*  to
+    describe origin or target service''s cloud information in the context of  incoming
+    or outgoing requests, respectively. However, the fieldsets  cloud.origin.* and
+    cloud.target.* must not be confused with the root cloud  fieldset that is used
+    to describe the cloud context of the actual service  under observation. The fieldset
+    cloud.origin.* may only be used in the  context of incoming requests or events
+    to provide the originating service''s  cloud information. The fieldset cloud.target.*
+    may only be used in the  context of outgoing requests or events to describe the
+    target service''s  cloud information.'
   group: 2
   name: cloud
   nestings:
@@ -1177,20 +1187,26 @@ cloud:
       at: cloud
       beta: Reusing the `cloud` fields in this location is currently considered beta.
       full: cloud.origin
+      short_override: Provides the cloud information of the origin entity in case
+        of an incoming request or event.
     - as: target
       at: cloud
       beta: Reusing the `cloud` fields in this location is currently considered beta.
       full: cloud.target
+      short_override: Provides the cloud information of the target entity in case
+        of an outgoing request or event.
     top_level: true
   reused_here:
   - beta: Reusing the `cloud` fields in this location is currently considered beta.
     full: cloud.origin
     schema_name: cloud
-    short: Fields about the cloud resource.
+    short: Provides the cloud information of the origin entity in case of an incoming
+      request or event.
   - beta: Reusing the `cloud` fields in this location is currently considered beta.
     full: cloud.target
     schema_name: cloud
-    short: Fields about the cloud resource.
+    short: Provides the cloud information of the target entity in case of an outgoing
+      request or event.
   short: Fields about the cloud resource.
   title: Cloud
   type: group
@@ -15096,6 +15112,14 @@ service:
       normalize: []
       short: Version of the service.
       type: keyword
+  footnote: The service fields may be self-nested under service.origin.* and service.target.*  to
+    describe origin or target services in the context of incoming or outgoing requests,  respectively.
+    However, the fieldsets service.origin.* and service.target.* must not be confused
+    with  the root service fieldset that is used to describe the actual service under
+    observation. The fieldset service.origin.* may only be used in the context of
+    incoming requests or  events to describe the originating service of the request.
+    The fieldset service.target.*  may only be used in the context of outgoing requests
+    or events to describe the target  service of the request.
   group: 2
   name: service
   nestings:
@@ -15109,21 +15133,25 @@ service:
       beta: Reusing the `service` fields in this location is currently considered
         beta.
       full: service.origin
+      short_override: Describes the origin service in case of an incoming request
+        or event.
     - as: target
       at: service
       beta: Reusing the `service` fields in this location is currently considered
         beta.
       full: service.target
+      short_override: Describes the target service in case of an outgoing request
+        or event.
     top_level: true
   reused_here:
   - beta: Reusing the `service` fields in this location is currently considered beta.
     full: service.origin
     schema_name: service
-    short: Fields describing the service for or from which the data was collected.
+    short: Describes the origin service in case of an incoming request or event.
   - beta: Reusing the `service` fields in this location is currently considered beta.
     full: service.target
     schema_name: service
-    short: Fields describing the service for or from which the data was collected.
+    short: Describes the target service in case of an outgoing request or event.
   short: Fields describing the service for or from which the data was collected.
   title: Service
   type: group

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -804,6 +804,152 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
+    cloud.origin.account.id:
+      dashed_name: cloud-origin-account-id
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      flat_name: cloud.origin.account.id
+      ignore_above: 1024
+      level: extended
+      name: account.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account or organization id.
+      type: keyword
+    cloud.origin.account.name:
+      dashed_name: cloud-origin-account-name
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      flat_name: cloud.origin.account.name
+      ignore_above: 1024
+      level: extended
+      name: account.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account name.
+      type: keyword
+    cloud.origin.availability_zone:
+      dashed_name: cloud-origin-availability-zone
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      flat_name: cloud.origin.availability_zone
+      ignore_above: 1024
+      level: extended
+      name: availability_zone
+      normalize: []
+      original_fieldset: cloud
+      short: Availability zone in which this host, resource, or service is located.
+      type: keyword
+    cloud.origin.instance.id:
+      dashed_name: cloud-origin-instance-id
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      flat_name: cloud.origin.instance.id
+      ignore_above: 1024
+      level: extended
+      name: instance.id
+      normalize: []
+      original_fieldset: cloud
+      short: Instance ID of the host machine.
+      type: keyword
+    cloud.origin.instance.name:
+      dashed_name: cloud-origin-instance-name
+      description: Instance name of the host machine.
+      flat_name: cloud.origin.instance.name
+      ignore_above: 1024
+      level: extended
+      name: instance.name
+      normalize: []
+      original_fieldset: cloud
+      short: Instance name of the host machine.
+      type: keyword
+    cloud.origin.machine.type:
+      dashed_name: cloud-origin-machine-type
+      description: Machine type of the host machine.
+      example: t2.medium
+      flat_name: cloud.origin.machine.type
+      ignore_above: 1024
+      level: extended
+      name: machine.type
+      normalize: []
+      original_fieldset: cloud
+      short: Machine type of the host machine.
+      type: keyword
+    cloud.origin.project.id:
+      dashed_name: cloud-origin-project-id
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      flat_name: cloud.origin.project.id
+      ignore_above: 1024
+      level: extended
+      name: project.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project id.
+      type: keyword
+    cloud.origin.project.name:
+      dashed_name: cloud-origin-project-name
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      flat_name: cloud.origin.project.name
+      ignore_above: 1024
+      level: extended
+      name: project.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project name.
+      type: keyword
+    cloud.origin.provider:
+      dashed_name: cloud-origin-provider
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      flat_name: cloud.origin.provider
+      ignore_above: 1024
+      level: extended
+      name: provider
+      normalize: []
+      original_fieldset: cloud
+      short: Name of the cloud provider.
+      type: keyword
+    cloud.origin.region:
+      dashed_name: cloud-origin-region
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      flat_name: cloud.origin.region
+      ignore_above: 1024
+      level: extended
+      name: region
+      normalize: []
+      original_fieldset: cloud
+      short: Region in which this host, resource, or service is located.
+      type: keyword
+    cloud.origin.service.name:
+      dashed_name: cloud-origin-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.origin.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud service name.
+      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.
@@ -868,6 +1014,152 @@ cloud:
       normalize: []
       short: The cloud service name.
       type: keyword
+    cloud.target.account.id:
+      dashed_name: cloud-target-account-id
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      flat_name: cloud.target.account.id
+      ignore_above: 1024
+      level: extended
+      name: account.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account or organization id.
+      type: keyword
+    cloud.target.account.name:
+      dashed_name: cloud-target-account-name
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      flat_name: cloud.target.account.name
+      ignore_above: 1024
+      level: extended
+      name: account.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account name.
+      type: keyword
+    cloud.target.availability_zone:
+      dashed_name: cloud-target-availability-zone
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      flat_name: cloud.target.availability_zone
+      ignore_above: 1024
+      level: extended
+      name: availability_zone
+      normalize: []
+      original_fieldset: cloud
+      short: Availability zone in which this host, resource, or service is located.
+      type: keyword
+    cloud.target.instance.id:
+      dashed_name: cloud-target-instance-id
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      flat_name: cloud.target.instance.id
+      ignore_above: 1024
+      level: extended
+      name: instance.id
+      normalize: []
+      original_fieldset: cloud
+      short: Instance ID of the host machine.
+      type: keyword
+    cloud.target.instance.name:
+      dashed_name: cloud-target-instance-name
+      description: Instance name of the host machine.
+      flat_name: cloud.target.instance.name
+      ignore_above: 1024
+      level: extended
+      name: instance.name
+      normalize: []
+      original_fieldset: cloud
+      short: Instance name of the host machine.
+      type: keyword
+    cloud.target.machine.type:
+      dashed_name: cloud-target-machine-type
+      description: Machine type of the host machine.
+      example: t2.medium
+      flat_name: cloud.target.machine.type
+      ignore_above: 1024
+      level: extended
+      name: machine.type
+      normalize: []
+      original_fieldset: cloud
+      short: Machine type of the host machine.
+      type: keyword
+    cloud.target.project.id:
+      dashed_name: cloud-target-project-id
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      flat_name: cloud.target.project.id
+      ignore_above: 1024
+      level: extended
+      name: project.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project id.
+      type: keyword
+    cloud.target.project.name:
+      dashed_name: cloud-target-project-name
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      flat_name: cloud.target.project.name
+      ignore_above: 1024
+      level: extended
+      name: project.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project name.
+      type: keyword
+    cloud.target.provider:
+      dashed_name: cloud-target-provider
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      flat_name: cloud.target.provider
+      ignore_above: 1024
+      level: extended
+      name: provider
+      normalize: []
+      original_fieldset: cloud
+      short: Name of the cloud provider.
+      type: keyword
+    cloud.target.region:
+      dashed_name: cloud-target-region
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      flat_name: cloud.target.region
+      ignore_above: 1024
+      level: extended
+      name: region
+      normalize: []
+      original_fieldset: cloud
+      short: Region in which this host, resource, or service is located.
+      type: keyword
+    cloud.target.service.name:
+      dashed_name: cloud-target-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.target.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud service name.
+      type: keyword
   footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from
     its host, the cloud info contains the data about this machine. If Metricbeat runs
     on a remote machine outside the cloud and fetches data from a service running
@@ -875,7 +1167,30 @@ cloud:
     on.'
   group: 2
   name: cloud
+  nestings:
+  - cloud.origin
+  - cloud.target
   prefix: cloud.
+  reusable:
+    expected:
+    - as: origin
+      at: cloud
+      beta: Reusing the `cloud` fields in this location is currently considered beta.
+      full: cloud.origin
+    - as: target
+      at: cloud
+      beta: Reusing the `cloud` fields in this location is currently considered beta.
+      full: cloud.target
+    top_level: true
+  reused_here:
+  - beta: Reusing the `cloud` fields in this location is currently considered beta.
+    full: cloud.origin
+    schema_name: cloud
+    short: Fields about the cloud resource.
+  - beta: Reusing the `cloud` fields in this location is currently considered beta.
+    full: cloud.target
+    schema_name: cloud
+    short: Fields about the cloud resource.
   short: Fields about the cloud resource.
   title: Cloud
   type: group
@@ -4181,6 +4496,72 @@ event:
   prefix: event.
   short: Fields breaking down the event details.
   title: Event
+  type: group
+faas:
+  beta: These fields are in beta and are subject to change.
+  description: TBD description
+  fields:
+    faas.coldstart:
+      dashed_name: faas-coldstart
+      description: Boolean value indicating a cold start of a function.
+      flat_name: faas.coldstart
+      level: extended
+      name: coldstart
+      normalize: []
+      short: Boolean value indicating a cold start of a function.
+      type: boolean
+    faas.execution:
+      dashed_name: faas-execution
+      description: The execution ID of the current function execution.
+      example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+      flat_name: faas.execution
+      ignore_above: 1024
+      level: extended
+      name: execution
+      normalize: []
+      short: The execution ID of the current function execution.
+      type: keyword
+    faas.trigger:
+      dashed_name: faas-trigger
+      description: Details about the function trigger.
+      flat_name: faas.trigger
+      level: extended
+      name: trigger
+      normalize: []
+      short: Details about the function trigger.
+      type: nested
+    faas.trigger.request_id:
+      dashed_name: faas-trigger-request-id
+      description: The ID of the trigger request , message, event, etc.
+      example: 123456789
+      flat_name: faas.trigger.request_id
+      ignore_above: 1024
+      level: extended
+      name: trigger.request_id
+      normalize: []
+      short: The ID of the trigger request , message, event, etc.
+      type: keyword
+    faas.trigger.type:
+      allowed_values:
+      - name: http
+      - name: pubsub
+      - name: datasource
+      - name: timer
+      - name: other
+      dashed_name: faas-trigger-type
+      description: The trigger for the cuntion execution.
+      flat_name: faas.trigger.type
+      ignore_above: 1024
+      level: extended
+      name: trigger.type
+      normalize: []
+      short: The trigger for the cuntion execution.
+      type: keyword
+  group: 2
+  name: faas
+  prefix: faas.
+  short: Fields describing functions as a service.
+  title: FaaS
   type: group
 file:
   description: 'A file is defined as a set of information that has been created on,
@@ -14371,6 +14752,158 @@ service:
       normalize: []
       short: Name of the service node.
       type: keyword
+    service.origin.address:
+      dashed_name: service-origin-address
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      flat_name: service.origin.address
+      ignore_above: 1024
+      level: extended
+      name: address
+      normalize: []
+      original_fieldset: service
+      short: Address of this service.
+      type: keyword
+    service.origin.environment:
+      beta: This field is beta and subject to change.
+      dashed_name: service-origin-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.origin.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      original_fieldset: service
+      short: Environment of the service.
+      type: keyword
+    service.origin.ephemeral_id:
+      dashed_name: service-origin-ephemeral-id
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      flat_name: service.origin.ephemeral_id
+      ignore_above: 1024
+      level: extended
+      name: ephemeral_id
+      normalize: []
+      original_fieldset: service
+      short: Ephemeral identifier of this service.
+      type: keyword
+    service.origin.id:
+      dashed_name: service-origin-id
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      flat_name: service.origin.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: service
+      short: Unique identifier of the running service.
+      type: keyword
+    service.origin.name:
+      dashed_name: service-origin-name
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      flat_name: service.origin.name
+      ignore_above: 1024
+      level: core
+      name: name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service.
+      type: keyword
+    service.origin.node.name:
+      dashed_name: service-origin-node-name
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      flat_name: service.origin.node.name
+      ignore_above: 1024
+      level: extended
+      name: node.name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service node.
+      type: keyword
+    service.origin.state:
+      dashed_name: service-origin-state
+      description: Current state of the service.
+      flat_name: service.origin.state
+      ignore_above: 1024
+      level: core
+      name: state
+      normalize: []
+      original_fieldset: service
+      short: Current state of the service.
+      type: keyword
+    service.origin.type:
+      dashed_name: service-origin-type
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      flat_name: service.origin.type
+      ignore_above: 1024
+      level: core
+      name: type
+      normalize: []
+      original_fieldset: service
+      short: The type of the service.
+      type: keyword
+    service.origin.version:
+      dashed_name: service-origin-version
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      flat_name: service.origin.version
+      ignore_above: 1024
+      level: core
+      name: version
+      normalize: []
+      original_fieldset: service
+      short: Version of the service.
+      type: keyword
     service.state:
       dashed_name: service-state
       description: Current state of the service.
@@ -14380,6 +14913,158 @@ service:
       name: state
       normalize: []
       short: Current state of the service.
+      type: keyword
+    service.target.address:
+      dashed_name: service-target-address
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      flat_name: service.target.address
+      ignore_above: 1024
+      level: extended
+      name: address
+      normalize: []
+      original_fieldset: service
+      short: Address of this service.
+      type: keyword
+    service.target.environment:
+      beta: This field is beta and subject to change.
+      dashed_name: service-target-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.target.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      original_fieldset: service
+      short: Environment of the service.
+      type: keyword
+    service.target.ephemeral_id:
+      dashed_name: service-target-ephemeral-id
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      flat_name: service.target.ephemeral_id
+      ignore_above: 1024
+      level: extended
+      name: ephemeral_id
+      normalize: []
+      original_fieldset: service
+      short: Ephemeral identifier of this service.
+      type: keyword
+    service.target.id:
+      dashed_name: service-target-id
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      flat_name: service.target.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: service
+      short: Unique identifier of the running service.
+      type: keyword
+    service.target.name:
+      dashed_name: service-target-name
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      flat_name: service.target.name
+      ignore_above: 1024
+      level: core
+      name: name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service.
+      type: keyword
+    service.target.node.name:
+      dashed_name: service-target-node-name
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      flat_name: service.target.node.name
+      ignore_above: 1024
+      level: extended
+      name: node.name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service node.
+      type: keyword
+    service.target.state:
+      dashed_name: service-target-state
+      description: Current state of the service.
+      flat_name: service.target.state
+      ignore_above: 1024
+      level: core
+      name: state
+      normalize: []
+      original_fieldset: service
+      short: Current state of the service.
+      type: keyword
+    service.target.type:
+      dashed_name: service-target-type
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      flat_name: service.target.type
+      ignore_above: 1024
+      level: core
+      name: type
+      normalize: []
+      original_fieldset: service
+      short: The type of the service.
+      type: keyword
+    service.target.version:
+      dashed_name: service-target-version
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      flat_name: service.target.version
+      ignore_above: 1024
+      level: core
+      name: version
+      normalize: []
+      original_fieldset: service
+      short: Version of the service.
       type: keyword
     service.type:
       dashed_name: service-type
@@ -14413,7 +15098,32 @@ service:
       type: keyword
   group: 2
   name: service
+  nestings:
+  - service.origin
+  - service.target
   prefix: service.
+  reusable:
+    expected:
+    - as: origin
+      at: service
+      beta: Reusing the `service` fields in this location is currently considered
+        beta.
+      full: service.origin
+    - as: target
+      at: service
+      beta: Reusing the `service` fields in this location is currently considered
+        beta.
+      full: service.target
+    top_level: true
+  reused_here:
+  - beta: Reusing the `service` fields in this location is currently considered beta.
+    full: service.origin
+    schema_name: service
+    short: Fields describing the service for or from which the data was collected.
+  - beta: Reusing the `service` fields in this location is currently considered beta.
+    full: service.target
+    schema_name: service
+    short: Fields describing the service for or from which the data was collected.
   short: Fields describing the service for or from which the data was collected.
   title: Service
   type: group

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -267,6 +267,74 @@
               }
             }
           },
+          "origin": {
+            "properties": {
+              "account": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "availability_zone": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "instance": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "machine": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "project": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "provider": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "service": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          },
           "project": {
             "properties": {
               "id": {
@@ -292,6 +360,74 @@
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              }
+            }
+          },
+          "target": {
+            "properties": {
+              "account": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "availability_zone": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "instance": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "machine": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "project": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "provider": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "service": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }
@@ -1118,6 +1254,30 @@
           "url": {
             "ignore_above": 1024,
             "type": "keyword"
+          }
+        }
+      },
+      "faas": {
+        "properties": {
+          "coldstart": {
+            "type": "boolean"
+          },
+          "execution": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "trigger": {
+            "properties": {
+              "request_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            },
+            "type": "nested"
           }
         }
       },
@@ -4442,9 +4602,97 @@
               }
             }
           },
+          "origin": {
+            "properties": {
+              "address": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "environment": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ephemeral_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "node": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "state": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "state": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "target": {
+            "properties": {
+              "address": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "environment": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ephemeral_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "node": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "state": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           },
           "type": {
             "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/component/cloud.json
+++ b/experimental/generated/elasticsearch/component/cloud.json
@@ -44,6 +44,74 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
             "project": {
               "properties": {
                 "id": {
@@ -69,6 +137,74 @@
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                }
+              }
+            },
+            "target": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/experimental/generated/elasticsearch/component/faas.json
+++ b/experimental/generated/elasticsearch/component/faas.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-faas.html",
+    "ecs_version": "8.0.0-dev+exp"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "faas": {
+          "properties": {
+            "coldstart": {
+              "type": "boolean"
+            },
+            "execution": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "trigger": {
+              "properties": {
+                "request_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experimental/generated/elasticsearch/component/service.json
+++ b/experimental/generated/elasticsearch/component/service.json
@@ -36,9 +36,97 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "state": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/template.json
+++ b/experimental/generated/elasticsearch/template.json
@@ -16,6 +16,7 @@
     "ecs_8.0.0-dev-exp_ecs",
     "ecs_8.0.0-dev-exp_error",
     "ecs_8.0.0-dev-exp_event",
+    "ecs_8.0.0-dev-exp_faas",
     "ecs_8.0.0-dev-exp_file",
     "ecs_8.0.0-dev-exp_group",
     "ecs_8.0.0-dev-exp_host",

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -481,6 +481,97 @@
       ignore_above: 1024
       description: Machine type of the host machine.
       example: t2.medium
+    - name: origin.account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      default_field: false
+    - name: origin.account.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      default_field: false
+    - name: origin.availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      default_field: false
+    - name: origin.instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      default_field: false
+    - name: origin.instance.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+      default_field: false
+    - name: origin.machine.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+      example: t2.medium
+      default_field: false
+    - name: origin.project.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      default_field: false
+    - name: origin.project.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      default_field: false
+    - name: origin.provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      default_field: false
+    - name: origin.region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      default_field: false
+    - name: origin.service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
     - name: project.id
       level: extended
       type: keyword
@@ -513,6 +604,97 @@
       description: Region in which this host, resource, or service is located.
       example: us-east-1
     - name: service.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      default_field: false
+    - name: target.account.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      default_field: false
+    - name: target.account.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      default_field: false
+    - name: target.availability_zone
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      default_field: false
+    - name: target.instance.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      default_field: false
+    - name: target.instance.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Instance name of the host machine.
+      default_field: false
+    - name: target.machine.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Machine type of the host machine.
+      example: t2.medium
+      default_field: false
+    - name: target.project.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      default_field: false
+    - name: target.project.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      default_field: false
+    - name: target.provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      default_field: false
+    - name: target.region
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      default_field: false
+    - name: target.service.name
       level: extended
       type: keyword
       ignore_above: 1024
@@ -1904,6 +2086,42 @@
         occurrence of this event can take place. Alert events, indicated by `event.kind:alert`,
         are a common use case for this field.'
       example: https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe
+      default_field: false
+  - name: faas
+    title: FaaS
+    group: 2
+    description: TBD description
+    type: group
+    fields:
+    - name: coldstart
+      level: extended
+      type: boolean
+      description: Boolean value indicating a cold start of a function.
+      default_field: false
+    - name: execution
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The execution ID of the current function execution.
+      example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+      default_field: false
+    - name: trigger
+      level: extended
+      type: nested
+      description: Details about the function trigger.
+      default_field: false
+    - name: trigger.request_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The ID of the trigger request , message, event, etc.
+      example: 123456789
+      default_field: false
+    - name: trigger.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The trigger for the cuntion execution.
       default_field: false
   - name: file
     title: File
@@ -5593,11 +5811,223 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+    - name: origin.address
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      default_field: false
+    - name: origin.environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
+    - name: origin.ephemeral_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      default_field: false
+    - name: origin.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      default_field: false
+    - name: origin.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      default_field: false
+    - name: origin.node.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      default_field: false
+    - name: origin.state
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Current state of the service.
+      default_field: false
+    - name: origin.type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      default_field: false
+    - name: origin.version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      default_field: false
     - name: state
       level: core
       type: keyword
       ignore_above: 1024
       description: Current state of the service.
+    - name: target.address
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      default_field: false
+    - name: target.environment
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      default_field: false
+    - name: target.ephemeral_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      default_field: false
+    - name: target.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      default_field: false
+    - name: target.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      default_field: false
+    - name: target.node.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      default_field: false
+    - name: target.state
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Current state of the service.
+      default_field: false
+    - name: target.type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      default_field: false
+    - name: target.version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      default_field: false
     - name: type
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -436,7 +436,17 @@
       from its host, the cloud info contains the data about this machine. If Metricbeat
       runs on a remote machine outside the cloud and fetches data from a service running
       in the cloud, the field contains cloud data from the machine the service is
-      running on.'
+      running on.
+
+      The cloud fields may be self-nested under cloud.origin.* and cloud.target.*  to
+      describe origin or target service''s cloud information in the context of  incoming
+      or outgoing requests, respectively. However, the fieldsets  cloud.origin.* and
+      cloud.target.* must not be confused with the root cloud  fieldset that is used
+      to describe the cloud context of the actual service  under observation. The
+      fieldset cloud.origin.* may only be used in the  context of incoming requests
+      or events to provide the originating service''s  cloud information. The fieldset
+      cloud.target.* may only be used in the  context of outgoing requests or events
+      to describe the target service''s  cloud information.'
     type: group
     fields:
     - name: account.id
@@ -5735,6 +5745,14 @@
       was collected.
 
       These fields help you find and correlate logs for a specific service and version.'
+    footnote: The service fields may be self-nested under service.origin.* and service.target.*  to
+      describe origin or target services in the context of incoming or outgoing requests,  respectively.
+      However, the fieldsets service.origin.* and service.target.* must not be confused
+      with  the root service fieldset that is used to describe the actual service
+      under observation. The fieldset service.origin.* may only be used in the context
+      of incoming requests or  events to describe the originating service of the request.
+      The fieldset service.target.*  may only be used in the context of outgoing requests
+      or events to describe the target  service of the request.
     type: group
     fields:
     - name: address

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -53,11 +53,33 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
 8.0.0-dev,true,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
 8.0.0-dev,true,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev,true,cloud,cloud.origin.account.id,keyword,extended,,666777888999,The cloud account or organization id.
+8.0.0-dev,true,cloud,cloud.origin.account.name,keyword,extended,,elastic-dev,The cloud account name.
+8.0.0-dev,true,cloud,cloud.origin.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
+8.0.0-dev,true,cloud,cloud.origin.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
+8.0.0-dev,true,cloud,cloud.origin.instance.name,keyword,extended,,,Instance name of the host machine.
+8.0.0-dev,true,cloud,cloud.origin.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev,true,cloud,cloud.origin.project.id,keyword,extended,,my-project,The cloud project id.
+8.0.0-dev,true,cloud,cloud.origin.project.name,keyword,extended,,my project,The cloud project name.
+8.0.0-dev,true,cloud,cloud.origin.provider,keyword,extended,,aws,Name of the cloud provider.
+8.0.0-dev,true,cloud,cloud.origin.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
+8.0.0-dev,true,cloud,cloud.origin.service.name,keyword,extended,,lambda,The cloud service name.
 8.0.0-dev,true,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
 8.0.0-dev,true,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
 8.0.0-dev,true,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
 8.0.0-dev,true,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
 8.0.0-dev,true,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
+8.0.0-dev,true,cloud,cloud.target.account.id,keyword,extended,,666777888999,The cloud account or organization id.
+8.0.0-dev,true,cloud,cloud.target.account.name,keyword,extended,,elastic-dev,The cloud account name.
+8.0.0-dev,true,cloud,cloud.target.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
+8.0.0-dev,true,cloud,cloud.target.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
+8.0.0-dev,true,cloud,cloud.target.instance.name,keyword,extended,,,Instance name of the host machine.
+8.0.0-dev,true,cloud,cloud.target.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+8.0.0-dev,true,cloud,cloud.target.project.id,keyword,extended,,my-project,The cloud project id.
+8.0.0-dev,true,cloud,cloud.target.project.name,keyword,extended,,my project,The cloud project name.
+8.0.0-dev,true,cloud,cloud.target.provider,keyword,extended,,aws,Name of the cloud provider.
+8.0.0-dev,true,cloud,cloud.target.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
+8.0.0-dev,true,cloud,cloud.target.service.name,keyword,extended,,lambda,The cloud service name.
 8.0.0-dev,true,container,container.id,keyword,core,,,Unique container id.
 8.0.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 8.0.0-dev,true,container,container.image.tag,keyword,extended,array,,Container image tags.
@@ -179,6 +201,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.0.0-dev,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.0.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
+8.0.0-dev,true,faas,faas.coldstart,boolean,extended,,,Boolean value indicating a cold start of a function.
+8.0.0-dev,true,faas,faas.execution,keyword,extended,,af9d5aa4-a685-4c5f-a22b-444f80b3cc28,The execution ID of the current function execution.
+8.0.0-dev,true,faas,faas.trigger,nested,extended,,,Details about the function trigger.
+8.0.0-dev,true,faas,faas.trigger.request_id,keyword,extended,,123456789,"The ID of the trigger request , message, event, etc."
+8.0.0-dev,true,faas,faas.trigger.type,keyword,extended,,,The trigger for the cuntion execution.
 8.0.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.0.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.0.0-dev,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
@@ -634,7 +661,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.0.0-dev,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.0.0-dev,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.0.0-dev,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
+8.0.0-dev,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
+8.0.0-dev,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+8.0.0-dev,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
+8.0.0-dev,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev,true,service,service.origin.state,keyword,core,,,Current state of the service.
+8.0.0-dev,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
+8.0.0-dev,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev,true,service,service.state,keyword,core,,,Current state of the service.
+8.0.0-dev,true,service,service.target.address,keyword,extended,,172.26.0.2:5432,Address of this service.
+8.0.0-dev,true,service,service.target.environment,keyword,extended,,production,Environment of the service.
+8.0.0-dev,true,service,service.target.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
+8.0.0-dev,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+8.0.0-dev,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
+8.0.0-dev,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.0.0-dev,true,service,service.target.state,keyword,core,,,Current state of the service.
+8.0.0-dev,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
+8.0.0-dev,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev,true,service,service.type,keyword,core,,elasticsearch,The type of the service.
 8.0.0-dev,true,service,service.version,keyword,core,,3.2.4,Version of the service.
 8.0.0-dev,true,source,source.address,keyword,extended,,,Source network address.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -628,6 +628,152 @@ cloud.machine.type:
   normalize: []
   short: Machine type of the host machine.
   type: keyword
+cloud.origin.account.id:
+  dashed_name: cloud-origin-account-id
+  description: 'The cloud account or organization id used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+  example: 666777888999
+  flat_name: cloud.origin.account.id
+  ignore_above: 1024
+  level: extended
+  name: account.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account or organization id.
+  type: keyword
+cloud.origin.account.name:
+  dashed_name: cloud-origin-account-name
+  description: 'The cloud account name or alias used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account name, Google Cloud ORG display name.'
+  example: elastic-dev
+  flat_name: cloud.origin.account.name
+  ignore_above: 1024
+  level: extended
+  name: account.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account name.
+  type: keyword
+cloud.origin.availability_zone:
+  dashed_name: cloud-origin-availability-zone
+  description: Availability zone in which this host, resource, or service is located.
+  example: us-east-1c
+  flat_name: cloud.origin.availability_zone
+  ignore_above: 1024
+  level: extended
+  name: availability_zone
+  normalize: []
+  original_fieldset: cloud
+  short: Availability zone in which this host, resource, or service is located.
+  type: keyword
+cloud.origin.instance.id:
+  dashed_name: cloud-origin-instance-id
+  description: Instance ID of the host machine.
+  example: i-1234567890abcdef0
+  flat_name: cloud.origin.instance.id
+  ignore_above: 1024
+  level: extended
+  name: instance.id
+  normalize: []
+  original_fieldset: cloud
+  short: Instance ID of the host machine.
+  type: keyword
+cloud.origin.instance.name:
+  dashed_name: cloud-origin-instance-name
+  description: Instance name of the host machine.
+  flat_name: cloud.origin.instance.name
+  ignore_above: 1024
+  level: extended
+  name: instance.name
+  normalize: []
+  original_fieldset: cloud
+  short: Instance name of the host machine.
+  type: keyword
+cloud.origin.machine.type:
+  dashed_name: cloud-origin-machine-type
+  description: Machine type of the host machine.
+  example: t2.medium
+  flat_name: cloud.origin.machine.type
+  ignore_above: 1024
+  level: extended
+  name: machine.type
+  normalize: []
+  original_fieldset: cloud
+  short: Machine type of the host machine.
+  type: keyword
+cloud.origin.project.id:
+  dashed_name: cloud-origin-project-id
+  description: 'The cloud project identifier.
+
+    Examples: Google Cloud Project id, Azure Project id.'
+  example: my-project
+  flat_name: cloud.origin.project.id
+  ignore_above: 1024
+  level: extended
+  name: project.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project id.
+  type: keyword
+cloud.origin.project.name:
+  dashed_name: cloud-origin-project-name
+  description: 'The cloud project name.
+
+    Examples: Google Cloud Project name, Azure Project name.'
+  example: my project
+  flat_name: cloud.origin.project.name
+  ignore_above: 1024
+  level: extended
+  name: project.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project name.
+  type: keyword
+cloud.origin.provider:
+  dashed_name: cloud-origin-provider
+  description: Name of the cloud provider. Example values are aws, azure, gcp, or
+    digitalocean.
+  example: aws
+  flat_name: cloud.origin.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  original_fieldset: cloud
+  short: Name of the cloud provider.
+  type: keyword
+cloud.origin.region:
+  dashed_name: cloud-origin-region
+  description: Region in which this host, resource, or service is located.
+  example: us-east-1
+  flat_name: cloud.origin.region
+  ignore_above: 1024
+  level: extended
+  name: region
+  normalize: []
+  original_fieldset: cloud
+  short: Region in which this host, resource, or service is located.
+  type: keyword
+cloud.origin.service.name:
+  dashed_name: cloud-origin-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.origin.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud service name.
+  type: keyword
 cloud.project.id:
   dashed_name: cloud-project-id
   description: 'The cloud project identifier.
@@ -690,6 +836,152 @@ cloud.service.name:
   level: extended
   name: service.name
   normalize: []
+  short: The cloud service name.
+  type: keyword
+cloud.target.account.id:
+  dashed_name: cloud-target-account-id
+  description: 'The cloud account or organization id used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+  example: 666777888999
+  flat_name: cloud.target.account.id
+  ignore_above: 1024
+  level: extended
+  name: account.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account or organization id.
+  type: keyword
+cloud.target.account.name:
+  dashed_name: cloud-target-account-name
+  description: 'The cloud account name or alias used to identify different entities
+    in a multi-tenant environment.
+
+    Examples: AWS account name, Google Cloud ORG display name.'
+  example: elastic-dev
+  flat_name: cloud.target.account.name
+  ignore_above: 1024
+  level: extended
+  name: account.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud account name.
+  type: keyword
+cloud.target.availability_zone:
+  dashed_name: cloud-target-availability-zone
+  description: Availability zone in which this host, resource, or service is located.
+  example: us-east-1c
+  flat_name: cloud.target.availability_zone
+  ignore_above: 1024
+  level: extended
+  name: availability_zone
+  normalize: []
+  original_fieldset: cloud
+  short: Availability zone in which this host, resource, or service is located.
+  type: keyword
+cloud.target.instance.id:
+  dashed_name: cloud-target-instance-id
+  description: Instance ID of the host machine.
+  example: i-1234567890abcdef0
+  flat_name: cloud.target.instance.id
+  ignore_above: 1024
+  level: extended
+  name: instance.id
+  normalize: []
+  original_fieldset: cloud
+  short: Instance ID of the host machine.
+  type: keyword
+cloud.target.instance.name:
+  dashed_name: cloud-target-instance-name
+  description: Instance name of the host machine.
+  flat_name: cloud.target.instance.name
+  ignore_above: 1024
+  level: extended
+  name: instance.name
+  normalize: []
+  original_fieldset: cloud
+  short: Instance name of the host machine.
+  type: keyword
+cloud.target.machine.type:
+  dashed_name: cloud-target-machine-type
+  description: Machine type of the host machine.
+  example: t2.medium
+  flat_name: cloud.target.machine.type
+  ignore_above: 1024
+  level: extended
+  name: machine.type
+  normalize: []
+  original_fieldset: cloud
+  short: Machine type of the host machine.
+  type: keyword
+cloud.target.project.id:
+  dashed_name: cloud-target-project-id
+  description: 'The cloud project identifier.
+
+    Examples: Google Cloud Project id, Azure Project id.'
+  example: my-project
+  flat_name: cloud.target.project.id
+  ignore_above: 1024
+  level: extended
+  name: project.id
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project id.
+  type: keyword
+cloud.target.project.name:
+  dashed_name: cloud-target-project-name
+  description: 'The cloud project name.
+
+    Examples: Google Cloud Project name, Azure Project name.'
+  example: my project
+  flat_name: cloud.target.project.name
+  ignore_above: 1024
+  level: extended
+  name: project.name
+  normalize: []
+  original_fieldset: cloud
+  short: The cloud project name.
+  type: keyword
+cloud.target.provider:
+  dashed_name: cloud-target-provider
+  description: Name of the cloud provider. Example values are aws, azure, gcp, or
+    digitalocean.
+  example: aws
+  flat_name: cloud.target.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  original_fieldset: cloud
+  short: Name of the cloud provider.
+  type: keyword
+cloud.target.region:
+  dashed_name: cloud-target-region
+  description: Region in which this host, resource, or service is located.
+  example: us-east-1
+  flat_name: cloud.target.region
+  ignore_above: 1024
+  level: extended
+  name: region
+  normalize: []
+  original_fieldset: cloud
+  short: Region in which this host, resource, or service is located.
+  type: keyword
+cloud.target.service.name:
+  dashed_name: cloud-target-service-name
+  description: 'The cloud service name is intended to distinguish services running
+    on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App
+    Engine, Azure VM vs App Server.
+
+    Examples: app engine, app service, cloud run, fargate, lambda.'
+  example: lambda
+  flat_name: cloud.target.service.name
+  ignore_above: 1024
+  level: extended
+  name: service.name
+  normalize: []
+  original_fieldset: cloud
   short: The cloud service name.
   type: keyword
 container.id:
@@ -2667,6 +2959,62 @@ event.url:
   name: url
   normalize: []
   short: Event investigation URL
+  type: keyword
+faas.coldstart:
+  dashed_name: faas-coldstart
+  description: Boolean value indicating a cold start of a function.
+  flat_name: faas.coldstart
+  level: extended
+  name: coldstart
+  normalize: []
+  short: Boolean value indicating a cold start of a function.
+  type: boolean
+faas.execution:
+  dashed_name: faas-execution
+  description: The execution ID of the current function execution.
+  example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+  flat_name: faas.execution
+  ignore_above: 1024
+  level: extended
+  name: execution
+  normalize: []
+  short: The execution ID of the current function execution.
+  type: keyword
+faas.trigger:
+  dashed_name: faas-trigger
+  description: Details about the function trigger.
+  flat_name: faas.trigger
+  level: extended
+  name: trigger
+  normalize: []
+  short: Details about the function trigger.
+  type: nested
+faas.trigger.request_id:
+  dashed_name: faas-trigger-request-id
+  description: The ID of the trigger request , message, event, etc.
+  example: 123456789
+  flat_name: faas.trigger.request_id
+  ignore_above: 1024
+  level: extended
+  name: trigger.request_id
+  normalize: []
+  short: The ID of the trigger request , message, event, etc.
+  type: keyword
+faas.trigger.type:
+  allowed_values:
+  - name: http
+  - name: pubsub
+  - name: datasource
+  - name: timer
+  - name: other
+  dashed_name: faas-trigger-type
+  description: The trigger for the cuntion execution.
+  flat_name: faas.trigger.type
+  ignore_above: 1024
+  level: extended
+  name: trigger.type
+  normalize: []
+  short: The trigger for the cuntion execution.
   type: keyword
 file.accessed:
   dashed_name: file-accessed
@@ -8119,6 +8467,157 @@ service.node.name:
   normalize: []
   short: Name of the service node.
   type: keyword
+service.origin.address:
+  dashed_name: service-origin-address
+  description: 'Address where data about this service was collected from.
+
+    This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+    path (sockets).'
+  example: 172.26.0.2:5432
+  flat_name: service.origin.address
+  ignore_above: 1024
+  level: extended
+  name: address
+  normalize: []
+  original_fieldset: service
+  short: Address of this service.
+  type: keyword
+service.origin.environment:
+  beta: This field is beta and subject to change.
+  dashed_name: service-origin-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.origin.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  original_fieldset: service
+  short: Environment of the service.
+  type: keyword
+service.origin.ephemeral_id:
+  dashed_name: service-origin-ephemeral-id
+  description: 'Ephemeral identifier of this service (if one exists).
+
+    This id normally changes across restarts, but `service.id` does not.'
+  example: 8a4f500f
+  flat_name: service.origin.ephemeral_id
+  ignore_above: 1024
+  level: extended
+  name: ephemeral_id
+  normalize: []
+  original_fieldset: service
+  short: Ephemeral identifier of this service.
+  type: keyword
+service.origin.id:
+  dashed_name: service-origin-id
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
+
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
+
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
+  example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+  flat_name: service.origin.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: service
+  short: Unique identifier of the running service.
+  type: keyword
+service.origin.name:
+  dashed_name: service-origin-name
+  description: 'Name of the service data is collected from.
+
+    The name of the service is normally user given. This allows for distributed services
+    that run on multiple hosts to correlate the related instances based on the name.
+
+    In the case of Elasticsearch the `service.name` could contain the cluster name.
+    For Beats the `service.name` is by default a copy of the `service.type` field
+    if no name is specified.'
+  example: elasticsearch-metrics
+  flat_name: service.origin.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service.
+  type: keyword
+service.origin.node.name:
+  dashed_name: service-origin-node-name
+  description: 'Name of a service node.
+
+    This allows for two nodes of the same service running on the same host to be differentiated.
+    Therefore, `service.node.name` should typically be unique across nodes of a given
+    service.
+
+    In the case of Elasticsearch, the `service.node.name` could contain the unique
+    node name within the Elasticsearch cluster. In cases where the service doesn''t
+    have the concept of a node name, the host name or container name can be used to
+    distinguish running instances that make up this service. If those do not provide
+    uniqueness (e.g. multiple instances of the service running on the same host) -
+    the node name can be manually set.'
+  example: instance-0000000016
+  flat_name: service.origin.node.name
+  ignore_above: 1024
+  level: extended
+  name: node.name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service node.
+  type: keyword
+service.origin.state:
+  dashed_name: service-origin-state
+  description: Current state of the service.
+  flat_name: service.origin.state
+  ignore_above: 1024
+  level: core
+  name: state
+  normalize: []
+  original_fieldset: service
+  short: Current state of the service.
+  type: keyword
+service.origin.type:
+  dashed_name: service-origin-type
+  description: 'The type of the service data is collected from.
+
+    The type can be used to group and correlate logs and metrics from one service
+    type.
+
+    Example: If logs or metrics are collected from Elasticsearch, `service.type` would
+    be `elasticsearch`.'
+  example: elasticsearch
+  flat_name: service.origin.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  original_fieldset: service
+  short: The type of the service.
+  type: keyword
+service.origin.version:
+  dashed_name: service-origin-version
+  description: 'Version of the service the data was collected from.
+
+    This allows to look at a data set only for a specific version of a service.'
+  example: 3.2.4
+  flat_name: service.origin.version
+  ignore_above: 1024
+  level: core
+  name: version
+  normalize: []
+  original_fieldset: service
+  short: Version of the service.
+  type: keyword
 service.state:
   dashed_name: service-state
   description: Current state of the service.
@@ -8128,6 +8627,157 @@ service.state:
   name: state
   normalize: []
   short: Current state of the service.
+  type: keyword
+service.target.address:
+  dashed_name: service-target-address
+  description: 'Address where data about this service was collected from.
+
+    This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+    path (sockets).'
+  example: 172.26.0.2:5432
+  flat_name: service.target.address
+  ignore_above: 1024
+  level: extended
+  name: address
+  normalize: []
+  original_fieldset: service
+  short: Address of this service.
+  type: keyword
+service.target.environment:
+  beta: This field is beta and subject to change.
+  dashed_name: service-target-environment
+  description: 'Identifies the environment where the service is running.
+
+    If the same service runs in different environments (production, staging, QA, development,
+    etc.), the environment can identify other instances of the same service. Can also
+    group services and applications from the same environment.'
+  example: production
+  flat_name: service.target.environment
+  ignore_above: 1024
+  level: extended
+  name: environment
+  normalize: []
+  original_fieldset: service
+  short: Environment of the service.
+  type: keyword
+service.target.ephemeral_id:
+  dashed_name: service-target-ephemeral-id
+  description: 'Ephemeral identifier of this service (if one exists).
+
+    This id normally changes across restarts, but `service.id` does not.'
+  example: 8a4f500f
+  flat_name: service.target.ephemeral_id
+  ignore_above: 1024
+  level: extended
+  name: ephemeral_id
+  normalize: []
+  original_fieldset: service
+  short: Ephemeral identifier of this service.
+  type: keyword
+service.target.id:
+  dashed_name: service-target-id
+  description: 'Unique identifier of the running service. If the service is comprised
+    of many nodes, the `service.id` should be the same for all nodes.
+
+    This id should uniquely identify the service. This makes it possible to correlate
+    logs and metrics for one specific service, no matter which particular node emitted
+    the event.
+
+    Note that if you need to see the events from one specific host of the service,
+    you should filter on that `host.name` or `host.id` instead.'
+  example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+  flat_name: service.target.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: service
+  short: Unique identifier of the running service.
+  type: keyword
+service.target.name:
+  dashed_name: service-target-name
+  description: 'Name of the service data is collected from.
+
+    The name of the service is normally user given. This allows for distributed services
+    that run on multiple hosts to correlate the related instances based on the name.
+
+    In the case of Elasticsearch the `service.name` could contain the cluster name.
+    For Beats the `service.name` is by default a copy of the `service.type` field
+    if no name is specified.'
+  example: elasticsearch-metrics
+  flat_name: service.target.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service.
+  type: keyword
+service.target.node.name:
+  dashed_name: service-target-node-name
+  description: 'Name of a service node.
+
+    This allows for two nodes of the same service running on the same host to be differentiated.
+    Therefore, `service.node.name` should typically be unique across nodes of a given
+    service.
+
+    In the case of Elasticsearch, the `service.node.name` could contain the unique
+    node name within the Elasticsearch cluster. In cases where the service doesn''t
+    have the concept of a node name, the host name or container name can be used to
+    distinguish running instances that make up this service. If those do not provide
+    uniqueness (e.g. multiple instances of the service running on the same host) -
+    the node name can be manually set.'
+  example: instance-0000000016
+  flat_name: service.target.node.name
+  ignore_above: 1024
+  level: extended
+  name: node.name
+  normalize: []
+  original_fieldset: service
+  short: Name of the service node.
+  type: keyword
+service.target.state:
+  dashed_name: service-target-state
+  description: Current state of the service.
+  flat_name: service.target.state
+  ignore_above: 1024
+  level: core
+  name: state
+  normalize: []
+  original_fieldset: service
+  short: Current state of the service.
+  type: keyword
+service.target.type:
+  dashed_name: service-target-type
+  description: 'The type of the service data is collected from.
+
+    The type can be used to group and correlate logs and metrics from one service
+    type.
+
+    Example: If logs or metrics are collected from Elasticsearch, `service.type` would
+    be `elasticsearch`.'
+  example: elasticsearch
+  flat_name: service.target.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  original_fieldset: service
+  short: The type of the service.
+  type: keyword
+service.target.version:
+  dashed_name: service-target-version
+  description: 'Version of the service the data was collected from.
+
+    This allows to look at a data set only for a specific version of a service.'
+  example: 3.2.4
+  flat_name: service.target.version
+  ignore_above: 1024
+  level: core
+  name: version
+  normalize: []
+  original_fieldset: service
+  short: Version of the service.
   type: keyword
 service.type:
   dashed_name: service-type

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1164,7 +1164,17 @@ cloud:
     its host, the cloud info contains the data about this machine. If Metricbeat runs
     on a remote machine outside the cloud and fetches data from a service running
     in the cloud, the field contains cloud data from the machine the service is running
-    on.'
+    on.
+
+    The cloud fields may be self-nested under cloud.origin.* and cloud.target.*  to
+    describe origin or target service''s cloud information in the context of  incoming
+    or outgoing requests, respectively. However, the fieldsets  cloud.origin.* and
+    cloud.target.* must not be confused with the root cloud  fieldset that is used
+    to describe the cloud context of the actual service  under observation. The fieldset
+    cloud.origin.* may only be used in the  context of incoming requests or events
+    to provide the originating service''s  cloud information. The fieldset cloud.target.*
+    may only be used in the  context of outgoing requests or events to describe the
+    target service''s  cloud information.'
   group: 2
   name: cloud
   nestings:
@@ -1177,20 +1187,26 @@ cloud:
       at: cloud
       beta: Reusing the `cloud` fields in this location is currently considered beta.
       full: cloud.origin
+      short_override: Provides the cloud information of the origin entity in case
+        of an incoming request or event.
     - as: target
       at: cloud
       beta: Reusing the `cloud` fields in this location is currently considered beta.
       full: cloud.target
+      short_override: Provides the cloud information of the target entity in case
+        of an outgoing request or event.
     top_level: true
   reused_here:
   - beta: Reusing the `cloud` fields in this location is currently considered beta.
     full: cloud.origin
     schema_name: cloud
-    short: Fields about the cloud resource.
+    short: Provides the cloud information of the origin entity in case of an incoming
+      request or event.
   - beta: Reusing the `cloud` fields in this location is currently considered beta.
     full: cloud.target
     schema_name: cloud
-    short: Fields about the cloud resource.
+    short: Provides the cloud information of the target entity in case of an outgoing
+      request or event.
   short: Fields about the cloud resource.
   title: Cloud
   type: group
@@ -10532,6 +10548,14 @@ service:
       normalize: []
       short: Version of the service.
       type: keyword
+  footnote: The service fields may be self-nested under service.origin.* and service.target.*  to
+    describe origin or target services in the context of incoming or outgoing requests,  respectively.
+    However, the fieldsets service.origin.* and service.target.* must not be confused
+    with  the root service fieldset that is used to describe the actual service under
+    observation. The fieldset service.origin.* may only be used in the context of
+    incoming requests or  events to describe the originating service of the request.
+    The fieldset service.target.*  may only be used in the context of outgoing requests
+    or events to describe the target  service of the request.
   group: 2
   name: service
   nestings:
@@ -10545,21 +10569,25 @@ service:
       beta: Reusing the `service` fields in this location is currently considered
         beta.
       full: service.origin
+      short_override: Describes the origin service in case of an incoming request
+        or event.
     - as: target
       at: service
       beta: Reusing the `service` fields in this location is currently considered
         beta.
       full: service.target
+      short_override: Describes the target service in case of an outgoing request
+        or event.
     top_level: true
   reused_here:
   - beta: Reusing the `service` fields in this location is currently considered beta.
     full: service.origin
     schema_name: service
-    short: Fields describing the service for or from which the data was collected.
+    short: Describes the origin service in case of an incoming request or event.
   - beta: Reusing the `service` fields in this location is currently considered beta.
     full: service.target
     schema_name: service
-    short: Fields describing the service for or from which the data was collected.
+    short: Describes the target service in case of an outgoing request or event.
   short: Fields describing the service for or from which the data was collected.
   title: Service
   type: group

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -804,6 +804,152 @@ cloud:
       normalize: []
       short: Machine type of the host machine.
       type: keyword
+    cloud.origin.account.id:
+      dashed_name: cloud-origin-account-id
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      flat_name: cloud.origin.account.id
+      ignore_above: 1024
+      level: extended
+      name: account.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account or organization id.
+      type: keyword
+    cloud.origin.account.name:
+      dashed_name: cloud-origin-account-name
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      flat_name: cloud.origin.account.name
+      ignore_above: 1024
+      level: extended
+      name: account.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account name.
+      type: keyword
+    cloud.origin.availability_zone:
+      dashed_name: cloud-origin-availability-zone
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      flat_name: cloud.origin.availability_zone
+      ignore_above: 1024
+      level: extended
+      name: availability_zone
+      normalize: []
+      original_fieldset: cloud
+      short: Availability zone in which this host, resource, or service is located.
+      type: keyword
+    cloud.origin.instance.id:
+      dashed_name: cloud-origin-instance-id
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      flat_name: cloud.origin.instance.id
+      ignore_above: 1024
+      level: extended
+      name: instance.id
+      normalize: []
+      original_fieldset: cloud
+      short: Instance ID of the host machine.
+      type: keyword
+    cloud.origin.instance.name:
+      dashed_name: cloud-origin-instance-name
+      description: Instance name of the host machine.
+      flat_name: cloud.origin.instance.name
+      ignore_above: 1024
+      level: extended
+      name: instance.name
+      normalize: []
+      original_fieldset: cloud
+      short: Instance name of the host machine.
+      type: keyword
+    cloud.origin.machine.type:
+      dashed_name: cloud-origin-machine-type
+      description: Machine type of the host machine.
+      example: t2.medium
+      flat_name: cloud.origin.machine.type
+      ignore_above: 1024
+      level: extended
+      name: machine.type
+      normalize: []
+      original_fieldset: cloud
+      short: Machine type of the host machine.
+      type: keyword
+    cloud.origin.project.id:
+      dashed_name: cloud-origin-project-id
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      flat_name: cloud.origin.project.id
+      ignore_above: 1024
+      level: extended
+      name: project.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project id.
+      type: keyword
+    cloud.origin.project.name:
+      dashed_name: cloud-origin-project-name
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      flat_name: cloud.origin.project.name
+      ignore_above: 1024
+      level: extended
+      name: project.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project name.
+      type: keyword
+    cloud.origin.provider:
+      dashed_name: cloud-origin-provider
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      flat_name: cloud.origin.provider
+      ignore_above: 1024
+      level: extended
+      name: provider
+      normalize: []
+      original_fieldset: cloud
+      short: Name of the cloud provider.
+      type: keyword
+    cloud.origin.region:
+      dashed_name: cloud-origin-region
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      flat_name: cloud.origin.region
+      ignore_above: 1024
+      level: extended
+      name: region
+      normalize: []
+      original_fieldset: cloud
+      short: Region in which this host, resource, or service is located.
+      type: keyword
+    cloud.origin.service.name:
+      dashed_name: cloud-origin-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.origin.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud service name.
+      type: keyword
     cloud.project.id:
       dashed_name: cloud-project-id
       description: 'The cloud project identifier.
@@ -868,6 +1014,152 @@ cloud:
       normalize: []
       short: The cloud service name.
       type: keyword
+    cloud.target.account.id:
+      dashed_name: cloud-target-account-id
+      description: 'The cloud account or organization id used to identify different
+        entities in a multi-tenant environment.
+
+        Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.'
+      example: 666777888999
+      flat_name: cloud.target.account.id
+      ignore_above: 1024
+      level: extended
+      name: account.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account or organization id.
+      type: keyword
+    cloud.target.account.name:
+      dashed_name: cloud-target-account-name
+      description: 'The cloud account name or alias used to identify different entities
+        in a multi-tenant environment.
+
+        Examples: AWS account name, Google Cloud ORG display name.'
+      example: elastic-dev
+      flat_name: cloud.target.account.name
+      ignore_above: 1024
+      level: extended
+      name: account.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud account name.
+      type: keyword
+    cloud.target.availability_zone:
+      dashed_name: cloud-target-availability-zone
+      description: Availability zone in which this host, resource, or service is located.
+      example: us-east-1c
+      flat_name: cloud.target.availability_zone
+      ignore_above: 1024
+      level: extended
+      name: availability_zone
+      normalize: []
+      original_fieldset: cloud
+      short: Availability zone in which this host, resource, or service is located.
+      type: keyword
+    cloud.target.instance.id:
+      dashed_name: cloud-target-instance-id
+      description: Instance ID of the host machine.
+      example: i-1234567890abcdef0
+      flat_name: cloud.target.instance.id
+      ignore_above: 1024
+      level: extended
+      name: instance.id
+      normalize: []
+      original_fieldset: cloud
+      short: Instance ID of the host machine.
+      type: keyword
+    cloud.target.instance.name:
+      dashed_name: cloud-target-instance-name
+      description: Instance name of the host machine.
+      flat_name: cloud.target.instance.name
+      ignore_above: 1024
+      level: extended
+      name: instance.name
+      normalize: []
+      original_fieldset: cloud
+      short: Instance name of the host machine.
+      type: keyword
+    cloud.target.machine.type:
+      dashed_name: cloud-target-machine-type
+      description: Machine type of the host machine.
+      example: t2.medium
+      flat_name: cloud.target.machine.type
+      ignore_above: 1024
+      level: extended
+      name: machine.type
+      normalize: []
+      original_fieldset: cloud
+      short: Machine type of the host machine.
+      type: keyword
+    cloud.target.project.id:
+      dashed_name: cloud-target-project-id
+      description: 'The cloud project identifier.
+
+        Examples: Google Cloud Project id, Azure Project id.'
+      example: my-project
+      flat_name: cloud.target.project.id
+      ignore_above: 1024
+      level: extended
+      name: project.id
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project id.
+      type: keyword
+    cloud.target.project.name:
+      dashed_name: cloud-target-project-name
+      description: 'The cloud project name.
+
+        Examples: Google Cloud Project name, Azure Project name.'
+      example: my project
+      flat_name: cloud.target.project.name
+      ignore_above: 1024
+      level: extended
+      name: project.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud project name.
+      type: keyword
+    cloud.target.provider:
+      dashed_name: cloud-target-provider
+      description: Name of the cloud provider. Example values are aws, azure, gcp,
+        or digitalocean.
+      example: aws
+      flat_name: cloud.target.provider
+      ignore_above: 1024
+      level: extended
+      name: provider
+      normalize: []
+      original_fieldset: cloud
+      short: Name of the cloud provider.
+      type: keyword
+    cloud.target.region:
+      dashed_name: cloud-target-region
+      description: Region in which this host, resource, or service is located.
+      example: us-east-1
+      flat_name: cloud.target.region
+      ignore_above: 1024
+      level: extended
+      name: region
+      normalize: []
+      original_fieldset: cloud
+      short: Region in which this host, resource, or service is located.
+      type: keyword
+    cloud.target.service.name:
+      dashed_name: cloud-target-service-name
+      description: 'The cloud service name is intended to distinguish services running
+        on different platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs
+        App Engine, Azure VM vs App Server.
+
+        Examples: app engine, app service, cloud run, fargate, lambda.'
+      example: lambda
+      flat_name: cloud.target.service.name
+      ignore_above: 1024
+      level: extended
+      name: service.name
+      normalize: []
+      original_fieldset: cloud
+      short: The cloud service name.
+      type: keyword
   footnote: 'Examples: If Metricbeat is running on an EC2 host and fetches data from
     its host, the cloud info contains the data about this machine. If Metricbeat runs
     on a remote machine outside the cloud and fetches data from a service running
@@ -875,7 +1167,30 @@ cloud:
     on.'
   group: 2
   name: cloud
+  nestings:
+  - cloud.origin
+  - cloud.target
   prefix: cloud.
+  reusable:
+    expected:
+    - as: origin
+      at: cloud
+      beta: Reusing the `cloud` fields in this location is currently considered beta.
+      full: cloud.origin
+    - as: target
+      at: cloud
+      beta: Reusing the `cloud` fields in this location is currently considered beta.
+      full: cloud.target
+    top_level: true
+  reused_here:
+  - beta: Reusing the `cloud` fields in this location is currently considered beta.
+    full: cloud.origin
+    schema_name: cloud
+    short: Fields about the cloud resource.
+  - beta: Reusing the `cloud` fields in this location is currently considered beta.
+    full: cloud.target
+    schema_name: cloud
+    short: Fields about the cloud resource.
   short: Fields about the cloud resource.
   title: Cloud
   type: group
@@ -3486,6 +3801,72 @@ event:
   prefix: event.
   short: Fields breaking down the event details.
   title: Event
+  type: group
+faas:
+  beta: These fields are in beta and are subject to change.
+  description: TBD description
+  fields:
+    faas.coldstart:
+      dashed_name: faas-coldstart
+      description: Boolean value indicating a cold start of a function.
+      flat_name: faas.coldstart
+      level: extended
+      name: coldstart
+      normalize: []
+      short: Boolean value indicating a cold start of a function.
+      type: boolean
+    faas.execution:
+      dashed_name: faas-execution
+      description: The execution ID of the current function execution.
+      example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
+      flat_name: faas.execution
+      ignore_above: 1024
+      level: extended
+      name: execution
+      normalize: []
+      short: The execution ID of the current function execution.
+      type: keyword
+    faas.trigger:
+      dashed_name: faas-trigger
+      description: Details about the function trigger.
+      flat_name: faas.trigger
+      level: extended
+      name: trigger
+      normalize: []
+      short: Details about the function trigger.
+      type: nested
+    faas.trigger.request_id:
+      dashed_name: faas-trigger-request-id
+      description: The ID of the trigger request , message, event, etc.
+      example: 123456789
+      flat_name: faas.trigger.request_id
+      ignore_above: 1024
+      level: extended
+      name: trigger.request_id
+      normalize: []
+      short: The ID of the trigger request , message, event, etc.
+      type: keyword
+    faas.trigger.type:
+      allowed_values:
+      - name: http
+      - name: pubsub
+      - name: datasource
+      - name: timer
+      - name: other
+      dashed_name: faas-trigger-type
+      description: The trigger for the cuntion execution.
+      flat_name: faas.trigger.type
+      ignore_above: 1024
+      level: extended
+      name: trigger.type
+      normalize: []
+      short: The trigger for the cuntion execution.
+      type: keyword
+  group: 2
+  name: faas
+  prefix: faas.
+  short: Fields describing functions as a service.
+  title: FaaS
   type: group
 file:
   description: 'A file is defined as a set of information that has been created on,
@@ -9807,6 +10188,158 @@ service:
       normalize: []
       short: Name of the service node.
       type: keyword
+    service.origin.address:
+      dashed_name: service-origin-address
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      flat_name: service.origin.address
+      ignore_above: 1024
+      level: extended
+      name: address
+      normalize: []
+      original_fieldset: service
+      short: Address of this service.
+      type: keyword
+    service.origin.environment:
+      beta: This field is beta and subject to change.
+      dashed_name: service-origin-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.origin.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      original_fieldset: service
+      short: Environment of the service.
+      type: keyword
+    service.origin.ephemeral_id:
+      dashed_name: service-origin-ephemeral-id
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      flat_name: service.origin.ephemeral_id
+      ignore_above: 1024
+      level: extended
+      name: ephemeral_id
+      normalize: []
+      original_fieldset: service
+      short: Ephemeral identifier of this service.
+      type: keyword
+    service.origin.id:
+      dashed_name: service-origin-id
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      flat_name: service.origin.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: service
+      short: Unique identifier of the running service.
+      type: keyword
+    service.origin.name:
+      dashed_name: service-origin-name
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      flat_name: service.origin.name
+      ignore_above: 1024
+      level: core
+      name: name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service.
+      type: keyword
+    service.origin.node.name:
+      dashed_name: service-origin-node-name
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      flat_name: service.origin.node.name
+      ignore_above: 1024
+      level: extended
+      name: node.name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service node.
+      type: keyword
+    service.origin.state:
+      dashed_name: service-origin-state
+      description: Current state of the service.
+      flat_name: service.origin.state
+      ignore_above: 1024
+      level: core
+      name: state
+      normalize: []
+      original_fieldset: service
+      short: Current state of the service.
+      type: keyword
+    service.origin.type:
+      dashed_name: service-origin-type
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      flat_name: service.origin.type
+      ignore_above: 1024
+      level: core
+      name: type
+      normalize: []
+      original_fieldset: service
+      short: The type of the service.
+      type: keyword
+    service.origin.version:
+      dashed_name: service-origin-version
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      flat_name: service.origin.version
+      ignore_above: 1024
+      level: core
+      name: version
+      normalize: []
+      original_fieldset: service
+      short: Version of the service.
+      type: keyword
     service.state:
       dashed_name: service-state
       description: Current state of the service.
@@ -9816,6 +10349,158 @@ service:
       name: state
       normalize: []
       short: Current state of the service.
+      type: keyword
+    service.target.address:
+      dashed_name: service-target-address
+      description: 'Address where data about this service was collected from.
+
+        This should be a URI, network address (ipv4:port or [ipv6]:port) or a resource
+        path (sockets).'
+      example: 172.26.0.2:5432
+      flat_name: service.target.address
+      ignore_above: 1024
+      level: extended
+      name: address
+      normalize: []
+      original_fieldset: service
+      short: Address of this service.
+      type: keyword
+    service.target.environment:
+      beta: This field is beta and subject to change.
+      dashed_name: service-target-environment
+      description: 'Identifies the environment where the service is running.
+
+        If the same service runs in different environments (production, staging, QA,
+        development, etc.), the environment can identify other instances of the same
+        service. Can also group services and applications from the same environment.'
+      example: production
+      flat_name: service.target.environment
+      ignore_above: 1024
+      level: extended
+      name: environment
+      normalize: []
+      original_fieldset: service
+      short: Environment of the service.
+      type: keyword
+    service.target.ephemeral_id:
+      dashed_name: service-target-ephemeral-id
+      description: 'Ephemeral identifier of this service (if one exists).
+
+        This id normally changes across restarts, but `service.id` does not.'
+      example: 8a4f500f
+      flat_name: service.target.ephemeral_id
+      ignore_above: 1024
+      level: extended
+      name: ephemeral_id
+      normalize: []
+      original_fieldset: service
+      short: Ephemeral identifier of this service.
+      type: keyword
+    service.target.id:
+      dashed_name: service-target-id
+      description: 'Unique identifier of the running service. If the service is comprised
+        of many nodes, the `service.id` should be the same for all nodes.
+
+        This id should uniquely identify the service. This makes it possible to correlate
+        logs and metrics for one specific service, no matter which particular node
+        emitted the event.
+
+        Note that if you need to see the events from one specific host of the service,
+        you should filter on that `host.name` or `host.id` instead.'
+      example: d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6
+      flat_name: service.target.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: service
+      short: Unique identifier of the running service.
+      type: keyword
+    service.target.name:
+      dashed_name: service-target-name
+      description: 'Name of the service data is collected from.
+
+        The name of the service is normally user given. This allows for distributed
+        services that run on multiple hosts to correlate the related instances based
+        on the name.
+
+        In the case of Elasticsearch the `service.name` could contain the cluster
+        name. For Beats the `service.name` is by default a copy of the `service.type`
+        field if no name is specified.'
+      example: elasticsearch-metrics
+      flat_name: service.target.name
+      ignore_above: 1024
+      level: core
+      name: name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service.
+      type: keyword
+    service.target.node.name:
+      dashed_name: service-target-node-name
+      description: 'Name of a service node.
+
+        This allows for two nodes of the same service running on the same host to
+        be differentiated. Therefore, `service.node.name` should typically be unique
+        across nodes of a given service.
+
+        In the case of Elasticsearch, the `service.node.name` could contain the unique
+        node name within the Elasticsearch cluster. In cases where the service doesn''t
+        have the concept of a node name, the host name or container name can be used
+        to distinguish running instances that make up this service. If those do not
+        provide uniqueness (e.g. multiple instances of the service running on the
+        same host) - the node name can be manually set.'
+      example: instance-0000000016
+      flat_name: service.target.node.name
+      ignore_above: 1024
+      level: extended
+      name: node.name
+      normalize: []
+      original_fieldset: service
+      short: Name of the service node.
+      type: keyword
+    service.target.state:
+      dashed_name: service-target-state
+      description: Current state of the service.
+      flat_name: service.target.state
+      ignore_above: 1024
+      level: core
+      name: state
+      normalize: []
+      original_fieldset: service
+      short: Current state of the service.
+      type: keyword
+    service.target.type:
+      dashed_name: service-target-type
+      description: 'The type of the service data is collected from.
+
+        The type can be used to group and correlate logs and metrics from one service
+        type.
+
+        Example: If logs or metrics are collected from Elasticsearch, `service.type`
+        would be `elasticsearch`.'
+      example: elasticsearch
+      flat_name: service.target.type
+      ignore_above: 1024
+      level: core
+      name: type
+      normalize: []
+      original_fieldset: service
+      short: The type of the service.
+      type: keyword
+    service.target.version:
+      dashed_name: service-target-version
+      description: 'Version of the service the data was collected from.
+
+        This allows to look at a data set only for a specific version of a service.'
+      example: 3.2.4
+      flat_name: service.target.version
+      ignore_above: 1024
+      level: core
+      name: version
+      normalize: []
+      original_fieldset: service
+      short: Version of the service.
       type: keyword
     service.type:
       dashed_name: service-type
@@ -9849,7 +10534,32 @@ service:
       type: keyword
   group: 2
   name: service
+  nestings:
+  - service.origin
+  - service.target
   prefix: service.
+  reusable:
+    expected:
+    - as: origin
+      at: service
+      beta: Reusing the `service` fields in this location is currently considered
+        beta.
+      full: service.origin
+    - as: target
+      at: service
+      beta: Reusing the `service` fields in this location is currently considered
+        beta.
+      full: service.target
+    top_level: true
+  reused_here:
+  - beta: Reusing the `service` fields in this location is currently considered beta.
+    full: service.origin
+    schema_name: service
+    short: Fields describing the service for or from which the data was collected.
+  - beta: Reusing the `service` fields in this location is currently considered beta.
+    full: service.target
+    schema_name: service
+    short: Fields describing the service for or from which the data was collected.
   short: Fields describing the service for or from which the data was collected.
   title: Service
   type: group

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -271,6 +271,74 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
             "project": {
               "properties": {
                 "id": {
@@ -296,6 +364,74 @@
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                }
+              }
+            },
+            "target": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }
@@ -846,6 +982,30 @@
             "url": {
               "ignore_above": 1024,
               "type": "keyword"
+            }
+          }
+        },
+        "faas": {
+          "properties": {
+            "coldstart": {
+              "type": "boolean"
+            },
+            "execution": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "trigger": {
+              "properties": {
+                "request_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
             }
           }
         },
@@ -2924,9 +3084,97 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "state": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/7/template.json
+++ b/generated/elasticsearch/7/template.json
@@ -267,6 +267,74 @@
               }
             }
           },
+          "origin": {
+            "properties": {
+              "account": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "availability_zone": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "instance": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "machine": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "project": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "provider": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "service": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          },
           "project": {
             "properties": {
               "id": {
@@ -292,6 +360,74 @@
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              }
+            }
+          },
+          "target": {
+            "properties": {
+              "account": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "availability_zone": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "instance": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "machine": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "project": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "provider": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "service": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }
@@ -831,6 +967,30 @@
           "url": {
             "ignore_above": 1024,
             "type": "keyword"
+          }
+        }
+      },
+      "faas": {
+        "properties": {
+          "coldstart": {
+            "type": "boolean"
+          },
+          "execution": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "trigger": {
+            "properties": {
+              "request_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            },
+            "type": "nested"
           }
         }
       },
@@ -2881,9 +3041,97 @@
               }
             }
           },
+          "origin": {
+            "properties": {
+              "address": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "environment": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ephemeral_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "node": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "state": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "state": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "target": {
+            "properties": {
+              "address": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "environment": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "ephemeral_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "node": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "state": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           },
           "type": {
             "ignore_above": 1024,

--- a/generated/elasticsearch/component/cloud.json
+++ b/generated/elasticsearch/component/cloud.json
@@ -44,6 +44,74 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
             "project": {
               "properties": {
                 "id": {
@@ -69,6 +137,74 @@
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                }
+              }
+            },
+            "target": {
+              "properties": {
+                "account": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "availability_zone": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "instance": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "machine": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "project": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "provider": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "service": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/generated/elasticsearch/component/faas.json
+++ b/generated/elasticsearch/component/faas.json
@@ -1,0 +1,36 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-faas.html",
+    "ecs_version": "8.0.0-dev"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "faas": {
+          "properties": {
+            "coldstart": {
+              "type": "boolean"
+            },
+            "execution": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "trigger": {
+              "properties": {
+                "request_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "nested"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/generated/elasticsearch/component/service.json
+++ b/generated/elasticsearch/component/service.json
@@ -36,9 +36,97 @@
                 }
               }
             },
+            "origin": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "state": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "target": {
+              "properties": {
+                "address": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "environment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "ephemeral_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "node": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "state": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "version": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "type": {
               "ignore_above": 1024,

--- a/generated/elasticsearch/template.json
+++ b/generated/elasticsearch/template.json
@@ -16,6 +16,7 @@
     "ecs_8.0.0-dev_ecs",
     "ecs_8.0.0-dev_error",
     "ecs_8.0.0-dev_event",
+    "ecs_8.0.0-dev_faas",
     "ecs_8.0.0-dev_file",
     "ecs_8.0.0-dev_group",
     "ecs_8.0.0-dev_host",

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -12,6 +12,15 @@
     runs on a remote machine outside the cloud and fetches data from a service
     running in the cloud, the field contains cloud data from the machine the
     service is running on.
+  reusable:
+    top_level: true
+    expected:
+      - at: cloud
+        as: origin
+        beta: Reusing the `cloud` fields in this location is currently considered beta.
+      - at: cloud
+        as: target
+        beta: Reusing the `cloud` fields in this location is currently considered beta.
   type: group
   fields:
     - name: provider

--- a/schemas/cloud.yml
+++ b/schemas/cloud.yml
@@ -12,15 +12,28 @@
     runs on a remote machine outside the cloud and fetches data from a service
     running in the cloud, the field contains cloud data from the machine the
     service is running on.
+
+    The cloud fields may be self-nested under cloud.origin.* and cloud.target.* 
+    to describe origin or target service's cloud information in the context of 
+    incoming or outgoing requests, respectively. However, the fieldsets 
+    cloud.origin.* and cloud.target.* must not be confused with the root cloud 
+    fieldset that is used to describe the cloud context of the actual service 
+    under observation. The fieldset cloud.origin.* may only be used in the 
+    context of incoming requests or events to provide the originating service's 
+    cloud information. The fieldset cloud.target.* may only be used in the 
+    context of outgoing requests or events to describe the target service's 
+    cloud information.
   reusable:
     top_level: true
     expected:
       - at: cloud
         as: origin
         beta: Reusing the `cloud` fields in this location is currently considered beta.
+        short_override: Provides the cloud information of the origin entity in case of an incoming request or event.
       - at: cloud
         as: target
         beta: Reusing the `cloud` fields in this location is currently considered beta.
+        short_override: Provides the cloud information of the target entity in case of an outgoing request or event.
   type: group
   fields:
     - name: provider

--- a/schemas/faas.yml
+++ b/schemas/faas.yml
@@ -1,0 +1,44 @@
+- name: faas
+  group: 2
+  title: FaaS
+  short: Fields describing functions as a service.
+  description: >
+    TBD description
+  beta: >
+    These fields are in beta and are subject to change.
+  type: group
+  fields:
+    - name: coldstart
+      description: > 
+        Boolean value indicating a cold start of a function.
+      type: boolean
+      level: extended
+    - name: execution
+      description: > 
+        The execution ID of the current function execution.
+      type: keyword
+      level: extended
+      example: "af9d5aa4-a685-4c5f-a22b-444f80b3cc28"
+    - name: trigger
+      level: extended
+      type: nested
+      description: >
+        Details about the function trigger.
+    - name: trigger.type
+      level: extended
+      type: keyword
+      description: >
+        The trigger for the cuntion execution.
+      allowed_values:
+        - name: http
+        - name: pubsub
+        - name: datasource
+        - name: timer
+        - name: other
+    - name: trigger.request_id
+      level: extended
+      type: keyword
+      description: >
+        The ID of the trigger request , message, event, etc.
+      example: 123456789
+      

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -8,6 +8,15 @@
 
     These fields help you find and correlate logs for a specific
     service and version.
+  reusable:
+    top_level: true
+    expected:
+      - at: service
+        as: origin
+        beta: Reusing the `service` fields in this location is currently considered beta.
+      - at: service
+        as: target
+        beta: Reusing the `service` fields in this location is currently considered beta.
   type: group
   fields:
 

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -8,15 +8,27 @@
 
     These fields help you find and correlate logs for a specific
     service and version.
+  footnote: >
+    The service fields may be self-nested under service.origin.* and service.target.* 
+    to describe origin or target services in the context of incoming or outgoing requests, 
+    respectively.
+    However, the fieldsets service.origin.* and service.target.* must not be confused with 
+    the root service fieldset that is used to describe the actual service under observation.
+    The fieldset service.origin.* may only be used in the context of incoming requests or 
+    events to describe the originating service of the request. The fieldset service.target.* 
+    may only be used in the context of outgoing requests or events to describe the target 
+    service of the request.
   reusable:
     top_level: true
     expected:
       - at: service
         as: origin
         beta: Reusing the `service` fields in this location is currently considered beta.
+        short_override: Describes the origin service in case of an incoming request or event.
       - at: service
         as: target
         beta: Reusing the `service` fields in this location is currently considered beta.
+        short_override: Describes the target service in case of an outgoing request or event.
   type: group
   fields:
 


### PR DESCRIPTION
Implements https://github.com/elastic/ecs/pull/1594

- Adds new `faas` fieldset and fields as beta
- Allows for nesting of `cloud.*` and `service.*` under `_.origin.*` and `_.target.*` as beta