### PR TITLE
`related.ip` example should be an array

### DIFF
--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -226,5 +226,5 @@ appeared:
 
 [source,sh]
 ----
-related.ip: 10.42.42.42
+related.ip: [ "10.42.42.42" ]
 ----

--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -226,5 +226,5 @@ appeared:
 
 [source,sh]
 ----
-related.ip: [ "10.42.42.42" ]
+related.ip: ["10.42.42.42"]
 ----


### PR DESCRIPTION
Correct this example usage of `related.ip` to use an array for the value: https://www.elastic.co/guide/en/ecs/current/ecs-principles-implementation.html#_related_fields.

Addresses #1918 