### PR TITLE
[1.10] Pin markupsafe for Jinja2 workaround (#1804)

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,3 +5,4 @@ yamllint==1.19.0
 mock==4.0.2
 gitpython==3.1.2
 Jinja2==2.11.3
+markupsafe==2.0.1


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.0` to `1.10`:
 - [Pin markupsafe for Jinja2 workaround (#1804)](https://github.com/elastic/ecs/pull/1804)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)