### PR TITLE
[8.2] Reuse as array definition (#1838)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -65,6 +65,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Adding optional field attribute, `pattern`. #1834
+* Added support for re-using a fieldset as an array. #1838
 
 #### Improvements
 

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -53,7 +53,7 @@ multiple places, like for example `geo`, which can appear under `source`, `desti
 }
 ```
 
-The `reusable` attribute is composed of `top_level`, `expected`, and `short_override` sub-attributes:
+The `reusable` attribute is composed of a few sub-attributes:
 
 - top\_level (optional, default true): Is this field set expected at the root of
   events or is it only expected in the nested locations?
@@ -61,6 +61,8 @@ The `reusable` attribute is composed of `top_level`, `expected`, and `short_over
   There are two valid notations to list expected locations.
 - short_override (optional, default null): Sets the short description for the
   nested field, overriding the default top-level short description.
+- normalize: Normalization steps that should be applied at ingestion time. Supported values:
+  - array: the content of the field should be an array (even when there's only one value).
 
 The "flat" (or dotted) notation to represent where the fields are nested:
 

--- a/scripts/generators/asciidoc_fields.py
+++ b/scripts/generators/asciidoc_fields.py
@@ -61,7 +61,8 @@ def render_nestings_reuse_section(fieldset):
             'flat_nesting': "{}.*".format(reused_here_entry['full']),
             'name': reused_here_entry['schema_name'],
             'short': reused_here_entry['short'],
-            'beta': reused_here_entry.get('beta', '')
+            'beta': reused_here_entry.get('beta', ''),
+            'normalize': reused_here_entry.get('normalize')
         })
 
     return sorted(rows, key=lambda x: x['flat_nesting'])

--- a/scripts/schema/finalizer.py
+++ b/scripts/schema/finalizer.py
@@ -150,6 +150,9 @@ def append_reused_here(reused_schema, reuse_entry, destination_schema):
         # Check for a short override, if not present, fall back to the top-level fieldset's short
         'short': reuse_entry['short_override'] if 'short_override' in reuse_entry else reused_schema['field_details']['short']
     }
+    # If it exists, bring through the normalization
+    if 'normalize' in reuse_entry:
+        reused_here_entry['normalize'] = reuse_entry['normalize']
     # Check for beta attribute
     if 'beta' in reuse_entry:
         reused_here_entry['beta'] = reuse_entry['beta']

--- a/scripts/templates/field_details.j2
+++ b/scripts/templates/field_details.j2
@@ -136,6 +136,11 @@ Note also that the `{{ fieldset['name'] }}` fields are not expected to be used d
 | {{ entry['short'] }}
 {%- endif %}
 
+{% if entry['normalize'] and 'array' in entry['normalize'] -%}
+
+Note: this reuse should contain an array of {{ entry['name'] }} field set objects.
+
+{% endif -%}
 // ===============================================================
 
 

--- a/scripts/tests/test_asciidoc_fields.py
+++ b/scripts/tests/test_asciidoc_fields.py
@@ -103,7 +103,13 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
                     'full': 'foo.as',
                     'schema_name': 'as',
                     'short': 'Fields describing an AS'
-                }
+                },
+                {
+                    'full': 'foo.file',
+                    'schema_name': 'file',
+                    'short': 'Fields describing files',
+                    'normalize': ['array']
+                },
             ],
             'group': 2,
             'name': 'foo',
@@ -214,6 +220,11 @@ class TestGeneratorsAsciiFields(unittest.TestCase):
         self.assertEqual('foo.as.*', foo_nesting_fields[0]['flat_nesting'])
         self.assertEqual('as', foo_nesting_fields[0]['name'])
         self.assertEqual('Fields describing an AS', foo_nesting_fields[0]['short'])
+
+        self.assertEqual('foo.file.*', foo_nesting_fields[1]['flat_nesting'])
+        self.assertEqual('file', foo_nesting_fields[1]['name'])
+        self.assertEqual('Fields describing files', foo_nesting_fields[1]['short'])
+        self.assertEqual(['array'], foo_nesting_fields[1]['normalize'])
 
     def test_check_for_usage_doc_true(self):
         usage_files = ["foo.asciidoc"]

--- a/scripts/tests/unit/test_schema_finalizer.py
+++ b/scripts/tests/unit/test_schema_finalizer.py
@@ -65,6 +65,7 @@ class TestSchemaFinalizer(unittest.TestCase):
                         'expected': [
                             {'full': 'process.parent', 'at': 'process', 'as': 'parent',
                                 'short_override': 'short override desc'},
+                            {'full': 'process.previous', 'at': 'process', 'as': 'previous', 'normalize': ['array']},
                             {'full': 'reuse.process', 'at': 'reuse', 'as': 'process'},
                             {'full': 'reuse.process.parent', 'at': 'reuse.process', 'as': 'parent'},
                             {'full': 'reuse.process.target', 'at': 'reuse.process', 'as': 'target'},
@@ -201,6 +202,7 @@ class TestSchemaFinalizer(unittest.TestCase):
         process_target_reuse_fields = fields['reuse']['fields']['process']['fields']['target']['fields']
         # Expected reuse
         self.assertIn('parent', process_fields)
+        self.assertIn('previous', process_fields)
         self.assertIn('user', server_fields)
         self.assertIn('target', user_fields)
         self.assertIn('effective', user_fields)
@@ -226,6 +228,7 @@ class TestSchemaFinalizer(unittest.TestCase):
         self.assertNotIn('target', server_fields['user']['fields'])
         # Legacy list of nestings, added to destination schema
         self.assertIn('process.parent', fields['process']['schema_details']['nestings'])
+        self.assertIn('process.previous', fields['process']['schema_details']['nestings'])
         self.assertIn('user.effective', fields['user']['schema_details']['nestings'])
         self.assertIn('user.target', fields['user']['schema_details']['nestings'])
         self.assertIn('server.user', fields['server']['schema_details']['nestings'])
@@ -233,6 +236,8 @@ class TestSchemaFinalizer(unittest.TestCase):
         self.assertIn('reuse.process.target.parent', fields['reuse']['schema_details']['nestings'])
         # Attribute 'reused_here' lists nestings inside a destination schema
         self.assertIn({'full': 'process.parent', 'schema_name': 'process', 'short': 'short override desc'},
+                      fields['process']['schema_details']['reused_here'])
+        self.assertIn({'full': 'process.previous', 'schema_name': 'process', 'short': 'short desc', 'normalize': ['array']},
                       fields['process']['schema_details']['reused_here'])
         self.assertIn({'full': 'user.effective', 'schema_name': 'user', 'short': 'short desc'},
                       fields['user']['schema_details']['reused_here'])


### PR DESCRIPTION
Backports the following commits to 8.2:
 - Reuse as array definition (#1838)