### PR TITLE
fix improper script block end

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -269,7 +269,8 @@ $ python scripts/generator.py --subset ../myproject/ecs/subset-fields/
 $ python scripts/generator.py --subset ../myproject/ecs/subset-fields/ ../myproject/ecs/more-subset-fields/
 $ python scripts/generator.py --subset ../myproject/ecs/custom-fields/subset.yml
 $ python scripts/generator.py --subset ../myproject/ecs/custom-fields/[some]*[re].yml
-$ python scripts/generator.py --subset ../myproject/ecs/custom-fields/myfile1.yml ../myproject/ecs/custom-fields/myfile2.yml```
+$ python scripts/generator.py --subset ../myproject/ecs/custom-fields/myfile1.yml ../myproject/ecs/custom-fields/myfile2.yml
+```
 
 Example subset file:
 


### PR DESCRIPTION
Putting the markdown characters for the end of a script block at the end of a line does not terminate the block. The 3 backticks are rendered as part of the script block. This change puts the 3 backticks on a dedicated line to end the script block.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? Y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? Y
- If submitting code/script changes, have you verified all tests pass locally using `make test`? Not relevant
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? Not relevant
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. Y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? N
