### PR TITLE
[8.3] Add type hints to schema modules (#1771)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -65,6 +65,8 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
+* Add type hints to `schema` modules. #1771
+
 #### Deprecated
 
 <!-- All empty sections:

--- a/scripts/_types/__init__.py
+++ b/scripts/_types/__init__.py
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from .schema_fields import (
+    AllowedValues,
+    Field,
+    FieldDetails,
+    FieldEntry,
+    FieldNestedEntry,
+    MultiField,
+    Reuseable,
+    SchemaDetails,
+)
+
+__all__ = [
+    "AllowedValues",
+    "Field",
+    "FieldDetails",
+    "FieldEntry",
+    "FieldNestedEntry",
+    "MultiField",
+    "Reuseable",
+    "SchemaDetails",
+]

--- a/scripts/_types/schema_fields.py
+++ b/scripts/_types/schema_fields.py
@@ -1,0 +1,97 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# 	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import (
+    Any,
+    Dict,
+    List,
+    TypedDict,
+)
+
+
+class MultiField(TypedDict, total=False):
+    doc_values: bool
+    index: bool
+    ignore_above: int
+    name: str
+    norms: bool
+    type: str
+
+
+class AllowedValues(TypedDict, total=False):
+    name: str
+    description: str
+
+
+class Field(TypedDict, total=False):
+    allowed_values: List[AllowedValues]
+    dashed_name: str
+    description: str
+    doc_values: bool
+    example: str
+    flat_name: str
+    footnote: str
+    ignore_above: int
+    index: bool
+    intermediate: bool
+    level: str
+    multi_fields: List[MultiField]
+    name: str
+    node_name: str
+    normalize: List[str]
+    norms: bool
+    required: bool
+    short: str
+    type: str
+
+
+class FieldDetails(TypedDict, total=False):
+    field_details: Field
+    fields: Dict[str, Field]
+
+
+class Reuseable(TypedDict, total=False):
+    expected: List[Any]
+    top_level: bool
+    order: int
+
+
+class SchemaDetails(TypedDict, total=False):
+    group: int
+    prefix: str
+    reusable: Reuseable
+    root: bool
+    title: str
+
+
+class FieldEntry(TypedDict, total=False):
+    field_details: Field
+    fields: Dict[str, Field]
+    schema_details: SchemaDetails
+
+
+class FieldNestedEntry(TypedDict, total=False):
+    description: str
+    fields: List[Field]
+    footnote: str
+    group: int
+    name: str
+    node_name: str
+    prefix: str
+    short: str
+    title: str
+    type: str

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -17,6 +17,9 @@
 
 import argparse
 import os
+from typing import (
+    Optional,
+)
 
 from generators import asciidoc_fields
 from generators import beats
@@ -30,12 +33,15 @@ from schema import cleaner
 from schema import finalizer
 from schema import subset_filter
 from schema import exclude_filter
+from _types import (
+    FieldEntry
+)
 
 
-def main():
+def main() -> None:
     args = argument_parser()
 
-    ecs_generated_version = read_version(args.ref)
+    ecs_generated_version: str = read_version(args.ref)
     print('Running generator. ECS version ' + ecs_generated_version)
 
     # default location to save files
@@ -59,7 +65,7 @@ def main():
         ecs_generated_version += "+exp"
         print('Experimental ECS version ' + ecs_generated_version)
 
-    fields = loader.load_schemas(ref=args.ref, included_files=args.include)
+    fields: dict[str, FieldEntry] = loader.load_schemas(ref=args.ref, included_files=args.include)
     cleaner.clean(fields, strict=args.strict)
     finalizer.finalize(fields)
     fields = subset_filter.filter(fields, args.subset, out_dir)
@@ -81,7 +87,7 @@ def main():
     asciidoc_fields.generate(nested, ecs_generated_version, docs_dir)
 
 
-def argument_parser():
+def argument_parser() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('--ref', action='store', help='Loads fields definitions from `./schemas` subdirectory from specified git reference. \
                                                        Note that "--include experimental/schemas" will also respect this git ref.')
@@ -111,7 +117,7 @@ def argument_parser():
     return args
 
 
-def read_version(ref=None):
+def read_version(ref: Optional[str] = None) -> str:
     if ref:
         print('Loading schemas from git ref ' + ref)
         tree = ecs_helpers.get_tree_by_ref(ref)

--- a/scripts/generators/intermediate_files.py
+++ b/scripts/generators/intermediate_files.py
@@ -16,10 +16,17 @@
 # under the License.
 
 import copy
+from os.path import join
+from typing import (
+    Dict,
+)
 
 from schema import visitor
 from generators import ecs_helpers
-from os.path import join
+from _types import (
+    Field,
+    FieldEntry,
+)
 
 
 def generate(fields, out_dir, default_dirs):
@@ -36,15 +43,15 @@ def generate(fields, out_dir, default_dirs):
     return nested, flat
 
 
-def generate_flat_fields(fields):
+def generate_flat_fields(fields: Dict[str, FieldEntry]) -> Dict[str, Field]:
     """Generate ecs_flat.yml"""
-    filtered = remove_non_root_reusables(fields)
-    flattened = {}
+    filtered: Dict[str, FieldEntry] = remove_non_root_reusables(fields)
+    flattened: Dict[str, Field] = {}
     visitor.visit_fields_with_memo(filtered, accumulate_field, flattened)
     return flattened
 
 
-def accumulate_field(details, memo):
+def accumulate_field(details: FieldEntry, memo: Field) -> None:
     """Visitor function that accumulates all field details in the memo dict"""
     if 'schema_details' in details or ecs_helpers.is_intermediate(details):
         return
@@ -93,7 +100,7 @@ def remove_internal_attributes(field_details):
     field_details.pop('intermediate', None)
 
 
-def remove_non_root_reusables(fields_nested):
+def remove_non_root_reusables(fields_nested: Dict[str, FieldEntry]) -> Dict[str, FieldEntry]:
     """
     Remove field sets that have top_level=false from the root of the field definitions.
 
@@ -105,7 +112,7 @@ def remove_non_root_reusables(fields_nested):
     the official information about each field set. It's the responsibility of
     users consuming ecs_nested.yml to skip the field sets with top_level=false.
     """
-    fields = {}
+    fields: Dict[str, FieldEntry] = {}
     for (name, field) in fields_nested.items():
         if 'reusable' not in field['schema_details'] or field['schema_details']['reusable']['top_level']:
             fields[name] = field

--- a/scripts/schema/cleaner.py
+++ b/scripts/schema/cleaner.py
@@ -16,9 +16,21 @@
 # under the License.
 
 import re
+from typing import (
+    Dict,
+    List,
+    Optional,
+    Union,
+)
 
 from generators import ecs_helpers
 from schema import visitor
+from _types import (
+    Field,
+    FieldDetails,
+    FieldEntry,
+    MultiField,
+)
 
 # This script performs a few cleanup functions in place, within the deeply nested
 # 'fields' structure passed to `clean(fields)`.
@@ -35,8 +47,10 @@ from schema import visitor
 # inside them. It doesn't perform field reuse, and therefore doesn't
 # deal with final field names either.
 
+strict_mode: Optional[bool]  # work-around from https://github.com/python/mypy/issues/5732
 
-def clean(fields, strict=False):
+
+def clean(fields: Dict[str, Field], strict: Optional[bool] = False) -> None:
     global strict_mode
     strict_mode = strict
     visitor.visit_fields(fields, fieldset_func=schema_cleanup, field_func=field_cleanup)
@@ -45,7 +59,7 @@ def clean(fields, strict=False):
 # Schema level cleanup
 
 
-def schema_cleanup(schema):
+def schema_cleanup(schema: FieldEntry) -> None:
     # Sanity check first
     schema_mandatory_attributes(schema)
     # trailing space cleanup
@@ -72,25 +86,25 @@ def schema_cleanup(schema):
 SCHEMA_MANDATORY_ATTRIBUTES = ['name', 'title', 'description']
 
 
-def schema_mandatory_attributes(schema):
+def schema_mandatory_attributes(schema: FieldEntry) -> None:
     """Ensures for the presence of the mandatory schema attributes and raises if any are missing"""
-    current_schema_attributes = sorted(list(schema['field_details'].keys()) +
-                                       list(schema['schema_details'].keys()))
-    missing_attributes = ecs_helpers.list_subtract(SCHEMA_MANDATORY_ATTRIBUTES, current_schema_attributes)
+    current_schema_attributes: List[str] = sorted(list(schema['field_details'].keys()) +
+                                                  list(schema['schema_details'].keys()))
+    missing_attributes: List[str] = ecs_helpers.list_subtract(SCHEMA_MANDATORY_ATTRIBUTES, current_schema_attributes)
     if len(missing_attributes) > 0:
         msg = "Schema {} is missing the following mandatory attributes: {}.\nFound these: {}".format(
             schema['field_details']['name'], ', '.join(missing_attributes), current_schema_attributes)
         raise ValueError(msg)
     if 'reusable' in schema['schema_details']:
-        reuse_attributes = sorted(schema['schema_details']['reusable'].keys())
-        missing_reuse_attributes = ecs_helpers.list_subtract(['expected', 'top_level'], reuse_attributes)
+        reuse_attributes: List[str] = sorted(schema['schema_details']['reusable'].keys())
+        missing_reuse_attributes: List[str] = ecs_helpers.list_subtract(['expected', 'top_level'], reuse_attributes)
         if len(missing_reuse_attributes) > 0:
             msg = "Reusable schema {} is missing the following reuse attributes: {}.\nFound these: {}".format(
                 schema['field_details']['name'], ', '.join(missing_reuse_attributes), reuse_attributes)
             raise ValueError(msg)
 
 
-def schema_assertions_and_warnings(schema):
+def schema_assertions_and_warnings(schema: FieldEntry) -> None:
     """Additional checks on a fleshed out schema"""
     single_line_short_description(schema, strict=strict_mode)
     if 'beta' in schema['field_details']:
@@ -99,7 +113,7 @@ def schema_assertions_and_warnings(schema):
         single_line_short_override_description(schema, strict=strict_mode)
 
 
-def normalize_reuse_notation(schema):
+def normalize_reuse_notation(schema: FieldEntry) -> None:
     """
     Replace single word reuse shorthands from the schema YAMLs with the explicit {at: , as:} notation.
 
@@ -123,9 +137,9 @@ def normalize_reuse_notation(schema):
             if 'at' in reuse_entry and 'as' in reuse_entry:
                 explicit_entry = reuse_entry
             else:
-                raise ValueError("When specifying reusable expected locations for {} " +
-                                 "with the dictionary notation, keys 'as' and 'at' are required. " +
-                                 "Got {}.".format(schema_name, reuse_entry))
+                raise ValueError(f"When specifying reusable expected locations for {schema_name} " +
+                                 f"with the dictionary notation, keys 'as' and 'at' are required. " +
+                                 f"Got {reuse_entry}.")
         else:  # Make it explicit
             explicit_entry = {'at': reuse_entry, 'as': schema_name}
         explicit_entry['full'] = explicit_entry['at'] + '.' + explicit_entry['as']
@@ -136,7 +150,7 @@ def normalize_reuse_notation(schema):
 # Field level cleanup
 
 
-def field_cleanup(field):
+def field_cleanup(field: FieldDetails) -> None:
     field_mandatory_attributes(field)
     if ecs_helpers.is_intermediate(field):
         return
@@ -148,7 +162,7 @@ def field_cleanup(field):
     field_assertions_and_warnings(field)
 
 
-def field_defaults(field):
+def field_defaults(field: FieldDetails) -> None:
     field['field_details'].setdefault('short', field['field_details']['description'])
     field['field_details'].setdefault('normalize', [])
     field_or_multi_field_datatype_defaults(field['field_details'])
@@ -159,7 +173,7 @@ def field_defaults(field):
                 mf['name'] = mf['type']
 
 
-def field_or_multi_field_datatype_defaults(field_details):
+def field_or_multi_field_datatype_defaults(field_details: Union[Field, MultiField]) -> None:
     """Sets datatype-related defaults on a canonical field or multi-field entries."""
     if field_details['type'] == 'keyword':
         field_details.setdefault('ignore_above', 1024)
@@ -177,12 +191,12 @@ FIELD_MANDATORY_ATTRIBUTES = ['name', 'description', 'type', 'level']
 ACCEPTABLE_FIELD_LEVELS = ['core', 'extended', 'custom']
 
 
-def field_mandatory_attributes(field):
+def field_mandatory_attributes(field: FieldDetails) -> None:
     """Ensures for the presence of the mandatory field attributes and raises if any are missing"""
     if ecs_helpers.is_intermediate(field):
         return
-    current_field_attributes = sorted(field['field_details'].keys())
-    missing_attributes = ecs_helpers.list_subtract(FIELD_MANDATORY_ATTRIBUTES, current_field_attributes)
+    current_field_attributes: List[str] = sorted(field['field_details'].keys())
+    missing_attributes: List[str] = ecs_helpers.list_subtract(FIELD_MANDATORY_ATTRIBUTES, current_field_attributes)
 
     # `alias` fields require a target `path` attribute.
     if field['field_details'].get('type') == 'alias' and 'path' not in current_field_attributes:
@@ -192,12 +206,12 @@ def field_mandatory_attributes(field):
         missing_attributes.append('scaling_factor')
 
     if len(missing_attributes) > 0:
-        msg = "Field is missing the following mandatory attributes: {}.\nFound these: {}.\nField details: {}"
+        msg: str = "Field is missing the following mandatory attributes: {}.\nFound these: {}.\nField details: {}"
         raise ValueError(msg.format(', '.join(missing_attributes),
                                     current_field_attributes, field))
 
 
-def field_assertions_and_warnings(field):
+def field_assertions_and_warnings(field: FieldDetails) -> None:
     """Additional checks on a fleshed out field"""
     if not ecs_helpers.is_intermediate(field):
         # check short description length if in strict mode
@@ -208,7 +222,7 @@ def field_assertions_and_warnings(field):
             validate_pattern_regex(field['field_details'], strict=strict_mode)
         check_example_value(field, strict=strict_mode)
         if field['field_details']['level'] not in ACCEPTABLE_FIELD_LEVELS:
-            msg = "Invalid level for field '{}'.\nValue: {}\nAcceptable values: {}".format(
+            msg: str = "Invalid level for field '{}'.\nValue: {}\nAcceptable values: {}".format(
                 field['field_details']['name'], field['field_details']['level'],
                 ACCEPTABLE_FIELD_LEVELS)
             raise ValueError(msg)
@@ -219,10 +233,10 @@ def field_assertions_and_warnings(field):
 SHORT_LIMIT = 120
 
 
-def single_line_short_check(short_to_check, short_name):
-    short_length = len(short_to_check)
+def single_line_short_check(short_to_check: str, short_name: str) -> Union[str, None]:
+    short_length: int = len(short_to_check)
     if "\n" in short_to_check or short_length > SHORT_LIMIT:
-        msg = "Short descriptions must be single line, and under {} characters (current length: {}).\n".format(
+        msg: str = "Short descriptions must be single line, and under {} characters (current length: {}).\n".format(
             SHORT_LIMIT, short_length)
         msg += "Offending field or field set: {}\nShort description:\n  {}".format(
             short_name,
@@ -239,32 +253,34 @@ def strict_warning_handler(message, strict):
         ecs_helpers.strict_warning(message)
 
 
-def single_line_short_description(schema_or_field, strict=True):
-    error = single_line_short_check(schema_or_field['field_details']['short'], schema_or_field['field_details']['name'])
+def single_line_short_description(schema_or_field: FieldEntry, strict: Optional[bool] = True):
+    error: Union[str, None] = single_line_short_check(
+        schema_or_field['field_details']['short'], schema_or_field['field_details']['name'])
     if error:
         strict_warning_handler(error, strict)
 
 
-def single_line_short_override_description(schema_or_field, strict=True):
+def single_line_short_override_description(schema_or_field: FieldEntry, strict: Optional[bool] = True):
     for field in schema_or_field['schema_details']['reusable']['expected']:
         if not 'short_override' in field:
             continue
-        error = single_line_short_check(field['short_override'], field['full'])
+        error: Union[str, None] = single_line_short_check(field['short_override'], field['full'])
         if error:
             strict_warning_handler(error, strict)
 
 
-def check_example_value(field, strict=True):
+def check_example_value(field: Union[List, FieldEntry], strict: Optional[bool] = True) -> None:
     """
     Checks if value of the example field is of type list or dict.
     Fails or warns (depending on strict mode) if so.
     """
-    example_value = field['field_details'].get('example', None)
+    example_value: Union[List, FieldEntry] = field['field_details'].get('example', None)
     pattern = field['field_details'].get('pattern', None)
     name = field['field_details']['name']
 
     if isinstance(example_value, (list, dict)):
-        msg = f"Example value for field `{name}` contains an object or array which must be quoted to avoid YAML interpretation."
+        field_name: str = field['field_details']['name']
+        msg: str = f"Example value for field `{field_name}` contains an object or array which must be quoted to avoid YAML interpretation."
         strict_warning_handler(msg, strict)
 
     if pattern:
@@ -282,9 +298,9 @@ def check_example_value(field, strict=True):
                 strict_warning_handler(msg, strict)
 
 
-def single_line_beta_description(schema_or_field, strict=True):
+def single_line_beta_description(schema_or_field: FieldEntry, strict: Optional[bool] = True) -> None:
     if "\n" in schema_or_field['field_details']['beta']:
-        msg = "Beta descriptions must be single line.\n"
+        msg: str = "Beta descriptions must be single line.\n"
         msg += f"Offending field or field set: {schema_or_field['field_details']['name']}"
         strict_warning_handler(msg, strict)
 

--- a/scripts/schema/exclude_filter.py
+++ b/scripts/schema/exclude_filter.py
@@ -15,15 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import (
+    Dict,
+    List,
+)
+
 from schema import loader
+from _types import (
+    Field,
+    FieldEntry,
+    FieldNestedEntry,
+)
 
 # This script should be run downstream of the subset filters - it takes
 # all ECS and custom fields already loaded by the latter and explicitly
 # removes a subset, for example, to simulate impact of future removals
 
 
-def exclude(fields, exclude_file_globs):
-    excludes = load_exclude_definitions(exclude_file_globs)
+def exclude(fields: Dict[str, FieldEntry], exclude_file_globs: List[str]) -> Dict[str, FieldEntry]:
+    excludes: List[FieldNestedEntry] = load_exclude_definitions(exclude_file_globs)
 
     if excludes:
         fields = exclude_fields(fields, excludes)
@@ -31,21 +41,26 @@ def exclude(fields, exclude_file_globs):
     return fields
 
 
-def long_path(path_as_list):
+def long_path(path_as_list: List[str]) -> str:
     return '.'.join([e for e in path_as_list])
 
 
-def pop_field(fields, node_path, path, removed):
+def pop_field(
+    fields: Dict[str, FieldEntry],
+    node_path: List[str],
+    path: List[str],
+    removed: List[str]
+) -> str:
     """pops a field from yaml derived dict using path derived from ordered list of nodes"""
     if node_path[0] in fields:
         if len(node_path) == 1:
-            flat_name = long_path(path)
+            flat_name: str = long_path(path)
             fields.pop(node_path[0])
             return flat_name
         else:
-            inner_field = node_path.pop(0)
+            inner_field: str = node_path.pop(0)
             if 'fields' in fields[inner_field]:
-                popped = pop_field(fields[inner_field]['fields'], node_path, path, removed)
+                popped: str = pop_field(fields[inner_field]['fields'], node_path, path, removed)
                 # if object field with no remaining fields and not 'base', pop it
                 if fields[inner_field]['fields'] == {} and inner_field != 'base':
                     fields.pop(inner_field)
@@ -54,21 +69,26 @@ def pop_field(fields, node_path, path, removed):
                 raise ValueError(
                     '--exclude specified, but no path to field {} found'.format(long_path(path)))
     else:
-        this_long_path = long_path(path)
+        this_long_path: str = long_path(path)
         # Check in case already removed parent
         if not any([this_long_path.startswith(long_path) for long_path in removed if long_path != None]):
             raise ValueError('--exclude specified, but no field {} found'.format(this_long_path))
 
 
-def exclude_trace_path(fields, item, path, removed):
+def exclude_trace_path(
+    fields: Dict[str, FieldEntry],
+    item: List[Field],
+    path: List[str],
+    removed: List[str]
+) -> None:
     """traverses paths to one or more nodes in a yaml derived dict"""
     for list_item in item:
-        node_path = path.copy()
+        node_path: List[str] = path.copy()
         # cater for name.with.dots
         for name in list_item['name'].split('.'):
             node_path.append(name)
         if not 'fields' in list_item:
-            parent = node_path[0]
+            parent: str = node_path[0]
             removed.append(pop_field(fields, node_path, node_path.copy(), removed))
             # if parent field has no remaining fields and not 'base', pop it
             if parent != 'base' and parent in fields and len(fields[parent]['fields']) == 0:
@@ -77,7 +97,7 @@ def exclude_trace_path(fields, item, path, removed):
             raise ValueError('--exclude specified, can\'t parse fields in file {}'.format(item))
 
 
-def exclude_fields(fields, excludes):
+def exclude_fields(fields: Dict[str, FieldEntry], excludes: List[FieldNestedEntry]) -> Dict[str, FieldEntry]:
     """Traverses fields and eliminates any field which matches the excludes"""
     if excludes:
         for ex_list in excludes:
@@ -86,10 +106,10 @@ def exclude_fields(fields, excludes):
     return fields
 
 
-def load_exclude_definitions(file_globs):
+def load_exclude_definitions(file_globs: List[str]) -> List[FieldNestedEntry]:
     if not file_globs:
         return []
-    excludes = loader.load_definitions(file_globs)
+    excludes: List[FieldNestedEntry] = loader.load_definitions(file_globs)
     if not excludes:
         raise ValueError('--exclude specified, but no exclusions found in {}'.format(file_globs))
     return excludes

--- a/scripts/schema/loader.py
+++ b/scripts/schema/loader.py
@@ -16,10 +16,24 @@
 # under the License.
 
 import copy
+import git
 import glob
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+)
 import yaml
 
 from generators import ecs_helpers
+from _types import (
+    Field,
+    FieldEntry,
+    FieldNestedEntry,
+    MultiField,
+    SchemaDetails,
+)
 
 # Loads main ECS schemas and optional additional schemas.
 # They are deeply nested, then merged together.
@@ -61,77 +75,85 @@ from generators import ecs_helpers
 EXPERIMENTAL_SCHEMA_DIR = 'experimental/schemas'
 
 
-def load_schemas(ref=None, included_files=[]):
+def load_schemas(
+    ref: Optional[str] = None,
+    included_files: Optional[List[str]] = []
+) -> Dict[str, FieldEntry]:
     """Loads ECS and custom schemas. They are returned deeply nested and merged."""
     # ECS fields (from git ref or not)
-    if ref:
-        schema_files_raw = load_schemas_from_git(ref)
-    else:
-        schema_files_raw = load_schema_files(ecs_helpers.ecs_files())
-    fields = deep_nesting_representation(schema_files_raw)
+    schema_files_raw: Dict[str, FieldNestedEntry] = load_schemas_from_git(
+        ref) if ref else load_schema_files(ecs_helpers.ecs_files())
+    fields: Dict[str, FieldEntry] = deep_nesting_representation(schema_files_raw)
 
     # Custom additional files
     if included_files and len(included_files) > 0:
         print('Loading user defined schemas: {0}'.format(included_files))
         # If --ref provided and --include loading experimental schemas
         if ref and EXPERIMENTAL_SCHEMA_DIR in included_files:
-            exp_schema_files_raw = load_schemas_from_git(ref, target_dir=EXPERIMENTAL_SCHEMA_DIR)
-            exp_fields = deep_nesting_representation(exp_schema_files_raw)
+            exp_schema_files_raw: Dict[str, FieldNestedEntry] = load_schemas_from_git(
+                ref, target_dir=EXPERIMENTAL_SCHEMA_DIR)
+            exp_fields: Dict[str, FieldEntry] = deep_nesting_representation(exp_schema_files_raw)
             fields = merge_fields(fields, exp_fields)
             included_files.remove(EXPERIMENTAL_SCHEMA_DIR)
         # Remaining additional custom files (never from git ref)
-        custom_files = ecs_helpers.glob_yaml_files(included_files)
-        custom_fields = deep_nesting_representation(load_schema_files(custom_files))
+        custom_files: List[str] = ecs_helpers.glob_yaml_files(included_files)
+        custom_fields: Dict[str, FieldEntry] = deep_nesting_representation(load_schema_files(custom_files))
         fields = merge_fields(fields, custom_fields)
     return fields
 
 
-def load_schema_files(files):
-    fields_nested = {}
+def load_schema_files(files: List[str]) -> Dict[str, FieldNestedEntry]:
+    fields_nested: Dict[str, FieldNestedEntry] = {}
     for f in files:
-        new_fields = read_schema_file(f)
+        new_fields: Dict[str, FieldNestedEntry] = read_schema_file(f)
         fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
     return fields_nested
 
 
-def load_schemas_from_git(ref, target_dir='schemas'):
-    tree = ecs_helpers.get_tree_by_ref(ref)
-    fields_nested = {}
+def load_schemas_from_git(
+    ref: str,
+    target_dir: Optional[str] = 'schemas'
+) -> Dict[str, FieldNestedEntry]:
+    tree: git.objects.tree.Tree = ecs_helpers.get_tree_by_ref(ref)
+    fields_nested: Dict[str, FieldNestedEntry] = {}
 
     # Handles case if target dir doesn't exists in git ref
     if ecs_helpers.path_exists_in_git_tree(tree, target_dir):
         for blob in tree[target_dir].blobs:
             if blob.name.endswith('.yml'):
-                new_fields = read_schema_blob(blob, ref)
+                new_fields: Dict[str, FieldNestedEntry] = read_schema_blob(blob, ref)
                 fields_nested = ecs_helpers.safe_merge_dicts(fields_nested, new_fields)
     else:
         raise KeyError(f"Target directory './{target_dir}' not present in git ref '{ref}'!")
     return fields_nested
 
 
-def read_schema_file(file_name):
+def read_schema_file(file_name: str) -> Dict[str, FieldNestedEntry]:
     """Read a raw schema yml file into a dict."""
     with open(file_name) as f:
-        raw = yaml.safe_load(f.read())
+        raw: List[FieldNestedEntry] = yaml.safe_load(f.read())
     return nest_schema(raw, file_name)
 
 
-def read_schema_blob(blob, ref):
+def read_schema_blob(
+    blob: git.objects.blob.Blob,
+    ref: str
+) -> Dict[str, FieldNestedEntry]:
     """Read a raw schema yml git blob into a dict."""
-    content = blob.data_stream.read().decode('utf-8')
-    raw = yaml.safe_load(content)
-    file_name = "{} (git ref {})".format(blob.name, ref)
+    content: str = blob.data_stream.read().decode('utf-8')
+    raw: List[FieldNestedEntry] = yaml.safe_load(content)
+    file_name: str = "{} (git ref {})".format(blob.name, ref)
     return nest_schema(raw, file_name)
 
 
-def nest_schema(raw, file_name):
+def nest_schema(raw: List[FieldNestedEntry], file_name: str) -> Dict[str, FieldNestedEntry]:
     """
     Raw schema files are an array of schema details: [{'name': 'base', ...}]
 
     This function loops over the array (usually 1 schema per file) and turns it into
     a dict with the schema name as the key: { 'base': { 'name': 'base', ...}}
     """
-    fields = {}
+    fields: Dict[str, FieldNestedEntry] = {}
     for schema in raw:
         if 'name' not in schema:
             raise ValueError("Schema file {} is missing mandatory attribute 'name'".format(file_name))
@@ -139,16 +161,17 @@ def nest_schema(raw, file_name):
     return fields
 
 
-def deep_nesting_representation(fields):
-    deeply_nested = {}
+def deep_nesting_representation(fields: Dict[str, FieldNestedEntry]) -> Dict[str, FieldEntry]:
+    deeply_nested: Dict[str, FieldEntry] = {}
     for (name, flat_schema) in fields.items():
+
         # We destructively select what goes into schema_details and child fields.
         # The rest is 'field_details'.
         flat_schema = flat_schema.copy()
         flat_schema['node_name'] = flat_schema['name']
 
         # Schema-only details. Not present on other nested field groups.
-        schema_details = {}
+        schema_details: SchemaDetails = {}
         for schema_key in ['root', 'group', 'reusable', 'title']:
             if schema_key in flat_schema:
                 schema_details[schema_key] = flat_schema.pop(schema_key)
@@ -164,12 +187,12 @@ def deep_nesting_representation(fields):
     return deeply_nested
 
 
-def nest_fields(field_array):
-    schema_root = {'fields': {}}
+def nest_fields(field_array: List[Field]) -> Dict[str, Dict[str, FieldEntry]]:
+    schema_root: Dict[str, Dict[str, FieldEntry]] = {'fields': {}}
     for field in field_array:
-        nested_levels = field['name'].split('.')
-        parent_fields = nested_levels[:-1]
-        leaf_field = nested_levels[-1]
+        nested_levels: List[str] = field['name'].split('.')
+        parent_fields: List[str] = nested_levels[:-1]
+        leaf_field: str = nested_levels[-1]
         # "nested_schema" is a cursor we move within the schema_root structure we're building.
         # Here we reset the cursor for this new field.
         nested_schema = schema_root['fields']
@@ -202,29 +225,29 @@ def nest_fields(field_array):
     return schema_root
 
 
-def array_of_maps_to_map(array_vals):
-    ret_map = {}
+def array_of_maps_to_map(array_vals: List[MultiField]) -> Dict[str, MultiField]:
+    ret_map: Dict[str, MultiField] = {}
     for map_val in array_vals:
-        name = map_val['name']
+        name: str = map_val['name']
         # if multiple name fields exist in the same custom definition this will take the last one
         ret_map[name] = map_val
     return ret_map
 
 
-def map_of_maps_to_array(map_vals):
-    ret_list = []
+def map_of_maps_to_array(map_vals: Dict[str, MultiField]) -> List[MultiField]:
+    ret_list: List[MultiField] = []
     for key in map_vals:
         ret_list.append(map_vals[key])
     return sorted(ret_list, key=lambda k: k['name'])
 
 
-def dedup_and_merge_lists(list_a, list_b):
-    list_a_map = array_of_maps_to_map(list_a)
+def dedup_and_merge_lists(list_a: List[MultiField], list_b: List[MultiField]) -> List[MultiField]:
+    list_a_map: Dict[str, MultiField] = array_of_maps_to_map(list_a)
     list_a_map.update(array_of_maps_to_map(list_b))
     return map_of_maps_to_array(list_a_map)
 
 
-def merge_fields(a, b):
+def merge_fields(a: Dict[str, FieldEntry], b: Dict[str, FieldEntry]) -> Dict[str, FieldEntry]:
     """Merge ECS field sets with custom field sets."""
     a = copy.deepcopy(a)
     b = copy.deepcopy(b)
@@ -275,7 +298,7 @@ def load_yaml_file(file_name):
 
 
 # You know, for silent tests
-def warn(message):
+def warn(message: str) -> None:
     print(message)
 
 

--- a/scripts/schema/subset_filter.py
+++ b/scripts/schema/subset_filter.py
@@ -16,27 +16,42 @@
 # under the License.
 
 import os
+from typing import (
+    Any,
+    Dict,
+    List,
+)
+
 from generators import intermediate_files
-from schema import cleaner, loader
+from schema import (
+    cleaner,
+    loader,
+)
+from _types import (
+    FieldEntry
+)
 
 # This script takes all ECS and custom fields already loaded, and lets users
 # filter out the ones they don't need.
 
 
-def filter(fields, subset_file_globs, out_dir):
-    subsets = load_subset_definitions(subset_file_globs)
+def filter(
+    fields: Dict[str, FieldEntry],
+    subset_file_globs: List[str],
+    out_dir: str
+) -> Dict[str, FieldEntry]:
+    subsets: List[Dict[str, Any]] = load_subset_definitions(subset_file_globs)
     for subset in subsets:
-        subfields = extract_matching_fields(fields, subset['fields'])
+        subfields: Dict[str, FieldEntry] = extract_matching_fields(fields, subset['fields'])
         intermediate_files.generate(subfields, os.path.join(out_dir, 'ecs', 'subset', subset['name']), False)
 
-    merged_subset = combine_all_subsets(subsets)
+    merged_subset: Dict[str, Any] = combine_all_subsets(subsets)
     if merged_subset:
         fields = extract_matching_fields(fields, merged_subset)
-
     return fields
 
 
-def combine_all_subsets(subsets):
+def combine_all_subsets(subsets: Dict[str, Any]) -> Dict[str, Any]:
     """Merges N subsets into one. Strips top level 'name' and 'fields' keys as well as non-ECS field options since we can't know how to merge those."""
     merged_subset = {}
     for subset in subsets:
@@ -45,26 +60,26 @@ def combine_all_subsets(subsets):
     return merged_subset
 
 
-def load_subset_definitions(file_globs):
+def load_subset_definitions(file_globs: List[str]) -> List[Dict[str, Any]]:
     if not file_globs:
         return []
-    subsets = loader.load_definitions(file_globs)
+    subsets: List[Dict[str, Any]] = loader.load_definitions(file_globs)
     if not subsets:
         raise ValueError('--subset specified, but no subsets found in {}'.format(file_globs))
     return subsets
 
 
-ecs_options = ['fields', 'enabled', 'index']
+ecs_options: List[str] = ['fields', 'enabled', 'index']
 
 
-def strip_non_ecs_options(subset):
+def strip_non_ecs_options(subset: Dict[str, Any]) -> None:
     for key in subset:
         subset[key] = {x: subset[key][x] for x in subset[key] if x in ecs_options}
         if 'fields' in subset[key] and isinstance(subset[key]['fields'], dict):
             strip_non_ecs_options(subset[key]['fields'])
 
 
-def merge_subsets(a, b):
+def merge_subsets(a: Dict[str, Any], b: Dict[str, Any]) -> None:
     """Merges field subset definitions together. The b subset is merged into the a subset. Assumes that subsets have been stripped of non-ecs options."""
     for key in b:
         if key not in a:
@@ -85,9 +100,12 @@ def merge_subsets(a, b):
             a[key].pop('index', None)
 
 
-def extract_matching_fields(fields, subset_definitions):
+def extract_matching_fields(
+    fields: Dict[str, FieldEntry],
+    subset_definitions: Dict[str, Any]
+) -> Dict[str, FieldEntry]:
     """Removes fields that are not in the subset definition. Returns a copy without modifying the input fields dict."""
-    retained_fields = {x: fields[x].copy() for x in subset_definitions}
+    retained_fields: Dict[str, FieldEntry] = {x: fields[x].copy() for x in subset_definitions}
     for key, val in subset_definitions.items():
         retained_fields[key]['field_details'] = fields[key]['field_details'].copy()
         for option in val:

--- a/scripts/schema/visitor.py
+++ b/scripts/schema/visitor.py
@@ -15,7 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
-def visit_fields(fields, fieldset_func=None, field_func=None):
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Optional,
+)
+
+from _types import (
+    Field,
+    FieldDetails,
+    FieldEntry,
+)
+
+
+def visit_fields(
+    fields: Dict[str, FieldEntry],
+    fieldset_func: Optional[Callable[[FieldEntry], None]] = None,
+    field_func: Optional[Callable[[FieldDetails], None]] = None
+) -> None:
     """
     This function navigates the deeply nested tree structure and runs provided
     functions on each fieldset or field encountered (both optional).
@@ -29,7 +47,7 @@ def visit_fields(fields, fieldset_func=None, field_func=None):
     The 'field_func(details)' provided will be called for each field, with the dictionary
     containing the field's details ({'field_details': {}, 'fields': {}).
     """
-    for (name, details) in fields.items():
+    for (_, details) in fields.items():
         if fieldset_func and 'schema_details' in details:
             fieldset_func(details)
         elif field_func and 'field_details' in details:
@@ -40,7 +58,11 @@ def visit_fields(fields, fieldset_func=None, field_func=None):
                          field_func=field_func)
 
 
-def visit_fields_with_path(fields, func, path=[]):
+def visit_fields_with_path(
+    fields: Dict[str, FieldEntry],
+    func: Callable[[FieldDetails], None],
+    path: Optional[List[str]] = []
+) -> None:
     """
     This function navigates the deeply nested tree structure and runs the provided
     function on all fields and field sets.
@@ -60,7 +82,11 @@ def visit_fields_with_path(fields, func, path=[]):
             visit_fields_with_path(details['fields'], func, path + new_nesting)
 
 
-def visit_fields_with_memo(fields, func, memo=None):
+def visit_fields_with_memo(
+    fields: Dict[str, FieldEntry],
+    func: Callable[[FieldEntry, Field], None],
+    memo: Optional[Dict[str, Field]] = None
+) -> None:
     """
     This function navigates the deeply nested tree structure and runs the provided
     function on all fields and field sets.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add type hints to schema modules (#1771)](https://github.com/elastic/ecs/pull/1771)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)