### PR TITLE
[1.12] [Bugfix] Add `flattened` fallback to `object` see issue #1649 (#1653)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -33,6 +33,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Add `object` as fallback for `flattened` type. #1653 
+
 #### Added
 
 #### Improvements

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -930,7 +930,7 @@
                   "type": "date"
                 },
                 "exports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "header": {
                   "properties": {
@@ -968,7 +968,7 @@
                   }
                 },
                 "imports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "sections": {
                   "properties": {
@@ -2149,7 +2149,7 @@
                   "type": "date"
                 },
                 "exports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "header": {
                   "properties": {
@@ -2187,7 +2187,7 @@
                   }
                 },
                 "imports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "sections": {
                   "properties": {
@@ -2375,7 +2375,7 @@
                       "type": "date"
                     },
                     "exports": {
-                      "type": "flattened"
+                      "type": "object"
                     },
                     "header": {
                       "properties": {
@@ -2413,7 +2413,7 @@
                       }
                     },
                     "imports": {
-                      "type": "flattened"
+                      "type": "object"
                     },
                     "sections": {
                       "properties": {
@@ -3323,7 +3323,7 @@
                               "type": "date"
                             },
                             "exports": {
-                              "type": "flattened"
+                              "type": "object"
                             },
                             "header": {
                               "properties": {
@@ -3361,7 +3361,7 @@
                               }
                             },
                             "imports": {
-                              "type": "flattened"
+                              "type": "object"
                             },
                             "sections": {
                               "properties": {
@@ -4131,7 +4131,7 @@
                           "type": "date"
                         },
                         "exports": {
-                          "type": "flattened"
+                          "type": "object"
                         },
                         "header": {
                           "properties": {
@@ -4169,7 +4169,7 @@
                           }
                         },
                         "imports": {
-                          "type": "flattened"
+                          "type": "object"
                         },
                         "sections": {
                           "properties": {

--- a/scripts/schema/oss.py
+++ b/scripts/schema/oss.py
@@ -16,7 +16,8 @@ TYPE_FALLBACKS = {
     'constant_keyword': 'keyword',
     'wildcard': 'keyword',
     'version': 'keyword',
-    'match_only_text': 'text'
+    'match_only_text': 'text',
+    'flattened': 'object'
 }
 
 


### PR DESCRIPTION
Backports the following commits to 1.12:
 - [Bugfix] Add `flattened` fallback to `object` see issue #1649 (#1653)