### PR TITLE
generated/elasticsearch/README.md: Fix cut index

### DIFF
--- a/generated/elasticsearch/README.md
+++ b/generated/elasticsearch/README.md
@@ -56,7 +56,7 @@ auth="elastic:elastic"
 version="$(cat version)"
 for file in `ls generated/elasticsearch/composable/component/*.json`
 do
-  fieldset=`echo $file | cut -d/ -f4 | cut -d. -f1 | tr A-Z a-z`
+  fieldset=`echo $file | cut -d/ -f5 | cut -d. -f1 | tr A-Z a-z`
   component_name="ecs_${version}_${fieldset}"
   api="_component_template/${component_name}"
 


### PR DESCRIPTION
The fifth field, not the fourth (since `cut` is indexes from one, not zero), contains the component name. Having `cut` keep the fourth field makes all templates have the name "component".

With `cut -d/ -f4`:

```console
$ ls generated/elasticsearch/composable/component/*.json -1 | cut -d/ -f4 | cut -d. -f1 | tr A-Z a-z
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
component
```

With `cut -d/ -f5`:

```console
$ ls generated/elasticsearch/composable/component/*.json -1 | cut -d/ -f5 | cut -d. -f1 | tr A-Z a-z
agent
base
client
cloud
container
data_stream
destination
dll
dns
ecs
email
error
event
faas
file
group
host
http
log
network
observer
orchestrator
organization
package
process
registry
related
rule
server
service
source
threat
tls
tracing
url
user_agent
user
vulnerability
```