### PR TITLE
Cut 8.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,56 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.12.2](https://github.com/elastic/ecs/compare/v1.12.1...v1.12.2)]
+## [8.0.0](https://github.com/elastic/ecs/compare/v1.12.2...v8.0.0)
+
+### Schema Changes
+
+#### Breaking changes
+
+* Remove `host.user.*` field reuse. #1439
+* Remove deprecation notice on `http.request.method`. #1443
+* Migrate `log.origin.file.line` from `integer` to `long`. #1533
+* Remove `log.original` field. #1580
+* Remove `process.ppid` field. #1596
+
+#### Bugfixes
+
+* Fixed the `default_field` flag for root fields in Beats generator. #1711
+
+#### Added
+
+* Added `faas.*` field set as beta. #1628, #1755
+
+#### Bugfixes
+
+* Fixed the `default_field` flag for root fields in Beats generator. #1711
+
+#### Improvements
+
+* Wildcard type field migration GA. #1582
+* `match_only_text` type field migration GA. #1584
+* Threat indicator fields GA from RFC 0008. #1586
+
+### Tooling and Artifact Changes
+
+#### Breaking Changes
+
+* Removing deprecated --oss from generator #1404
+* Removing use-cases directory #1405
+* Remove Go code generator. #1567
+* Remove template generation for ES6. #1680
+* Update folder structure for generated ES artifacts. #1700, #1762
+* Updated support for overridable composable settings template. #1737
+
+#### Improvements
+
+* Align input options for --include and --subset arguments #1519
+* Remove remaining Go deps after removing Go code generator. #1585
+* Add explicit `default_field: true` for Beats artifacts. #1633
+* Reorganize docs directory structure. #1679
+* Added support for `analyzer` definitions for text fields. #1737
+
+## [1.12.2](https://github.com/elastic/ecs/compare/v1.12.1...v1.12.2)
 
 ### Tooling and Artifact Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,9 @@ All notable changes to this project will be documented in this file based on the
 * Remove `log.original` field. #1580
 * Remove `process.ppid` field. #1596
 
-#### Bugfixes
-
-* Fixed the `default_field` flag for root fields in Beats generator. #1711
-
 #### Added
 
 * Added `faas.*` field set as beta. #1628, #1755
-
-#### Bugfixes
-
-* Fixed the `default_field` flag for root fields in Beats generator. #1711
 
 #### Improvements
 
@@ -51,6 +43,10 @@ All notable changes to this project will be documented in this file based on the
 * Add explicit `default_field: true` for Beats artifacts. #1633
 * Reorganize docs directory structure. #1679
 * Added support for `analyzer` definitions for text fields. #1737
+
+#### Bugfixes
+
+* Fixed the `default_field` flag for root fields in Beats generator. #1711
 
 ## [1.12.2](https://github.com/elastic/ecs/compare/v1.12.1...v1.12.2)
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -32,55 +32,6 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-## 8.0.0 (Feature Freeze)
-
-### Schema Changes
-
-#### Breaking changes
-
-* Remove `host.user.*` field reuse. #1439
-* Remove deprecation notice on `http.request.method`. #1443
-* Migrate `log.origin.file.line` from `integer` to `long`. #1533
-* Remove `log.original` field. #1580
-* Remove `process.ppid` field. #1596
-
-#### Bugfixes
-
-* Fixed the `default_field` flag for root fields in Beats generator. #1711
-
-#### Added
-
-* Added `faas.*` field set as beta. #1628, #1755
-
-#### Bugfixes
-
-* Fixed the `default_field` flag for root fields in Beats generator. #1711
-
-#### Improvements
-
-* Wildcard type field migration GA. #1582
-* `match_only_text` type field migration GA. #1584
-* Threat indicator fields GA from RFC 0008. #1586
-
-### Tooling and Artifact Changes
-
-#### Breaking Changes
-
-* Removing deprecated --oss from generator #1404
-* Removing use-cases directory #1405
-* Remove Go code generator. #1567
-* Remove template generation for ES6. #1680
-* Update folder structure for generated ES artifacts. #1700, #1762
-* Updated support for overridable composable settings template. #1737
-
-#### Improvements
-
-* Align input options for --include and --subset arguments #1519
-* Remove remaining Go deps after removing Go code generator. #1585
-* Add explicit `default_field: true` for Beats artifacts. #1633
-* Reorganize docs directory structure. #1679
-* Added support for `analyzer` definitions for text fields. #1737
-
 <!-- All empty sections:
 
 ## Unreleased


### PR DESCRIPTION
Move upcoming 8.0.0 changelog notes from CHANGELOG.next to CHANGELOG.
