### PR TITLE
Higher default compression for composable templates

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -58,6 +58,7 @@ Thanks, you're awesome :-) -->
 
 * Update refs from master to main in USAGE.md etc #1658
 * Clean up trailing spaces and additional newlines in schemas #1667
+* Use higher compression as default in composable index template settings. #1712
 
 ## 8.0.0 (Hard Feature Freeze)
 

--- a/experimental/generated/elasticsearch/composable/template.json
+++ b/experimental/generated/elasticsearch/composable/template.json
@@ -65,6 +65,7 @@
     },
     "settings": {
       "index": {
+        "codec": "best_compression",
         "mapping": {
           "total_fields": {
             "limit": 2000

--- a/generated/elasticsearch/composable/template.json
+++ b/generated/elasticsearch/composable/template.json
@@ -64,6 +64,7 @@
     },
     "settings": {
       "index": {
+        "codec": "best_compression",
         "mapping": {
           "total_fields": {
             "limit": 2000

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -45,6 +45,7 @@ def save_composable_template(ecs_version, component_names, out_dir, mapping_sett
         "template": {
             "settings": {
                 "index": {
+                    "codec" : "best_compression",
                     "mapping": {
                         "total_fields": {
                             "limit": 2000

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -45,7 +45,7 @@ def save_composable_template(ecs_version, component_names, out_dir, mapping_sett
         "template": {
             "settings": {
                 "index": {
-                    "codec" : "best_compression",
+                    "codec": "best_compression",
                     "mapping": {
                         "total_fields": {
                             "limit": 2000


### PR DESCRIPTION
Addresses https://github.com/elastic/ecs/issues/1339

The built-in index templates settings in Elasticsearch (logs-settings, metrics-settings, synthetics-settings) enable a higher compression ratio (DEFLATE vs LZ4) as the default now with the new indexing strategy: `index.codec: best_compression`