### PR TITLE
[1.11] [Bugfix] Add `flattened` fallback to `object` see issue #1649 (#1653)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Add `object` as fallback for `flattened` type. #1653 
+
 #### Added
 
 #### Improvements

--- a/generated/elasticsearch/6/template.json
+++ b/generated/elasticsearch/6/template.json
@@ -915,7 +915,7 @@
                   "type": "date"
                 },
                 "exports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "header": {
                   "properties": {
@@ -953,7 +953,7 @@
                   }
                 },
                 "imports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "sections": {
                   "properties": {
@@ -2123,7 +2123,7 @@
                   "type": "date"
                 },
                 "exports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "header": {
                   "properties": {
@@ -2161,7 +2161,7 @@
                   }
                 },
                 "imports": {
-                  "type": "flattened"
+                  "type": "object"
                 },
                 "sections": {
                   "properties": {
@@ -2339,7 +2339,7 @@
                       "type": "date"
                     },
                     "exports": {
-                      "type": "flattened"
+                      "type": "object"
                     },
                     "header": {
                       "properties": {
@@ -2377,7 +2377,7 @@
                       }
                     },
                     "imports": {
-                      "type": "flattened"
+                      "type": "object"
                     },
                     "sections": {
                       "properties": {
@@ -3269,7 +3269,7 @@
                               "type": "date"
                             },
                             "exports": {
-                              "type": "flattened"
+                              "type": "object"
                             },
                             "header": {
                               "properties": {
@@ -3307,7 +3307,7 @@
                               }
                             },
                             "imports": {
-                              "type": "flattened"
+                              "type": "object"
                             },
                             "sections": {
                               "properties": {
@@ -3960,7 +3960,7 @@
                           "type": "date"
                         },
                         "exports": {
-                          "type": "flattened"
+                          "type": "object"
                         },
                         "header": {
                           "properties": {
@@ -3998,7 +3998,7 @@
                           }
                         },
                         "imports": {
-                          "type": "flattened"
+                          "type": "object"
                         },
                         "sections": {
                           "properties": {

--- a/scripts/schema/oss.py
+++ b/scripts/schema/oss.py
@@ -15,7 +15,9 @@ from schema import visitor
 TYPE_FALLBACKS = {
     'constant_keyword': 'keyword',
     'wildcard': 'keyword',
-    'version': 'keyword'
+    'version': 'keyword',
+    'match_only_text': 'text',
+    'flattened': 'object'
 }
 
 


### PR DESCRIPTION
Backports the following commits to 1.11:
 - [Bugfix] Add `flattened` fallback to `object` see issue #1649 (#1653)