### PR TITLE
Expand `[source|destination|client|server].domain` field descriptions

### DIFF
--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -355,7 +355,7 @@ example: `184`
 
 | The domain name of the client system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -1268,7 +1268,7 @@ example: `184`
 
 | The domain name of the destination system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -7191,7 +7191,7 @@ example: `184`
 
 | The domain name of the server system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -7697,7 +7697,7 @@ example: `184`
 
 | The domain name of the source system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -355,7 +355,7 @@ example: `184`
 
 | The domain name of the client system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value derive may from the original event or be added from enrichment.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -355,7 +355,7 @@ example: `184`
 
 | The domain name of the client system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -1268,7 +1268,7 @@ example: `184`
 
 | The domain name of the destination system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -7191,7 +7191,7 @@ example: `184`
 
 | The domain name of the server system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 
@@ -7697,7 +7697,7 @@ example: `184`
 
 | The domain name of the source system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -353,13 +353,15 @@ example: `184`
 [[field-client-domain]]
 <<field-client-domain, client.domain>>
 
-| Client domain.
+| The domain name of the client system.
+
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
 
 type: keyword
 
 
 
-
+example: `foo.example.com`
 
 | core
 
@@ -1264,13 +1266,15 @@ example: `184`
 [[field-destination-domain]]
 <<field-destination-domain, destination.domain>>
 
-| Destination domain.
+| The domain name of the destination system.
+
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
 
 type: keyword
 
 
 
-
+example: `foo.example.com`
 
 | core
 
@@ -7185,13 +7189,15 @@ example: `184`
 [[field-server-domain]]
 <<field-server-domain, server.domain>>
 
-| Server domain.
+| The domain name of the server system.
+
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
 
 type: keyword
 
 
 
-
+example: `foo.example.com`
 
 | core
 
@@ -7689,13 +7695,15 @@ example: `184`
 [[field-source-domain]]
 <<field-source-domain, source.domain>>
 
-| Source domain.
+| The domain name of the source system.
+
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may from the original event or added from enrichment.
 
 type: keyword
 
 
 
-
+example: `foo.example.com`
 
 | core
 

--- a/docs/field-details.asciidoc
+++ b/docs/field-details.asciidoc
@@ -355,7 +355,7 @@ example: `184`
 
 | The domain name of the client system.
 
-This value may be a host name, a fully qualified domain name, or other host naming format. The value derive may from the original event or be added from enrichment.
+This value may be a host name, a fully qualified domain name, or other host naming format. The value may derive from the original event or be added from enrichment.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -255,7 +255,7 @@
       ignore_above: 1024
       description: 'The domain name of the client system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -1044,7 +1044,7 @@
       ignore_above: 1024
       description: 'The domain name of the destination system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -5819,7 +5819,7 @@
       ignore_above: 1024
       description: 'The domain name of the server system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -6432,7 +6432,7 @@
       ignore_above: 1024
       description: 'The domain name of the source system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -253,7 +253,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Client domain.
+      description: 'The domain name of the client system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -1037,7 +1041,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Destination domain.
+      description: 'The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -5807,7 +5815,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Server domain.
+      description: 'The domain name of the server system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -6415,7 +6427,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Source domain.
+      description: 'The domain name of the source system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -256,7 +256,8 @@
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value derive may from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -1044,7 +1045,8 @@
       description: 'The domain name of the destination system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -5818,7 +5820,8 @@
       description: 'The domain name of the server system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -6430,7 +6433,8 @@
       description: 'The domain name of the source system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -256,7 +256,7 @@
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value derive may from the original event or be added from
+        naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
     - name: geo.city_name

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -21,7 +21,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev+exp,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
-8.1.0-dev+exp,true,client,client.domain,keyword,core,,,Client domain.
+8.1.0-dev+exp,true,client,client.domain,keyword,core,,foo.example.com,The domain name of the client.
 8.1.0-dev+exp,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev+exp,true,client,client.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev+exp,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -107,7 +107,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev+exp,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
-8.1.0-dev+exp,true,destination,destination.domain,keyword,core,,,Destination domain.
+8.1.0-dev+exp,true,destination,destination.domain,keyword,core,,foo.example.com,The domain name of the destination.
 8.1.0-dev+exp,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev+exp,true,destination,destination.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev+exp,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -657,7 +657,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev+exp,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
-8.1.0-dev+exp,true,server,server.domain,keyword,core,,,Server domain.
+8.1.0-dev+exp,true,server,server.domain,keyword,core,,foo.example.com,The domain name of the server.
 8.1.0-dev+exp,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev+exp,true,server,server.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev+exp,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -722,7 +722,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev+exp,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev+exp,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
-8.1.0-dev+exp,true,source,source.domain,keyword,core,,,Source domain.
+8.1.0-dev+exp,true,source,source.domain,keyword,core,,foo.example.com,The domain name of the source.
 8.1.0-dev+exp,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev+exp,true,source,source.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev+exp,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -226,13 +226,17 @@ client.bytes:
   type: long
 client.domain:
   dashed_name: client-domain
-  description: Client domain.
+  description: 'The domain name of the client system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Client domain.
+  short: The domain name of the client.
   type: keyword
 client.geo.city_name:
   dashed_name: client-geo-city-name
@@ -1279,13 +1283,17 @@ destination.bytes:
   type: long
 destination.domain:
   dashed_name: destination-domain
-  description: Destination domain.
+  description: 'The domain name of the destination system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Destination domain.
+  short: The domain name of the destination.
   type: keyword
 destination.geo.city_name:
   dashed_name: destination-geo-city-name
@@ -8337,13 +8345,17 @@ server.bytes:
   type: long
 server.domain:
   dashed_name: server-domain
-  description: Server domain.
+  description: 'The domain name of the server system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Server domain.
+  short: The domain name of the server.
   type: keyword
 server.geo.city_name:
   dashed_name: server-geo-city-name
@@ -9237,13 +9249,17 @@ source.bytes:
   type: long
 source.domain:
   dashed_name: source-domain
-  description: Source domain.
+  description: 'The domain name of the source system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Source domain.
+  short: The domain name of the source.
   type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -229,7 +229,7 @@ client.domain:
   description: 'The domain name of the client system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value derive may from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
@@ -1286,7 +1286,7 @@ destination.domain:
   description: 'The domain name of the destination system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
@@ -8348,7 +8348,7 @@ server.domain:
   description: 'The domain name of the server system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
@@ -9252,7 +9252,7 @@ source.domain:
   description: 'The domain name of the source system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -228,8 +228,8 @@ client.domain:
   dashed_name: client-domain
   description: 'The domain name of the client system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
@@ -1285,8 +1285,8 @@ destination.domain:
   dashed_name: destination-domain
   description: 'The domain name of the destination system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
@@ -8347,8 +8347,8 @@ server.domain:
   dashed_name: server-domain
   description: 'The domain name of the server system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
@@ -9251,8 +9251,8 @@ source.domain:
   dashed_name: source-domain
   description: 'The domain name of the source system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -229,7 +229,7 @@ client.domain:
   description: 'The domain name of the client system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value derive may from the original event or be added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -391,7 +391,8 @@ client:
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value derive may from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: client.domain
       ignore_above: 1024
@@ -1706,7 +1707,8 @@ destination:
       description: 'The domain name of the destination system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: destination.domain
       ignore_above: 1024
@@ -10084,7 +10086,8 @@ server:
       description: 'The domain name of the server system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: server.domain
       ignore_above: 1024
@@ -11072,7 +11075,8 @@ source:
       description: 'The domain name of the source system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: source.domain
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -391,7 +391,7 @@ client:
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value derive may from the original event or be added from
+        naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
       flat_name: client.domain

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -388,13 +388,17 @@ client:
       type: long
     client.domain:
       dashed_name: client-domain
-      description: Client domain.
+      description: 'The domain name of the client system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: client.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Client domain.
+      short: The domain name of the client.
       type: keyword
     client.geo.city_name:
       dashed_name: client-geo-city-name
@@ -1699,13 +1703,17 @@ destination:
       type: long
     destination.domain:
       dashed_name: destination-domain
-      description: Destination domain.
+      description: 'The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: destination.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Destination domain.
+      short: The domain name of the destination.
       type: keyword
     destination.geo.city_name:
       dashed_name: destination-geo-city-name
@@ -10073,13 +10081,17 @@ server:
       type: long
     server.domain:
       dashed_name: server-domain
-      description: Server domain.
+      description: 'The domain name of the server system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: server.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Server domain.
+      short: The domain name of the server.
       type: keyword
     server.geo.city_name:
       dashed_name: server-geo-city-name
@@ -11057,13 +11069,17 @@ source:
       type: long
     source.domain:
       dashed_name: source-domain
-      description: Source domain.
+      description: 'The domain name of the source system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: source.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Source domain.
+      short: The domain name of the source.
       type: keyword
     source.geo.city_name:
       dashed_name: source-geo-city-name

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -390,7 +390,7 @@ client:
       dashed_name: client-domain
       description: 'The domain name of the client system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -1706,7 +1706,7 @@ destination:
       dashed_name: destination-domain
       description: 'The domain name of the destination system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -10085,7 +10085,7 @@ server:
       dashed_name: server-domain
       description: 'The domain name of the server system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -11074,7 +11074,7 @@ source:
       dashed_name: source-domain
       description: 'The domain name of the source system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -203,7 +203,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Client domain.
+      description: 'The domain name of the client system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -949,7 +953,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Destination domain.
+      description: 'The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -5548,7 +5556,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Server domain.
+      description: 'The domain name of the server system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword
@@ -6156,7 +6168,11 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: Source domain.
+      description: 'The domain name of the source system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -206,7 +206,8 @@
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value derive may from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -956,7 +957,8 @@
       description: 'The domain name of the destination system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -5559,7 +5561,8 @@
       description: 'The domain name of the server system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core
@@ -6171,7 +6174,8 @@
       description: 'The domain name of the source system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
     - name: geo.city_name
       level: core

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -205,7 +205,7 @@
       ignore_above: 1024
       description: 'The domain name of the client system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -956,7 +956,7 @@
       ignore_above: 1024
       description: 'The domain name of the destination system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -5560,7 +5560,7 @@
       ignore_above: 1024
       description: 'The domain name of the server system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -6173,7 +6173,7 @@
       ignore_above: 1024
       description: 'The domain name of the source system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -206,7 +206,7 @@
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value derive may from the original event or be added from
+        naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
     - name: geo.city_name

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -14,7 +14,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev,true,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev,true,client,client.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev,true,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
-8.1.0-dev,true,client,client.domain,keyword,core,,,Client domain.
+8.1.0-dev,true,client,client.domain,keyword,core,,foo.example.com,The domain name of the client.
 8.1.0-dev,true,client,client.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev,true,client,client.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev,true,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -94,7 +94,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev,true,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev,true,destination,destination.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev,true,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
-8.1.0-dev,true,destination,destination.domain,keyword,core,,,Destination domain.
+8.1.0-dev,true,destination,destination.domain,keyword,core,,foo.example.com,The domain name of the destination.
 8.1.0-dev,true,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev,true,destination,destination.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev,true,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -622,7 +622,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev,true,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev,true,server,server.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev,true,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
-8.1.0-dev,true,server,server.domain,keyword,core,,,Server domain.
+8.1.0-dev,true,server,server.domain,keyword,core,,foo.example.com,The domain name of the server.
 8.1.0-dev,true,server,server.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev,true,server,server.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev,true,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
@@ -687,7 +687,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.1.0-dev,true,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
 8.1.0-dev,true,source,source.as.organization.name.text,match_only_text,extended,,Google LLC,Organization name.
 8.1.0-dev,true,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
-8.1.0-dev,true,source,source.domain,keyword,core,,,Source domain.
+8.1.0-dev,true,source,source.domain,keyword,core,,foo.example.com,The domain name of the source.
 8.1.0-dev,true,source,source.geo.city_name,keyword,core,,Montreal,City name.
 8.1.0-dev,true,source,source.geo.continent_code,keyword,core,,NA,Continent code.
 8.1.0-dev,true,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -160,7 +160,7 @@ client.domain:
   description: 'The domain name of the client system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value derive may from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
@@ -1155,7 +1155,7 @@ destination.domain:
   description: 'The domain name of the destination system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
@@ -7971,7 +7971,7 @@ server.domain:
   description: 'The domain name of the server system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
@@ -8875,7 +8875,7 @@ source.domain:
   description: 'The domain name of the source system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may from the original event or added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -159,8 +159,8 @@ client.domain:
   dashed_name: client-domain
   description: 'The domain name of the client system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
@@ -1154,8 +1154,8 @@ destination.domain:
   dashed_name: destination-domain
   description: 'The domain name of the destination system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
@@ -7970,8 +7970,8 @@ server.domain:
   dashed_name: server-domain
   description: 'The domain name of the server system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
@@ -8874,8 +8874,8 @@ source.domain:
   dashed_name: source-domain
   description: 'The domain name of the source system.
 
-    This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value may derive from the original event or be added from enrichment.'
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -160,7 +160,7 @@ client.domain:
   description: 'The domain name of the client system.
 
     This value may be a host name, a fully qualified domain name, or other host naming
-    format. The value derive may from the original event or be added from enrichment.'
+    format. The value may derive from the original event or be added from enrichment.'
   example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -157,13 +157,17 @@ client.bytes:
   type: long
 client.domain:
   dashed_name: client-domain
-  description: Client domain.
+  description: 'The domain name of the client system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: client.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Client domain.
+  short: The domain name of the client.
   type: keyword
 client.geo.city_name:
   dashed_name: client-geo-city-name
@@ -1148,13 +1152,17 @@ destination.bytes:
   type: long
 destination.domain:
   dashed_name: destination-domain
-  description: Destination domain.
+  description: 'The domain name of the destination system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: destination.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Destination domain.
+  short: The domain name of the destination.
   type: keyword
 destination.geo.city_name:
   dashed_name: destination-geo-city-name
@@ -7960,13 +7968,17 @@ server.bytes:
   type: long
 server.domain:
   dashed_name: server-domain
-  description: Server domain.
+  description: 'The domain name of the server system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: server.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Server domain.
+  short: The domain name of the server.
   type: keyword
 server.geo.city_name:
   dashed_name: server-geo-city-name
@@ -8860,13 +8872,17 @@ source.bytes:
   type: long
 source.domain:
   dashed_name: source-domain
-  description: Source domain.
+  description: 'The domain name of the source system.
+
+    This value may be a host name, a fully qualified domain name, or other host naming
+    format. The value may from the original event or added from enrichment.'
+  example: foo.example.com
   flat_name: source.domain
   ignore_above: 1024
   level: core
   name: domain
   normalize: []
-  short: Source domain.
+  short: The domain name of the source.
   type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -311,7 +311,7 @@ client:
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value derive may from the original event or be added from
+        naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
       flat_name: client.domain

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -310,7 +310,7 @@ client:
       dashed_name: client-domain
       description: 'The domain name of the client system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -1564,7 +1564,7 @@ destination:
       dashed_name: destination-domain
       description: 'The domain name of the destination system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -9682,7 +9682,7 @@ server:
       dashed_name: server-domain
       description: 'The domain name of the server system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com
@@ -10671,7 +10671,7 @@ source:
       dashed_name: source-domain
       description: 'The domain name of the source system.
 
-        This value may be a host name, a fully qualified domain name, or other host
+        This value may be a host name, a fully qualified domain name, or another host
         naming format. The value may derive from the original event or be added from
         enrichment.'
       example: foo.example.com

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -311,7 +311,8 @@ client:
       description: 'The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value derive may from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: client.domain
       ignore_above: 1024
@@ -1564,7 +1565,8 @@ destination:
       description: 'The domain name of the destination system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: destination.domain
       ignore_above: 1024
@@ -9681,7 +9683,8 @@ server:
       description: 'The domain name of the server system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: server.domain
       ignore_above: 1024
@@ -10669,7 +10672,8 @@ source:
       description: 'The domain name of the source system.
 
         This value may be a host name, a fully qualified domain name, or other host
-        naming format. The value may from the original event or added from enrichment.'
+        naming format. The value may derive from the original event or be added from
+        enrichment.'
       example: foo.example.com
       flat_name: source.domain
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -308,13 +308,17 @@ client:
       type: long
     client.domain:
       dashed_name: client-domain
-      description: Client domain.
+      description: 'The domain name of the client system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: client.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Client domain.
+      short: The domain name of the client.
       type: keyword
     client.geo.city_name:
       dashed_name: client-geo-city-name
@@ -1557,13 +1561,17 @@ destination:
       type: long
     destination.domain:
       dashed_name: destination-domain
-      description: Destination domain.
+      description: 'The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: destination.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Destination domain.
+      short: The domain name of the destination.
       type: keyword
     destination.geo.city_name:
       dashed_name: destination-geo-city-name
@@ -9670,13 +9678,17 @@ server:
       type: long
     server.domain:
       dashed_name: server-domain
-      description: Server domain.
+      description: 'The domain name of the server system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: server.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Server domain.
+      short: The domain name of the server.
       type: keyword
     server.geo.city_name:
       dashed_name: server-geo-city-name
@@ -10654,13 +10666,17 @@ source:
       type: long
     source.domain:
       dashed_name: source-domain
-      description: Source domain.
+      description: 'The domain name of the source system.
+
+        This value may be a host name, a fully qualified domain name, or other host
+        naming format. The value may from the original event or added from enrichment.'
+      example: foo.example.com
       flat_name: source.domain
       ignore_above: 1024
       level: core
       name: domain
       normalize: []
-      short: Source domain.
+      short: The domain name of the source.
       type: keyword
     source.geo.city_name:
       dashed_name: source-geo-city-name

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -80,6 +80,18 @@
       description: >
         Client domain.
 
+    - name: domain
+      level: core
+      type: keyword
+      short: The domain name of the client.
+      example: foo.example.com
+      description: >
+        The domain name of the client system.
+
+        This value may be a host name, a fully qualified domain name, or other
+        host naming format. The value may from the original event or added from
+        enrichment.
+
     - name: registered_domain
       level: extended
       type: keyword

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -88,7 +88,7 @@
       description: >
         The domain name of the client system.
 
-        This value may be a host name, a fully qualified domain name, or other
+        This value may be a host name, a fully qualified domain name, or another
         host naming format. The value may derive from the original event or be
         added from enrichment.
 

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -89,8 +89,8 @@
         The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other
-        host naming format. The value may from the original event or added from
-        enrichment.
+        host naming format. The value derive may from the original event or be
+        added from enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -89,7 +89,7 @@
         The domain name of the client system.
 
         This value may be a host name, a fully qualified domain name, or other
-        host naming format. The value derive may from the original event or be
+        host naming format. The value may derive from the original event or be
         added from enrichment.
 
     - name: registered_domain

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -72,8 +72,14 @@
     - name: domain
       level: core
       type: keyword
+      short: The domain name of the destination.
+      example: foo.example.com
       description: >
-        Destination domain.
+        The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or other
+        host naming format. The value may from the original event or added from
+        enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -78,8 +78,8 @@
         The domain name of the destination system.
 
         This value may be a host name, a fully qualified domain name, or other
-        host naming format. The value may from the original event or added from
-        enrichment.
+        host naming format. The value may derive from the original event or be
+        added from enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -77,7 +77,7 @@
       description: >
         The domain name of the destination system.
 
-        This value may be a host name, a fully qualified domain name, or other
+        This value may be a host name, a fully qualified domain name, or another
         host naming format. The value may derive from the original event or be
         added from enrichment.
 

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -77,8 +77,14 @@
     - name: domain
       level: core
       type: keyword
+      short: The domain name of the server.
+      example: foo.example.com
       description: >
-        Server domain.
+        The domain name of the server system.
+
+        This value may be a host name, a fully qualified domain name, or other
+        host naming format. The value may from the original event or added from
+        enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -83,8 +83,8 @@
         The domain name of the server system.
 
         This value may be a host name, a fully qualified domain name, or other
-        host naming format. The value may from the original event or added from
-        enrichment.
+        host naming format. The value may derive from the original event or be
+        added from enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -82,7 +82,7 @@
       description: >
         The domain name of the server system.
 
-        This value may be a host name, a fully qualified domain name, or other
+        This value may be a host name, a fully qualified domain name, or another
         host naming format. The value may derive from the original event or be
         added from enrichment.
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -72,8 +72,14 @@
     - name: domain
       level: core
       type: keyword
+      short: The domain name of the source.
+      example: foo.example.com
       description: >
-        Source domain.
+        The domain name of the source system.
+
+        This value may be a host name, a fully qualified domain name, or other
+        host naming format. The value may from the original event or added from
+        enrichment.
 
     - name: registered_domain
       level: extended

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -77,7 +77,7 @@
       description: >
         The domain name of the source system.
 
-        This value may be a host name, a fully qualified domain name, or other
+        This value may be a host name, a fully qualified domain name, or another
         host naming format. The value may derive from the original event or be
         added from enrichment.
 

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -78,8 +78,8 @@
         The domain name of the source system.
 
         This value may be a host name, a fully qualified domain name, or other
-        host naming format. The value may from the original event or added from
-        enrichment.
+        host naming format. The value may derive from the original event or be
+        added from enrichment.
 
     - name: registered_domain
       level: extended


### PR DESCRIPTION
Revisit the description for the `.domain` fields for `source.*`, `destination.*`, `client.*`, and `server.*` field sets.

Also, add `example` and `short` attributes for each field.

Fixes #1663 