### PR TITLE
[8.2] [RFC] RFC 0010 `email.*` field set - stage 3 changes (#1794)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,6 +48,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* `email.*` field set now GA. #1794
+
 #### Deprecated
 
 ### Tooling and Artifact Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2581,8 +2581,6 @@ Event details relating to an email transaction.
 
 This field set focuses on the email message header, body, and attachments. Network protocols that send and receive email messages such as SMTP are outside the scope of the `email.*` fields.
 
-beta::[ These fields are in beta and subject to change.]
-
 [discrete]
 ==== Email Field Details
 

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -206,8 +206,6 @@ change, end, info, start
 [[ecs-event-category-email]]
 ==== email
 
-beta:[ This event categorization value is beta and subject to change. ]
-
 This category is used for events relating to email messages, email attachments, and email network or protocol activity.
 
 Emails events can be produced by email security gateways, mail transfer agents, email cloud service providers, or mail server monitoring applications.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2744,8 +2744,7 @@ event.category:
     - info
     - start
     name: driver
-  - beta: This event categorization value is beta and subject to change.
-    description: 'This category is used for events relating to email messages, email
+  - description: 'This category is used for events relating to email messages, email
       attachments, and email network or protocol activity.
 
       Emails events can be produced by email security gateways, mail transfer agents,

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3113,7 +3113,6 @@ elf:
   title: ELF Header
   type: group
 email:
-  beta: These fields are in beta and subject to change.
   description: 'Event details relating to an email transaction.
 
     This field set focuses on the email message header, body, and attachments. Network
@@ -3615,8 +3614,7 @@ event:
         - info
         - start
         name: driver
-      - beta: This event categorization value is beta and subject to change.
-        description: 'This category is used for events relating to email messages,
+      - description: 'This category is used for events relating to email messages,
           email attachments, and email network or protocol activity.
 
           Emails events can be produced by email security gateways, mail transfer

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2675,8 +2675,7 @@ event.category:
     - info
     - start
     name: driver
-  - beta: This event categorization value is beta and subject to change.
-    description: 'This category is used for events relating to email messages, email
+  - description: 'This category is used for events relating to email messages, email
       attachments, and email network or protocol activity.
 
       Emails events can be produced by email security gateways, mail transfer agents,

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3033,7 +3033,6 @@ elf:
   title: ELF Header
   type: group
 email:
-  beta: These fields are in beta and subject to change.
   description: 'Event details relating to an email transaction.
 
     This field set focuses on the email message header, body, and attachments. Network
@@ -3535,8 +3534,7 @@ event:
         - info
         - start
         name: driver
-      - beta: This event categorization value is beta and subject to change.
-        description: 'This category is used for events relating to email messages,
+      - description: 'This category is used for events relating to email messages,
           email attachments, and email network or protocol activity.
 
           Emails events can be produced by email security gateways, mail transfer

--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -7,8 +7,6 @@
 
     This field set focuses on the email message header, body, and attachments. Network protocols that send and receive
     email messages such as SMTP are outside the scope of the `email.*` fields.
-  beta: >
-    These fields are in beta and subject to change.
   type: group
   fields:
     - name: attachments

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -213,8 +213,6 @@
             cloud service providers, or mail server monitoring applications.
           expected_event_types:
             - info
-          beta: >
-            This event categorization value is beta and subject to change.
         - name: file
           description: >
             Relating to a set of information that has been created on, or has existed on a filesystem.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[RFC] RFC 0010 `email.*` field set - stage 3 changes (#1794)](https://github.com/elastic/ecs/pull/1794)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)