### PR TITLE
docs/using-ecs/guidelines/implementation: example json formatting fix

### DIFF
--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -130,7 +130,7 @@ fields nested under network transaction fields like `source.*`, `destination.*`,
 {
   "source": {
     "address": "8.8.8.8",
-    "ip": 8.8.8.8,
+    "ip": "8.8.8.8",
     "geo": {
       "continent_name": "North America",
       "country_name": "United States",

--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -130,13 +130,13 @@ fields nested under network transaction fields like `source.*`, `destination.*`,
 {
   "source": {
     "address": "8.8.8.8",
-	  "ip": 8.8.8.8,
+    "ip": 8.8.8.8,
     "geo": {
       "continent_name": "North America",
       "country_name": "United States",
       "country_iso_code": "US",
       "location": { "lat": 37.751, "lon": -97.822 }
-	}
+    }
   }
 }
 ----


### PR DESCRIPTION
This PR only fixes json example (indentation and string formatting) in `docs/using-ecs/guidelines/implementation.asciidoc`

See the broken example live: https://www.elastic.co/guide/en/ecs/current/ecs-principles-implementation.html#_lookup
<img width="746" alt="Screenshot 2022-02-15 at 13 42 25" src="https://user-images.githubusercontent.com/1488874/154064336-cb5673ef-2ad1-4b85-bc58-7f426e814fd7.png">
s