### PR TITLE
[1.4] docs: fix link to APM Overview (#1710)

### DIFF
--- a/docs/products-solutions.asciidoc
+++ b/docs/products-solutions.asciidoc
@@ -4,7 +4,7 @@
 The following Elastic products support ECS out of the box, as of version 7.0:
 
 * {beats-ref}/beats-reference.html[{beats}]
-* {apm-get-started-ref}/overview.html[APM]
+* {apm-guide-ref}/apm-overview.html[APM]
 * {security-guide}/es-overview.html[Elastic Security]
 ** {security-guide}/siem-field-reference.html[Elastic Security Field Reference] - a list of ECS fields used in the SIEM app
 * https://www.elastic.co/products/endpoint-security[Elastic Endpoint Security
@@ -15,4 +15,3 @@ Server]
 * {observability-guide}/analyze-metrics.html[Metrics Monitoring]
 
 // TODO Insert community & partner solutions here
-


### PR DESCRIPTION
Backports the following commits to 1.4:
 - docs: fix link to APM Overview (#1710)