### PR TITLE
Tuning stale workflow action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,5 +20,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR is stale because it has been open for 60 days with no activity.'
         stale-pr-label: 'stale'
+        ascending: true
         days-before-pr-stale: 60
-        days-before-pr-close: -1
+        days-before-issue-stale: -1
+        days-before-close: -1
+        operations-per-run: 120


### PR DESCRIPTION
Adjust the action now that I better understand how it runs:

* action doesn't offer a way only to evaluate PRs except labeling. Settings `days-before-close: -1` so now PRs or issues are inadvertently closed
* ensure issues are never marked `Stale` (for now): `days-before-issue-stale: -1`
* evaluate in ascending order: `ascending: true`
* up the max operations allowed from default (30) to 120: `operations-per-run: 120`