### PR TITLE
Add additional log.syslog fields

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Add six new syslog fields to `log.syslog.*`. #xxxx
+
 #### Improvements
 
 #### Deprecated

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,8 +16,6 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Add six new syslog fields to `log.syslog.*`. #1793
-
 #### Improvements
 
 #### Deprecated
@@ -49,6 +47,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Add beta `container.*` metric fields. #1789
+* Add six new syslog fields to `log.syslog.*`. #1793
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,7 +16,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Add six new syslog fields to `log.syslog.*`. #xxxx
+* Add six new syslog fields to `log.syslog.*`. #1793
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5434,22 +5434,6 @@ example: `sshd`
 // ===============================================================
 
 |
-[[field-log-syslog-data]]
-<<field-log-syslog-data, log.syslog.data>>
-
-| Structured data expressed in RFC 5424 messages, if available.
-
-type: flattened
-
-
-
-
-
-| extended
-
-// ===============================================================
-
-|
 [[field-log-syslog-facility-code]]
 <<field-log-syslog-facility-code, log.syslog.facility.code>>
 
@@ -5487,7 +5471,7 @@ example: `local7`
 [[field-log-syslog-hostname]]
 <<field-log-syslog-hostname, log.syslog.hostname>>
 
-| The hostname, FQDN, or IP of the machine that originally sent the Syslog message.
+| The hostname, FQDN, or IP of the machine that originally sent the Syslog message. This is sourced from the hostname field of the syslog header. Depending on the environment, this value may be different from the host that handled the event, especially if the host handling the events is acting as a collector.
 
 type: keyword
 
@@ -5586,12 +5570,28 @@ example: `Error`
 // ===============================================================
 
 |
+[[field-log-syslog-structured-data]]
+<<field-log-syslog-structured-data, log.syslog.structured_data>>
+
+| Structured data expressed in RFC 5424 messages, if available. These are key-value pairs formed from the structured data portion of the syslog message, as defined in RFC 5424 Section 6.3.
+
+type: flattened
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-log-syslog-version]]
 <<field-log-syslog-version, log.syslog.version>>
 
 | The version of the Syslog protocol specification. Only applicable for RFC 5424 messages.
 
-type: long
+type: keyword
 
 
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5418,6 +5418,38 @@ type: object
 // ===============================================================
 
 |
+[[field-log-syslog-appname]]
+<<field-log-syslog-appname, log.syslog.appname>>
+
+| The device or application that originated the Syslog message, if available.
+
+type: keyword
+
+
+
+example: `sshd`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-log-syslog-data]]
+<<field-log-syslog-data, log.syslog.data>>
+
+| Structured data expressed in RFC 5424 messages, if available.
+
+type: flattened
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-log-syslog-facility-code]]
 <<field-log-syslog-facility-code, log.syslog.facility.code>>
 
@@ -5452,6 +5484,38 @@ example: `local7`
 // ===============================================================
 
 |
+[[field-log-syslog-hostname]]
+<<field-log-syslog-hostname, log.syslog.hostname>>
+
+| The hostname, FQDN, or IP of the machine that originally sent the Syslog message.
+
+type: keyword
+
+
+
+example: `example-host`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-log-syslog-msgid]]
+<<field-log-syslog-msgid, log.syslog.msgid>>
+
+| An identifier for the type of Syslog message, if available. Only applicable for RFC 5424 messages.
+
+type: keyword
+
+
+
+example: `ID47`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-log-syslog-priority]]
 <<field-log-syslog-priority, log.syslog.priority>>
 
@@ -5464,6 +5528,22 @@ type: long
 
 
 example: `135`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-log-syslog-procid]]
+<<field-log-syslog-procid, log.syslog.procid>>
+
+| The process name or id that originated the Syslog message, if available.
+
+type: keyword
+
+
+
+example: `12345`
 
 | extended
 
@@ -5500,6 +5580,22 @@ type: keyword
 
 
 example: `Error`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-log-syslog-version]]
+<<field-log-syslog-version, log.syslog.version>>
+
+| The version of the Syslog protocol specification. Only applicable for RFC 5424 messages.
+
+type: long
+
+
+
+example: `1`
 
 | extended
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5537,7 +5537,7 @@ example: `135`
 [[field-log-syslog-procid]]
 <<field-log-syslog-procid, log.syslog.procid>>
 
-| The process name or id that originated the Syslog message, if available.
+| The process name or ID that originated the Syslog message, if available.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3894,7 +3894,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The process name or id that originated the Syslog message, if available.
+      description: The process name or ID that originated the Syslog message, if available.
       example: 12345
       default_field: false
     - name: syslog.severity.code

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3837,6 +3837,19 @@
       type: object
       description: The Syslog metadata of the event, if the event was transmitted
         via Syslog. Please see RFCs 5424 or 3164.
+    - name: syslog.appname
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The device or application that originated the Syslog message, if
+        available.
+      example: sshd
+      default_field: false
+    - name: syslog.data
+      level: extended
+      type: flattened
+      description: Structured data expressed in RFC 5424 messages, if available.
+      default_field: false
     - name: syslog.facility.code
       level: extended
       type: long
@@ -3852,6 +3865,22 @@
       ignore_above: 1024
       description: The Syslog text-based facility of the log event, if available.
       example: local7
+    - name: syslog.hostname
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The hostname, FQDN, or IP of the machine that originally sent the
+        Syslog message.
+      example: example-host
+      default_field: false
+    - name: syslog.msgid
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: An identifier for the type of Syslog message, if available. Only
+        applicable for RFC 5424 messages.
+      example: ID47
+      default_field: false
     - name: syslog.priority
       level: extended
       type: long
@@ -3861,6 +3890,13 @@
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.'
       example: 135
+    - name: syslog.procid
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The process name or id that originated the Syslog message, if available.
+      example: 12345
+      default_field: false
     - name: syslog.severity.code
       level: extended
       type: long
@@ -3882,6 +3918,13 @@
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error
+    - name: syslog.version
+      level: extended
+      type: long
+      description: The version of the Syslog protocol specification. Only applicable
+        for RFC 5424 messages.
+      example: 1
+      default_field: false
   - name: network
     title: Network
     group: 2

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3845,11 +3845,6 @@
         available.
       example: sshd
       default_field: false
-    - name: syslog.data
-      level: extended
-      type: flattened
-      description: Structured data expressed in RFC 5424 messages, if available.
-      default_field: false
     - name: syslog.facility.code
       level: extended
       type: long
@@ -3870,7 +3865,10 @@
       type: keyword
       ignore_above: 1024
       description: The hostname, FQDN, or IP of the machine that originally sent the
-        Syslog message.
+        Syslog message. This is sourced from the hostname field of the syslog header.
+        Depending on the environment, this value may be different from the host that
+        handled the event, especially if the host handling the events is acting as
+        a collector.
       example: example-host
       default_field: false
     - name: syslog.msgid
@@ -3918,9 +3916,17 @@
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error
+    - name: syslog.structured_data
+      level: extended
+      type: flattened
+      description: Structured data expressed in RFC 5424 messages, if available. These
+        are key-value pairs formed from the structured data portion of the syslog
+        message, as defined in RFC 5424 Section 6.3.
+      default_field: false
     - name: syslog.version
       level: extended
-      type: long
+      type: keyword
+      ignore_above: 1024
       description: The version of the Syslog protocol specification. Only applicable
         for RFC 5424 messages.
       example: 1

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -412,7 +412,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.3.0-dev+exp,true,log,log.syslog,object,extended,,,Syslog metadata
 8.3.0-dev+exp,true,log,log.syslog.appname,keyword,extended,,sshd,The device or application that originated the Syslog message.
-8.3.0-dev+exp,true,log,log.syslog.data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
 8.3.0-dev+exp,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.3.0-dev+exp,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
 8.3.0-dev+exp,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
@@ -421,7 +420,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,log,log.syslog.procid,keyword,extended,,12345,The process name or ID that originated the Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev+exp,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
-8.3.0-dev+exp,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.
+8.3.0-dev+exp,true,log,log.syslog.structured_data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
+8.3.0-dev+exp,true,log,log.syslog.version,keyword,extended,,1,Syslog protocol version.
 8.3.0-dev+exp,true,network,network.application,keyword,extended,,aim,Application level protocol name.
 8.3.0-dev+exp,true,network,network.bytes,long,core,,368,Total bytes transferred in both directions.
 8.3.0-dev+exp,true,network,network.community_id,keyword,extended,,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -411,11 +411,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.3.0-dev+exp,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.3.0-dev+exp,true,log,log.syslog,object,extended,,,Syslog metadata
+8.3.0-dev+exp,true,log,log.syslog.appname,keyword,extended,,sshd,The device or application that originated the Syslog message.
+8.3.0-dev+exp,true,log,log.syslog.data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
 8.3.0-dev+exp,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.3.0-dev+exp,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
+8.3.0-dev+exp,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
+8.3.0-dev+exp,true,log,log.syslog.msgid,keyword,extended,,ID47,An identifier for the type of Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.
+8.3.0-dev+exp,true,log,log.syslog.procid,keyword,extended,,12345,The process name or id that originated the Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev+exp,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
+8.3.0-dev+exp,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.
 8.3.0-dev+exp,true,network,network.application,keyword,extended,,aim,Application level protocol name.
 8.3.0-dev+exp,true,network,network.bytes,long,core,,368,Total bytes transferred in both directions.
 8.3.0-dev+exp,true,network,network.community_id,keyword,extended,,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -418,7 +418,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.msgid,keyword,extended,,ID47,An identifier for the type of Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.
-8.3.0-dev+exp,true,log,log.syslog.procid,keyword,extended,,12345,The process name or id that originated the Syslog message.
+8.3.0-dev+exp,true,log,log.syslog.procid,keyword,extended,,12345,The process name or ID that originated the Syslog message.
 8.3.0-dev+exp,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev+exp,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
 8.3.0-dev+exp,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5454,6 +5454,26 @@ log.syslog:
   normalize: []
   short: Syslog metadata
   type: object
+log.syslog.appname:
+  dashed_name: log-syslog-appname
+  description: The device or application that originated the Syslog message, if available.
+  example: sshd
+  flat_name: log.syslog.appname
+  ignore_above: 1024
+  level: extended
+  name: syslog.appname
+  normalize: []
+  short: The device or application that originated the Syslog message.
+  type: keyword
+log.syslog.data:
+  dashed_name: log-syslog-data
+  description: Structured data expressed in RFC 5424 messages, if available.
+  flat_name: log.syslog.data
+  level: extended
+  name: syslog.data
+  normalize: []
+  short: Structured data expressed in RFC 5424 messages.
+  type: flattened
 log.syslog.facility.code:
   dashed_name: log-syslog-facility-code
   description: 'The Syslog numeric facility of the log event, if available.
@@ -5479,6 +5499,30 @@ log.syslog.facility.name:
   normalize: []
   short: Syslog text-based facility of the event.
   type: keyword
+log.syslog.hostname:
+  dashed_name: log-syslog-hostname
+  description: The hostname, FQDN, or IP of the machine that originally sent the Syslog
+    message.
+  example: example-host
+  flat_name: log.syslog.hostname
+  ignore_above: 1024
+  level: extended
+  name: syslog.hostname
+  normalize: []
+  short: The host that originated the Syslog message.
+  type: keyword
+log.syslog.msgid:
+  dashed_name: log-syslog-msgid
+  description: An identifier for the type of Syslog message, if available. Only applicable
+    for RFC 5424 messages.
+  example: ID47
+  flat_name: log.syslog.msgid
+  ignore_above: 1024
+  level: extended
+  name: syslog.msgid
+  normalize: []
+  short: An identifier for the type of Syslog message.
+  type: keyword
 log.syslog.priority:
   dashed_name: log-syslog-priority
   description: 'Syslog numeric priority of the event, if available.
@@ -5493,6 +5537,17 @@ log.syslog.priority:
   normalize: []
   short: Syslog priority of the event.
   type: long
+log.syslog.procid:
+  dashed_name: log-syslog-procid
+  description: The process name or id that originated the Syslog message, if available.
+  example: 12345
+  flat_name: log.syslog.procid
+  ignore_above: 1024
+  level: extended
+  name: syslog.procid
+  normalize: []
+  short: The process name or id that originated the Syslog message.
+  type: keyword
 log.syslog.severity.code:
   dashed_name: log-syslog-severity-code
   description: 'The Syslog numeric severity of the log event, if available.
@@ -5524,6 +5579,17 @@ log.syslog.severity.name:
   normalize: []
   short: Syslog text-based severity of the event.
   type: keyword
+log.syslog.version:
+  dashed_name: log-syslog-version
+  description: The version of the Syslog protocol specification. Only applicable for
+    RFC 5424 messages.
+  example: 1
+  flat_name: log.syslog.version
+  level: extended
+  name: syslog.version
+  normalize: []
+  short: Syslog protocol version.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5465,15 +5465,6 @@ log.syslog.appname:
   normalize: []
   short: The device or application that originated the Syslog message.
   type: keyword
-log.syslog.data:
-  dashed_name: log-syslog-data
-  description: Structured data expressed in RFC 5424 messages, if available.
-  flat_name: log.syslog.data
-  level: extended
-  name: syslog.data
-  normalize: []
-  short: Structured data expressed in RFC 5424 messages.
-  type: flattened
 log.syslog.facility.code:
   dashed_name: log-syslog-facility-code
   description: 'The Syslog numeric facility of the log event, if available.
@@ -5502,7 +5493,9 @@ log.syslog.facility.name:
 log.syslog.hostname:
   dashed_name: log-syslog-hostname
   description: The hostname, FQDN, or IP of the machine that originally sent the Syslog
-    message.
+    message. This is sourced from the hostname field of the syslog header. Depending
+    on the environment, this value may be different from the host that handled the
+    event, especially if the host handling the events is acting as a collector.
   example: example-host
   flat_name: log.syslog.hostname
   ignore_above: 1024
@@ -5579,17 +5572,29 @@ log.syslog.severity.name:
   normalize: []
   short: Syslog text-based severity of the event.
   type: keyword
+log.syslog.structured_data:
+  dashed_name: log-syslog-structured-data
+  description: Structured data expressed in RFC 5424 messages, if available. These
+    are key-value pairs formed from the structured data portion of the syslog message,
+    as defined in RFC 5424 Section 6.3.
+  flat_name: log.syslog.structured_data
+  level: extended
+  name: syslog.structured_data
+  normalize: []
+  short: Structured data expressed in RFC 5424 messages.
+  type: flattened
 log.syslog.version:
   dashed_name: log-syslog-version
   description: The version of the Syslog protocol specification. Only applicable for
     RFC 5424 messages.
   example: 1
   flat_name: log.syslog.version
+  ignore_above: 1024
   level: extended
   name: syslog.version
   normalize: []
   short: Syslog protocol version.
-  type: long
+  type: keyword
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5539,14 +5539,14 @@ log.syslog.priority:
   type: long
 log.syslog.procid:
   dashed_name: log-syslog-procid
-  description: The process name or id that originated the Syslog message, if available.
+  description: The process name or ID that originated the Syslog message, if available.
   example: 12345
   flat_name: log.syslog.procid
   ignore_above: 1024
   level: extended
   name: syslog.procid
   normalize: []
-  short: The process name or id that originated the Syslog message.
+  short: The process name or ID that originated the Syslog message.
   type: keyword
 log.syslog.severity.code:
   dashed_name: log-syslog-severity-code

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6872,14 +6872,14 @@ log:
       type: long
     log.syslog.procid:
       dashed_name: log-syslog-procid
-      description: The process name or id that originated the Syslog message, if available.
+      description: The process name or ID that originated the Syslog message, if available.
       example: 12345
       flat_name: log.syslog.procid
       ignore_above: 1024
       level: extended
       name: syslog.procid
       normalize: []
-      short: The process name or id that originated the Syslog message.
+      short: The process name or ID that originated the Syslog message.
       type: keyword
     log.syslog.severity.code:
       dashed_name: log-syslog-severity-code

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6798,15 +6798,6 @@ log:
       normalize: []
       short: The device or application that originated the Syslog message.
       type: keyword
-    log.syslog.data:
-      dashed_name: log-syslog-data
-      description: Structured data expressed in RFC 5424 messages, if available.
-      flat_name: log.syslog.data
-      level: extended
-      name: syslog.data
-      normalize: []
-      short: Structured data expressed in RFC 5424 messages.
-      type: flattened
     log.syslog.facility.code:
       dashed_name: log-syslog-facility-code
       description: 'The Syslog numeric facility of the log event, if available.
@@ -6835,7 +6826,10 @@ log:
     log.syslog.hostname:
       dashed_name: log-syslog-hostname
       description: The hostname, FQDN, or IP of the machine that originally sent the
-        Syslog message.
+        Syslog message. This is sourced from the hostname field of the syslog header.
+        Depending on the environment, this value may be different from the host that
+        handled the event, especially if the host handling the events is acting as
+        a collector.
       example: example-host
       flat_name: log.syslog.hostname
       ignore_above: 1024
@@ -6912,17 +6906,29 @@ log:
       normalize: []
       short: Syslog text-based severity of the event.
       type: keyword
+    log.syslog.structured_data:
+      dashed_name: log-syslog-structured-data
+      description: Structured data expressed in RFC 5424 messages, if available. These
+        are key-value pairs formed from the structured data portion of the syslog
+        message, as defined in RFC 5424 Section 6.3.
+      flat_name: log.syslog.structured_data
+      level: extended
+      name: syslog.structured_data
+      normalize: []
+      short: Structured data expressed in RFC 5424 messages.
+      type: flattened
     log.syslog.version:
       dashed_name: log-syslog-version
       description: The version of the Syslog protocol specification. Only applicable
         for RFC 5424 messages.
       example: 1
       flat_name: log.syslog.version
+      ignore_above: 1024
       level: extended
       name: syslog.version
       normalize: []
       short: Syslog protocol version.
-      type: long
+      type: keyword
   group: 2
   name: log
   prefix: log.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6786,6 +6786,27 @@ log:
       normalize: []
       short: Syslog metadata
       type: object
+    log.syslog.appname:
+      dashed_name: log-syslog-appname
+      description: The device or application that originated the Syslog message, if
+        available.
+      example: sshd
+      flat_name: log.syslog.appname
+      ignore_above: 1024
+      level: extended
+      name: syslog.appname
+      normalize: []
+      short: The device or application that originated the Syslog message.
+      type: keyword
+    log.syslog.data:
+      dashed_name: log-syslog-data
+      description: Structured data expressed in RFC 5424 messages, if available.
+      flat_name: log.syslog.data
+      level: extended
+      name: syslog.data
+      normalize: []
+      short: Structured data expressed in RFC 5424 messages.
+      type: flattened
     log.syslog.facility.code:
       dashed_name: log-syslog-facility-code
       description: 'The Syslog numeric facility of the log event, if available.
@@ -6811,6 +6832,30 @@ log:
       normalize: []
       short: Syslog text-based facility of the event.
       type: keyword
+    log.syslog.hostname:
+      dashed_name: log-syslog-hostname
+      description: The hostname, FQDN, or IP of the machine that originally sent the
+        Syslog message.
+      example: example-host
+      flat_name: log.syslog.hostname
+      ignore_above: 1024
+      level: extended
+      name: syslog.hostname
+      normalize: []
+      short: The host that originated the Syslog message.
+      type: keyword
+    log.syslog.msgid:
+      dashed_name: log-syslog-msgid
+      description: An identifier for the type of Syslog message, if available. Only
+        applicable for RFC 5424 messages.
+      example: ID47
+      flat_name: log.syslog.msgid
+      ignore_above: 1024
+      level: extended
+      name: syslog.msgid
+      normalize: []
+      short: An identifier for the type of Syslog message.
+      type: keyword
     log.syslog.priority:
       dashed_name: log-syslog-priority
       description: 'Syslog numeric priority of the event, if available.
@@ -6825,6 +6870,17 @@ log:
       normalize: []
       short: Syslog priority of the event.
       type: long
+    log.syslog.procid:
+      dashed_name: log-syslog-procid
+      description: The process name or id that originated the Syslog message, if available.
+      example: 12345
+      flat_name: log.syslog.procid
+      ignore_above: 1024
+      level: extended
+      name: syslog.procid
+      normalize: []
+      short: The process name or id that originated the Syslog message.
+      type: keyword
     log.syslog.severity.code:
       dashed_name: log-syslog-severity-code
       description: 'The Syslog numeric severity of the log event, if available.
@@ -6856,6 +6912,17 @@ log:
       normalize: []
       short: Syslog text-based severity of the event.
       type: keyword
+    log.syslog.version:
+      dashed_name: log-syslog-version
+      description: The version of the Syslog protocol specification. Only applicable
+        for RFC 5424 messages.
+      example: 1
+      flat_name: log.syslog.version
+      level: extended
+      name: syslog.version
+      normalize: []
+      short: Syslog protocol version.
+      type: long
   group: 2
   name: log
   prefix: log.

--- a/experimental/generated/elasticsearch/composable/component/log.json
+++ b/experimental/generated/elasticsearch/composable/component/log.json
@@ -49,9 +49,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "data": {
-                  "type": "flattened"
-                },
                 "facility": {
                   "properties": {
                     "code": {
@@ -89,8 +86,12 @@
                     }
                   }
                 },
+                "structured_data": {
+                  "type": "flattened"
+                },
                 "version": {
-                  "type": "long"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               },
               "type": "object"

--- a/experimental/generated/elasticsearch/composable/component/log.json
+++ b/experimental/generated/elasticsearch/composable/component/log.json
@@ -45,6 +45,13 @@
             },
             "syslog": {
               "properties": {
+                "appname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "type": "flattened"
+                },
                 "facility": {
                   "properties": {
                     "code": {
@@ -56,8 +63,20 @@
                     }
                   }
                 },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "msgid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "priority": {
                   "type": "long"
+                },
+                "procid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "severity": {
                   "properties": {
@@ -69,6 +88,9 @@
                       "type": "keyword"
                     }
                   }
+                },
+                "version": {
+                  "type": "long"
                 }
               },
               "type": "object"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1976,6 +1976,13 @@
           },
           "syslog": {
             "properties": {
+              "appname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "data": {
+                "type": "flattened"
+              },
               "facility": {
                 "properties": {
                   "code": {
@@ -1987,8 +1994,20 @@
                   }
                 }
               },
+              "hostname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "msgid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "priority": {
                 "type": "long"
+              },
+              "procid": {
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "severity": {
                 "properties": {
@@ -2000,6 +2019,9 @@
                     "type": "keyword"
                   }
                 }
+              },
+              "version": {
+                "type": "long"
               }
             },
             "type": "object"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1980,9 +1980,6 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "data": {
-                "type": "flattened"
-              },
               "facility": {
                 "properties": {
                   "code": {
@@ -2020,8 +2017,12 @@
                   }
                 }
               },
+              "structured_data": {
+                "type": "flattened"
+              },
               "version": {
-                "type": "long"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             },
             "type": "object"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3795,11 +3795,6 @@
         available.
       example: sshd
       default_field: false
-    - name: syslog.data
-      level: extended
-      type: flattened
-      description: Structured data expressed in RFC 5424 messages, if available.
-      default_field: false
     - name: syslog.facility.code
       level: extended
       type: long
@@ -3820,7 +3815,10 @@
       type: keyword
       ignore_above: 1024
       description: The hostname, FQDN, or IP of the machine that originally sent the
-        Syslog message.
+        Syslog message. This is sourced from the hostname field of the syslog header.
+        Depending on the environment, this value may be different from the host that
+        handled the event, especially if the host handling the events is acting as
+        a collector.
       example: example-host
       default_field: false
     - name: syslog.msgid
@@ -3868,9 +3866,17 @@
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error
+    - name: syslog.structured_data
+      level: extended
+      type: flattened
+      description: Structured data expressed in RFC 5424 messages, if available. These
+        are key-value pairs formed from the structured data portion of the syslog
+        message, as defined in RFC 5424 Section 6.3.
+      default_field: false
     - name: syslog.version
       level: extended
-      type: long
+      type: keyword
+      ignore_above: 1024
       description: The version of the Syslog protocol specification. Only applicable
         for RFC 5424 messages.
       example: 1

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3844,7 +3844,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The process name or id that originated the Syslog message, if available.
+      description: The process name or ID that originated the Syslog message, if available.
       example: 12345
       default_field: false
     - name: syslog.severity.code

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3787,6 +3787,19 @@
       type: object
       description: The Syslog metadata of the event, if the event was transmitted
         via Syslog. Please see RFCs 5424 or 3164.
+    - name: syslog.appname
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The device or application that originated the Syslog message, if
+        available.
+      example: sshd
+      default_field: false
+    - name: syslog.data
+      level: extended
+      type: flattened
+      description: Structured data expressed in RFC 5424 messages, if available.
+      default_field: false
     - name: syslog.facility.code
       level: extended
       type: long
@@ -3802,6 +3815,22 @@
       ignore_above: 1024
       description: The Syslog text-based facility of the log event, if available.
       example: local7
+    - name: syslog.hostname
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The hostname, FQDN, or IP of the machine that originally sent the
+        Syslog message.
+      example: example-host
+      default_field: false
+    - name: syslog.msgid
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: An identifier for the type of Syslog message, if available. Only
+        applicable for RFC 5424 messages.
+      example: ID47
+      default_field: false
     - name: syslog.priority
       level: extended
       type: long
@@ -3811,6 +3840,13 @@
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.'
       example: 135
+    - name: syslog.procid
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The process name or id that originated the Syslog message, if available.
+      example: 12345
+      default_field: false
     - name: syslog.severity.code
       level: extended
       type: long
@@ -3832,6 +3868,13 @@
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error
+    - name: syslog.version
+      level: extended
+      type: long
+      description: The version of the Syslog protocol specification. Only applicable
+        for RFC 5424 messages.
+      example: 1
+      default_field: false
   - name: network
     title: Network
     group: 2

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -404,11 +404,17 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
 8.3.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.3.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata
+8.3.0-dev,true,log,log.syslog.appname,keyword,extended,,sshd,The device or application that originated the Syslog message.
+8.3.0-dev,true,log,log.syslog.data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
 8.3.0-dev,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.3.0-dev,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
+8.3.0-dev,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
+8.3.0-dev,true,log,log.syslog.msgid,keyword,extended,,ID47,An identifier for the type of Syslog message.
 8.3.0-dev,true,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.
+8.3.0-dev,true,log,log.syslog.procid,keyword,extended,,12345,The process name or id that originated the Syslog message.
 8.3.0-dev,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
+8.3.0-dev,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.
 8.3.0-dev,true,network,network.application,keyword,extended,,aim,Application level protocol name.
 8.3.0-dev,true,network,network.bytes,long,core,,368,Total bytes transferred in both directions.
 8.3.0-dev,true,network,network.community_id,keyword,extended,,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -405,7 +405,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
 8.3.0-dev,true,log,log.syslog,object,extended,,,Syslog metadata
 8.3.0-dev,true,log,log.syslog.appname,keyword,extended,,sshd,The device or application that originated the Syslog message.
-8.3.0-dev,true,log,log.syslog.data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
 8.3.0-dev,true,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
 8.3.0-dev,true,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
 8.3.0-dev,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
@@ -414,7 +413,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,log,log.syslog.procid,keyword,extended,,12345,The process name or ID that originated the Syslog message.
 8.3.0-dev,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
-8.3.0-dev,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.
+8.3.0-dev,true,log,log.syslog.structured_data,flattened,extended,,,Structured data expressed in RFC 5424 messages.
+8.3.0-dev,true,log,log.syslog.version,keyword,extended,,1,Syslog protocol version.
 8.3.0-dev,true,network,network.application,keyword,extended,,aim,Application level protocol name.
 8.3.0-dev,true,network,network.bytes,long,core,,368,Total bytes transferred in both directions.
 8.3.0-dev,true,network,network.community_id,keyword,extended,,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -411,7 +411,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,log,log.syslog.hostname,keyword,extended,,example-host,The host that originated the Syslog message.
 8.3.0-dev,true,log,log.syslog.msgid,keyword,extended,,ID47,An identifier for the type of Syslog message.
 8.3.0-dev,true,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.
-8.3.0-dev,true,log,log.syslog.procid,keyword,extended,,12345,The process name or id that originated the Syslog message.
+8.3.0-dev,true,log,log.syslog.procid,keyword,extended,,12345,The process name or ID that originated the Syslog message.
 8.3.0-dev,true,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
 8.3.0-dev,true,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
 8.3.0-dev,true,log,log.syslog.version,long,extended,,1,Syslog protocol version.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5396,15 +5396,6 @@ log.syslog.appname:
   normalize: []
   short: The device or application that originated the Syslog message.
   type: keyword
-log.syslog.data:
-  dashed_name: log-syslog-data
-  description: Structured data expressed in RFC 5424 messages, if available.
-  flat_name: log.syslog.data
-  level: extended
-  name: syslog.data
-  normalize: []
-  short: Structured data expressed in RFC 5424 messages.
-  type: flattened
 log.syslog.facility.code:
   dashed_name: log-syslog-facility-code
   description: 'The Syslog numeric facility of the log event, if available.
@@ -5433,7 +5424,9 @@ log.syslog.facility.name:
 log.syslog.hostname:
   dashed_name: log-syslog-hostname
   description: The hostname, FQDN, or IP of the machine that originally sent the Syslog
-    message.
+    message. This is sourced from the hostname field of the syslog header. Depending
+    on the environment, this value may be different from the host that handled the
+    event, especially if the host handling the events is acting as a collector.
   example: example-host
   flat_name: log.syslog.hostname
   ignore_above: 1024
@@ -5510,17 +5503,29 @@ log.syslog.severity.name:
   normalize: []
   short: Syslog text-based severity of the event.
   type: keyword
+log.syslog.structured_data:
+  dashed_name: log-syslog-structured-data
+  description: Structured data expressed in RFC 5424 messages, if available. These
+    are key-value pairs formed from the structured data portion of the syslog message,
+    as defined in RFC 5424 Section 6.3.
+  flat_name: log.syslog.structured_data
+  level: extended
+  name: syslog.structured_data
+  normalize: []
+  short: Structured data expressed in RFC 5424 messages.
+  type: flattened
 log.syslog.version:
   dashed_name: log-syslog-version
   description: The version of the Syslog protocol specification. Only applicable for
     RFC 5424 messages.
   example: 1
   flat_name: log.syslog.version
+  ignore_above: 1024
   level: extended
   name: syslog.version
   normalize: []
   short: Syslog protocol version.
-  type: long
+  type: keyword
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5385,6 +5385,26 @@ log.syslog:
   normalize: []
   short: Syslog metadata
   type: object
+log.syslog.appname:
+  dashed_name: log-syslog-appname
+  description: The device or application that originated the Syslog message, if available.
+  example: sshd
+  flat_name: log.syslog.appname
+  ignore_above: 1024
+  level: extended
+  name: syslog.appname
+  normalize: []
+  short: The device or application that originated the Syslog message.
+  type: keyword
+log.syslog.data:
+  dashed_name: log-syslog-data
+  description: Structured data expressed in RFC 5424 messages, if available.
+  flat_name: log.syslog.data
+  level: extended
+  name: syslog.data
+  normalize: []
+  short: Structured data expressed in RFC 5424 messages.
+  type: flattened
 log.syslog.facility.code:
   dashed_name: log-syslog-facility-code
   description: 'The Syslog numeric facility of the log event, if available.
@@ -5410,6 +5430,30 @@ log.syslog.facility.name:
   normalize: []
   short: Syslog text-based facility of the event.
   type: keyword
+log.syslog.hostname:
+  dashed_name: log-syslog-hostname
+  description: The hostname, FQDN, or IP of the machine that originally sent the Syslog
+    message.
+  example: example-host
+  flat_name: log.syslog.hostname
+  ignore_above: 1024
+  level: extended
+  name: syslog.hostname
+  normalize: []
+  short: The host that originated the Syslog message.
+  type: keyword
+log.syslog.msgid:
+  dashed_name: log-syslog-msgid
+  description: An identifier for the type of Syslog message, if available. Only applicable
+    for RFC 5424 messages.
+  example: ID47
+  flat_name: log.syslog.msgid
+  ignore_above: 1024
+  level: extended
+  name: syslog.msgid
+  normalize: []
+  short: An identifier for the type of Syslog message.
+  type: keyword
 log.syslog.priority:
   dashed_name: log-syslog-priority
   description: 'Syslog numeric priority of the event, if available.
@@ -5424,6 +5468,17 @@ log.syslog.priority:
   normalize: []
   short: Syslog priority of the event.
   type: long
+log.syslog.procid:
+  dashed_name: log-syslog-procid
+  description: The process name or id that originated the Syslog message, if available.
+  example: 12345
+  flat_name: log.syslog.procid
+  ignore_above: 1024
+  level: extended
+  name: syslog.procid
+  normalize: []
+  short: The process name or id that originated the Syslog message.
+  type: keyword
 log.syslog.severity.code:
   dashed_name: log-syslog-severity-code
   description: 'The Syslog numeric severity of the log event, if available.
@@ -5455,6 +5510,17 @@ log.syslog.severity.name:
   normalize: []
   short: Syslog text-based severity of the event.
   type: keyword
+log.syslog.version:
+  dashed_name: log-syslog-version
+  description: The version of the Syslog protocol specification. Only applicable for
+    RFC 5424 messages.
+  example: 1
+  flat_name: log.syslog.version
+  level: extended
+  name: syslog.version
+  normalize: []
+  short: Syslog protocol version.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5470,14 +5470,14 @@ log.syslog.priority:
   type: long
 log.syslog.procid:
   dashed_name: log-syslog-procid
-  description: The process name or id that originated the Syslog message, if available.
+  description: The process name or ID that originated the Syslog message, if available.
   example: 12345
   flat_name: log.syslog.procid
   ignore_above: 1024
   level: extended
   name: syslog.procid
   normalize: []
-  short: The process name or id that originated the Syslog message.
+  short: The process name or ID that originated the Syslog message.
   type: keyword
 log.syslog.severity.code:
   dashed_name: log-syslog-severity-code

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6792,14 +6792,14 @@ log:
       type: long
     log.syslog.procid:
       dashed_name: log-syslog-procid
-      description: The process name or id that originated the Syslog message, if available.
+      description: The process name or ID that originated the Syslog message, if available.
       example: 12345
       flat_name: log.syslog.procid
       ignore_above: 1024
       level: extended
       name: syslog.procid
       normalize: []
-      short: The process name or id that originated the Syslog message.
+      short: The process name or ID that originated the Syslog message.
       type: keyword
     log.syslog.severity.code:
       dashed_name: log-syslog-severity-code

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6706,6 +6706,27 @@ log:
       normalize: []
       short: Syslog metadata
       type: object
+    log.syslog.appname:
+      dashed_name: log-syslog-appname
+      description: The device or application that originated the Syslog message, if
+        available.
+      example: sshd
+      flat_name: log.syslog.appname
+      ignore_above: 1024
+      level: extended
+      name: syslog.appname
+      normalize: []
+      short: The device or application that originated the Syslog message.
+      type: keyword
+    log.syslog.data:
+      dashed_name: log-syslog-data
+      description: Structured data expressed in RFC 5424 messages, if available.
+      flat_name: log.syslog.data
+      level: extended
+      name: syslog.data
+      normalize: []
+      short: Structured data expressed in RFC 5424 messages.
+      type: flattened
     log.syslog.facility.code:
       dashed_name: log-syslog-facility-code
       description: 'The Syslog numeric facility of the log event, if available.
@@ -6731,6 +6752,30 @@ log:
       normalize: []
       short: Syslog text-based facility of the event.
       type: keyword
+    log.syslog.hostname:
+      dashed_name: log-syslog-hostname
+      description: The hostname, FQDN, or IP of the machine that originally sent the
+        Syslog message.
+      example: example-host
+      flat_name: log.syslog.hostname
+      ignore_above: 1024
+      level: extended
+      name: syslog.hostname
+      normalize: []
+      short: The host that originated the Syslog message.
+      type: keyword
+    log.syslog.msgid:
+      dashed_name: log-syslog-msgid
+      description: An identifier for the type of Syslog message, if available. Only
+        applicable for RFC 5424 messages.
+      example: ID47
+      flat_name: log.syslog.msgid
+      ignore_above: 1024
+      level: extended
+      name: syslog.msgid
+      normalize: []
+      short: An identifier for the type of Syslog message.
+      type: keyword
     log.syslog.priority:
       dashed_name: log-syslog-priority
       description: 'Syslog numeric priority of the event, if available.
@@ -6745,6 +6790,17 @@ log:
       normalize: []
       short: Syslog priority of the event.
       type: long
+    log.syslog.procid:
+      dashed_name: log-syslog-procid
+      description: The process name or id that originated the Syslog message, if available.
+      example: 12345
+      flat_name: log.syslog.procid
+      ignore_above: 1024
+      level: extended
+      name: syslog.procid
+      normalize: []
+      short: The process name or id that originated the Syslog message.
+      type: keyword
     log.syslog.severity.code:
       dashed_name: log-syslog-severity-code
       description: 'The Syslog numeric severity of the log event, if available.
@@ -6776,6 +6832,17 @@ log:
       normalize: []
       short: Syslog text-based severity of the event.
       type: keyword
+    log.syslog.version:
+      dashed_name: log-syslog-version
+      description: The version of the Syslog protocol specification. Only applicable
+        for RFC 5424 messages.
+      example: 1
+      flat_name: log.syslog.version
+      level: extended
+      name: syslog.version
+      normalize: []
+      short: Syslog protocol version.
+      type: long
   group: 2
   name: log
   prefix: log.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6718,15 +6718,6 @@ log:
       normalize: []
       short: The device or application that originated the Syslog message.
       type: keyword
-    log.syslog.data:
-      dashed_name: log-syslog-data
-      description: Structured data expressed in RFC 5424 messages, if available.
-      flat_name: log.syslog.data
-      level: extended
-      name: syslog.data
-      normalize: []
-      short: Structured data expressed in RFC 5424 messages.
-      type: flattened
     log.syslog.facility.code:
       dashed_name: log-syslog-facility-code
       description: 'The Syslog numeric facility of the log event, if available.
@@ -6755,7 +6746,10 @@ log:
     log.syslog.hostname:
       dashed_name: log-syslog-hostname
       description: The hostname, FQDN, or IP of the machine that originally sent the
-        Syslog message.
+        Syslog message. This is sourced from the hostname field of the syslog header.
+        Depending on the environment, this value may be different from the host that
+        handled the event, especially if the host handling the events is acting as
+        a collector.
       example: example-host
       flat_name: log.syslog.hostname
       ignore_above: 1024
@@ -6832,17 +6826,29 @@ log:
       normalize: []
       short: Syslog text-based severity of the event.
       type: keyword
+    log.syslog.structured_data:
+      dashed_name: log-syslog-structured-data
+      description: Structured data expressed in RFC 5424 messages, if available. These
+        are key-value pairs formed from the structured data portion of the syslog
+        message, as defined in RFC 5424 Section 6.3.
+      flat_name: log.syslog.structured_data
+      level: extended
+      name: syslog.structured_data
+      normalize: []
+      short: Structured data expressed in RFC 5424 messages.
+      type: flattened
     log.syslog.version:
       dashed_name: log-syslog-version
       description: The version of the Syslog protocol specification. Only applicable
         for RFC 5424 messages.
       example: 1
       flat_name: log.syslog.version
+      ignore_above: 1024
       level: extended
       name: syslog.version
       normalize: []
       short: Syslog protocol version.
-      type: long
+      type: keyword
   group: 2
   name: log
   prefix: log.

--- a/generated/elasticsearch/composable/component/log.json
+++ b/generated/elasticsearch/composable/component/log.json
@@ -49,9 +49,6 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "data": {
-                  "type": "flattened"
-                },
                 "facility": {
                   "properties": {
                     "code": {
@@ -89,8 +86,12 @@
                     }
                   }
                 },
+                "structured_data": {
+                  "type": "flattened"
+                },
                 "version": {
-                  "type": "long"
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               },
               "type": "object"

--- a/generated/elasticsearch/composable/component/log.json
+++ b/generated/elasticsearch/composable/component/log.json
@@ -45,6 +45,13 @@
             },
             "syslog": {
               "properties": {
+                "appname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "data": {
+                  "type": "flattened"
+                },
                 "facility": {
                   "properties": {
                     "code": {
@@ -56,8 +63,20 @@
                     }
                   }
                 },
+                "hostname": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "msgid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "priority": {
                   "type": "long"
+                },
+                "procid": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 },
                 "severity": {
                   "properties": {
@@ -69,6 +88,9 @@
                       "type": "keyword"
                     }
                   }
+                },
+                "version": {
+                  "type": "long"
                 }
               },
               "type": "object"

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1938,9 +1938,6 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "data": {
-                "type": "flattened"
-              },
               "facility": {
                 "properties": {
                   "code": {
@@ -1978,8 +1975,12 @@
                   }
                 }
               },
+              "structured_data": {
+                "type": "flattened"
+              },
               "version": {
-                "type": "long"
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             },
             "type": "object"

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1934,6 +1934,13 @@
           },
           "syslog": {
             "properties": {
+              "appname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "data": {
+                "type": "flattened"
+              },
               "facility": {
                 "properties": {
                   "code": {
@@ -1945,8 +1952,20 @@
                   }
                 }
               },
+              "hostname": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "msgid": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "priority": {
                 "type": "long"
+              },
+              "procid": {
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "severity": {
                 "properties": {
@@ -1958,6 +1977,9 @@
                     "type": "keyword"
                   }
                 }
+              },
+              "version": {
+                "type": "long"
               }
             },
             "type": "object"

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -156,3 +156,50 @@
 
         According to RFCs 5424 and 3164, the priority is 8 * facility + severity.
         This number is therefore expected to contain a value between 0 and 191.
+
+    - name: syslog.version
+      level: extended
+      type: long
+      example: 1
+      short: Syslog protocol version.
+      description: >
+        The version of the Syslog protocol specification. Only applicable for RFC 5424 messages.
+
+    - name: syslog.hostname
+      level: extended
+      type: keyword
+      example: example-host
+      short: The host that originated the Syslog message.
+      description: >
+        The hostname, FQDN, or IP of the machine that originally sent the Syslog message.
+
+    - name: syslog.appname
+      level: extended
+      type: keyword
+      example: sshd
+      short: The device or application that originated the Syslog message.
+      description: >
+        The device or application that originated the Syslog message, if available.
+
+    - name: syslog.procid
+      level: extended
+      type: keyword
+      example: 12345
+      short: The process name or id that originated the Syslog message.
+      description: >
+        The process name or id that originated the Syslog message, if available.
+
+    - name: syslog.msgid
+      level: extended
+      type: keyword
+      example: ID47
+      short: An identifier for the type of Syslog message.
+      description: >
+        An identifier for the type of Syslog message, if available. Only applicable for RFC 5424 messages.
+
+    - name: syslog.data
+      level: extended
+      type: flattened
+      short: Structured data expressed in RFC 5424 messages.
+      description: >
+        Structured data expressed in RFC 5424 messages, if available.

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -159,7 +159,7 @@
 
     - name: syslog.version
       level: extended
-      type: long
+      type: keyword
       example: 1
       short: Syslog protocol version.
       description: >
@@ -171,7 +171,11 @@
       example: example-host
       short: The host that originated the Syslog message.
       description: >
-        The hostname, FQDN, or IP of the machine that originally sent the Syslog message.
+        The hostname, FQDN, or IP of the machine that originally sent the Syslog
+        message. This is sourced from the hostname field of the syslog header.
+        Depending on the environment, this value may be different from the host
+        that handled the event, especially if the host handling the events is acting
+        as a collector.
 
     - name: syslog.appname
       level: extended
@@ -197,9 +201,11 @@
       description: >
         An identifier for the type of Syslog message, if available. Only applicable for RFC 5424 messages.
 
-    - name: syslog.data
+    - name: syslog.structured_data
       level: extended
       type: flattened
       short: Structured data expressed in RFC 5424 messages.
       description: >
-        Structured data expressed in RFC 5424 messages, if available.
+        Structured data expressed in RFC 5424 messages, if available. These are
+        key-value pairs formed from the structured data portion of the syslog
+        message, as defined in RFC 5424 Section 6.3.

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -185,9 +185,9 @@
       level: extended
       type: keyword
       example: 12345
-      short: The process name or id that originated the Syslog message.
+      short: The process name or ID that originated the Syslog message.
       description: >
-        The process name or id that originated the Syslog message, if available.
+        The process name or ID that originated the Syslog message, if available.
 
     - name: syslog.msgid
       level: extended


### PR DESCRIPTION
- Add additional fields for RFC 5424 messages (log.syslog.version,
log.syslog.msgid, log.syslog.data)
- Add log.syslog.hostname, log.syslog.appname, and log.syslog.procid
for hostname, process name, and process ID fields present in syslog
messages, respectively. These fields are added since it is not always
known that user wants these values copied to the more general ECS fields
(host.hostname, process.name, process.pid).