### PR TITLE
[8.3] Adding orchestrator.resource.id (#1878)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -46,6 +46,7 @@ Thanks, you're awesome :-) -->
 
 * Added `pattern` attribute to `.mac` fields. #1871
 * Add `orchestrator.cluster.id` #1875
+* Add `orchestrator.resource.id` #1878
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -6403,6 +6403,22 @@ example: `elastic`
 // ===============================================================
 
 |
+[[field-orchestrator-resource-id]]
+<<field-orchestrator-resource-id, orchestrator.resource.id>>
+
+| Unique ID of the resource being acted upon.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-orchestrator-resource-name]]
 <<field-orchestrator-resource-name, orchestrator.resource.name>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -4506,6 +4506,12 @@
         setups).
       example: elastic
       default_field: false
+    - name: resource.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique ID of the resource being acted upon.
+      default_field: false
     - name: resource.name
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -493,6 +493,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.
 8.3.0-dev+exp,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
 8.3.0-dev+exp,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
+8.3.0-dev+exp,true,orchestrator,orchestrator.resource.id,keyword,extended,,,Unique ID of the resource being acted upon.
 8.3.0-dev+exp,true,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
 8.3.0-dev+exp,true,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
 8.3.0-dev+exp,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6486,6 +6486,16 @@ orchestrator.organization:
   normalize: []
   short: Organization affected by the event (for multi-tenant orchestrator setups).
   type: keyword
+orchestrator.resource.id:
+  dashed_name: orchestrator-resource-id
+  description: Unique ID of the resource being acted upon.
+  flat_name: orchestrator.resource.id
+  ignore_above: 1024
+  level: extended
+  name: resource.id
+  normalize: []
+  short: Unique ID of the resource being acted upon.
+  type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
   description: Name of the resource being acted upon.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7914,6 +7914,16 @@ orchestrator:
       normalize: []
       short: Organization affected by the event (for multi-tenant orchestrator setups).
       type: keyword
+    orchestrator.resource.id:
+      dashed_name: orchestrator-resource-id
+      description: Unique ID of the resource being acted upon.
+      flat_name: orchestrator.resource.id
+      ignore_above: 1024
+      level: extended
+      name: resource.id
+      normalize: []
+      short: Unique ID of the resource being acted upon.
+      type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
       description: Name of the resource being acted upon.

--- a/experimental/generated/elasticsearch/composable/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/composable/component/orchestrator.json
@@ -42,6 +42,10 @@
             },
             "resource": {
               "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2368,6 +2368,10 @@
           },
           "resource": {
             "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -4456,6 +4456,12 @@
         setups).
       example: elastic
       default_field: false
+    - name: resource.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique ID of the resource being acted upon.
+      default_field: false
     - name: resource.name
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -486,6 +486,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.
 8.3.0-dev,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
 8.3.0-dev,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
+8.3.0-dev,true,orchestrator,orchestrator.resource.id,keyword,extended,,,Unique ID of the resource being acted upon.
 8.3.0-dev,true,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
 8.3.0-dev,true,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
 8.3.0-dev,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6417,6 +6417,16 @@ orchestrator.organization:
   normalize: []
   short: Organization affected by the event (for multi-tenant orchestrator setups).
   type: keyword
+orchestrator.resource.id:
+  dashed_name: orchestrator-resource-id
+  description: Unique ID of the resource being acted upon.
+  flat_name: orchestrator.resource.id
+  ignore_above: 1024
+  level: extended
+  name: resource.id
+  normalize: []
+  short: Unique ID of the resource being acted upon.
+  type: keyword
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
   description: Name of the resource being acted upon.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7834,6 +7834,16 @@ orchestrator:
       normalize: []
       short: Organization affected by the event (for multi-tenant orchestrator setups).
       type: keyword
+    orchestrator.resource.id:
+      dashed_name: orchestrator-resource-id
+      description: Unique ID of the resource being acted upon.
+      flat_name: orchestrator.resource.id
+      ignore_above: 1024
+      level: extended
+      name: resource.id
+      normalize: []
+      short: Unique ID of the resource being acted upon.
+      type: keyword
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
       description: Name of the resource being acted upon.

--- a/generated/elasticsearch/composable/component/orchestrator.json
+++ b/generated/elasticsearch/composable/component/orchestrator.json
@@ -42,6 +42,10 @@
             },
             "resource": {
               "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2326,6 +2326,10 @@
           },
           "resource": {
             "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/schemas/orchestrator.yml
+++ b/schemas/orchestrator.yml
@@ -83,6 +83,12 @@
       description: >
         Type of resource being acted upon.
 
+    - name: resource.id
+      level: extended
+      type: keyword
+      description: >
+        Unique ID of the resource being acted upon.            
+
     - name: api_version
       level: extended
       example: v1beta1


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Adding orchestrator.resource.id (#1878)](https://github.com/elastic/ecs/pull/1878)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)