### PR TITLE
Reuse as array definition

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -545,6 +545,7 @@ example: `co.uk`
 | <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
+
 // ===============================================================
 
 
@@ -552,12 +553,14 @@ example: `co.uk`
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `client.user.*`
 | <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
+
 
 // ===============================================================
 
@@ -796,6 +799,7 @@ Note also that the `cloud` fields may be used directly at the root of the events
 
 Provides the cloud information of the origin entity in case of an incoming request or event.
 
+
 // ===============================================================
 
 
@@ -803,6 +807,7 @@ Provides the cloud information of the origin entity in case of an incoming reque
 | <<ecs-cloud,cloud>>| beta:[ Reusing the `cloud` fields in this location is currently considered beta.]
 
 Provides the cloud information of the target entity in case of an outgoing request or event.
+
 
 // ===============================================================
 
@@ -1566,6 +1571,7 @@ example: `co.uk`
 | <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
+
 // ===============================================================
 
 
@@ -1573,12 +1579,14 @@ example: `co.uk`
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `destination.user.*`
 | <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
+
 
 // ===============================================================
 
@@ -1664,6 +1672,7 @@ example: `C:\Windows\System32\kernel32.dll`
 | <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
+
 // ===============================================================
 
 
@@ -1671,12 +1680,14 @@ example: `C:\Windows\System32\kernel32.dll`
 | <<ecs-hash,hash>>
 | Hashes, usually file hashes.
 
+
 // ===============================================================
 
 
 | `dll.pe.*`
 | <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
+
 
 // ===============================================================
 
@@ -2944,6 +2955,7 @@ example: `Spambot v2.5`
 | <<ecs-hash,hash>>
 | Hashes, usually file hashes.
 
+
 // ===============================================================
 
 
@@ -4192,6 +4204,7 @@ Note also that the `file` fields may be used directly at the root of the events.
 | <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
+
 // ===============================================================
 
 
@@ -4200,12 +4213,14 @@ Note also that the `file` fields may be used directly at the root of the events.
 
 These fields contain Linux Executable Linkable Format (ELF) metadata.
 
+
 // ===============================================================
 
 
 | `file.hash.*`
 | <<ecs-hash,hash>>
 | Hashes, usually file hashes.
+
 
 // ===============================================================
 
@@ -4214,12 +4229,14 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 | <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
 
+
 // ===============================================================
 
 
 | `file.x509.*`
 | <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
+
 
 // ===============================================================
 
@@ -4993,12 +5010,14 @@ example: `1325`
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `host.os.*`
 | <<ecs-os,os>>
 | OS fields contain information about the operating system.
+
 
 // ===============================================================
 
@@ -5920,12 +5939,14 @@ example: `ipv4`
 | <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
+
 // ===============================================================
 
 
 | `network.vlan.*`
 | <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
+
 
 // ===============================================================
 
@@ -6191,12 +6212,14 @@ type: keyword
 | <<ecs-interface,interface>>
 | Fields to describe observer interface information.
 
+
 // ===============================================================
 
 
 | `observer.egress.vlan.*`
 | <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
+
 
 // ===============================================================
 
@@ -6205,12 +6228,14 @@ type: keyword
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `observer.ingress.interface.*`
 | <<ecs-interface,interface>>
 | Fields to describe observer interface information.
+
 
 // ===============================================================
 
@@ -6219,12 +6244,14 @@ type: keyword
 | <<ecs-vlan,vlan>>
 | Fields to describe observed VLAN information.
 
+
 // ===============================================================
 
 
 | `observer.os.*`
 | <<ecs-os,os>>
 | OS fields contain information about the operating system.
+
 
 // ===============================================================
 
@@ -7350,6 +7377,7 @@ Note also that the `process` fields may be used directly at the root of the even
 | <<ecs-code_signature,code_signature>>
 | These fields contain information about binary code signatures.
 
+
 // ===============================================================
 
 
@@ -7358,12 +7386,14 @@ Note also that the `process` fields may be used directly at the root of the even
 
 These fields contain Linux Executable Linkable Format (ELF) metadata.
 
+
 // ===============================================================
 
 
 | `process.hash.*`
 | <<ecs-hash,hash>>
 | Hashes, usually file hashes.
+
 
 // ===============================================================
 
@@ -7372,12 +7402,14 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 | <<ecs-process,process>>
 | Information about the parent process.
 
+
 // ===============================================================
 
 
 | `process.pe.*`
 | <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
+
 
 // ===============================================================
 
@@ -8063,6 +8095,7 @@ example: `co.uk`
 | <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
+
 // ===============================================================
 
 
@@ -8070,12 +8103,14 @@ example: `co.uk`
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `server.user.*`
 | <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
+
 
 // ===============================================================
 
@@ -8300,6 +8335,7 @@ Note also that the `service` fields may be used directly at the root of the even
 
 Describes the origin service in case of an incoming request or event.
 
+
 // ===============================================================
 
 
@@ -8307,6 +8343,7 @@ Describes the origin service in case of an incoming request or event.
 | <<ecs-service,service>>| beta:[ Reusing the `service` fields in this location is currently considered beta.]
 
 Describes the target service in case of an outgoing request or event.
+
 
 // ===============================================================
 
@@ -8569,6 +8606,7 @@ example: `co.uk`
 | <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
 
+
 // ===============================================================
 
 
@@ -8576,12 +8614,14 @@ example: `co.uk`
 | <<ecs-geo,geo>>
 | Fields describing a location.
 
+
 // ===============================================================
 
 
 | `source.user.*`
 | <<ecs-user,user>>
 | Fields to describe the user relevant to the event.
+
 
 // ===============================================================
 
@@ -9779,6 +9819,7 @@ example: `https://attack.mitre.org/techniques/T1059/001/`
 
 Fields describing an Autonomous System (Internet routing prefix).
 
+
 // ===============================================================
 
 
@@ -9786,6 +9827,7 @@ Fields describing an Autonomous System (Internet routing prefix).
 | <<ecs-file,file>>| beta:[ Reusing the `file` fields in this location is currently considered beta.]
 
 Fields describing files.
+
 
 // ===============================================================
 
@@ -9795,6 +9837,7 @@ Fields describing files.
 
 Fields describing a location.
 
+
 // ===============================================================
 
 
@@ -9802,6 +9845,7 @@ Fields describing a location.
 | <<ecs-registry,registry>>| beta:[ Reusing the `registry` fields in this location is currently considered beta.]
 
 Fields related to Windows Registry operations.
+
 
 // ===============================================================
 
@@ -9811,6 +9855,7 @@ Fields related to Windows Registry operations.
 
 Fields that let you store URLs in various forms.
 
+
 // ===============================================================
 
 
@@ -9819,12 +9864,14 @@ Fields that let you store URLs in various forms.
 
 These fields contain x509 certificate metadata.
 
+
 // ===============================================================
 
 
 | `threat.indicator.as.*`
 | <<ecs-as,as>>
 | Fields describing an Autonomous System (Internet routing prefix).
+
 
 // ===============================================================
 
@@ -9833,12 +9880,14 @@ These fields contain x509 certificate metadata.
 | <<ecs-file,file>>
 | Fields describing files.
 
+
 // ===============================================================
 
 
 | `threat.indicator.geo.*`
 | <<ecs-geo,geo>>
 | Fields describing a location.
+
 
 // ===============================================================
 
@@ -9847,6 +9896,7 @@ These fields contain x509 certificate metadata.
 | <<ecs-registry,registry>>
 | Fields related to Windows Registry operations.
 
+
 // ===============================================================
 
 
@@ -9854,12 +9904,14 @@ These fields contain x509 certificate metadata.
 | <<ecs-url,url>>
 | Fields that let you store URLs in various forms.
 
+
 // ===============================================================
 
 
 | `threat.indicator.x509.*`
 | <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
+
 
 // ===============================================================
 
@@ -10383,12 +10435,14 @@ example: `tls`
 | <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
 
+
 // ===============================================================
 
 
 | `tls.server.x509.*`
 | <<ecs-x509,x509>>
 | These fields contain x509 certificate metadata.
+
 
 // ===============================================================
 
@@ -10950,12 +11004,14 @@ Note also that the `user` fields may be used directly at the root of the events.
 | <<ecs-user,user>>
 | Captures changes made to a user.
 
+
 // ===============================================================
 
 
 | `user.effective.*`
 | <<ecs-user,user>>
 | User whose privileges were assumed.
+
 
 // ===============================================================
 
@@ -10964,12 +11020,14 @@ Note also that the `user` fields may be used directly at the root of the events.
 | <<ecs-group,group>>
 | User's group relevant to the event.
 
+
 // ===============================================================
 
 
 | `user.target.*`
 | <<ecs-user,user>>
 | Targeted user of action taken.
+
 
 // ===============================================================
 
@@ -11091,6 +11149,7 @@ example: `12.0`
 | `user_agent.os.*`
 | <<ecs-os,os>>
 | OS fields contain information about the operating system.
+
 
 // ===============================================================
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,7 +53,7 @@ multiple places, like for example `geo`, which can appear under `source`, `desti
 }
 ```
 
-The `reusable` attribute is composed of `top_level`, `expected`, and `short_override` sub-attributes:
+The `reusable` attribute is composed of a few sub-attributes:
 
 - top\_level (optional, default true): Is this field set expected at the root of
   events or is it only expected in the nested locations?
@@ -61,6 +61,8 @@ The `reusable` attribute is composed of `top_level`, `expected`, and `short_over
   There are two valid notations to list expected locations.
 - short_override (optional, default null): Sets the short description for the
   nested field, overriding the default top-level short description.
+- normalize: Normalization steps that should be applied at ingestion time. Supported values:
+  - array: the content of the field should be an array (even when there's only one value).
 
 The "flat" (or dotted) notation to represent where the fields are nested:
 

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -61,7 +61,8 @@ def render_nestings_reuse_section(fieldset):
             'flat_nesting': "{}.*".format(reused_here_entry['full']),
             'name': reused_here_entry['schema_name'],
             'short': reused_here_entry['short'],
-            'beta': reused_here_entry.get('beta', '')
+            'beta': reused_here_entry.get('beta', ''),
+            'normalize': reused_here_entry.get('normalize')
         })
 
     return sorted(rows, key=lambda x: x['flat_nesting'])

--- a/scripts/schema/finalizer.py
+++ b/scripts/schema/finalizer.py
@@ -150,6 +150,9 @@ def append_reused_here(reused_schema, reuse_entry, destination_schema):
         # Check for a short override, if not present, fall back to the top-level fieldset's short
         'short': reuse_entry['short_override'] if 'short_override' in reuse_entry else reused_schema['field_details']['short']
     }
+    # If it exists, bring through the normalization
+    if 'normalize' in reuse_entry:
+        reused_here_entry['normalize'] = reuse_entry['normalize']
     # Check for beta attribute
     if 'beta' in reuse_entry:
         reused_here_entry['beta'] = reuse_entry['beta']

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -136,6 +136,12 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 | {{ entry['short'] }}
 {%- endif %}
 
+{% if entry['normalize'] and 'array' in entry['normalize'] -%}
+
+Note: this reuse should contain an array of <fieldset> objects.
+
+
+{% endif %}
 // ===============================================================
 
 

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -140,7 +140,6 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 
 Note: this reuse should contain an array of <fieldset> objects.
 
-
 {% endif %}
 // ===============================================================
 

--- a/scripts/tests/test_asciidoc_fields.py
+++ b/scripts/tests/test_asciidoc_fields.py
@@ -103,7 +103,13 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
                     'full': 'foo.as',
                     'schema_name': 'as',
                     'short': 'Fields describing an AS'
-                }
+                },
+                {
+                    'full': 'foo.file',
+                    'schema_name': 'file',
+                    'short': 'Fields describing files',
+                    'normalize': ['array']
+                },
             ],
             'group': 2,
             'name': 'foo',
@@ -214,6 +220,11 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
         self.assertEqual('foo.as.*', foo_nesting_fields[0]['flat_nesting'])
         self.assertEqual('as', foo_nesting_fields[0]['name'])
         self.assertEqual('Fields describing an AS', foo_nesting_fields[0]['short'])
+
+        self.assertEqual('foo.file.*', foo_nesting_fields[1]['flat_nesting'])
+        self.assertEqual('file', foo_nesting_fields[1]['name'])
+        self.assertEqual('Fields describing files', foo_nesting_fields[1]['short'])
+        self.assertEqual(['array'], foo_nesting_fields[1]['normalize'])
 
     def test_check_for_usage_doc_true(self):
         usage_files = ["foo.asciidoc"]

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -65,6 +65,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                         'expected': [
                             {'full': 'process.parent', 'at': 'process', 'as': 'parent',
                                 'short_override': 'short override desc'},
+                            {'full': 'process.previous', 'at': 'process', 'as': 'previous', 'normalize': ['array']},
                             {'full': 'reuse.process', 'at': 'reuse', 'as': 'process'},
                             {'full': 'reuse.process.parent', 'at': 'reuse.process', 'as': 'parent'},
                             {'full': 'reuse.process.target', 'at': 'reuse.process', 'as': 'target'},
@@ -201,6 +202,7 @@ class TestSchemaFinalizer(unittest.TestCase):
         process_target_reuse_fields = fields['reuse']['fields']['process']['fields']['target']['fields']
         # Expected reuse
         self.assertIn('parent', process_fields)
+        self.assertIn('previous', process_fields)
         self.assertIn('user', server_fields)
         self.assertIn('target', user_fields)
         self.assertIn('effective', user_fields)
@@ -226,6 +228,7 @@ class TestSchemaFinalizer(unittest.TestCase):
         self.assertNotIn('target', server_fields['user']['fields'])
         # Legacy list of nestings, added to destination schema
         self.assertIn('process.parent', fields['process']['schema_details']['nestings'])
+        self.assertIn('process.previous', fields['process']['schema_details']['nestings'])
         self.assertIn('user.effective', fields['user']['schema_details']['nestings'])
         self.assertIn('user.target', fields['user']['schema_details']['nestings'])
         self.assertIn('server.user', fields['server']['schema_details']['nestings'])
@@ -233,6 +236,8 @@ class TestSchemaFinalizer(unittest.TestCase):
         self.assertIn('reuse.process.target.parent', fields['reuse']['schema_details']['nestings'])
         # Attribute 'reused_here' lists nestings inside a destination schema
         self.assertIn({'full': 'process.parent', 'schema_name': 'process', 'short': 'short override desc'},
+                      fields['process']['schema_details']['reused_here'])
+        self.assertIn({'full': 'process.previous', 'schema_name': 'process', 'short': 'short desc', 'normalize': ['array']},
                       fields['process']['schema_details']['reused_here'])
         self.assertIn({'full': 'user.effective', 'schema_name': 'user', 'short': 'short desc'},
                       fields['user']['schema_details']['reused_here'])


### PR DESCRIPTION
Closes #1736 

By adding a normalize as array attribute a re-use definition, users will now be able to re-use a field set as an array.

Example: 
```
- at: process
  as: previous
  short_override: An array of all previous executions for the process, including the initial fork details.
  normalize:
    - array
```
-------->

This makes it so we have a note in the docs that we intend an array as seen here:
<img width="500" alt="Screen Shot 2022-02-28 at 4 04 54 PM" src="https://user-images.githubusercontent.com/9203126/156058826-024e64b5-1cf3-4a44-aa6a-0d16a35129cb.png">