### PR TITLE
[8.2] Include abbr in `FaaS` field set description (#1755)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -103,7 +103,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Added `faas.*` field set as beta. #1628
+* Added `faas.*` field set as beta. #1628, #1755
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -3497,7 +3497,7 @@ example: `https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38f
 [[ecs-faas]]
 === FaaS Fields
 
-The user fields describe information about the function as a service that is relevant to the event.
+The user fields describe information about the function as a service (FaaS) that is relevant to the event.
 
 beta::[ These fields are in beta and are subject to change.]
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2439,7 +2439,7 @@
     title: FaaS
     group: 2
     description: The user fields describe information about the function as a service
-      that is relevant to the event.
+      (FaaS) that is relevant to the event.
     type: group
     default_field: true
     fields:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4346,7 +4346,7 @@ event:
 faas:
   beta: These fields are in beta and are subject to change.
   description: The user fields describe information about the function as a service
-    that is relevant to the event.
+    (FaaS) that is relevant to the event.
   fields:
     faas.coldstart:
       dashed_name: faas-coldstart

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2351,7 +2351,7 @@
     title: FaaS
     group: 2
     description: The user fields describe information about the function as a service
-      that is relevant to the event.
+      (FaaS) that is relevant to the event.
     type: group
     default_field: true
     fields:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4204,7 +4204,7 @@ event:
 faas:
   beta: These fields are in beta and are subject to change.
   description: The user fields describe information about the function as a service
-    that is relevant to the event.
+    (FaaS) that is relevant to the event.
   fields:
     faas.coldstart:
       dashed_name: faas-coldstart

--- a/schemas/faas.yml
+++ b/schemas/faas.yml
@@ -21,7 +21,7 @@
   short: Fields describing functions as a service.
   description: >
     The user fields describe information about the function
-    as a service that is relevant to the event.
+    as a service (FaaS) that is relevant to the event.
   beta: >
     These fields are in beta and are subject to change.
   type: group


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Include abbr in `FaaS` field set description (#1755)