### PR TITLE
[8.2] Remove unnecessary guidance from `agent.name` description (#1919)

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -174,8 +174,6 @@ example: `8a4f500d`
 
 This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from.
 
-If no name is given, the name is often left empty.
-
 type: keyword
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -104,9 +104,7 @@
 
         This is a name that can be given to an agent. This can be helpful if for example
         two Filebeat instances are running on the same host but a human readable separation
-        is needed on which Filebeat instance data is coming from.
-
-        If no name is given, the name is often left empty.'
+        is needed on which Filebeat instance data is coming from.'
       example: foo
     - name: type
       level: core

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -64,9 +64,7 @@ agent.name:
 
     This is a name that can be given to an agent. This can be helpful if for example
     two Filebeat instances are running on the same host but a human readable separation
-    is needed on which Filebeat instance data is coming from.
-
-    If no name is given, the name is often left empty.'
+    is needed on which Filebeat instance data is coming from.'
   example: foo
   flat_name: agent.name
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -54,9 +54,7 @@ agent:
 
         This is a name that can be given to an agent. This can be helpful if for example
         two Filebeat instances are running on the same host but a human readable separation
-        is needed on which Filebeat instance data is coming from.
-
-        If no name is given, the name is often left empty.'
+        is needed on which Filebeat instance data is coming from.'
       example: foo
       flat_name: agent.name
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -104,9 +104,7 @@
 
         This is a name that can be given to an agent. This can be helpful if for example
         two Filebeat instances are running on the same host but a human readable separation
-        is needed on which Filebeat instance data is coming from.
-
-        If no name is given, the name is often left empty.'
+        is needed on which Filebeat instance data is coming from.'
       example: foo
     - name: type
       level: core

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -64,9 +64,7 @@ agent.name:
 
     This is a name that can be given to an agent. This can be helpful if for example
     two Filebeat instances are running on the same host but a human readable separation
-    is needed on which Filebeat instance data is coming from.
-
-    If no name is given, the name is often left empty.'
+    is needed on which Filebeat instance data is coming from.'
   example: foo
   flat_name: agent.name
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -54,9 +54,7 @@ agent:
 
         This is a name that can be given to an agent. This can be helpful if for example
         two Filebeat instances are running on the same host but a human readable separation
-        is needed on which Filebeat instance data is coming from.
-
-        If no name is given, the name is often left empty.'
+        is needed on which Filebeat instance data is coming from.'
       example: foo
       flat_name: agent.name
       ignore_above: 1024

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -60,8 +60,6 @@
         for example two Filebeat instances are running on the same host
         but a human readable separation is needed on which Filebeat instance
         data is coming from.
-
-        If no name is given, the name is often left empty.
       example: foo
 
     - name: type


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.2`:
 - [Remove unnecessary guidance from `agent.name` description (#1919)](https://github.com/elastic/ecs/pull/1919)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)