### PR TITLE
Add temporary workflow to sync master to main branch

### DIFF
--- a/.github/workflows/sync-main-branch.yml
+++ b/.github/workflows/sync-main-branch.yml
@@ -1,0 +1,27 @@
+# Synchronize all pushes to 'master' branch with 'main' branch to facilitate migration
+name: "Sync main branch"
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync_latest_from_upstream:
+    runs-on: ubuntu-latest
+    name: Sync latest commits from master branch
+    if: github.repository == 'elastic/ecs'
+
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.0
+        with:
+          target_sync_branch: main
+          target_repo_token: ${{ secrets.GH_ACTIONS_TOKEN }}
+          upstream_sync_branch: master
+          upstream_sync_repo: elastic/ecs


### PR DESCRIPTION
Keep `main` in sync with `master` branch during default branch rename migration.
