### PR TITLE
[8.2] [DOCS] Add release notes section (#1800)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Adding release notes section into ECS docs. #1800
+
 #### Improvements
 
 #### Deprecated

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -5,7 +5,10 @@
 include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:ecs_github_repo_link: https://github.com/elastic/ecs/blob/{source_branch}
+:ecs_repo: https://github.com/elastic/ecs/
+:ecs_github_repo_link: {ecs_repo}blob/{source_branch}
+:ecs_issue: {ecs_repo}issues/
+:ecs_pull: {ecs_repo}pull/
 
 [[ecs-reference]]
 == Overview
@@ -67,3 +70,4 @@ include::fields/fields.asciidoc[]
 include::fields/field-values.asciidoc[]
 include::migrating/index.asciidoc[]
 include::additional-info/index.asciidoc[]
+include::release-notes/index.asciidoc[]

--- a/docs/release-notes/8.0.asciidoc
+++ b/docs/release-notes/8.0.asciidoc
@@ -1,0 +1,61 @@
+[[ecs-release-notes-8.0.0]]
+=== 8.0.0
+
+[[schema-changes-8.0.0]]
+[float]
+==== Schema changes
+
+[[schema-breaking-8.0.0]]
+[float]
+===== Breaking changes
+
+* Remove `host.user.*` field reuse. {ecs_pull}1439[#1439]
+* Remove deprecation notice on `http.request.method`. {ecs_pull}1443[#1443]
+* Migrate `log.origin.file.line` from `integer` to `long`. {ecs_pull}1533[#1533]
+* Remove `log.original` field. {ecs_pull}1580[#1580]
+* Remove `process.ppid` field. {ecs_pull}1596[#1596]
+
+[[schema-added-8.0.0]]
+[float]
+===== Added
+
+* Added `faas.*` field set as beta. {ecs_pull}1628[#1628], {ecs_pull}1755[#1755]
+
+[[schema-improvements-8.0.0]]
+[float]
+===== Improvements
+
+* Wildcard type field migration GA. {ecs_pull}1582[#1582]
+* `match_only_text` type field migration GA. {ecs_pull}1584[#1584]
+* Threat indicator fields GA from RFC 0008. {ecs_pull}1586[#1586]
+
+[[tooling-changes-8.0.0]]
+[float]
+==== Tooling and artifact changes
+
+[[tooling-breaking-8.0.0]]
+[float]
+===== Breaking Changes
+
+* Removing deprecated --oss from generator {ecs_pull}1404[#1404]
+* Removing use-cases directory {ecs_pull}1405[#1405]
+* Remove Go code generator. {ecs_pull}1567[#1567]
+* Remove template generation for ES6. {ecs_pull}1680[#1680]
+* Update folder structure for generated ES artifacts. {ecs_pull}1700[#1700], {ecs_pull}1762[#1762]
+* Updated support for overridable composable settings template. {ecs_pull}1737[#1737]
+
+[[tooling-improvements-8.0.0]]
+[float]
+===== Improvements
+
+* Align input options for --include and --subset arguments {ecs_pull}1519[#1519]
+* Remove remaining Go deps after removing Go code generator. {ecs_pull}1585[#1585]
+* Add explicit `default_field: true` for Beats artifacts. {ecs_pull}1633[#1633]
+* Reorganize docs directory structure. {ecs_pull}1679[#1679]
+* Added support for `analyzer` definitions for text fields. {ecs_pull}1737[#1737]
+
+[[tooling-bugfixes-8.0.0]]
+[float]
+===== Bugfixes
+
+* Fixed the `default_field` flag for root fields in Beats generator. {ecs_pull}1711[#1711]

--- a/docs/release-notes/8.1.asciidoc
+++ b/docs/release-notes/8.1.asciidoc
@@ -1,0 +1,4 @@
+[[ecs-release-notes-8.1.0]]
+=== 8.1.0
+
+coming[8.1.0]

--- a/docs/release-notes/8.2.asciidoc
+++ b/docs/release-notes/8.2.asciidoc
@@ -1,0 +1,4 @@
+[[ecs-release-notes-8.2.0]]
+=== 8.2.0
+
+coming[8.2.0]

--- a/docs/release-notes/index.asciidoc
+++ b/docs/release-notes/index.asciidoc
@@ -1,0 +1,17 @@
+[[ecs-release-notes]]
+== Release Notes
+
+This section summarizes the changes in each release.
+
+* <<ecs-release-notes-8.2.0, {ecs} version 8.2.0>>
+* <<ecs-release-notes-8.1.0, {ecs} version 8.1.0>>
+* <<ecs-release-notes-8.0.0, {ecs} version 8.0.0>>
+
+// Use these for links to issue and pulls. Note issues and pulls redirect one to
+// each other on Github, so don't worry too much on using the right prefix.
+:issue: https://github.com/elastic/ecs/issues/
+:pull: https://github.com/elastic/ecs/pull/
+
+include::8.2.asciidoc[]
+include::8.1.asciidoc[]
+include::8.0.asciidoc[]

--- a/scripts/templates/index.j2
+++ b/scripts/templates/index.j2
@@ -5,7 +5,10 @@
 include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:ecs_github_repo_link: https://github.com/elastic/ecs/blob/{source_branch}
+:ecs_repo: https://github.com/elastic/ecs/
+:ecs_github_repo_link: {ecs_repo}blob/{source_branch}
+:ecs_issue: {ecs_repo}issues/
+:ecs_pull: {ecs_repo}pull/
 
 [[ecs-reference]]
 == Overview
@@ -67,3 +70,4 @@ include::fields/fields.asciidoc[]
 include::fields/field-values.asciidoc[]
 include::migrating/index.asciidoc[]
 include::additional-info/index.asciidoc[]
+include::release-notes/index.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [[DOCS] Add release notes section (#1800)](https://github.com/elastic/ecs/pull/1800)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)