### PR TITLE
[8.2] CTI addendum threat.feed.name, threat.feed.dashboard_id (#1844)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -50,6 +50,7 @@ Thanks, you're awesome :-) -->
 * Add six new syslog fields to `log.syslog.*`. #1793
 * Added `faas.id`, `faas.name` and `faas.version` fields as beta. #1796
 * Added linux event model beta fields and reuses to support RFC 0030. #1842, #1847
+* Added `threat.feed.dashboard_id`, `threat.feed.description`, `threat.feed.name`, `threat.feed.reference` fields. #1844
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -9613,6 +9613,35 @@
         with the given indicator
       example: indicator_match_rule
       default_field: false
+    - name: feed.dashboard_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The saved object ID of the dashboard belonging to the threat feed
+        for displaying dashboard links to threat feeds in Kibana.
+      example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+      default_field: false
+    - name: feed.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Description of the threat feed in a UI friendly format.
+      example: Threat feed from the AlienVault Open Threat eXchange network.
+      default_field: false
+    - name: feed.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of the threat feed in UI friendly format.
+      example: AlienVault OTX
+      default_field: false
+    - name: feed.reference
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Reference information for the threat feed in a UI friendly format.
+      example: https://otx.alienvault.com
+      default_field: false
     - name: framework
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1150,6 +1150,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev+exp,true,threat,threat.enrichments.matched.index,keyword,extended,,filebeat-8.0.0-2021.05.23-000011,Matched indicator index
 8.2.0-dev+exp,true,threat,threat.enrichments.matched.occurred,date,extended,,2021-10-05 17:00:58.326000+00:00,Date of match
 8.2.0-dev+exp,true,threat,threat.enrichments.matched.type,keyword,extended,,indicator_match_rule,Type of indicator match
+8.2.0-dev+exp,true,threat,threat.feed.dashboard_id,keyword,extended,,5ba16340-72e6-11eb-a3e3-b3cc7c78a70f,Feed dashboard ID.
+8.2.0-dev+exp,true,threat,threat.feed.description,keyword,extended,,Threat feed from the AlienVault Open Threat eXchange network.,Description of the threat feed.
+8.2.0-dev+exp,true,threat,threat.feed.name,keyword,extended,,AlienVault OTX,Name of the threat feed.
+8.2.0-dev+exp,true,threat,threat.feed.reference,keyword,extended,,https://otx.alienvault.com,Reference for the threat feed.
 8.2.0-dev+exp,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 8.2.0-dev+exp,true,threat,threat.group.alias,keyword,extended,array,"[ ""Magecart Group 6"" ]",Alias of the group.
 8.2.0-dev+exp,true,threat,threat.group.id,keyword,extended,,G0037,ID of the group.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -14492,6 +14492,51 @@ threat.enrichments.matched.type:
   normalize: []
   short: Type of indicator match
   type: keyword
+threat.feed.dashboard_id:
+  dashed_name: threat-feed-dashboard-id
+  description: The saved object ID of the dashboard belonging to the threat feed for
+    displaying dashboard links to threat feeds in Kibana.
+  example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+  flat_name: threat.feed.dashboard_id
+  ignore_above: 1024
+  level: extended
+  name: feed.dashboard_id
+  normalize: []
+  short: Feed dashboard ID.
+  type: keyword
+threat.feed.description:
+  dashed_name: threat-feed-description
+  description: Description of the threat feed in a UI friendly format.
+  example: Threat feed from the AlienVault Open Threat eXchange network.
+  flat_name: threat.feed.description
+  ignore_above: 1024
+  level: extended
+  name: feed.description
+  normalize: []
+  short: Description of the threat feed.
+  type: keyword
+threat.feed.name:
+  dashed_name: threat-feed-name
+  description: The name of the threat feed in UI friendly format.
+  example: AlienVault OTX
+  flat_name: threat.feed.name
+  ignore_above: 1024
+  level: extended
+  name: feed.name
+  normalize: []
+  short: Name of the threat feed.
+  type: keyword
+threat.feed.reference:
+  dashed_name: threat-feed-reference
+  description: Reference information for the threat feed in a UI friendly format.
+  example: https://otx.alienvault.com
+  flat_name: threat.feed.reference
+  ignore_above: 1024
+  level: extended
+  name: feed.reference
+  normalize: []
+  short: Reference for the threat feed.
+  type: keyword
 threat.framework:
   dashed_name: threat-framework
   description: Name of the threat framework used to further categorize and classify

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -16562,6 +16562,51 @@ threat:
       normalize: []
       short: Type of indicator match
       type: keyword
+    threat.feed.dashboard_id:
+      dashed_name: threat-feed-dashboard-id
+      description: The saved object ID of the dashboard belonging to the threat feed
+        for displaying dashboard links to threat feeds in Kibana.
+      example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+      flat_name: threat.feed.dashboard_id
+      ignore_above: 1024
+      level: extended
+      name: feed.dashboard_id
+      normalize: []
+      short: Feed dashboard ID.
+      type: keyword
+    threat.feed.description:
+      dashed_name: threat-feed-description
+      description: Description of the threat feed in a UI friendly format.
+      example: Threat feed from the AlienVault Open Threat eXchange network.
+      flat_name: threat.feed.description
+      ignore_above: 1024
+      level: extended
+      name: feed.description
+      normalize: []
+      short: Description of the threat feed.
+      type: keyword
+    threat.feed.name:
+      dashed_name: threat-feed-name
+      description: The name of the threat feed in UI friendly format.
+      example: AlienVault OTX
+      flat_name: threat.feed.name
+      ignore_above: 1024
+      level: extended
+      name: feed.name
+      normalize: []
+      short: Name of the threat feed.
+      type: keyword
+    threat.feed.reference:
+      dashed_name: threat-feed-reference
+      description: Reference information for the threat feed in a UI friendly format.
+      example: https://otx.alienvault.com
+      flat_name: threat.feed.reference
+      ignore_above: 1024
+      level: extended
+      name: feed.reference
+      normalize: []
+      short: Reference for the threat feed.
+      type: keyword
     threat.framework:
       dashed_name: threat-framework
       description: Name of the threat framework used to further categorize and classify

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -800,6 +800,26 @@
               },
               "type": "nested"
             },
+            "feed": {
+              "properties": {
+                "dashboard_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "framework": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -5378,6 +5378,26 @@
             },
             "type": "nested"
           },
+          "feed": {
+            "properties": {
+              "dashboard_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "reference": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "framework": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -9563,6 +9563,35 @@
         with the given indicator
       example: indicator_match_rule
       default_field: false
+    - name: feed.dashboard_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The saved object ID of the dashboard belonging to the threat feed
+        for displaying dashboard links to threat feeds in Kibana.
+      example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+      default_field: false
+    - name: feed.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Description of the threat feed in a UI friendly format.
+      example: Threat feed from the AlienVault Open Threat eXchange network.
+      default_field: false
+    - name: feed.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of the threat feed in UI friendly format.
+      example: AlienVault OTX
+      default_field: false
+    - name: feed.reference
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Reference information for the threat feed in a UI friendly format.
+      example: https://otx.alienvault.com
+      default_field: false
     - name: framework
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1143,6 +1143,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.2.0-dev,true,threat,threat.enrichments.matched.index,keyword,extended,,filebeat-8.0.0-2021.05.23-000011,Matched indicator index
 8.2.0-dev,true,threat,threat.enrichments.matched.occurred,date,extended,,2021-10-05 17:00:58.326000+00:00,Date of match
 8.2.0-dev,true,threat,threat.enrichments.matched.type,keyword,extended,,indicator_match_rule,Type of indicator match
+8.2.0-dev,true,threat,threat.feed.dashboard_id,keyword,extended,,5ba16340-72e6-11eb-a3e3-b3cc7c78a70f,Feed dashboard ID.
+8.2.0-dev,true,threat,threat.feed.description,keyword,extended,,Threat feed from the AlienVault Open Threat eXchange network.,Description of the threat feed.
+8.2.0-dev,true,threat,threat.feed.name,keyword,extended,,AlienVault OTX,Name of the threat feed.
+8.2.0-dev,true,threat,threat.feed.reference,keyword,extended,,https://otx.alienvault.com,Reference for the threat feed.
 8.2.0-dev,true,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
 8.2.0-dev,true,threat,threat.group.alias,keyword,extended,array,"[ ""Magecart Group 6"" ]",Alias of the group.
 8.2.0-dev,true,threat,threat.group.id,keyword,extended,,G0037,ID of the group.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -14423,6 +14423,51 @@ threat.enrichments.matched.type:
   normalize: []
   short: Type of indicator match
   type: keyword
+threat.feed.dashboard_id:
+  dashed_name: threat-feed-dashboard-id
+  description: The saved object ID of the dashboard belonging to the threat feed for
+    displaying dashboard links to threat feeds in Kibana.
+  example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+  flat_name: threat.feed.dashboard_id
+  ignore_above: 1024
+  level: extended
+  name: feed.dashboard_id
+  normalize: []
+  short: Feed dashboard ID.
+  type: keyword
+threat.feed.description:
+  dashed_name: threat-feed-description
+  description: Description of the threat feed in a UI friendly format.
+  example: Threat feed from the AlienVault Open Threat eXchange network.
+  flat_name: threat.feed.description
+  ignore_above: 1024
+  level: extended
+  name: feed.description
+  normalize: []
+  short: Description of the threat feed.
+  type: keyword
+threat.feed.name:
+  dashed_name: threat-feed-name
+  description: The name of the threat feed in UI friendly format.
+  example: AlienVault OTX
+  flat_name: threat.feed.name
+  ignore_above: 1024
+  level: extended
+  name: feed.name
+  normalize: []
+  short: Name of the threat feed.
+  type: keyword
+threat.feed.reference:
+  dashed_name: threat-feed-reference
+  description: Reference information for the threat feed in a UI friendly format.
+  example: https://otx.alienvault.com
+  flat_name: threat.feed.reference
+  ignore_above: 1024
+  level: extended
+  name: feed.reference
+  normalize: []
+  short: Reference for the threat feed.
+  type: keyword
 threat.framework:
   dashed_name: threat-framework
   description: Name of the threat framework used to further categorize and classify

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -16482,6 +16482,51 @@ threat:
       normalize: []
       short: Type of indicator match
       type: keyword
+    threat.feed.dashboard_id:
+      dashed_name: threat-feed-dashboard-id
+      description: The saved object ID of the dashboard belonging to the threat feed
+        for displaying dashboard links to threat feeds in Kibana.
+      example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+      flat_name: threat.feed.dashboard_id
+      ignore_above: 1024
+      level: extended
+      name: feed.dashboard_id
+      normalize: []
+      short: Feed dashboard ID.
+      type: keyword
+    threat.feed.description:
+      dashed_name: threat-feed-description
+      description: Description of the threat feed in a UI friendly format.
+      example: Threat feed from the AlienVault Open Threat eXchange network.
+      flat_name: threat.feed.description
+      ignore_above: 1024
+      level: extended
+      name: feed.description
+      normalize: []
+      short: Description of the threat feed.
+      type: keyword
+    threat.feed.name:
+      dashed_name: threat-feed-name
+      description: The name of the threat feed in UI friendly format.
+      example: AlienVault OTX
+      flat_name: threat.feed.name
+      ignore_above: 1024
+      level: extended
+      name: feed.name
+      normalize: []
+      short: Name of the threat feed.
+      type: keyword
+    threat.feed.reference:
+      dashed_name: threat-feed-reference
+      description: Reference information for the threat feed in a UI friendly format.
+      example: https://otx.alienvault.com
+      flat_name: threat.feed.reference
+      ignore_above: 1024
+      level: extended
+      name: feed.reference
+      normalize: []
+      short: Reference for the threat feed.
+      type: keyword
     threat.framework:
       dashed_name: threat-framework
       description: Name of the threat framework used to further categorize and classify

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -800,6 +800,26 @@
               },
               "type": "nested"
             },
+            "feed": {
+              "properties": {
+                "dashboard_id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "description": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "reference": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "framework": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -5336,6 +5336,26 @@
             },
             "type": "nested"
           },
+          "feed": {
+            "properties": {
+              "dashboard_id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "reference": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "framework": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -259,6 +259,38 @@
         Identifies the type of match that caused the event to be enriched with the given indicator
       example: indicator_match_rule
 
+    - name: feed.dashboard_id
+      level: extended
+      type: keyword
+      short: Feed dashboard ID.
+      description: >
+          The saved object ID of the dashboard belonging to the threat feed for displaying dashboard links to threat feeds in Kibana.
+      example: 5ba16340-72e6-11eb-a3e3-b3cc7c78a70f
+
+    - name: feed.name
+      level: extended
+      type: keyword
+      short: Name of the threat feed.
+      description: >
+        The name of the threat feed in UI friendly format.
+      example: "AlienVault OTX"
+
+    - name: feed.description
+      level: extended
+      type: keyword
+      short: Description of the threat feed.
+      description: >
+        Description of the threat feed in a UI friendly format.
+      example: "Threat feed from the AlienVault Open Threat eXchange network."
+
+    - name: feed.reference
+      level: extended
+      type: keyword
+      short: Reference for the threat feed.
+      description: >
+        Reference information for the threat feed in a UI friendly format.
+      example: "https://otx.alienvault.com"
+
     - name: framework
       level: extended
       type: keyword


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [CTI addendum threat.feed.name, threat.feed.dashboard_id (#1844)](https://github.com/elastic/ecs/pull/1844)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)