### PR TITLE
[8.3] Add pattern attribute to `.mac` fields (#1871)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -44,6 +44,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Added `pattern` attribute to `.mac` fields. #1871
+
 #### Improvements
 
 #### Deprecated

--- a/USAGE.md
+++ b/USAGE.md
@@ -408,6 +408,7 @@ Strict mode requires the following conditions, else the script exits on an excep
 
 * Short descriptions must be less than or equal to 120 characters.
 * Example values containing arrays or objects must be quoted to avoid unexpected YAML interpretation when the schema files or artifacts are relied on downstream.
+* If a regex `pattern` is defined, the example values will be checked against it.
 
 The current artifacts generated and published in the ECS repo will always be created using strict mode. However, older ECS versions (pre `v1.5.0`) will cause
 an exception if attempting to generate them using `--strict`. This is due to schema validation checks introduced after that version was released.

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1144,6 +1144,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip
@@ -3549,6 +3550,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: name
       level: core
       type: keyword
@@ -4348,6 +4350,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: name
       level: extended
       type: keyword
@@ -7379,6 +7382,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip
@@ -7992,6 +7996,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -400,6 +400,7 @@ client.mac:
   level: core
   name: mac
   normalize: []
+  patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the client.
   type: keyword
 client.nat.ip:
@@ -1463,6 +1464,7 @@ destination.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the destination.
   type: keyword
 destination.nat.ip:
@@ -5057,6 +5059,7 @@ host.mac:
   name: mac
   normalize:
   - array
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
   type: keyword
 host.name:
@@ -6236,6 +6239,7 @@ observer.mac:
   name: mac
   normalize:
   - array
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
   type: keyword
 observer.name:
@@ -10854,6 +10858,7 @@ server.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the server.
   type: keyword
 server.nat.ip:
@@ -11758,6 +11763,7 @@ source.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the source.
   type: keyword
 source.nat.ip:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -564,6 +564,7 @@ client:
       level: core
       name: mac
       normalize: []
+      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the client.
       type: keyword
     client.nat.ip:
@@ -1886,6 +1887,7 @@ destination:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the destination.
       type: keyword
     destination.nat.ip:
@@ -6328,6 +6330,7 @@ host:
       name: mac
       normalize:
       - array
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
       type: keyword
     host.name:
@@ -7626,6 +7629,7 @@ observer:
       name: mac
       normalize:
       - array
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
       type: keyword
     observer.name:
@@ -12824,6 +12828,7 @@ server:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the server.
       type: keyword
     server.nat.ip:
@@ -13813,6 +13818,7 @@ source:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the source.
       type: keyword
     source.nat.ip:

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1094,6 +1094,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip
@@ -3499,6 +3500,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: name
       level: core
       type: keyword
@@ -4298,6 +4300,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: name
       level: extended
       type: keyword
@@ -7329,6 +7332,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip
@@ -7942,6 +7946,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -331,6 +331,7 @@ client.mac:
   level: core
   name: mac
   normalize: []
+  patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the client.
   type: keyword
 client.nat.ip:
@@ -1394,6 +1395,7 @@ destination.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the destination.
   type: keyword
 destination.nat.ip:
@@ -4988,6 +4990,7 @@ host.mac:
   name: mac
   normalize:
   - array
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: Host MAC addresses.
   type: keyword
 host.name:
@@ -6167,6 +6170,7 @@ observer.mac:
   name: mac
   normalize:
   - array
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC addresses of the observer.
   type: keyword
 observer.name:
@@ -10785,6 +10789,7 @@ server.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the server.
   type: keyword
 server.nat.ip:
@@ -11689,6 +11694,7 @@ source.mac:
   level: core
   name: mac
   normalize: []
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the source.
   type: keyword
 source.nat.ip:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -484,6 +484,7 @@ client:
       level: core
       name: mac
       normalize: []
+      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the client.
       type: keyword
     client.nat.ip:
@@ -1806,6 +1807,7 @@ destination:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the destination.
       type: keyword
     destination.nat.ip:
@@ -6248,6 +6250,7 @@ host:
       name: mac
       normalize:
       - array
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: Host MAC addresses.
       type: keyword
     host.name:
@@ -7546,6 +7549,7 @@ observer:
       name: mac
       normalize:
       - array
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC addresses of the observer.
       type: keyword
     observer.name:
@@ -12744,6 +12748,7 @@ server:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the server.
       type: keyword
     server.nat.ip:
@@ -13733,6 +13738,7 @@ source:
       level: core
       name: mac
       normalize: []
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the source.
       type: keyword
     source.nat.ip:

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -65,6 +65,7 @@
       level: core
       type: keyword
       short: MAC address of the client.
+      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: 00-00-5E-00-53-23
       description: >
         MAC address of the client.

--- a/schemas/destination.yml
+++ b/schemas/destination.yml
@@ -60,6 +60,7 @@
       level: core
       type: keyword
       short: MAC address of the destination.
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: 00-00-5E-00-53-23
       description: >
         MAC address of the destination.

--- a/schemas/host.yml
+++ b/schemas/host.yml
@@ -72,6 +72,7 @@
       level: core
       type: keyword
       short: Host MAC addresses.
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       description: >
         Host MAC addresses.
@@ -189,7 +190,7 @@
       beta: This field is beta and subject to change.
       description: >
         Linux boot uuid taken from /proc/sys/kernel/random/boot_id. Note the boot_id value from /proc may or may not be the same in containers as on the host. Some container runtimes will bind mount a new boot_id value onto the proc file in each container.
-    
+
     - name: pid_ns_ino
       level: extended
       type: keyword

--- a/schemas/observer.yml
+++ b/schemas/observer.yml
@@ -36,6 +36,7 @@
     - name: mac
       level: core
       type: keyword
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: '["00-00-5E-00-53-23", "00-00-5E-00-53-24"]'
       short: MAC addresses of the observer.
       description: >

--- a/schemas/server.yml
+++ b/schemas/server.yml
@@ -65,6 +65,7 @@
       level: core
       type: keyword
       short: MAC address of the server.
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: 00-00-5E-00-53-23
       description: >
         MAC address of the server.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -68,6 +68,7 @@
       level: core
       type: keyword
       short: MAC address of the source.
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: 00-00-5E-00-53-23
       description: >
         MAC address of the source.

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -268,10 +268,18 @@ def check_example_value(field, strict=True):
         strict_warning_handler(msg, strict)
 
     if pattern:
-        match = re.match(pattern, example_value)
-        if not match:
-            msg = f"Example value for field `{name}` does not match the regex defined in the pattern attribute: `{pattern}`."
-            strict_warning_handler(msg, strict)
+        # Examples with arrays must be handled
+        if 'array' in field['field_details']['normalize']:
+            # strips unnecessary chars in order to split each example value
+            example_values = example_value.translate(str.maketrans('', '', '"[] ')).split(',')
+        else:
+            example_values = [example_value]
+
+        for example_value in example_values:
+            match = re.match(pattern, example_value)
+            if not match:
+                msg = f"Example value for field `{name}` does not match the regex defined in the pattern attribute: `{pattern}`."
+                strict_warning_handler(msg, strict)
 
 
 def single_line_beta_description(schema_or_field, strict=True):

--- a/scripts/tests/unit/test_schema_cleaner.py
+++ b/scripts/tests/unit/test_schema_cleaner.py
@@ -418,7 +418,8 @@ class TestSchemaCleaner(unittest.TestCase):
             'field_details': {
                 'name': 'test',
                 'example': 'AA',
-                'pattern': 'A{3}'
+                'pattern': 'A{3}',
+                'normalize': [],
             }
         }
         with self.assertRaisesRegex(ValueError, 'does not match the regex defined in the pattern'):
@@ -429,7 +430,39 @@ class TestSchemaCleaner(unittest.TestCase):
             'field_details': {
                 'name': 'test',
                 'example': 'AA',
-                'pattern': 'A{3}'
+                'pattern': 'A{3}',
+                'normalize': [],
+            }
+        }
+        try:
+            with self.assertWarnsRegex(UserWarning, 'does not match the regex defined in the pattern'):
+                cleaner.check_example_value(field, strict=False)
+        except Exception:
+            self.fail("clean.check_example_value() raised Exception unexpectedly.")
+
+    def test_example_array_of_values_mismatch_with_pattern(self):
+        field = {
+            'field_details': {
+                'name': 'test',
+                'example': "['AAA', 'AA']",
+                'pattern': 'A{3}',
+                'normalize': [
+                    'array'
+                ]
+            }
+        }
+        with self.assertRaisesRegex(ValueError, 'does not match the regex defined in the pattern'):
+            cleaner.check_example_value(field)
+
+    def test_example_array_of_values_mismatch_with_patterns_strict_disabled(self):
+        field = {
+            'field_details': {
+                'name': 'test',
+                'example': "['AAA', 'AA']",
+                'pattern': 'A{3}',
+                'normalize': [
+                    'array'
+                ]
             }
         }
         try:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add pattern attribute to `.mac` fields (#1871)](https://github.com/elastic/ecs/pull/1871)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)