### PR TITLE
[8.2] Add optional `pattern` attribute (#1834)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -64,6 +64,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Adding optional field attribute, `pattern`. #1834
+
 #### Improvements
 
 * Update refs from master to main in USAGE.md etc #1658

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -162,6 +162,7 @@ Supported keys to describe fields
 - index (optional): If `False`, means field is not indexed (overrides type). This parameter has no effect
   on a `wildcard` field.
 - format: Field format that can be used in a Kibana index template.
+- pattern (optional): A regular expression that expresses the expected constraints of the field's string values.
 - normalize: Normalization steps that should be applied at ingestion time. Supported values:
   - array: the content of the field should be an array (even when there's only one value).
 - beta (optional): Adds a beta marker for the field to the description. The text provided in this attribute is used as content of the beta marker in the documentation. Note that when a whole field set is marked as beta, it is not necessary nor recommended to mark all fields in the field set as beta. Beta notices should not have newlines.

--- a/scripts/generators/beats.py
+++ b/scripts/generators/beats.py
@@ -75,7 +75,7 @@ def fieldset_field_array(source_fields, fieldset_prefix):
                     'ignore_above', 'multi_fields', 'format', 'input_format',
                     'output_format', 'output_precision', 'description',
                     'example', 'enabled', 'index', 'doc_values', 'path',
-                    'scaling_factor']
+                    'scaling_factor', 'pattern']
     multi_fields_allowed_keys = ['name', 'type', 'norms', 'default_field', 'normalizer', 'ignore_above']
 
     fields = []

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import copy
+import re
 
 from generators import ecs_helpers
 from schema import visitor
@@ -202,9 +202,11 @@ def field_assertions_and_warnings(field):
     if not ecs_helpers.is_intermediate(field):
         # check short description length if in strict mode
         single_line_short_description(field, strict=strict_mode)
-        check_example_value(field, strict=strict_mode)
         if 'beta' in field['field_details']:
             single_line_beta_description(field, strict=strict_mode)
+        if 'pattern' in field['field_details']:
+            validate_pattern_regex(field['field_details'], strict=strict_mode)
+        check_example_value(field, strict=strict_mode)
         if field['field_details']['level'] not in ACCEPTABLE_FIELD_LEVELS:
             msg = "Invalid level for field '{}'.\nValue: {}\nAcceptable values: {}".format(
                 field['field_details']['name'], field['field_details']['level'],
@@ -229,13 +231,18 @@ def single_line_short_check(short_to_check, short_name):
     return None
 
 
+def strict_warning_handler(message, strict):
+    """Handles warnings based on --strict mode"""
+    if strict:
+        raise ValueError(message)
+    else:
+        ecs_helpers.strict_warning(message)
+
+
 def single_line_short_description(schema_or_field, strict=True):
     error = single_line_short_check(schema_or_field['field_details']['short'], schema_or_field['field_details']['name'])
     if error:
-        if strict:
-            raise ValueError(error)
-        else:
-            ecs_helpers.strict_warning(error)
+        strict_warning_handler(error, strict)
 
 
 def single_line_short_override_description(schema_or_field, strict=True):
@@ -244,10 +251,7 @@ def single_line_short_override_description(schema_or_field, strict=True):
             continue
         error = single_line_short_check(field['short_override'], field['full'])
         if error:
-            if strict:
-                raise ValueError(error)
-            else:
-                ecs_helpers.strict_warning(error)
+            strict_warning_handler(error, strict)
 
 
 def check_example_value(field, strict=True):
@@ -256,20 +260,34 @@ def check_example_value(field, strict=True):
     Fails or warns (depending on strict mode) if so.
     """
     example_value = field['field_details'].get('example', None)
+    pattern = field['field_details'].get('pattern', None)
+    name = field['field_details']['name']
+
     if isinstance(example_value, (list, dict)):
-        name = field['field_details']['name']
         msg = f"Example value for field `{name}` contains an object or array which must be quoted to avoid YAML interpretation."
-        if strict:
-            raise ValueError(msg)
-        else:
-            ecs_helpers.strict_warning(msg)
+        strict_warning_handler(msg, strict)
+
+    if pattern:
+        match = re.match(pattern, example_value)
+        if not match:
+            msg = f"Example value for field `{name}` does not match the regex defined in the pattern attribute: `{pattern}`."
+            strict_warning_handler(msg, strict)
 
 
 def single_line_beta_description(schema_or_field, strict=True):
     if "\n" in schema_or_field['field_details']['beta']:
         msg = "Beta descriptions must be single line.\n"
         msg += f"Offending field or field set: {schema_or_field['field_details']['name']}"
-        if strict:
-            raise ValueError(msg)
-        else:
-            ecs_helpers.strict_warning(msg)
+        strict_warning_handler(msg, strict)
+
+
+def validate_pattern_regex(field, strict=True):
+    """
+    Validates if field['pattern'] contains a valid regular expression.
+    """
+    try:
+        re.compile(field['pattern'])
+    except re.error:
+        msg = "Pattern value must be a valid regular expression.\n"
+        msg += f"Offending field name: {field['name']}"
+        strict_warning_handler(msg, strict)

--- a/scripts/tests/unit/test_beats_generator.py
+++ b/scripts/tests/unit/test_beats_generator.py
@@ -90,6 +90,38 @@ class TestGeneratorsBeatsFields(unittest.TestCase):
         self.assertFalse(field_entry['index'])
         self.assertFalse(field_entry['doc_values'])
 
+    def test_fieldset_field_array_allowed_keys(self):
+        fields = {
+            'id': {
+                'dashed_name': 'agent-id',
+                'description': 'description',
+                'flat_name': 'agent.id',
+                'level': 'extended',
+                'name': 'agent.id',
+                'normalize': [],
+                'short': 'short',
+                'type': 'keyword',
+                'index': False,
+                'doc_values': False,
+                'pattern': '[.*]',
+                'foo': 'bar'
+            }
+        }
+
+        beats_fields = beats.fieldset_field_array(fields, '')
+        field_entry = beats_fields[0]
+        self.assertIn('description', field_entry)
+        self.assertIn('level', field_entry)
+        self.assertIn('name', field_entry)
+        self.assertIn('type', field_entry)
+        self.assertIn('index', field_entry)
+        self.assertIn('doc_values', field_entry)
+        self.assertNotIn('foo', field_entry)
+        self.assertNotIn('dashed_name', field_entry)
+        self.assertNotIn('flat_name', field_entry)
+        self.assertNotIn('normalize', field_entry)
+        self.assertNotIn('short', field_entry)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/tests/unit/test_schema_cleaner.py
+++ b/scripts/tests/unit/test_schema_cleaner.py
@@ -329,6 +329,32 @@ class TestSchemaCleaner(unittest.TestCase):
         except Exception:
             self.fail("cleaner.single_line_short_description() raised Exception unexpectedly.")
 
+    def test_field_pattern_regex_raises_if_invalid(self):
+        field = {
+            'name': 'test',
+            'pattern': '[.*'
+        }
+        with self.assertRaisesRegex(ValueError, 'Pattern value must be a valid regular expression'):
+            cleaner.validate_pattern_regex(field, strict=True)
+
+    def test_field_pattern_regex_warns_strict_disabled(self):
+        field = {
+            'name': 'test',
+            'pattern': '[.*'
+        }
+        try:
+            with self.assertWarnsRegex(UserWarning, 'valid regular expression'):
+                cleaner.validate_pattern_regex(field, strict=False)
+        except Exception:
+            self.fail("cleaner.validate_pattern_regex() raised Exception unexpectedly.")
+
+    def test_field_pattern_regex_success(self):
+        field = {
+            'name': 'test',
+            'pattern': '[.*]'
+        }
+        self.assertIsNone(cleaner.validate_pattern_regex(field))
+
     def test_field_example_value_is_object_raises(self):
         field = {
             'field_details': {
@@ -386,6 +412,31 @@ class TestSchemaCleaner(unittest.TestCase):
                 cleaner.check_example_value(field, strict=False)
         except Exception:
             self.fail("cleaner.check_example_value() raised Exception unexpectedly.")
+
+    def test_example_value_mismatch_with_pattern(self):
+        field = {
+            'field_details': {
+                'name': 'test',
+                'example': 'AA',
+                'pattern': 'A{3}'
+            }
+        }
+        with self.assertRaisesRegex(ValueError, 'does not match the regex defined in the pattern'):
+            cleaner.check_example_value(field)
+
+    def test_example_value_mismatch_with_pattern_strict_disabled(self):
+        field = {
+            'field_details': {
+                'name': 'test',
+                'example': 'AA',
+                'pattern': 'A{3}'
+            }
+        }
+        try:
+            with self.assertWarnsRegex(UserWarning, 'does not match the regex defined in the pattern'):
+                cleaner.check_example_value(field, strict=False)
+        except Exception:
+            self.fail("clean.check_example_value() raised Exception unexpectedly.")
 
     def test_very_long_short_override_description_raises(self):
         schema = {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Add optional `pattern` attribute (#1834)](https://github.com/elastic/ecs/pull/1834)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)