### PR TITLE
Beats: fix default_field setting for root fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Fixed the `default_field` flag for root fields in Beats generator. #1711
+
 #### Added
 
 #### Improvements

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -20,6 +20,7 @@
 
       Required field for all events.'
     example: '2016-05-23T08:05:34.853Z'
+    default_field: true
   - name: labels
     level: core
     type: object
@@ -31,6 +32,7 @@
 
       Example: `docker` and `k8s` labels.'
     example: '{"application": "foo-bar", "env": "production"}'
+    default_field: true
   - name: message
     level: core
     type: match_only_text
@@ -42,12 +44,14 @@
 
       If multiple messages exist, they can be combined into one message.'
     example: Hello World
+    default_field: true
   - name: tags
     level: core
     type: keyword
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
+    default_field: true
   - name: agent
     title: Agent
     group: 2
@@ -10255,7 +10259,6 @@
       A span represents an operation within a transaction, such as a request to another
       service, or a database query.'
     example: 3ff9a8981b7ccd5a
-    default_field: false
   - name: trace.id
     level: extended
     type: keyword
@@ -10265,6 +10268,7 @@
       A trace groups multiple events like transactions that belong together. For example,
       a user request handled by multiple inter-connected services.'
     example: 4bf92f3577b34da6a3ce929d0e0e4736
+    default_field: true
   - name: transaction.id
     level: extended
     type: keyword
@@ -10274,6 +10278,7 @@
       A transaction is the highest level of work measured within a service, such as
       a request to a server.'
     example: 00f067aa0ba902b7
+    default_field: true
   - name: url
     title: URL
     group: 2

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -20,6 +20,7 @@
 
       Required field for all events.'
     example: '2016-05-23T08:05:34.853Z'
+    default_field: true
   - name: labels
     level: core
     type: object
@@ -31,6 +32,7 @@
 
       Example: `docker` and `k8s` labels.'
     example: '{"application": "foo-bar", "env": "production"}'
+    default_field: true
   - name: message
     level: core
     type: match_only_text
@@ -42,12 +44,14 @@
 
       If multiple messages exist, they can be combined into one message.'
     example: Hello World
+    default_field: true
   - name: tags
     level: core
     type: keyword
     ignore_above: 1024
     description: List of keywords used to tag each event.
     example: '["production", "env2"]'
+    default_field: true
   - name: agent
     title: Agent
     group: 2
@@ -10167,7 +10171,6 @@
       A span represents an operation within a transaction, such as a request to another
       service, or a database query.'
     example: 3ff9a8981b7ccd5a
-    default_field: false
   - name: trace.id
     level: extended
     type: keyword
@@ -10177,6 +10180,7 @@
       A trace groups multiple events like transactions that belong together. For example,
       a user request handled by multiple inter-connected services.'
     example: 4bf92f3577b34da6a3ce929d0e0e4736
+    default_field: true
   - name: transaction.id
     level: extended
     type: keyword
@@ -10186,6 +10190,7 @@
       A transaction is the highest level of work measured within a service, such as
       a request to a server.'
     example: 00f067aa0ba902b7
+    default_field: true
   - name: url
     title: URL
     group: 2

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -21,11 +21,8 @@ from generators import ecs_helpers
 
 
 def generate(ecs_nested, ecs_version, out_dir):
-    # Load temporary allowlist for default_fields workaround.
-    df_allowlist = ecs_helpers.yaml_load('scripts/generators/beats_default_fields_allowlist.yml')
-
     # base first
-    beats_fields = fieldset_field_array(ecs_nested['base']['fields'], df_allowlist, ecs_nested['base']['prefix'])
+    beats_fields = fieldset_field_array(ecs_nested['base']['fields'], ecs_nested['base']['prefix'])
 
     allowed_fieldset_keys = ['name', 'title', 'group', 'description', 'footnote', 'type']
     # other fieldsets
@@ -36,14 +33,17 @@ def generate(ecs_nested, ecs_version, out_dir):
 
         # Handle when `root:true`
         if fieldset.get('root', False):
-            beats_fields.extend(fieldset_field_array(fieldset['fields'], df_allowlist, fieldset['prefix']))
+            beats_fields.extend(fieldset_field_array(fieldset['fields'], fieldset['prefix']))
             continue
 
         beats_field = ecs_helpers.dict_copy_keys_ordered(fieldset, allowed_fieldset_keys)
-        if 'default_field' not in beats_field:
-            beats_field['default_field'] = True
-        beats_field['fields'] = fieldset_field_array(fieldset['fields'], df_allowlist, fieldset['prefix'])
+        beats_field['fields'] = fieldset_field_array(fieldset['fields'], fieldset['prefix'])
         beats_fields.append(beats_field)
+
+    # Load temporary allowlist for default_fields workaround.
+    df_allowlist = ecs_helpers.yaml_load('scripts/generators/beats_default_fields_allowlist.yml')
+    # Set default_field configuration.
+    set_default_field(beats_fields, df_allowlist)
 
     beats_file = OrderedDict()
     beats_file['key'] = 'ecs'
@@ -54,7 +54,23 @@ def generate(ecs_nested, ecs_version, out_dir):
     write_beats_yaml(beats_file, ecs_version, out_dir)
 
 
-def fieldset_field_array(source_fields, df_allowlist, fieldset_prefix):
+def set_default_field(fields, df_allowlist, df=False, path=''):
+    for fld in fields:
+        fld_df = fld.get('default_field', df)
+        fld_path = fld['name']
+        if path != '' and not fld.get('root', False):
+            fld_path = path + '.' + fld_path
+        fld_type = fld.get('type', 'keyword')
+        expected = fld_path in df_allowlist or (fld_path == fld['name'] and fld_type == 'group')
+        if fld_df != expected:
+            ecs_helpers.ordered_dict_insert(fld, 'default_field', expected, before_key='fields')
+        if fld_type == 'group':
+            set_default_field(fld['fields'], df_allowlist, df=expected, path=fld_path)
+        elif 'multi_fields' in fld:
+            set_default_field(fld['multi_fields'], df_allowlist, df=expected, path=fld_path)
+
+
+def fieldset_field_array(source_fields, fieldset_prefix):
     allowed_keys = ['name', 'level', 'required', 'type', 'object_type',
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
@@ -74,18 +90,11 @@ def fieldset_field_array(source_fields, df_allowlist, fieldset_prefix):
         cleaned_multi_fields = []
         if 'multi_fields' in ecs_field:
             for mf in ecs_field['multi_fields']:
-                # Set default_field if necessary. Avoid adding the key if the parent
-                # field already is marked with default_field: false.
-                if not mf['flat_name'] in df_allowlist and ecs_field['flat_name'] in df_allowlist:
-                    mf['default_field'] = False
                 cleaned_multi_fields.append(
                     ecs_helpers.dict_copy_keys_ordered(mf, multi_fields_allowed_keys))
             beats_field['multi_fields'] = cleaned_multi_fields
 
         beats_field['name'] = contextual_name
-
-        if not ecs_field['flat_name'] in df_allowlist:
-            beats_field['default_field'] = False
 
         fields.append(beats_field)
     return sorted(fields, key=lambda x: x['name'])

--- a/scripts/generators/ecs_helpers.py
+++ b/scripts/generators/ecs_helpers.py
@@ -60,6 +60,24 @@ def dict_sorted_by_keys(dct, sort_keys):
     return list(map(lambda t: t[-1], sorted(tuples)))
 
 
+def ordered_dict_insert(dct, new_key, new_value, before_key=None, after_key=None):
+    output = OrderedDict()
+    inserted = False
+    for key, value in dct.items():
+        if not inserted and before_key is not None and key == before_key:
+            output[new_key] = new_value
+            inserted = True
+        output[key] = value
+        if not inserted and after_key is not None and key == after_key:
+            output[new_key] = new_value
+            inserted = True
+    if not inserted:
+        output[new_key] = new_value
+    dct.clear()
+    for key, value in output.items():
+        dct[key] = value
+
+
 def safe_merge_dicts(a, b):
     """Merges two dictionaries into one. If duplicate keys are detected a ValueError is raised."""
     c = deepcopy(a)

--- a/scripts/tests/unit/test_beats_generator.py
+++ b/scripts/tests/unit/test_beats_generator.py
@@ -43,7 +43,7 @@ class TestGeneratorsBeatsFields(unittest.TestCase):
                 'type': 'keyword'
             }
         }
-        beats_fields = beats.fieldset_field_array(fields, self.df_allowlist, 'prefix')
+        beats_fields = beats.fieldset_field_array(fields, 'prefix')
         self.assertIsInstance(beats_fields, list)
         self.assertIsInstance(beats_fields[0], OrderedDict)
 
@@ -62,7 +62,7 @@ class TestGeneratorsBeatsFields(unittest.TestCase):
             }
         }
 
-        beats_fields = beats.fieldset_field_array(fields, self.df_allowlist, '')
+        beats_fields = beats.fieldset_field_array(fields, '')
         field_entry = beats_fields[0]
         self.assertEqual(field_entry['type'], 'keyword')
         self.assertEqual(field_entry['ignore_above'], 1024)
@@ -84,7 +84,7 @@ class TestGeneratorsBeatsFields(unittest.TestCase):
             }
         }
 
-        beats_fields = beats.fieldset_field_array(fields, self.df_allowlist, '')
+        beats_fields = beats.fieldset_field_array(fields, '')
         field_entry = beats_fields[0]
         self.assertEqual(field_entry['type'], 'keyword')
         self.assertFalse(field_entry['index'])


### PR DESCRIPTION
The generator was adding the `default_field` setting to non-root fieldsets, causing top-level fields (like `message`) to be excluded from the `default_field` index template configuration.

Relates https://github.com/elastic/beats/issues/29633