### PR TITLE
Separate packages required for testing/linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,7 @@ There are two primary ways in which you can contribute to ECS.
 You need these tools to contribute to the ECS repo:
 
 * [Git](https://git-scm.com/)
-* [Python 3.6+](https://www.python.org/)
-* [Go 1.13](https://golang.org/)
+* [Python 3.8+](https://www.python.org/)
 
 ### Submitting Changes
 

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test: ve
 # Create a virtualenv to run Python.
 .PHONY: ve
 ve: build/ve/bin/activate
-build/ve/bin/activate: scripts/requirements.txt
+build/ve/bin/activate: scripts/requirements.txt scripts/requirements-dev.txt
 	@test -d build/ve || python3 -mvenv build/ve
 	@build/ve/bin/pip install -Ur scripts/requirements.txt -r scripts/requirements-dev.txt
 	@touch build/ve/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ test: ve
 ve: build/ve/bin/activate
 build/ve/bin/activate: scripts/requirements.txt
 	@test -d build/ve || python3 -mvenv build/ve
-	@build/ve/bin/pip install -Ur scripts/requirements.txt
+	@build/ve/bin/pip install -Ur scripts/requirements.txt -r scripts/requirements-dev.txt
 	@touch build/ve/bin/activate
 
 # Check YAML syntax (currently not enforced).

--- a/USAGE.md
+++ b/USAGE.md
@@ -114,7 +114,7 @@ by using `build/ve/bin/python` instead of `python` in the examples shown here.
 
 #### Option 2: Install dependencies via pip
 
-Install dependencies using `pip` (An active `virutalenv` is recommended):
+Install dependencies using `pip` (An active `virtualenv` is recommended):
 
 ```
 $ pip install -r scripts/requirements.txt

--- a/USAGE.md
+++ b/USAGE.md
@@ -20,8 +20,7 @@ relevant artifacts for their unique set of data sources.
 - [Setup and Install](#setup-and-install)
   * [Prerequisites](#prerequisites)
     + [Clone from GitHub](#clone-from-github)
-    + [Option 1: Install dependencies via make (recommended)](#option-1-install-dependencies-via-make-recommended)
-    + [Option 2: Install dependencies via pip](#option-2-install-dependencies-via-pip)
+    + [Install dependencies](#install-dependencies)
 - [Usage](#usage)
   * [Getting Started - Generating Artifacts](#getting-started---generating-artifacts)
   * [Generator Options](#generator-options)
@@ -99,20 +98,7 @@ Prior to installing dependencies or running the tools, it's recommended to check
 $ git checkout v1.5.0
 ```
 
-#### Option 1: Install dependencies via make (recommended)
-
-Setting up a `virtualenv` (`venv`) can be accomplished by running `make ve` the top-level of the ECS repo:
-
-```
-$ make ve
-```
-
-All necessary Python dependencies will also be installed with `pip`.
-
-You can use the Python and dependencies from this isolated virtual environment
-by using `build/ve/bin/python` instead of `python` in the examples shown here.
-
-#### Option 2: Install dependencies via pip
+#### Install dependencies
 
 Install dependencies using `pip` (An active `virtualenv` is recommended):
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -77,7 +77,7 @@ See [usage-example/](usage-example/) for a complete example with source files.
 
 ### Prerequisites
 
-* [Python 3.6+](https://www.python.org/)
+* [Python 3.8+](https://www.python.org/)
 * [make](https://www.gnu.org/software/make/)
 * [pip](https://pypi.org/project/pip/)
 * [git](https://git-scm.com/)

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,0 +1,6 @@
+# License: MIT
+autopep8==1.4.4
+# License: BSD
+mock==4.0.2
+# License: GPLv3
+yamllint==1.19.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,12 @@
 pip
+# License: MIT
 PyYAML==5.4
+# License: MIT
 autopep8==1.4.4
 yamllint==1.19.0
+# License: BSD
 mock==4.0.2
+# License: BSD
 gitpython==3.1.2
+# License: BSD
 Jinja2==2.11.3

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,11 +1,6 @@
 pip
 # License: MIT
 PyYAML==5.4
-# License: MIT
-autopep8==1.4.4
-yamllint==1.19.0
-# License: BSD
-mock==4.0.2
 # License: BSD
 gitpython==3.1.2
 # License: BSD


### PR DESCRIPTION
 Most uses do not need to install the dependencies required for testing and lining, and this change splits `requirements.txt` into `requirements.txt` and `requirements-dev.txt`.

`make ve` has been updated to include the additional file, and I updated the repo docs as well. I thought it prudent to simplify our install instructions in `USAGE.md`, but I'm open to discussion if anyone feels differently.