### PR TITLE
[8.3] Adding cluster.id to the orchestrator field set (#1875)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -45,6 +45,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `pattern` attribute to `.mac` fields. #1871
+* Add `orchestrator.cluster.id` #1875
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -4467,6 +4467,12 @@
       description: API version being used to carry out the action
       example: v1beta1
       default_field: false
+    - name: cluster.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique ID of the cluster.
+      default_field: false
     - name: cluster.name
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -487,6 +487,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,observer,observer.vendor,keyword,core,,Symantec,Vendor name of the observer.
 8.3.0-dev+exp,true,observer,observer.version,keyword,core,,,Observer version.
 8.3.0-dev+exp,true,orchestrator,orchestrator.api_version,keyword,extended,,v1beta1,API version being used to carry out the action
+8.3.0-dev+exp,true,orchestrator,orchestrator.cluster.id,keyword,extended,,,Unique ID of the cluster.
 8.3.0-dev+exp,true,orchestrator,orchestrator.cluster.name,keyword,extended,,,Name of the cluster.
 8.3.0-dev+exp,true,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the API used to manage the cluster.
 8.3.0-dev+exp,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6424,6 +6424,16 @@ orchestrator.api_version:
   normalize: []
   short: API version being used to carry out the action
   type: keyword
+orchestrator.cluster.id:
+  dashed_name: orchestrator-cluster-id
+  description: Unique ID of the cluster.
+  flat_name: orchestrator.cluster.id
+  ignore_above: 1024
+  level: extended
+  name: cluster.id
+  normalize: []
+  short: Unique ID of the cluster.
+  type: keyword
 orchestrator.cluster.name:
   dashed_name: orchestrator-cluster-name
   description: Name of the cluster.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7851,6 +7851,16 @@ orchestrator:
       normalize: []
       short: API version being used to carry out the action
       type: keyword
+    orchestrator.cluster.id:
+      dashed_name: orchestrator-cluster-id
+      description: Unique ID of the cluster.
+      flat_name: orchestrator.cluster.id
+      ignore_above: 1024
+      level: extended
+      name: cluster.id
+      normalize: []
+      short: Unique ID of the cluster.
+      type: keyword
     orchestrator.cluster.name:
       dashed_name: orchestrator-cluster-name
       description: Name of the cluster.

--- a/experimental/generated/elasticsearch/composable/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/composable/component/orchestrator.json
@@ -14,6 +14,10 @@
             },
             "cluster": {
               "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2340,6 +2340,10 @@
           },
           "cluster": {
             "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4417,6 +4417,12 @@
       description: API version being used to carry out the action
       example: v1beta1
       default_field: false
+    - name: cluster.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique ID of the cluster.
+      default_field: false
     - name: cluster.name
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -480,6 +480,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,observer,observer.vendor,keyword,core,,Symantec,Vendor name of the observer.
 8.3.0-dev,true,observer,observer.version,keyword,core,,,Observer version.
 8.3.0-dev,true,orchestrator,orchestrator.api_version,keyword,extended,,v1beta1,API version being used to carry out the action
+8.3.0-dev,true,orchestrator,orchestrator.cluster.id,keyword,extended,,,Unique ID of the cluster.
 8.3.0-dev,true,orchestrator,orchestrator.cluster.name,keyword,extended,,,Name of the cluster.
 8.3.0-dev,true,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the API used to manage the cluster.
 8.3.0-dev,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6355,6 +6355,16 @@ orchestrator.api_version:
   normalize: []
   short: API version being used to carry out the action
   type: keyword
+orchestrator.cluster.id:
+  dashed_name: orchestrator-cluster-id
+  description: Unique ID of the cluster.
+  flat_name: orchestrator.cluster.id
+  ignore_above: 1024
+  level: extended
+  name: cluster.id
+  normalize: []
+  short: Unique ID of the cluster.
+  type: keyword
 orchestrator.cluster.name:
   dashed_name: orchestrator-cluster-name
   description: Name of the cluster.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7771,6 +7771,16 @@ orchestrator:
       normalize: []
       short: API version being used to carry out the action
       type: keyword
+    orchestrator.cluster.id:
+      dashed_name: orchestrator-cluster-id
+      description: Unique ID of the cluster.
+      flat_name: orchestrator.cluster.id
+      ignore_above: 1024
+      level: extended
+      name: cluster.id
+      normalize: []
+      short: Unique ID of the cluster.
+      type: keyword
     orchestrator.cluster.name:
       dashed_name: orchestrator-cluster-name
       description: Name of the cluster.

--- a/generated/elasticsearch/composable/component/orchestrator.json
+++ b/generated/elasticsearch/composable/component/orchestrator.json
@@ -14,6 +14,10 @@
             },
             "cluster": {
               "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2298,6 +2298,10 @@
           },
           "cluster": {
             "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/schemas/orchestrator.yml
+++ b/schemas/orchestrator.yml
@@ -30,6 +30,12 @@
       description: >
         Name of the cluster.
 
+    - name: cluster.id
+      level: extended
+      type: keyword
+      description: >
+        Unique ID of the cluster.        
+
     - name: cluster.url
       level: extended
       type: keyword


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Adding cluster.id to the orchestrator field set (#1875)](https://github.com/elastic/ecs/pull/1875)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)