### PR TITLE
docs: fix link to APM Overview

### DIFF
--- a/docs/migrating/products-solutions.asciidoc
+++ b/docs/migrating/products-solutions.asciidoc
@@ -4,7 +4,7 @@
 The following Elastic products support ECS out of the box, as of version 7.0:
 
 * {beats-ref}/beats-reference.html[{beats}]
-* {apm-get-started-ref}/overview.html[APM]
+* {apm-guide-ref}/apm-overview.html[APM]
 * {security-guide}/es-overview.html[Elastic Security]
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the Security app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
@@ -16,4 +16,3 @@ Server]
 * {ls}' {es} output has an {logstash-ref}/plugins-outputs-elasticsearch.html#_compatibility_with_the_elastic_common_schema_ecs[ECS compatibility mode]
 
 // TODO Insert community & partner solutions here
-


### PR DESCRIPTION
In 7.16, the APM integration became generally available 🎉. As a part of this change, the APM Server Reference and APM Overview were deprecated and replaced with a new [APM Guide](https://www.elastic.co/guide/en/apm/guide/current/index.html). This PR updates a link in the ECS documentation to point to the new APM guide.

Unfortunately, when 7.17 is released, the old link will fail. To fix this, we need to backport this PR all the way to 1.3 😬 (which I'm happy to do). The broken links can be seen in https://github.com/elastic/docs/pull/2333, but I've also included a summary below.

```
4:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.10/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.11/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.12/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.3/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.4/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.5/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.6/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.7/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.8/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/1.9/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/8.0/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/8.1/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/current/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
14:17:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/ecs/master/ecs-products-solutions.html contains broken links to:
14:17:47 INFO:build_docs:   - en/apm/get-started/7.17/overview.html
```