### PR TITLE
[8.1] docs/using-ecs/guidelines/implementation: example json formatting fix (#1775)

### DIFF
--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -130,13 +130,13 @@ fields nested under network transaction fields like `source.*`, `destination.*`,
 {
   "source": {
     "address": "8.8.8.8",
-	  "ip": 8.8.8.8,
+    "ip": "8.8.8.8",
     "geo": {
       "continent_name": "North America",
       "country_name": "United States",
       "country_iso_code": "US",
       "location": { "lat": 37.751, "lon": -97.822 }
-	}
+    }
   }
 }
 ----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [docs/using-ecs/guidelines/implementation: example json formatting fix (#1775)](https://github.com/elastic/ecs/pull/1775)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)