### PR TITLE
[8.2] Remove brackets from `email.message.id` example (#1841)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -53,7 +53,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* `email.*` field set now GA. #1794
+* `email.*` field set now GA. #1794, #1841
 
 #### Deprecated
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2810,7 +2810,7 @@ type: wildcard
 
 
 
-example: `<81ce15$8r2j59@mail01.example.com>`
+example: `81ce15$8r2j59@mail01.example.com`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2020,7 +2020,7 @@
       type: wildcard
       description: Identifier from the RFC 5322 `Message-ID:` email header that refers
         to a particular email message.
-      example: <81ce15$8r2j59@mail01.example.com>
+      example: 81ce15$8r2j59@mail01.example.com
       default_field: false
     - name: origination_timestamp
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -204,7 +204,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev+exp,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 8.2.0-dev+exp,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 8.2.0-dev+exp,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-8.2.0-dev+exp,true,email,email.message_id,wildcard,extended,,<81ce15$8r2j59@mail01.example.com>,Value from the Message-ID header.
+8.2.0-dev+exp,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 8.2.0-dev+exp,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 8.2.0-dev+exp,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 8.2.0-dev+exp,true,email,email.sender.address,keyword,extended,,,Address of the message sender.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2512,7 +2512,7 @@ email.message_id:
   dashed_name: email-message-id
   description: Identifier from the RFC 5322 `Message-ID:` email header that refers
     to a particular email message.
-  example: <81ce15$8r2j59@mail01.example.com>
+  example: 81ce15$8r2j59@mail01.example.com
   flat_name: email.message_id
   level: extended
   name: message_id

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3344,7 +3344,7 @@ email:
       dashed_name: email-message-id
       description: Identifier from the RFC 5322 `Message-ID:` email header that refers
         to a particular email message.
-      example: <81ce15$8r2j59@mail01.example.com>
+      example: 81ce15$8r2j59@mail01.example.com
       flat_name: email.message_id
       level: extended
       name: message_id

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1970,7 +1970,7 @@
       type: wildcard
       description: Identifier from the RFC 5322 `Message-ID:` email header that refers
         to a particular email message.
-      example: <81ce15$8r2j59@mail01.example.com>
+      example: 81ce15$8r2j59@mail01.example.com
       default_field: false
     - name: origination_timestamp
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -197,7 +197,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev,true,email,email.direction,keyword,extended,,inbound,Direction of the message.
 8.2.0-dev,true,email,email.from.address,keyword,extended,array,sender@example.com,The sender's email address.
 8.2.0-dev,true,email,email.local_id,keyword,extended,,c26dbea0-80d5-463b-b93c-4e8b708219ce,Unique identifier given by the source.
-8.2.0-dev,true,email,email.message_id,wildcard,extended,,<81ce15$8r2j59@mail01.example.com>,Value from the Message-ID header.
+8.2.0-dev,true,email,email.message_id,wildcard,extended,,81ce15$8r2j59@mail01.example.com,Value from the Message-ID header.
 8.2.0-dev,true,email,email.origination_timestamp,date,extended,,2020-11-10T22:12:34.8196921Z,Date and time the email was composed.
 8.2.0-dev,true,email,email.reply_to.address,keyword,extended,array,reply.here@example.com,Address replies should be delivered to.
 8.2.0-dev,true,email,email.sender.address,keyword,extended,,,Address of the message sender.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2443,7 +2443,7 @@ email.message_id:
   dashed_name: email-message-id
   description: Identifier from the RFC 5322 `Message-ID:` email header that refers
     to a particular email message.
-  example: <81ce15$8r2j59@mail01.example.com>
+  example: 81ce15$8r2j59@mail01.example.com
   flat_name: email.message_id
   level: extended
   name: message_id

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3264,7 +3264,7 @@ email:
       dashed_name: email-message-id
       description: Identifier from the RFC 5322 `Message-ID:` email header that refers
         to a particular email message.
-      example: <81ce15$8r2j59@mail01.example.com>
+      example: 81ce15$8r2j59@mail01.example.com
       flat_name: email.message_id
       level: extended
       name: message_id

--- a/schemas/email.yml
+++ b/schemas/email.yml
@@ -126,7 +126,7 @@
       description: >
         Identifier from the RFC 5322 `Message-ID:` email header that refers to a particular email
         message.
-      example: "<81ce15$8r2j59@mail01.example.com>"
+      example: "81ce15$8r2j59@mail01.example.com"
 
     - name: origination_timestamp
       level: extended


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Remove brackets from `email.message.id` example (#1841)](https://github.com/elastic/ecs/pull/1841)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)