### PR TITLE
[8.2] Added `id`, `name` and `version` fields for `faas` (#1796)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -81,6 +81,7 @@ Thanks, you're awesome :-) -->
 
 * Added two new fields (sha384,tlsh) to hash schema and one field to pe schema (pehash). #1678
 * Added `email.*` beta field set. ##1688, #1705
+* Added `faas.id` and `faas.name` fields. #1796
 
 #### Removed
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,7 +48,7 @@ Thanks, you're awesome :-) -->
 
 * Add beta `container.*` metric fields. #1789
 * Add six new syslog fields to `log.syslog.*`. #1793
-* Added `faas.id` and `faas.name` fields. #1796
+* Added `faas.id`, `faas.name` and `faas.version` fields as beta. #1796
 
 #### Improvements
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,6 +48,7 @@ Thanks, you're awesome :-) -->
 
 * Add beta `container.*` metric fields. #1789
 * Add six new syslog fields to `log.syslog.*`. #1793
+* Added `faas.id` and `faas.name` fields. #1796
 
 #### Improvements
 
@@ -65,13 +66,9 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-<<<<<<< HEAD
-#### Deprecated
-=======
 * Update refs from master to main in USAGE.md etc #1658
 * Clean up trailing spaces and additional newlines in schemas #1667
 * Use higher compression as default in composable index template settings. #1712
->>>>>>> 9b653645 (Higher default compression for composable templates (#1712))
 
 ## 8.1.0 (Hard Feature Freeze)
 
@@ -81,7 +78,6 @@ Thanks, you're awesome :-) -->
 
 * Added two new fields (sha384,tlsh) to hash schema and one field to pe schema (pehash). #1678
 * Added `email.*` beta field set. ##1688, #1705
-* Added `faas.id` and `faas.name` fields. #1796
 
 #### Removed
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -70,6 +70,8 @@ Thanks, you're awesome :-) -->
 * Clean up trailing spaces and additional newlines in schemas #1667
 * Use higher compression as default in composable index template settings. #1712
 
+#### Deprecated
+
 ## 8.1.0 (Hard Feature Freeze)
 
 ### Schema Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -3649,6 +3649,40 @@ example: `af9d5aa4-a685-4c5f-a22b-444f80b3cc28`
 // ===============================================================
 
 |
+[[field-faas-id]]
+<<field-faas-id, faas.id>>
+
+| The unique identifier of a serverless function.
+
+For AWS Lambda it's the function ARN (Amazon Resource Name) without a version or alias suffix.
+
+type: keyword
+
+
+
+example: `arn:aws:lambda:us-west-2:123456789012:function:my-function`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-name]]
+<<field-faas-name, faas.name>>
+
+| The name of a serverless function.
+
+type: keyword
+
+
+
+example: `my-function`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-faas-trigger]]
 <<field-faas-trigger, faas.trigger>>
 
@@ -3703,6 +3737,22 @@ type: keyword
 
 
 example: `http`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-faas-version]]
+<<field-faas-version, faas.version>>
+
+| The version of a serverless function.
+
+type: keyword
+
+
+
+example: `123`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2455,6 +2455,23 @@
       description: The execution ID of the current function execution.
       example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
       default_field: false
+    - name: id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The unique identifier of a serverless function.
+
+        For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+        or alias suffix.'
+      example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+      default_field: false
+    - name: name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of a serverless function.
+      example: my-function
+      default_field: false
     - name: trigger
       level: extended
       type: nested
@@ -2474,6 +2491,13 @@
       description: "The trigger for the function execution.\nExpected values are:\n\
         \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
       example: http
+      default_field: false
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The version of a serverless function.
+      example: '123'
       default_field: false
   - name: file
     title: File

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -246,9 +246,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 8.2.0-dev+exp,true,faas,faas.coldstart,boolean,extended,,,Boolean value indicating a cold start of a function.
 8.2.0-dev+exp,true,faas,faas.execution,keyword,extended,,af9d5aa4-a685-4c5f-a22b-444f80b3cc28,The execution ID of the current function execution.
+8.2.0-dev+exp,true,faas,faas.id,keyword,extended,,arn:aws:lambda:us-west-2:123456789012:function:my-function,The unique identifier of a serverless function.
+8.2.0-dev+exp,true,faas,faas.name,keyword,extended,,my-function,The name of a serverless function.
 8.2.0-dev+exp,true,faas,faas.trigger,nested,extended,,,Details about the function trigger.
 8.2.0-dev+exp,true,faas,faas.trigger.request_id,keyword,extended,,123456789,"The ID of the trigger request , message, event, etc."
 8.2.0-dev+exp,true,faas,faas.trigger.type,keyword,extended,,http,The trigger for the function execution.
+8.2.0-dev+exp,true,faas,faas.version,keyword,extended,,123,The version of a serverless function.
 8.2.0-dev+exp,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.2.0-dev+exp,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.2.0-dev+exp,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3475,6 +3475,31 @@ faas.execution:
   normalize: []
   short: The execution ID of the current function execution.
   type: keyword
+faas.id:
+  dashed_name: faas-id
+  description: 'The unique identifier of a serverless function.
+
+    For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+    or alias suffix.'
+  example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+  flat_name: faas.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  short: The unique identifier of a serverless function.
+  type: keyword
+faas.name:
+  dashed_name: faas-name
+  description: The name of a serverless function.
+  example: my-function
+  flat_name: faas.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  short: The name of a serverless function.
+  type: keyword
 faas.trigger:
   dashed_name: faas-trigger
   description: Details about the function trigger.
@@ -3506,6 +3531,17 @@ faas.trigger.type:
   name: trigger.type
   normalize: []
   short: The trigger for the function execution.
+  type: keyword
+faas.version:
+  dashed_name: faas-version
+  description: The version of a serverless function.
+  example: '123'
+  flat_name: faas.version
+  ignore_above: 1024
+  level: extended
+  name: version
+  normalize: []
+  short: The version of a serverless function.
   type: keyword
 file.accessed:
   dashed_name: file-accessed

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4372,6 +4372,31 @@ faas:
       normalize: []
       short: The execution ID of the current function execution.
       type: keyword
+    faas.id:
+      dashed_name: faas-id
+      description: 'The unique identifier of a serverless function.
+
+        For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+        or alias suffix.'
+      example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+      flat_name: faas.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      short: The unique identifier of a serverless function.
+      type: keyword
+    faas.name:
+      dashed_name: faas-name
+      description: The name of a serverless function.
+      example: my-function
+      flat_name: faas.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      short: The name of a serverless function.
+      type: keyword
     faas.trigger:
       dashed_name: faas-trigger
       description: Details about the function trigger.
@@ -4403,6 +4428,17 @@ faas:
       name: trigger.type
       normalize: []
       short: The trigger for the function execution.
+      type: keyword
+    faas.version:
+      dashed_name: faas-version
+      description: The version of a serverless function.
+      example: '123'
+      flat_name: faas.version
+      ignore_above: 1024
+      level: extended
+      name: version
+      normalize: []
+      short: The version of a serverless function.
       type: keyword
   group: 2
   name: faas

--- a/experimental/generated/elasticsearch/composable/component/faas.json
+++ b/experimental/generated/elasticsearch/composable/component/faas.json
@@ -15,6 +15,14 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "trigger": {
               "properties": {
                 "request_id": {
@@ -27,6 +35,10 @@
                 }
               },
               "type": "nested"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -1227,6 +1227,14 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "name": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "trigger": {
             "properties": {
               "request_id": {
@@ -1239,6 +1247,10 @@
               }
             },
             "type": "nested"
+          },
+          "version": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2405,6 +2405,23 @@
       description: The execution ID of the current function execution.
       example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28
       default_field: false
+    - name: id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The unique identifier of a serverless function.
+
+        For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+        or alias suffix.'
+      example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+      default_field: false
+    - name: name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of a serverless function.
+      example: my-function
+      default_field: false
     - name: trigger
       level: extended
       type: nested
@@ -2424,6 +2441,13 @@
       description: "The trigger for the function execution.\nExpected values are:\n\
         \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
       example: http
+      default_field: false
+    - name: version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The version of a serverless function.
+      example: '123'
       default_field: false
   - name: file
     title: File

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -239,9 +239,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
 8.2.0-dev,true,faas,faas.coldstart,boolean,extended,,,Boolean value indicating a cold start of a function.
 8.2.0-dev,true,faas,faas.execution,keyword,extended,,af9d5aa4-a685-4c5f-a22b-444f80b3cc28,The execution ID of the current function execution.
+8.2.0-dev,true,faas,faas.id,keyword,extended,,arn:aws:lambda:us-west-2:123456789012:function:my-function,The unique identifier of a serverless function.
+8.2.0-dev,true,faas,faas.name,keyword,extended,,my-function,The name of a serverless function.
 8.2.0-dev,true,faas,faas.trigger,nested,extended,,,Details about the function trigger.
 8.2.0-dev,true,faas,faas.trigger.request_id,keyword,extended,,123456789,"The ID of the trigger request , message, event, etc."
 8.2.0-dev,true,faas,faas.trigger.type,keyword,extended,,http,The trigger for the function execution.
+8.2.0-dev,true,faas,faas.version,keyword,extended,,123,The version of a serverless function.
 8.2.0-dev,true,file,file.accessed,date,extended,,,Last time the file was accessed.
 8.2.0-dev,true,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
 8.2.0-dev,true,file,file.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3406,6 +3406,31 @@ faas.execution:
   normalize: []
   short: The execution ID of the current function execution.
   type: keyword
+faas.id:
+  dashed_name: faas-id
+  description: 'The unique identifier of a serverless function.
+
+    For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+    or alias suffix.'
+  example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+  flat_name: faas.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  short: The unique identifier of a serverless function.
+  type: keyword
+faas.name:
+  dashed_name: faas-name
+  description: The name of a serverless function.
+  example: my-function
+  flat_name: faas.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  short: The name of a serverless function.
+  type: keyword
 faas.trigger:
   dashed_name: faas-trigger
   description: Details about the function trigger.
@@ -3437,6 +3462,17 @@ faas.trigger.type:
   name: trigger.type
   normalize: []
   short: The trigger for the function execution.
+  type: keyword
+faas.version:
+  dashed_name: faas-version
+  description: The version of a serverless function.
+  example: '123'
+  flat_name: faas.version
+  ignore_above: 1024
+  level: extended
+  name: version
+  normalize: []
+  short: The version of a serverless function.
   type: keyword
 file.accessed:
   dashed_name: file-accessed

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4292,6 +4292,31 @@ faas:
       normalize: []
       short: The execution ID of the current function execution.
       type: keyword
+    faas.id:
+      dashed_name: faas-id
+      description: 'The unique identifier of a serverless function.
+
+        For AWS Lambda it''s the function ARN (Amazon Resource Name) without a version
+        or alias suffix.'
+      example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+      flat_name: faas.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      short: The unique identifier of a serverless function.
+      type: keyword
+    faas.name:
+      dashed_name: faas-name
+      description: The name of a serverless function.
+      example: my-function
+      flat_name: faas.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      short: The name of a serverless function.
+      type: keyword
     faas.trigger:
       dashed_name: faas-trigger
       description: Details about the function trigger.
@@ -4323,6 +4348,17 @@ faas:
       name: trigger.type
       normalize: []
       short: The trigger for the function execution.
+      type: keyword
+    faas.version:
+      dashed_name: faas-version
+      description: The version of a serverless function.
+      example: '123'
+      flat_name: faas.version
+      ignore_above: 1024
+      level: extended
+      name: version
+      normalize: []
+      short: The version of a serverless function.
       type: keyword
   group: 2
   name: faas

--- a/generated/elasticsearch/composable/component/faas.json
+++ b/generated/elasticsearch/composable/component/faas.json
@@ -15,6 +15,14 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
             "trigger": {
               "properties": {
                 "request_id": {
@@ -27,6 +35,10 @@
                 }
               },
               "type": "nested"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
             }
           }
         }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -1185,6 +1185,14 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "id": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "name": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "trigger": {
             "properties": {
               "request_id": {
@@ -1197,6 +1205,10 @@
               }
             },
             "type": "nested"
+          },
+          "version": {
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },

--- a/rfcs/text/0027-faas-fields.md
+++ b/rfcs/text/0027-faas-fields.md
@@ -59,6 +59,9 @@ Discussing the initial proposal with Andrew Wilkins, we came up with an adapted 
 ### New Fields
 Field | Type | Example | Description | Use case
  -- | -- | --  | --  |--
+faas.id | keyword | `arn:aws:lambda:us-west-2:123456789012:function:my-function`  | The unique identifier of a serverless function. For AWS Lambda it's the function ARN (Amazon Resource Name) without a version or alias suffix.  | Correlation of traces, logs and metrics for a specific serverless function.
+faas.name | keyword | `my-function`  | The name of a serverless function.  | Display name of a serverless function.
+faas.version | keyword | `123`  | The version of a serverless function.  | Group / differentiate data by the version of a serverless function.
 faas.coldstart | boolean | true | Boolean value indicating a cold start of a function | Can be used in the UI denote function coldstarts.
 faas.execution | keyword | "af9d5aa4-a685-4c5f-a22b-444f80b3cc28" | The execution ID of the current function execution. | Allows correlation with CloudWatch logs and metrics
 faas.trigger.type | keyword | "http" | one of `http`,`pubsub`,`datasource`, `timer`, `other` | Allows differentiating different function types
@@ -94,6 +97,9 @@ Done.
 Stage 1: Describe at a high-level how these field changes will be used in practice. Real world examples are encouraged. The goal here is to understand how people would leverage these fields to gain insights or solve problems. ~1-3 paragraphs.
 -->
 
+### `faas.id`, `faas.name` & `faas.version`
+Allows for correlating traces, logs and metrics for individual serverless functions and versions. `faas.name` will be used as the display name of serverless functions in the UI.
+
 ### `faas.coldstart`
 Will be used in the APM UI to mark function invocations that resultet from a coldstart. This is a useful information for the end users to differentiate coldstart behaviour from warmstart function invocations.
 
@@ -122,6 +128,9 @@ The mapping to the proposed fields for this example is layed out in the followin
 
 target ECS field | source field
 --- | ---
+faas.id | `context.invokedFunctionArn`
+faas.name | `context.functionName`
+faas.version | `context.functionVersion`
 faas.coldstart | No source field. Determined by the APM agent on the first Lambda function invocation.
 faas.execution | `context.awsRequestId`
 faas.trigger.type | No source field. Determined by the APM agent based on the `event object` type. Would be `http` in this example.

--- a/rfcs/text/0027/faas.yml
+++ b/rfcs/text/0027/faas.yml
@@ -9,6 +9,27 @@
     Google Cloud Functions, etc.
   type: group
   fields:
+    - name: id
+      level: extended
+      example: arn:aws:lambda:us-west-2:123456789012:function:my-function
+      type: keyword
+      short: The unique identifier of a serverless function.
+      description: >
+        The unique identifier of a serverless function.
+
+        For AWS Lambda it's the function ARN (Amazon Resource Name) without a version or alias suffix.
+    - name: name
+      level: extended
+      example: my-function
+      type: keyword
+      description: >
+        The name of a serverless function.
+    - name: version
+      level: extended
+      example: 123
+      type: keyword
+      description: >
+        The version of a serverless function.
     - name: execution
       level: extended
       example: af9d5aa4-a685-4c5f-a22b-444f80b3cc28

--- a/schemas/faas.yml
+++ b/schemas/faas.yml
@@ -26,6 +26,27 @@
     These fields are in beta and are subject to change.
   type: group
   fields:
+    - name: name
+      description: >
+        The name of a serverless function.
+      type: keyword
+      level: extended
+      example: "my-function"
+    - name: id
+      short: The unique identifier of a serverless function.
+      description: >
+        The unique identifier of a serverless function.
+
+        For AWS Lambda it's the function ARN (Amazon Resource Name) without a version or alias suffix.
+      type: keyword
+      level: extended
+      example: "arn:aws:lambda:us-west-2:123456789012:function:my-function"
+    - name: version
+      description: >
+        The version of a serverless function.
+      type: keyword
+      level: extended
+      example: "123"
     - name: coldstart
       description: >
         Boolean value indicating a cold start of a function.


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Added `id`, `name` and `version` fields for `faas` (#1796)