### PR TITLE
[8.3] [DOCS] Include constraints for `process.env_vars` object field (#1884)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -73,7 +73,7 @@ Thanks, you're awesome :-) -->
 * Add beta `container.*` metric fields. #1789
 * Add six new syslog fields to `log.syslog.*`. #1793
 * Added `faas.id`, `faas.name` and `faas.version` fields as beta. #1796
-* Added linux event model beta fields and reuses to support RFC 0030. #1842, #1847
+* Added linux event model beta fields and reuses to support RFC 0030. #1842, #1847, #1884
 * Added `threat.feed.dashboard_id`, `threat.feed.description`, `threat.feed.name`, `threat.feed.reference` fields. #1844
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7200,6 +7200,8 @@ example: `c2c455d9f99375d`
 
 Environment variables (`env_vars`) set at the time of the event. May be filtered to protect sensitive information.
 
+The field should not contain nested objects. All values should use `keyword`.
+
 type: object
 
 
@@ -7300,7 +7302,7 @@ example: `ssh`
 [[field-process-pgid]]
 <<field-process-pgid, process.pgid>>
 
-| Deprecated for removal in next major version release. This field is superseded by  `process.group_leader.pid`.
+| Deprecated for removal in next major version release. This field is superseded by `process.group_leader.pid`.
 
 Identifier of the group of processes the process belongs to.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5440,8 +5440,10 @@
     - name: env_vars
       level: extended
       type: object
-      description: Environment variables (`env_vars`) set at the time of the event.
+      description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
+
+        The field should not contain nested objects. All values should use `keyword`.'
       example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
       default_field: false
     - name: executable
@@ -6292,7 +6294,7 @@
       type: long
       format: string
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       default_field: false
@@ -6531,7 +6533,7 @@
       type: long
       format: string
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
     - name: pid

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7751,8 +7751,10 @@ process.entry_leader.working_directory:
 process.env_vars:
   beta: This field is beta and subject to change.
   dashed_name: process-env-vars
-  description: Environment variables (`env_vars`) set at the time of the event. May
+  description: 'Environment variables (`env_vars`) set at the time of the event. May
     be filtered to protect sensitive information.
+
+    The field should not contain nested objects. All values should use `keyword`.'
   example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
   flat_name: process.env_vars
   level: extended
@@ -9164,7 +9166,7 @@ process.parent.pe.product:
 process.parent.pgid:
   dashed_name: process-parent-pgid
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `process.group_leader.pid`.
+    superseded by `process.group_leader.pid`.
 
     Identifier of the group of processes the process belongs to.'
   flat_name: process.parent.pgid
@@ -9566,7 +9568,7 @@ process.pe.product:
 process.pgid:
   dashed_name: process-pgid
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `process.group_leader.pid`.
+    superseded by `process.group_leader.pid`.
 
     Identifier of the group of processes the process belongs to.'
   flat_name: process.pgid

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9450,8 +9450,10 @@ process:
     process.env_vars:
       beta: This field is beta and subject to change.
       dashed_name: process-env-vars
-      description: Environment variables (`env_vars`) set at the time of the event.
+      description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
+
+        The field should not contain nested objects. All values should use `keyword`.'
       example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
       flat_name: process.env_vars
       level: extended
@@ -10863,7 +10865,7 @@ process:
     process.parent.pgid:
       dashed_name: process-parent-pgid
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       flat_name: process.parent.pgid
@@ -11265,7 +11267,7 @@ process:
     process.pgid:
       dashed_name: process-pgid
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       flat_name: process.pgid

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5390,8 +5390,10 @@
     - name: env_vars
       level: extended
       type: object
-      description: Environment variables (`env_vars`) set at the time of the event.
+      description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
+
+        The field should not contain nested objects. All values should use `keyword`.'
       example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
       default_field: false
     - name: executable
@@ -6242,7 +6244,7 @@
       type: long
       format: string
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       default_field: false
@@ -6481,7 +6483,7 @@
       type: long
       format: string
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
     - name: pid

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7682,8 +7682,10 @@ process.entry_leader.working_directory:
 process.env_vars:
   beta: This field is beta and subject to change.
   dashed_name: process-env-vars
-  description: Environment variables (`env_vars`) set at the time of the event. May
+  description: 'Environment variables (`env_vars`) set at the time of the event. May
     be filtered to protect sensitive information.
+
+    The field should not contain nested objects. All values should use `keyword`.'
   example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
   flat_name: process.env_vars
   level: extended
@@ -9095,7 +9097,7 @@ process.parent.pe.product:
 process.parent.pgid:
   dashed_name: process-parent-pgid
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `process.group_leader.pid`.
+    superseded by `process.group_leader.pid`.
 
     Identifier of the group of processes the process belongs to.'
   flat_name: process.parent.pgid
@@ -9497,7 +9499,7 @@ process.pe.product:
 process.pgid:
   dashed_name: process-pgid
   description: 'Deprecated for removal in next major version release. This field is
-    superseded by  `process.group_leader.pid`.
+    superseded by `process.group_leader.pid`.
 
     Identifier of the group of processes the process belongs to.'
   flat_name: process.pgid

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9370,8 +9370,10 @@ process:
     process.env_vars:
       beta: This field is beta and subject to change.
       dashed_name: process-env-vars
-      description: Environment variables (`env_vars`) set at the time of the event.
+      description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
+
+        The field should not contain nested objects. All values should use `keyword`.'
       example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
       flat_name: process.env_vars
       level: extended
@@ -10783,7 +10785,7 @@ process:
     process.parent.pgid:
       dashed_name: process-parent-pgid
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       flat_name: process.parent.pgid
@@ -11185,7 +11187,7 @@ process:
     process.pgid:
       dashed_name: process-pgid
       description: 'Deprecated for removal in next major version release. This field
-        is superseded by  `process.group_leader.pid`.
+        is superseded by `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.'
       flat_name: process.pgid

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -117,7 +117,7 @@
       type: long
       short: Deprecated identifier of the group of processes the process belongs to.
       description: >
-        Deprecated for removal in next major version release. This field is superseded by 
+        Deprecated for removal in next major version release. This field is superseded by
         `process.group_leader.pid`.
 
         Identifier of the group of processes the process belongs to.
@@ -239,7 +239,7 @@
       example: "2016-05-23T08:05:34.853Z"
       description: >
         The time the process ended.
-    
+
     - name: interactive
       level: extended
       type: boolean
@@ -250,9 +250,9 @@
         Whether the process is connected to an interactive shell.
 
         Process interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.
-        
+
         Note: A non-interactive process can belong to an interactive session and is simply one that does not have open file descriptors reading the controlling TTY on FD 0 (stdin) or writing to the controlling TTY on FD 2 (stderr). A backgrounded process is still considered interactive if stdin and stderr are connected to the controlling TTY.
-   
+
     - name: same_as_process
       level: extended
       type: boolean
@@ -264,13 +264,13 @@
 
         For example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*`
         The same applies for both `process.session_leader` and `process.entry_leader`.
-        
+
         This field exists to the benefit of EQL and other rule engines since it's not possible to compare equality between two fields in a single document.
         e.g
         `process.entity_id` = `process.group_leader.entity_id` (top level process is the process group leader)
         OR
         `process.entity_id` = `process.entry_leader.entity_id` (top level process is the entry session leader)
-        
+
         Instead these rules could be written like:
         `process.group_leader.same_as_process: true`
         OR
@@ -286,6 +286,8 @@
       description: >
         Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
+
+        The field should not contain nested objects. All values should use `keyword`.
       example: "{\"USER\": \"elastic\",\"LANG\": \"en_US.UTF-8\",\"HOME\": \"/home/elastic\"}"
 
     - name: entry_meta.type
@@ -313,7 +315,7 @@
       short: Information about the controlling TTY device.
       description: >
         Information about the controlling TTY device. If set, the process belongs to an interactive session.
-        
+
     - name: tty.char_device.major
       level: extended
       type: long


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [[DOCS] Include constraints for `process.env_vars` object field (#1884)](https://github.com/elastic/ecs/pull/1884)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)