### PR TITLE
[8.1] Bump dependencies (#1782)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -58,6 +58,7 @@ Thanks, you're awesome :-) -->
 
 * Update refs from master to main in USAGE.md etc #1658
 * Clean up trailing spaces and additional newlines in schemas #1667
+* Bump dependencies. #1782
 
 <!-- All empty sections:
 

--- a/scripts/requirements-dev.txt
+++ b/scripts/requirements-dev.txt
@@ -1,6 +1,6 @@
 # License: MIT
-autopep8==1.4.4
+autopep8==1.6.0
 # License: BSD
-mock==4.0.2
+mock==4.0.3
 # License: GPLv3
-yamllint==1.19.0
+yamllint==1.26.3

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,7 +1,7 @@
 pip
 # License: MIT
-PyYAML==5.4
+PyYAML==6.0
 # License: BSD
-gitpython==3.1.2
+gitpython==3.1.27
 # License: BSD
-Jinja2==2.11.3
+Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Bump dependencies (#1782)](https://github.com/elastic/ecs/pull/1782)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)