### PR TITLE
docs: fix link

### DIFF
--- a/docs/usage/service.asciidoc
+++ b/docs/usage/service.asciidoc
@@ -40,7 +40,7 @@ An example for this use case is a log entry being recorded for a particular serv
 ====== Describing external services in an invocation relationship
 
 Multiple services can be in an invocation relationship.
-Where it is possible to apply {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] on all the involved services
+Where it is possible to apply https://www.elastic.co/guide/en/apm/guide/current/apm-distributed-tracing.html[distributed tracing] on all the involved services
 describe the individual services <<ecs-service-usage-service-at-root,using root-level service fields>>
 and use the <<ecs-related,tracing fields>> to represent the invocation relationship.
 


### PR DESCRIPTION
Fixes an external link to the APM Guide.