### PR TITLE
Advancing linux event model fields to GA

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -54,6 +54,7 @@ Thanks, you're awesome :-) -->
 * Add `orchestrator.resource.parent.type` #1889
 * Add `orchestrator.resource.ip` #1889
 * Add `container.image.hash.all` #1889
+* Advanced linux event model fields and re-uses to GA. #1926
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7248,9 +7248,7 @@ example: `c2c455d9f99375d`
 [[field-process-env-vars]]
 <<field-process-env-vars, process.env_vars>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Environment variables (`env_vars`) set at the time of the event. May be filtered to protect sensitive information.
+| Environment variables (`env_vars`) set at the time of the event. May be filtered to protect sensitive information.
 
 The field should not contain nested objects. All values should use `keyword`.
 
@@ -7308,9 +7306,7 @@ example: `137`
 [[field-process-interactive]]
 <<field-process-interactive, process.interactive>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Whether the process is connected to an interactive shell.
+| Whether the process is connected to an interactive shell.
 
 Process interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.
 
@@ -7460,9 +7456,7 @@ Multi-fields:
 [[field-process-tty]]
 <<field-process-tty, process.tty>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Information about the controlling TTY device. If set, the process belongs to an interactive session.
+| Information about the controlling TTY device. If set, the process belongs to an interactive session.
 
 type: object
 
@@ -7478,9 +7472,7 @@ type: object
 [[field-process-tty-char-device-major]]
 <<field-process-tty-char-device-major, process.tty.char_device.major>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0. For more details, please refer to the Linux kernel documentation.
+| The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0. For more details, please refer to the Linux kernel documentation.
 
 type: long
 
@@ -7496,9 +7488,7 @@ example: `1`
 [[field-process-tty-char-device-minor]]
 <<field-process-tty-char-device-minor, process.tty.char_device.minor>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
+| The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
 
 type: long
 
@@ -7606,25 +7596,22 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 
 | `process.entry_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
+| <<ecs-process,process>>
+| First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
@@ -7638,17 +7625,15 @@ Remote client information such as ip, port and geo location.
 
 
 | `process.group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The effective group (egid).
+| <<ecs-group,group>>
+| The effective group (egid).
 
 // ===============================================================
 
 
 | `process.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the process group leader. In some cases this may be the same as the top level process.
+| <<ecs-process,process>>
+| Information about the process group leader. In some cases this may be the same as the top level process.
 
 // ===============================================================
 
@@ -7668,9 +7653,8 @@ Information about the process group leader. In some cases this may be the same a
 
 
 | `process.parent.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent's process group leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent's process group leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
@@ -7683,9 +7667,8 @@ Information about the parent's process group leader. Only pid, start and entity_
 
 
 | `process.previous.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-An array of previous executions for the process, including the initial fork. Only executable and args are set.
+| <<ecs-process,process>>
+| An array of previous executions for the process, including the initial fork. Only executable and args are set.
 
 Note: this reuse should contain an array of process field set objects.
 
@@ -7693,65 +7676,57 @@ Note: this reuse should contain an array of process field set objects.
 
 
 | `process.real_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The real group (rgid).
+| <<ecs-group,group>>
+| The real group (rgid).
 
 // ===============================================================
 
 
 | `process.real_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The real user (ruid). Identifies the real owner of the process.
+| <<ecs-user,user>>
+| The real user (ruid). Identifies the real owner of the process.
 
 // ===============================================================
 
 
 | `process.saved_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The saved group (sgid).
+| <<ecs-group,group>>
+| The saved group (sgid).
 
 // ===============================================================
 
 
 | `process.saved_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The saved user (suid).
+| <<ecs-user,user>>
+| The saved user (suid).
 
 // ===============================================================
 
 
 | `process.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
+| <<ecs-process,process>>
+| Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
 
 // ===============================================================
 
 
 | `process.session_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the session leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the session leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.session_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.supplemental_groups.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-An array of supplemental groups.
+| <<ecs-group,group>>
+| An array of supplemental groups.
 
 Note: this reuse should contain an array of group field set objects.
 
@@ -7759,9 +7734,8 @@ Note: this reuse should contain an array of group field set objects.
 
 
 | `process.user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The effective user (euid).
+| <<ecs-user,user>>
+| The effective user (euid).
 
 // ===============================================================
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7617,9 +7617,8 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 
 | `process.entry_meta.source.*`
-| <<ecs-source,source>>| beta:[ Reusing the `source` fields in this location is currently considered beta.]
-
-Remote client information such as ip, port and geo location.
+| <<ecs-source,source>>
+| Remote client information such as ip, port and geo location.
 
 // ===============================================================
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7236,9 +7236,7 @@ example: `c2c455d9f99375d`
 [[field-process-entry-meta-type]]
 <<field-process-entry-meta-type, process.entry_meta.type>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
+| The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
 
 Note: This field is only set on process.session_leader.
 
@@ -7392,9 +7390,7 @@ example: `4242`
 [[field-process-same-as-process]]
 <<field-process-same-as-process, process.same_as_process>>
 
-| beta:[ This field is beta and subject to change. ]
-
-This boolean is used to identify if a leader process is the same as the top level process.
+| This boolean is used to identify if a leader process is the same as the top level process.
 
 For example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7347,7 +7347,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console'
@@ -7398,7 +7397,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7586,7 +7584,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7700,7 +7697,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7712,7 +7708,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7727,7 +7722,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -7786,7 +7780,6 @@ process.entry_leader.working_directory:
   short: The working directory of the process.
   type: keyword
 process.env_vars:
-  beta: This field is beta and subject to change.
   dashed_name: process-env-vars
   description: 'Environment variables (`env_vars`) set at the time of the event. May
     be filtered to protect sensitive information.
@@ -7935,7 +7928,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8037,7 +8029,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8151,7 +8142,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8163,7 +8153,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8178,7 +8167,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8314,7 +8302,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9057,7 +9044,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9402,7 +9388,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9414,7 +9399,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9429,7 +9413,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -9881,7 +9864,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10069,7 +10051,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10183,7 +10164,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10195,7 +10175,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10210,7 +10189,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10340,7 +10318,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10351,7 +10328,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10365,7 +10341,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -12210,8 +12210,7 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
   - full: process.user
@@ -14122,7 +14121,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5940,22 +5940,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -9047,7 +9043,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console'
@@ -9098,7 +9093,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9286,7 +9280,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9400,7 +9393,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9412,7 +9404,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9427,7 +9418,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9486,7 +9476,6 @@ process:
       short: The working directory of the process.
       type: keyword
     process.env_vars:
-      beta: This field is beta and subject to change.
       dashed_name: process-env-vars
       description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
@@ -9635,7 +9624,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9737,7 +9725,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9851,7 +9838,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9863,7 +9849,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9878,7 +9863,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -10014,7 +9998,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -10757,7 +10740,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11102,7 +11084,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11114,7 +11095,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11129,7 +11109,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11581,7 +11560,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11769,7 +11747,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -11883,7 +11860,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11895,7 +11871,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11910,7 +11885,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12040,7 +12014,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12051,7 +12024,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12065,7 +12037,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12165,64 +12136,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12230,20 +12183,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12265,63 +12214,51 @@ process:
     full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -20922,17 +20859,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     top_level: true

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7278,7 +7278,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console'
@@ -7329,7 +7328,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7517,7 +7515,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7631,7 +7628,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7643,7 +7639,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7658,7 +7653,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -7717,7 +7711,6 @@ process.entry_leader.working_directory:
   short: The working directory of the process.
   type: keyword
 process.env_vars:
-  beta: This field is beta and subject to change.
   dashed_name: process-env-vars
   description: 'Environment variables (`env_vars`) set at the time of the event. May
     be filtered to protect sensitive information.
@@ -7866,7 +7859,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7968,7 +7960,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8082,7 +8073,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8094,7 +8084,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8109,7 +8098,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8245,7 +8233,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8988,7 +8975,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9333,7 +9319,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9345,7 +9330,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9360,7 +9344,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -9812,7 +9795,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10000,7 +9982,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10114,7 +10095,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10126,7 +10106,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10141,7 +10120,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10271,7 +10249,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10282,7 +10259,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10296,7 +10272,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5860,22 +5860,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -8967,7 +8963,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console'
@@ -9018,7 +9013,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9206,7 +9200,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9320,7 +9313,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9332,7 +9324,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9347,7 +9338,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9406,7 +9396,6 @@ process:
       short: The working directory of the process.
       type: keyword
     process.env_vars:
-      beta: This field is beta and subject to change.
       dashed_name: process-env-vars
       description: 'Environment variables (`env_vars`) set at the time of the event.
         May be filtered to protect sensitive information.
@@ -9555,7 +9544,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9657,7 +9645,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9771,7 +9758,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9783,7 +9769,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9798,7 +9783,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9934,7 +9918,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -10677,7 +10660,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11022,7 +11004,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11034,7 +11015,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11049,7 +11029,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11501,7 +11480,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11689,7 +11667,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -11803,7 +11780,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11815,7 +11791,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11830,7 +11805,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11960,7 +11934,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11971,7 +11944,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11985,7 +11957,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12085,64 +12056,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12150,20 +12103,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12185,63 +12134,51 @@ process:
     full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -20842,17 +20779,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     top_level: true

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -12130,8 +12130,7 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
   - full: process.user
@@ -14042,7 +14041,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -32,19 +32,15 @@
       - at: process
         as: group
         short_override: The effective group (egid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: real_group
         short_override: The real group (rgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: saved_group
         short_override: The saved group (sgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: supplemental_groups
         short_override: An array of supplemental groups.
-        beta: Reusing the `group` fields in this location is currently considered beta.
         normalize:
           - array
 

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -35,39 +35,30 @@
       - at: process
         as: entry_leader
         short_override: First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: session_leader
         short_override: Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: group_leader
         short_override: Information about the process group leader. In some cases this may be the same as the top level process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.parent
         as: group_leader
         short_override: Information about the parent's process group leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader
         as: parent
         short_override: Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader
         as: parent
         short_override: Information about the session leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader.parent
         as: session_leader
         short_override: Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader.parent
         as: session_leader
         short_override: Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: previous
         short_override: An array of previous executions for the process, including the initial fork. Only executable and args are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
         normalize:
           - array
 
@@ -244,7 +235,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: Whether the process is connected to an interactive shell.
       description: >
         Whether the process is connected to an interactive shell.
@@ -257,7 +247,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: This boolean is used to identify if a leader process is the same as the top level process.
       description: >
         This boolean is used to identify if a leader process is the same as the top level process.
@@ -281,7 +270,6 @@
     - name: env_vars
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       short: Environment variables set at the time of the event.
       description: >
         Environment variables (`env_vars`) set at the time of the event.
@@ -293,7 +281,6 @@
     - name: entry_meta.type
       level: extended
       type: keyword
-      beta: This field is beta and subject to change.
       short: The entry type for the entry session leader.
       description: >
         The entry type for the entry session leader.
@@ -302,7 +289,6 @@
     - name: entry_meta.source
       level: extended
       type: source
-      beta: This field is beta and subject to change.
       short: Entry point information for a session.
       description: >
         Entry point information for a session.
@@ -311,7 +297,6 @@
     - name: tty
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       short: Information about the controlling TTY device.
       description: >
         Information about the controlling TTY device. If set, the process belongs to an interactive session.
@@ -319,7 +304,6 @@
     - name: tty.char_device.major
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's major number.
       description: >
         The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0. For more details, please refer to the Linux kernel documentation.
@@ -328,7 +312,6 @@
     - name: tty.char_device.minor
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's minor number.
       description: >
         The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -34,7 +34,6 @@
       - at: process.entry_meta
         as: source
         short_override: Remote client information such as ip, port and geo location.
-        beta: Reusing the `source` fields in this location is currently considered beta.
 
   fields:
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -45,15 +45,12 @@
       - at: process
         as: user
         short_override: The effective user (euid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: saved_user
         short_override: The saved user (suid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: real_user
         short_override: The real user (ruid). Identifies the real owner of the process.
-        beta: Reusing the `user` fields in this location is currently considered beta.
 
   type: group
   fields:


### PR DESCRIPTION
The [RFC](https://github.com/elastic/ecs/blob/main/rfcs/text/0030-linux-event-model.md) has advanced to stage 3, and we want to advance the fields to GA to officially finish the addition.