### PR TITLE
docs: fix doc build errors

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,7 +2,7 @@
 :doctype: book
 :ecs: ECS
 
-include::{asciidoc-dir}/../../shared/versions/stack/7.x.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/7.16.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[ecs-reference]]


### PR DESCRIPTION
1.2 docs are hardcoded to the stack 7.x branch which no longer exists. This PR points them to 7.16 instead.