### PR TITLE
[8.3] Add orchestrator (resource.parent.type and resource.ip) and container (image.hash.all) fields (#1889)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -47,6 +47,9 @@ Thanks, you're awesome :-) -->
 * Added `pattern` attribute to `.mac` fields. #1871
 * Add `orchestrator.cluster.id` #1875
 * Add `orchestrator.resource.id` #1878
+* Add `orchestrator.resource.parent.type` #1889
+* Add `orchestrator.resource.ip` #1889
+* Add `container.image.hash.all` #1889
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -1092,6 +1092,25 @@ type: keyword
 // ===============================================================
 
 |
+[[field-container-image-hash-all]]
+<<field-container-image-hash-all, container.image.hash.all>>
+
+| An array of digests of the image the container was built on. Each digest consists of the hash algorithm and value in this format: `algorithm:value`. Algorithm names should align with the field names in the ECS hash field set.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-container-image-name]]
 <<field-container-image-name, container.image.name>>
 
@@ -6419,6 +6438,25 @@ type: keyword
 // ===============================================================
 
 |
+[[field-orchestrator-resource-ip]]
+<<field-orchestrator-resource-ip, orchestrator.resource.ip>>
+
+| IP address assigned to the resource associated with the event being observed. In the case of a Kubernetes Pod, this array would contain only one element: the IP of the Pod (as opposed to the Node on which the Pod is running).
+
+type: ip
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-orchestrator-resource-name]]
 <<field-orchestrator-resource-name, orchestrator.resource.name>>
 
@@ -6429,6 +6467,22 @@ type: keyword
 
 
 example: `test-pod-cdcws`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-orchestrator-resource-parent-type]]
+<<field-orchestrator-resource-parent-type, orchestrator.resource.parent.type>>
+
+| Type or kind of the parent resource associated with the event being observed. In Kubernetes, this will be the name of a built-in workload resource (e.g., Deployment, StatefulSet, DaemonSet).
+
+type: keyword
+
+
+
+example: `DaemonSet`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -897,6 +897,15 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+    - name: image.hash.all
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'An array of digests of the image the container was built on. Each
+        digest consists of the hash algorithm and value in this format: `algorithm:value`.
+        Algorithm names should align with the field names in the ECS hash field set.'
+      example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      default_field: false
     - name: image.name
       level: extended
       type: keyword
@@ -4512,12 +4521,29 @@
       ignore_above: 1024
       description: Unique ID of the resource being acted upon.
       default_field: false
+    - name: resource.ip
+      level: extended
+      type: ip
+      description: 'IP address assigned to the resource associated with the event
+        being observed. In the case of a Kubernetes Pod, this array would contain
+        only one element: the IP of the Pod (as opposed to the Node on which the Pod
+        is running).'
+      default_field: false
     - name: resource.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Name of the resource being acted upon.
       example: test-pod-cdcws
+      default_field: false
+    - name: resource.parent.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Type or kind of the parent resource associated with the event being
+        observed. In Kubernetes, this will be the name of a built-in workload resource
+        (e.g., Deployment, StatefulSet, DaemonSet).
+      example: DaemonSet
       default_field: false
     - name: resource.type
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -91,6 +91,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,container,container.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
 8.3.0-dev+exp,true,container,container.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
 8.3.0-dev+exp,true,container,container.id,keyword,core,,,Unique container id.
+8.3.0-dev+exp,true,container,container.image.hash.all,keyword,extended,array,[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26],An array of digests of the image the container was built on.
 8.3.0-dev+exp,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 8.3.0-dev+exp,true,container,container.image.tag,keyword,extended,array,,Container image tags.
 8.3.0-dev+exp,true,container,container.labels,object,extended,,,Image labels.
@@ -494,7 +495,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
 8.3.0-dev+exp,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
 8.3.0-dev+exp,true,orchestrator,orchestrator.resource.id,keyword,extended,,,Unique ID of the resource being acted upon.
+8.3.0-dev+exp,true,orchestrator,orchestrator.resource.ip,ip,extended,array,,IP address assigned to the resource associated with the event being observed.
 8.3.0-dev+exp,true,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
+8.3.0-dev+exp,true,orchestrator,orchestrator.resource.parent.type,keyword,extended,,DaemonSet,Type or kind of the parent resource associated with the event being observed.
 8.3.0-dev+exp,true,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
 8.3.0-dev+exp,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 8.3.0-dev+exp,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1102,6 +1102,20 @@ container.id:
   normalize: []
   short: Unique container id.
   type: keyword
+container.image.hash.all:
+  dashed_name: container-image-hash-all
+  description: 'An array of digests of the image the container was built on. Each
+    digest consists of the hash algorithm and value in this format: `algorithm:value`.
+    Algorithm names should align with the field names in the ECS hash field set.'
+  example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+  flat_name: container.image.hash.all
+  ignore_above: 1024
+  level: extended
+  name: image.hash.all
+  normalize:
+  - array
+  short: An array of digests of the image the container was built on.
+  type: keyword
 container.image.name:
   dashed_name: container-image-name
   description: Name of the image the container was built on.
@@ -6496,6 +6510,18 @@ orchestrator.resource.id:
   normalize: []
   short: Unique ID of the resource being acted upon.
   type: keyword
+orchestrator.resource.ip:
+  dashed_name: orchestrator-resource-ip
+  description: 'IP address assigned to the resource associated with the event being
+    observed. In the case of a Kubernetes Pod, this array would contain only one element:
+    the IP of the Pod (as opposed to the Node on which the Pod is running).'
+  flat_name: orchestrator.resource.ip
+  level: extended
+  name: resource.ip
+  normalize:
+  - array
+  short: IP address assigned to the resource associated with the event being observed.
+  type: ip
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
   description: Name of the resource being acted upon.
@@ -6506,6 +6532,19 @@ orchestrator.resource.name:
   name: resource.name
   normalize: []
   short: Name of the resource being acted upon.
+  type: keyword
+orchestrator.resource.parent.type:
+  dashed_name: orchestrator-resource-parent-type
+  description: Type or kind of the parent resource associated with the event being
+    observed. In Kubernetes, this will be the name of a built-in workload resource
+    (e.g., Deployment, StatefulSet, DaemonSet).
+  example: DaemonSet
+  flat_name: orchestrator.resource.parent.type
+  ignore_above: 1024
+  level: extended
+  name: resource.parent.type
+  normalize: []
+  short: Type or kind of the parent resource associated with the event being observed.
   type: keyword
 orchestrator.resource.type:
   dashed_name: orchestrator-resource-type

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1482,6 +1482,20 @@ container:
       normalize: []
       short: Unique container id.
       type: keyword
+    container.image.hash.all:
+      dashed_name: container-image-hash-all
+      description: 'An array of digests of the image the container was built on. Each
+        digest consists of the hash algorithm and value in this format: `algorithm:value`.
+        Algorithm names should align with the field names in the ECS hash field set.'
+      example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      flat_name: container.image.hash.all
+      ignore_above: 1024
+      level: extended
+      name: image.hash.all
+      normalize:
+      - array
+      short: An array of digests of the image the container was built on.
+      type: keyword
     container.image.name:
       dashed_name: container-image-name
       description: Name of the image the container was built on.
@@ -7924,6 +7938,19 @@ orchestrator:
       normalize: []
       short: Unique ID of the resource being acted upon.
       type: keyword
+    orchestrator.resource.ip:
+      dashed_name: orchestrator-resource-ip
+      description: 'IP address assigned to the resource associated with the event
+        being observed. In the case of a Kubernetes Pod, this array would contain
+        only one element: the IP of the Pod (as opposed to the Node on which the Pod
+        is running).'
+      flat_name: orchestrator.resource.ip
+      level: extended
+      name: resource.ip
+      normalize:
+      - array
+      short: IP address assigned to the resource associated with the event being observed.
+      type: ip
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
       description: Name of the resource being acted upon.
@@ -7934,6 +7961,19 @@ orchestrator:
       name: resource.name
       normalize: []
       short: Name of the resource being acted upon.
+      type: keyword
+    orchestrator.resource.parent.type:
+      dashed_name: orchestrator-resource-parent-type
+      description: Type or kind of the parent resource associated with the event being
+        observed. In Kubernetes, this will be the name of a built-in workload resource
+        (e.g., Deployment, StatefulSet, DaemonSet).
+      example: DaemonSet
+      flat_name: orchestrator.resource.parent.type
+      ignore_above: 1024
+      level: extended
+      name: resource.parent.type
+      normalize: []
+      short: Type or kind of the parent resource associated with the event being observed.
       type: keyword
     orchestrator.resource.type:
       dashed_name: orchestrator-resource-type

--- a/experimental/generated/elasticsearch/composable/component/container.json
+++ b/experimental/generated/elasticsearch/composable/component/container.json
@@ -40,6 +40,14 @@
             },
             "image": {
               "properties": {
+                "hash": {
+                  "properties": {
+                    "all": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/composable/component/orchestrator.json
+++ b/experimental/generated/elasticsearch/composable/component/orchestrator.json
@@ -46,9 +46,20 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "ip": {
+                  "type": "ip"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -509,6 +509,14 @@
           },
           "image": {
             "properties": {
+              "hash": {
+                "properties": {
+                  "all": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2372,9 +2380,20 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "ip": {
+                "type": "ip"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "parent": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               },
               "type": {
                 "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -847,6 +847,15 @@
       type: keyword
       ignore_above: 1024
       description: Unique container id.
+    - name: image.hash.all
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'An array of digests of the image the container was built on. Each
+        digest consists of the hash algorithm and value in this format: `algorithm:value`.
+        Algorithm names should align with the field names in the ECS hash field set.'
+      example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      default_field: false
     - name: image.name
       level: extended
       type: keyword
@@ -4462,12 +4471,29 @@
       ignore_above: 1024
       description: Unique ID of the resource being acted upon.
       default_field: false
+    - name: resource.ip
+      level: extended
+      type: ip
+      description: 'IP address assigned to the resource associated with the event
+        being observed. In the case of a Kubernetes Pod, this array would contain
+        only one element: the IP of the Pod (as opposed to the Node on which the Pod
+        is running).'
+      default_field: false
     - name: resource.name
       level: extended
       type: keyword
       ignore_above: 1024
       description: Name of the resource being acted upon.
       example: test-pod-cdcws
+      default_field: false
+    - name: resource.parent.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Type or kind of the parent resource associated with the event being
+        observed. In Kubernetes, this will be the name of a built-in workload resource
+        (e.g., Deployment, StatefulSet, DaemonSet).
+      example: DaemonSet
       default_field: false
     - name: resource.type
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -84,6 +84,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,container,container.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
 8.3.0-dev,true,container,container.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
 8.3.0-dev,true,container,container.id,keyword,core,,,Unique container id.
+8.3.0-dev,true,container,container.image.hash.all,keyword,extended,array,[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26],An array of digests of the image the container was built on.
 8.3.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
 8.3.0-dev,true,container,container.image.tag,keyword,extended,array,,Container image tags.
 8.3.0-dev,true,container,container.labels,object,extended,,,Image labels.
@@ -487,7 +488,9 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
 8.3.0-dev,true,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
 8.3.0-dev,true,orchestrator,orchestrator.resource.id,keyword,extended,,,Unique ID of the resource being acted upon.
+8.3.0-dev,true,orchestrator,orchestrator.resource.ip,ip,extended,array,,IP address assigned to the resource associated with the event being observed.
 8.3.0-dev,true,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
+8.3.0-dev,true,orchestrator,orchestrator.resource.parent.type,keyword,extended,,DaemonSet,Type or kind of the parent resource associated with the event being observed.
 8.3.0-dev,true,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
 8.3.0-dev,true,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
 8.3.0-dev,true,organization,organization.id,keyword,extended,,,Unique identifier for the organization.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1033,6 +1033,20 @@ container.id:
   normalize: []
   short: Unique container id.
   type: keyword
+container.image.hash.all:
+  dashed_name: container-image-hash-all
+  description: 'An array of digests of the image the container was built on. Each
+    digest consists of the hash algorithm and value in this format: `algorithm:value`.
+    Algorithm names should align with the field names in the ECS hash field set.'
+  example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+  flat_name: container.image.hash.all
+  ignore_above: 1024
+  level: extended
+  name: image.hash.all
+  normalize:
+  - array
+  short: An array of digests of the image the container was built on.
+  type: keyword
 container.image.name:
   dashed_name: container-image-name
   description: Name of the image the container was built on.
@@ -6427,6 +6441,18 @@ orchestrator.resource.id:
   normalize: []
   short: Unique ID of the resource being acted upon.
   type: keyword
+orchestrator.resource.ip:
+  dashed_name: orchestrator-resource-ip
+  description: 'IP address assigned to the resource associated with the event being
+    observed. In the case of a Kubernetes Pod, this array would contain only one element:
+    the IP of the Pod (as opposed to the Node on which the Pod is running).'
+  flat_name: orchestrator.resource.ip
+  level: extended
+  name: resource.ip
+  normalize:
+  - array
+  short: IP address assigned to the resource associated with the event being observed.
+  type: ip
 orchestrator.resource.name:
   dashed_name: orchestrator-resource-name
   description: Name of the resource being acted upon.
@@ -6437,6 +6463,19 @@ orchestrator.resource.name:
   name: resource.name
   normalize: []
   short: Name of the resource being acted upon.
+  type: keyword
+orchestrator.resource.parent.type:
+  dashed_name: orchestrator-resource-parent-type
+  description: Type or kind of the parent resource associated with the event being
+    observed. In Kubernetes, this will be the name of a built-in workload resource
+    (e.g., Deployment, StatefulSet, DaemonSet).
+  example: DaemonSet
+  flat_name: orchestrator.resource.parent.type
+  ignore_above: 1024
+  level: extended
+  name: resource.parent.type
+  normalize: []
+  short: Type or kind of the parent resource associated with the event being observed.
   type: keyword
 orchestrator.resource.type:
   dashed_name: orchestrator-resource-type

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1402,6 +1402,20 @@ container:
       normalize: []
       short: Unique container id.
       type: keyword
+    container.image.hash.all:
+      dashed_name: container-image-hash-all
+      description: 'An array of digests of the image the container was built on. Each
+        digest consists of the hash algorithm and value in this format: `algorithm:value`.
+        Algorithm names should align with the field names in the ECS hash field set.'
+      example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      flat_name: container.image.hash.all
+      ignore_above: 1024
+      level: extended
+      name: image.hash.all
+      normalize:
+      - array
+      short: An array of digests of the image the container was built on.
+      type: keyword
     container.image.name:
       dashed_name: container-image-name
       description: Name of the image the container was built on.
@@ -7844,6 +7858,19 @@ orchestrator:
       normalize: []
       short: Unique ID of the resource being acted upon.
       type: keyword
+    orchestrator.resource.ip:
+      dashed_name: orchestrator-resource-ip
+      description: 'IP address assigned to the resource associated with the event
+        being observed. In the case of a Kubernetes Pod, this array would contain
+        only one element: the IP of the Pod (as opposed to the Node on which the Pod
+        is running).'
+      flat_name: orchestrator.resource.ip
+      level: extended
+      name: resource.ip
+      normalize:
+      - array
+      short: IP address assigned to the resource associated with the event being observed.
+      type: ip
     orchestrator.resource.name:
       dashed_name: orchestrator-resource-name
       description: Name of the resource being acted upon.
@@ -7854,6 +7881,19 @@ orchestrator:
       name: resource.name
       normalize: []
       short: Name of the resource being acted upon.
+      type: keyword
+    orchestrator.resource.parent.type:
+      dashed_name: orchestrator-resource-parent-type
+      description: Type or kind of the parent resource associated with the event being
+        observed. In Kubernetes, this will be the name of a built-in workload resource
+        (e.g., Deployment, StatefulSet, DaemonSet).
+      example: DaemonSet
+      flat_name: orchestrator.resource.parent.type
+      ignore_above: 1024
+      level: extended
+      name: resource.parent.type
+      normalize: []
+      short: Type or kind of the parent resource associated with the event being observed.
       type: keyword
     orchestrator.resource.type:
       dashed_name: orchestrator-resource-type

--- a/generated/elasticsearch/composable/component/container.json
+++ b/generated/elasticsearch/composable/component/container.json
@@ -40,6 +40,14 @@
             },
             "image": {
               "properties": {
+                "hash": {
+                  "properties": {
+                    "all": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/composable/component/orchestrator.json
+++ b/generated/elasticsearch/composable/component/orchestrator.json
@@ -46,9 +46,20 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "ip": {
+                  "type": "ip"
+                },
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "parent": {
+                  "properties": {
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -467,6 +467,14 @@
           },
           "image": {
             "properties": {
+              "hash": {
+                "properties": {
+                  "all": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2330,9 +2338,20 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "ip": {
+                "type": "ip"
+              },
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "parent": {
+                "properties": {
+                  "type": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
               },
               "type": {
                 "ignore_above": 1024,

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -75,6 +75,18 @@
       normalize:
         - array
 
+    - name: image.hash.all
+      level: extended
+      type: keyword
+      short: An array of digests of the image the container was built on.
+      description: >
+        An array of digests of the image the container was built on.
+        Each digest consists of the hash algorithm and value in this format: `algorithm:value`.
+        Algorithm names should align with the field names in the ECS hash field set.
+      example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      normalize:
+        - array
+
     - name: labels
       level: extended
       type: object

--- a/schemas/orchestrator.yml
+++ b/schemas/orchestrator.yml
@@ -83,6 +83,25 @@
       description: >
         Type of resource being acted upon.
 
+    - name: resource.parent.type
+      level: extended
+      type: keyword
+      example: DaemonSet
+      short: Type or kind of the parent resource associated with the event being observed.
+      description: >
+        Type or kind of the parent resource associated with the event being observed.
+        In Kubernetes, this will be the name of a built-in workload resource (e.g., Deployment, StatefulSet, DaemonSet).
+
+    - name: resource.ip
+      level: extended
+      type: ip
+      short: IP address assigned to the resource associated with the event being observed.
+      description: >
+        IP address assigned to the resource associated with the event being observed.
+        In the case of a Kubernetes Pod, this array would contain only one element: the IP of the Pod (as opposed to the Node on which the Pod is running).
+      normalize:
+        - array
+
     - name: resource.id
       level: extended
       type: keyword


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add orchestrator (resource.parent.type and resource.ip) and container (image.hash.all) fields (#1889)](https://github.com/elastic/ecs/pull/1889)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)