### PR TITLE
[8.3] Add node.role to service schema (#1916)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Add `service.node.role` #1916
+
 #### Improvements
 
 #### Deprecated

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8602,6 +8602,30 @@ example: `instance-0000000016`
 // ===============================================================
 
 |
+[[field-service-node-role]]
+<<field-service-node-role, service.node.role>>
+
+| Role of a service node.
+
+This allows for distinction between different running roles of the same service.
+
+In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+Other services could use this to distinguish between a `web` and `worker` role running as part of the service.
+
+type: keyword
+
+
+
+example: `background-tasks`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-service-state]]
 <<field-service-state, service.state>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -7650,6 +7650,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+    - name: node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      default_field: false
     - name: origin.address
       level: extended
       type: keyword
@@ -7727,6 +7744,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+      default_field: false
+    - name: origin.node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
       default_field: false
     - name: origin.state
       level: core
@@ -7838,6 +7872,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+      default_field: false
+    - name: target.node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
       default_field: false
     - name: target.state
       level: core

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -896,12 +896,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev+exp,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev+exp,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev+exp,true,service,service.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev+exp,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.3.0-dev+exp,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.3.0-dev+exp,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.3.0-dev+exp,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev+exp,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev+exp,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev+exp,true,service,service.origin.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev+exp,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.3.0-dev+exp,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0-dev+exp,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -912,6 +914,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev+exp,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev+exp,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev+exp,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev+exp,true,service,service.target.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev+exp,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.3.0-dev+exp,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0-dev+exp,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11252,6 +11252,26 @@ service.node.name:
   normalize: []
   short: Name of the service node.
   type: keyword
+service.node.role:
+  dashed_name: service-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  short: Role of the service node.
+  type: keyword
 service.origin.address:
   dashed_name: service-origin-address
   description: 'Address where data about this service was collected from.
@@ -11359,6 +11379,27 @@ service.origin.node.name:
   normalize: []
   original_fieldset: service
   short: Name of the service node.
+  type: keyword
+service.origin.node.role:
+  dashed_name: service-origin-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.origin.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  original_fieldset: service
+  short: Role of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11520,6 +11561,27 @@ service.target.node.name:
   normalize: []
   original_fieldset: service
   short: Name of the service node.
+  type: keyword
+service.target.node.role:
+  dashed_name: service-target-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.target.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  original_fieldset: service
+  short: Role of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13250,6 +13250,27 @@ service:
       normalize: []
       short: Name of the service node.
       type: keyword
+    service.node.role:
+      dashed_name: service-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      short: Role of the service node.
+      type: keyword
     service.origin.address:
       dashed_name: service-origin-address
       description: 'Address where data about this service was collected from.
@@ -13358,6 +13379,28 @@ service:
       normalize: []
       original_fieldset: service
       short: Name of the service node.
+      type: keyword
+    service.origin.node.role:
+      dashed_name: service-origin-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.origin.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      original_fieldset: service
+      short: Role of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13520,6 +13563,28 @@ service:
       normalize: []
       original_fieldset: service
       short: Name of the service node.
+      type: keyword
+    service.target.node.role:
+      dashed_name: service-target-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.target.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      original_fieldset: service
+      short: Role of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/experimental/generated/elasticsearch/composable/component/service.json
+++ b/experimental/generated/elasticsearch/composable/component/service.json
@@ -33,6 +33,10 @@
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "role": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -61,6 +65,10 @@
                 "node": {
                   "properties": {
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }
@@ -109,6 +117,10 @@
                 "node": {
                   "properties": {
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -4254,6 +4254,10 @@
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "role": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -4282,6 +4286,10 @@
               "node": {
                 "properties": {
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "role": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }
@@ -4330,6 +4338,10 @@
               "node": {
                 "properties": {
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "role": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -7600,6 +7600,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+    - name: node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      default_field: false
     - name: origin.address
       level: extended
       type: keyword
@@ -7677,6 +7694,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+      default_field: false
+    - name: origin.node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
       default_field: false
     - name: origin.state
       level: core
@@ -7788,6 +7822,23 @@
         provide uniqueness (e.g. multiple instances of the service running on the
         same host) - the node name can be manually set.'
       example: instance-0000000016
+      default_field: false
+    - name: target.node.role
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
       default_field: false
     - name: target.state
       level: core

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -889,12 +889,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev,true,service,service.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.3.0-dev,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.3.0-dev,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.3.0-dev,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev,true,service,service.origin.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.3.0-dev,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0-dev,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -905,6 +907,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0-dev,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0-dev,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0-dev,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+8.3.0-dev,true,service,service.target.node.role,keyword,extended,,background-tasks,Role of the service node.
 8.3.0-dev,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.3.0-dev,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0-dev,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -11183,6 +11183,26 @@ service.node.name:
   normalize: []
   short: Name of the service node.
   type: keyword
+service.node.role:
+  dashed_name: service-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  short: Role of the service node.
+  type: keyword
 service.origin.address:
   dashed_name: service-origin-address
   description: 'Address where data about this service was collected from.
@@ -11290,6 +11310,27 @@ service.origin.node.name:
   normalize: []
   original_fieldset: service
   short: Name of the service node.
+  type: keyword
+service.origin.node.role:
+  dashed_name: service-origin-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.origin.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  original_fieldset: service
+  short: Role of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11451,6 +11492,27 @@ service.target.node.name:
   normalize: []
   original_fieldset: service
   short: Name of the service node.
+  type: keyword
+service.target.node.role:
+  dashed_name: service-target-node-role
+  description: 'Role of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: background-tasks
+  flat_name: service.target.node.role
+  ignore_above: 1024
+  level: extended
+  name: node.role
+  normalize: []
+  original_fieldset: service
+  short: Role of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -13170,6 +13170,27 @@ service:
       normalize: []
       short: Name of the service node.
       type: keyword
+    service.node.role:
+      dashed_name: service-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      short: Role of the service node.
+      type: keyword
     service.origin.address:
       dashed_name: service-origin-address
       description: 'Address where data about this service was collected from.
@@ -13278,6 +13299,28 @@ service:
       normalize: []
       original_fieldset: service
       short: Name of the service node.
+      type: keyword
+    service.origin.node.role:
+      dashed_name: service-origin-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.origin.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      original_fieldset: service
+      short: Role of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13440,6 +13483,28 @@ service:
       normalize: []
       original_fieldset: service
       short: Name of the service node.
+      type: keyword
+    service.target.node.role:
+      dashed_name: service-target-node-role
+      description: 'Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: background-tasks
+      flat_name: service.target.node.role
+      ignore_above: 1024
+      level: extended
+      name: node.role
+      normalize: []
+      original_fieldset: service
+      short: Role of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/generated/elasticsearch/composable/component/service.json
+++ b/generated/elasticsearch/composable/component/service.json
@@ -33,6 +33,10 @@
                 "name": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "role": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -61,6 +65,10 @@
                 "node": {
                   "properties": {
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }
@@ -109,6 +117,10 @@
                 "node": {
                   "properties": {
                     "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "role": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -4212,6 +4212,10 @@
               "name": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "role": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -4240,6 +4244,10 @@
               "node": {
                 "properties": {
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "role": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }
@@ -4288,6 +4296,10 @@
               "node": {
                 "properties": {
                   "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "role": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -116,6 +116,21 @@
         (e.g. multiple instances of the service running on the same host) - the
         node name can be manually set.
 
+    - name: node.role
+      level: extended
+      type: keyword
+      example: "background-tasks"
+      short: Role of the service node.
+      description: >
+        Role of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or `data`.
+
+        Other services could use this to distinguish between a `web` and `worker` role running as part of the service.
 
     - name: type
       level: core


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Add node.role to service schema (#1916)](https://github.com/elastic/ecs/pull/1916)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)