### PR TITLE
[8.2] add 8.0.1 release notes (#1818)

### DIFF
--- a/docs/release-notes/8.0.1.asciidoc
+++ b/docs/release-notes/8.0.1.asciidoc
@@ -1,0 +1,12 @@
+[[ecs-release-notes-8.0.1]]
+=== 8.0.1
+
+[[tooling-changes-8.0.1]]
+[float]
+==== Tooling and artifact changes
+
+[[tooling-bugfixes-8.0.1]]
+[float]
+===== Bugfixes
+
+* Pin `markupsafe==2.0.1` to resolve `ImportError` exception. {ecs_pull}1804[#1804]

--- a/docs/release-notes/index.asciidoc
+++ b/docs/release-notes/index.asciidoc
@@ -5,6 +5,7 @@ This section summarizes the changes in each release.
 
 * <<ecs-release-notes-8.2.0, {ecs} version 8.2.0>>
 * <<ecs-release-notes-8.1.0, {ecs} version 8.1.0>>
+* <<ecs-release-notes-8.0.1, {ecs} version 8.0.1>>
 * <<ecs-release-notes-8.0.0, {ecs} version 8.0.0>>
 
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
@@ -14,4 +15,5 @@ This section summarizes the changes in each release.
 
 include::8.2.asciidoc[]
 include::8.1.asciidoc[]
+include::8.0.1.asciidoc[]
 include::8.0.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [add 8.0.1 release notes (#1818)](https://github.com/elastic/ecs/pull/1818)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)