### PR TITLE
Pin markupsafe for Jinja2 workaround

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,3 +5,4 @@ yamllint==1.19.0
 mock==4.0.2
 gitpython==3.1.2
 Jinja2==2.11.3
+markupsafe==2.0.1


### PR DESCRIPTION
Recently, Markupsafe released version `2.1.0`, and the [change](https://github.com/pallets/markupsafe/issues/286#issuecomment-1044491026) now causes versions of Jinja2 2.x to throw an exception when running the generator script:

```python
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```

A more recent version of Jinja2 resolves the issue: https://github.com/elastic/ecs/pull/1782.

Bumping a dependency to the next major for previous ECS releases feels excessive. However, new installs and CI for any backport to an older branch will fail without a fix. 

The following branches will have `markupsafe==2.0.1` pinned in their requirements files:

* `8.0` -> `8.0.1` will be released including the fix.
* `1.12`
* `1.11`
* `1.10`
* `1.9`
* `1.8`
* `1.7`
* `1.6`

Branches pre-`1.6.` did not use `Jinja2` as a dependency, so they are not affected.