### PR TITLE
RFC 0028 Stage 1 - Add `cgroup.*` fields to experimental schema

### DIFF
--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -146,6 +146,56 @@
         default_field: false
       description: Organization name.
       example: Google LLC
+  - name: cgroup
+    title: Common cgroup metrics
+    group: 2
+    description: Fields related to control group (cgroup) metrics. Due to controller
+      changes between V1 and V2, many same or similar metrics will often appear under
+      different controller names. These fields are common to both cgroup versions.
+    type: group
+    default_field: true
+    fields:
+    - name: cpu.periods
+      level: extended
+      type: long
+      description: Number of period intervals that have elapsed.
+      example: 454839343
+      default_field: false
+    - name: cpu.throttled.us
+      level: extended
+      type: long
+      description: Microseconds of CPU throttled time.
+      example: 15000
+      default_field: false
+    - name: cpu.usage
+      level: extended
+      type: scaled_float
+      description: CPU usage, normalized by the CPU count.
+      scaling_factor: 1000
+      default_field: false
+    - name: memory.limit
+      level: extended
+      type: long
+      description: Memory limit within the cgroup.
+      example: 256
+      default_field: false
+    - name: memory.swap.usage
+      level: extended
+      type: long
+      description: The amount of cgroup memory in swap.
+      example: 5600
+      default_field: false
+    - name: memory.usage
+      level: extended
+      type: long
+      description: Memory usage in bytes
+      example: 25600
+      default_field: false
+    - name: version
+      level: extended
+      type: long
+      description: The cgroup version linked to the metrics
+      default_field: false
   - name: client
     title: Client
     group: 2

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -9,6 +9,13 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev+exp,true,agent,agent.name,keyword,core,,foo,Custom name of the agent.
 8.1.0-dev+exp,true,agent,agent.type,keyword,core,,filebeat,Type of the agent.
 8.1.0-dev+exp,true,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
+8.1.0-dev+exp,true,cgroup,cgroup.cpu.periods,long,extended,,454839343,Number of period intervals that have elapsed.
+8.1.0-dev+exp,true,cgroup,cgroup.cpu.throttled.us,long,extended,,15000,Microseconds of CPU throttled time.
+8.1.0-dev+exp,true,cgroup,cgroup.cpu.usage,scaled_float,extended,,,"CPU usage, normalized by the CPU count."
+8.1.0-dev+exp,true,cgroup,cgroup.memory.limit,long,extended,,256,Memory limit within the cgroup.
+8.1.0-dev+exp,true,cgroup,cgroup.memory.swap.usage,long,extended,,5600,The amount of cgroup memory in swap.
+8.1.0-dev+exp,true,cgroup,cgroup.memory.usage,long,extended,,25600,Memory usage in bytes
+8.1.0-dev+exp,true,cgroup,cgroup.version,long,extended,,,The cgroup version linked to the metrics
 8.1.0-dev+exp,true,client,client.address,keyword,extended,,,Client network address.
 8.1.0-dev+exp,true,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
 8.1.0-dev+exp,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -101,6 +101,75 @@ agent.version:
   normalize: []
   short: Version of the agent.
   type: keyword
+cgroup.cpu.periods:
+  dashed_name: cgroup-cpu-periods
+  description: Number of period intervals that have elapsed.
+  example: 454839343
+  flat_name: cgroup.cpu.periods
+  level: extended
+  name: cpu.periods
+  normalize: []
+  short: Number of period intervals that have elapsed.
+  type: long
+cgroup.cpu.throttled.us:
+  dashed_name: cgroup-cpu-throttled-us
+  description: Microseconds of CPU throttled time.
+  example: 15000
+  flat_name: cgroup.cpu.throttled.us
+  level: extended
+  name: cpu.throttled.us
+  normalize: []
+  short: Microseconds of CPU throttled time.
+  type: long
+cgroup.cpu.usage:
+  dashed_name: cgroup-cpu-usage
+  description: CPU usage, normalized by the CPU count.
+  flat_name: cgroup.cpu.usage
+  level: extended
+  name: cpu.usage
+  normalize: []
+  scaling_factor: 1000
+  short: CPU usage, normalized by the CPU count.
+  type: scaled_float
+cgroup.memory.limit:
+  dashed_name: cgroup-memory-limit
+  description: Memory limit within the cgroup.
+  example: 256
+  flat_name: cgroup.memory.limit
+  level: extended
+  name: memory.limit
+  normalize: []
+  short: Memory limit within the cgroup.
+  type: long
+cgroup.memory.swap.usage:
+  dashed_name: cgroup-memory-swap-usage
+  description: The amount of cgroup memory in swap.
+  example: 5600
+  flat_name: cgroup.memory.swap.usage
+  level: extended
+  name: memory.swap.usage
+  normalize: []
+  short: The amount of cgroup memory in swap.
+  type: long
+cgroup.memory.usage:
+  dashed_name: cgroup-memory-usage
+  description: Memory usage in bytes
+  example: 25600
+  flat_name: cgroup.memory.usage
+  level: extended
+  name: memory.usage
+  normalize: []
+  short: Memory usage in bytes
+  type: long
+cgroup.version:
+  dashed_name: cgroup-version
+  description: The cgroup version linked to the metrics
+  flat_name: cgroup.version
+  level: extended
+  name: version
+  normalize: []
+  short: The cgroup version linked to the metrics
+  type: long
 client.address:
   dashed_name: client-address
   description: 'Some event client addresses are defined ambiguously. The event will

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -235,6 +235,86 @@ base:
   short: All fields defined directly at the root of the events.
   title: Base
   type: group
+cgroup:
+  description: Fields related to control group (cgroup) metrics. Due to controller
+    changes between V1 and V2, many same or similar metrics will often appear under
+    different controller names. These fields are common to both cgroup versions.
+  fields:
+    cgroup.cpu.periods:
+      dashed_name: cgroup-cpu-periods
+      description: Number of period intervals that have elapsed.
+      example: 454839343
+      flat_name: cgroup.cpu.periods
+      level: extended
+      name: cpu.periods
+      normalize: []
+      short: Number of period intervals that have elapsed.
+      type: long
+    cgroup.cpu.throttled.us:
+      dashed_name: cgroup-cpu-throttled-us
+      description: Microseconds of CPU throttled time.
+      example: 15000
+      flat_name: cgroup.cpu.throttled.us
+      level: extended
+      name: cpu.throttled.us
+      normalize: []
+      short: Microseconds of CPU throttled time.
+      type: long
+    cgroup.cpu.usage:
+      dashed_name: cgroup-cpu-usage
+      description: CPU usage, normalized by the CPU count.
+      flat_name: cgroup.cpu.usage
+      level: extended
+      name: cpu.usage
+      normalize: []
+      scaling_factor: 1000
+      short: CPU usage, normalized by the CPU count.
+      type: scaled_float
+    cgroup.memory.limit:
+      dashed_name: cgroup-memory-limit
+      description: Memory limit within the cgroup.
+      example: 256
+      flat_name: cgroup.memory.limit
+      level: extended
+      name: memory.limit
+      normalize: []
+      short: Memory limit within the cgroup.
+      type: long
+    cgroup.memory.swap.usage:
+      dashed_name: cgroup-memory-swap-usage
+      description: The amount of cgroup memory in swap.
+      example: 5600
+      flat_name: cgroup.memory.swap.usage
+      level: extended
+      name: memory.swap.usage
+      normalize: []
+      short: The amount of cgroup memory in swap.
+      type: long
+    cgroup.memory.usage:
+      dashed_name: cgroup-memory-usage
+      description: Memory usage in bytes
+      example: 25600
+      flat_name: cgroup.memory.usage
+      level: extended
+      name: memory.usage
+      normalize: []
+      short: Memory usage in bytes
+      type: long
+    cgroup.version:
+      dashed_name: cgroup-version
+      description: The cgroup version linked to the metrics
+      flat_name: cgroup.version
+      level: extended
+      name: version
+      normalize: []
+      short: The cgroup version linked to the metrics
+      type: long
+  group: 2
+  name: cgroup
+  prefix: cgroup.
+  short: fields common to cgroups V1 and V2
+  title: Common cgroup metrics
+  type: group
 client:
   description: 'A client is defined as the initiator of a network connection for events
     regarding sessions, connections, or bidirectional flow records.

--- a/experimental/generated/elasticsearch/7/template.json
+++ b/experimental/generated/elasticsearch/7/template.json
@@ -54,6 +54,48 @@
           }
         }
       },
+      "cgroup": {
+        "properties": {
+          "cpu": {
+            "properties": {
+              "periods": {
+                "type": "long"
+              },
+              "throttled": {
+                "properties": {
+                  "us": {
+                    "type": "long"
+                  }
+                }
+              },
+              "usage": {
+                "scaling_factor": 1000,
+                "type": "scaled_float"
+              }
+            }
+          },
+          "memory": {
+            "properties": {
+              "limit": {
+                "type": "long"
+              },
+              "swap": {
+                "properties": {
+                  "usage": {
+                    "type": "long"
+                  }
+                }
+              },
+              "usage": {
+                "type": "long"
+              }
+            }
+          },
+          "version": {
+            "type": "long"
+          }
+        }
+      },
       "client": {
         "properties": {
           "address": {

--- a/experimental/generated/elasticsearch/component/cgroup.json
+++ b/experimental/generated/elasticsearch/component/cgroup.json
@@ -1,0 +1,54 @@
+{
+  "_meta": {
+    "documentation": "https://www.elastic.co/guide/en/ecs/current/ecs-cgroup.html",
+    "ecs_version": "8.1.0-dev+exp"
+  },
+  "template": {
+    "mappings": {
+      "properties": {
+        "cgroup": {
+          "properties": {
+            "cpu": {
+              "properties": {
+                "periods": {
+                  "type": "long"
+                },
+                "throttled": {
+                  "properties": {
+                    "us": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "usage": {
+                  "scaling_factor": 1000,
+                  "type": "scaled_float"
+                }
+              }
+            },
+            "memory": {
+              "properties": {
+                "limit": {
+                  "type": "long"
+                },
+                "swap": {
+                  "properties": {
+                    "usage": {
+                      "type": "long"
+                    }
+                  }
+                },
+                "usage": {
+                  "type": "long"
+                }
+              }
+            },
+            "version": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experimental/generated/elasticsearch/template.json
+++ b/experimental/generated/elasticsearch/template.json
@@ -41,6 +41,7 @@
     "ecs_8.1.0-dev-exp_user",
     "ecs_8.1.0-dev-exp_user_agent",
     "ecs_8.1.0-dev-exp_vulnerability",
+    "ecs_8.1.0-dev-exp_cgroup",
     "ecs_8.1.0-dev-exp_email"
   ],
   "index_patterns": [

--- a/experimental/schemas/cgroup.yml
+++ b/experimental/schemas/cgroup.yml
@@ -1,0 +1,52 @@
+---
+- name: cgroup
+  title: Common cgroup metrics
+  group: 2
+  short: fields common to cgroups V1 and V2
+  description: >
+    Fields related to control group (cgroup) metrics. Due to controller changes
+    between V1 and V2, many same or similar metrics will often appear under
+    different controller names. These fields are common to both cgroup versions.
+  type: group
+  fields:
+    - name: version
+      level: extended
+      type: long
+      description: >
+        The cgroup version linked to the metrics
+    - name: cpu.periods
+      level: extended
+      type: long
+      example: 454839343
+      description: >
+        Number of period intervals that have elapsed.
+    - name: cpu.throttled.us
+      level: extended
+      type: long
+      example: 15000
+      description: >
+        Microseconds of CPU throttled time.
+    - name: cpu.usage
+      level: extended
+      type: scaled_float
+      scaling_factor: 1000
+      description: >
+        CPU usage, normalized by the CPU count.
+    - name: memory.usage
+      level: extended
+      type: long
+      example: 25600
+      description: >
+        Memory usage in bytes
+    - name: memory.limit
+      level: extended
+      type: long
+      example: 256
+      description: >
+        Memory limit within the cgroup.
+    - name: memory.swap.usage
+      level: extended
+      type: long
+      example: 5600
+      description: >
+        The amount of cgroup memory in swap.


### PR DESCRIPTION
Add the proposed fields from [RFC 0028](https://github.com/elastic/ecs/blob/main/rfcs/text/0028-cgroups.md) stage 1 to the experimental ECS schema. (#1627 )
