### PR TITLE
[8.0] Add missing changelog entry for #1679

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -66,6 +66,7 @@ Thanks, you're awesome :-) -->
 
 * Remove remaining Go deps after removing Go code generator. #1585
 * Add explicit `default_field: true` for Beats artifacts. #1633
+* Reorganize docs directory structure. #1679
 
 <!-- All empty sections:
 


### PR DESCRIPTION

Backports the following commits to 8.0:
 - add missing changelog entry for #1679