### PR TITLE
[8.3] Re-adding missing process fields (#1906)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -73,6 +73,14 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
+## 8.2.1
+
+### Schema Changes
+
+#### Bugfixes
+
+* Adding missing process fields for documentation. #1906
+
 <!-- All empty sections:
 
 ## Unreleased

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7245,6 +7245,26 @@ example: `c2c455d9f99375d`
 // ===============================================================
 
 |
+[[field-process-entry-meta-type]]
+<<field-process-entry-meta-type, process.entry_meta.type>>
+
+| beta:[ This field is beta and subject to change. ]
+
+The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+Note: This field is only set on process.session_leader.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-process-env-vars]]
 <<field-process-env-vars, process.env_vars>>
 
@@ -7381,6 +7401,32 @@ type: long
 example: `4242`
 
 | core
+
+// ===============================================================
+
+|
+[[field-process-same-as-process]]
+<<field-process-same-as-process, process.same_as_process>>
+
+| beta:[ This field is beta and subject to change. ]
+
+This boolean is used to identify if a leader process is the same as the top level process.
+
+For example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.
+
+This field exists to the benefit of EQL and other rule engines since it's not possible to compare equality between two fields in a single document. e.g `process.entity_id` = `process.group_leader.entity_id` (top level process is the process group leader) OR `process.entity_id` = `process.entry_leader.entity_id` (top level process is the entry session leader)
+
+Instead these rules could be written like: `process.group_leader.same_as_process: true` OR `process.entry_leader.same_as_process: true`
+
+Note: This field is only set on `process.entry_leader`, `process.session_leader` and `process.group_leader`.
+
+type: boolean
+
+
+
+example: `True`
+
+| extended
 
 // ===============================================================
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5195,7 +5195,9 @@
       type: keyword
       ignore_above: 1024
       description: 'The entry type for the entry session leader. Values include: init(e.g
-        systemd), sshd, ssm, kubelet, teleport, terminal, console'
+        systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+        Note: This field is only set on process.session_leader.'
       default_field: false
     - name: entry_leader.executable
       level: extended

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7350,7 +7350,9 @@ process.entry_leader.entry_meta.type:
   beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
-    systemd), sshd, ssm, kubelet, teleport, terminal, console'
+    systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+    Note: This field is only set on process.session_leader.'
   flat_name: process.entry_leader.entry_meta.type
   ignore_above: 1024
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9050,7 +9050,9 @@ process:
       beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
-        systemd), sshd, ssm, kubelet, teleport, terminal, console'
+        systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+        Note: This field is only set on process.session_leader.'
       flat_name: process.entry_leader.entry_meta.type
       ignore_above: 1024
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5145,7 +5145,9 @@
       type: keyword
       ignore_above: 1024
       description: 'The entry type for the entry session leader. Values include: init(e.g
-        systemd), sshd, ssm, kubelet, teleport, terminal, console'
+        systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+        Note: This field is only set on process.session_leader.'
       default_field: false
     - name: entry_leader.executable
       level: extended

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7281,7 +7281,9 @@ process.entry_leader.entry_meta.type:
   beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
-    systemd), sshd, ssm, kubelet, teleport, terminal, console'
+    systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+    Note: This field is only set on process.session_leader.'
   flat_name: process.entry_leader.entry_meta.type
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -8970,7 +8970,9 @@ process:
       beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
-        systemd), sshd, ssm, kubelet, teleport, terminal, console'
+        systemd), sshd, ssm, kubelet, teleport, terminal, console
+
+        Note: This field is only set on process.session_leader.'
       flat_name: process.entry_leader.entry_meta.type
       ignore_above: 1024
       level: extended

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -299,6 +299,8 @@
         The entry type for the entry session leader.
         Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
 
+        Note: This field is only set on process.session_leader.
+
     - name: entry_meta.source
       level: extended
       type: source

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -139,6 +139,10 @@ fields:
             fields:
               id: {}
               name: {}
+      entry_meta:
+        fields:
+          type:
+            docs_only: True
       env_vars: {}
       executable: {}
       exit_code: {}
@@ -278,6 +282,8 @@ fields:
         fields:
           id: {}
           name: {}
+      same_as_process:
+        docs_only: True
       saved_group:
         fields:
           id: {}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.3`:
 - [Re-adding missing process fields (#1906)](https://github.com/elastic/ecs/pull/1906)

<!--- Backport version: 7.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)