### PR TITLE
[8.3] `related.ip` example should be an array (#1922)

### DIFF
--- a/docs/using-ecs/guidelines/implementation.asciidoc
+++ b/docs/using-ecs/guidelines/implementation.asciidoc
@@ -226,5 +226,5 @@ appeared:
 
 [source,sh]
 ----
-related.ip: 10.42.42.42
+related.ip: ["10.42.42.42"]
 ----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [`related.ip` example should be an array (#1922)](https://github.com/elastic/ecs/pull/1922)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)