### PR TITLE
[8.3] Container metrics GA (#1927)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -54,6 +54,7 @@ Thanks, you're awesome :-) -->
 * Add `orchestrator.resource.parent.type` #1889
 * Add `orchestrator.resource.ip` #1889
 * Add `container.image.hash.all` #1889
+* Advanced `container.*` metric fields to GA. #1927
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -1023,9 +1023,7 @@ These fields help correlate data based containers from any runtime.
 [[field-container-cpu-usage]]
 <<field-container-cpu-usage, container.cpu.usage>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1. Scaling factor: 1000.
+| Percent CPU used which is normalized by the number of CPU cores and it ranges from 0 to 1. Scaling factor: 1000.
 
 type: scaled_float
 
@@ -1041,9 +1039,7 @@ type: scaled_float
 [[field-container-disk-read-bytes]]
 <<field-container-disk-read-bytes, container.disk.read.bytes>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.
+| The total number of bytes (gauge) read successfully (aggregated from all disks) since the last metric collection.
 
 type: long
 
@@ -1059,9 +1055,7 @@ type: long
 [[field-container-disk-write-bytes]]
 <<field-container-disk-write-bytes, container.disk.write.bytes>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.
+| The total number of bytes (gauge) written successfully (aggregated from all disks) since the last metric collection.
 
 type: long
 
@@ -1163,9 +1157,7 @@ type: object
 [[field-container-memory-usage]]
 <<field-container-memory-usage, container.memory.usage>>
 
-| beta:[ This field is beta and subject to change. ]
-
-Memory usage percentage and it ranges from 0 to 1. Scaling factor: 1000.
+| Memory usage percentage and it ranges from 0 to 1. Scaling factor: 1000.
 
 type: scaled_float
 
@@ -1197,9 +1189,7 @@ type: keyword
 [[field-container-network-egress-bytes]]
 <<field-container-network-egress-bytes, container.network.egress.bytes>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The number of bytes (gauge) sent out on all network interfaces by the container since the last metric collection.
+| The number of bytes (gauge) sent out on all network interfaces by the container since the last metric collection.
 
 type: long
 
@@ -1215,9 +1205,7 @@ type: long
 [[field-container-network-ingress-bytes]]
 <<field-container-network-ingress-bytes, container.network.ingress.bytes>>
 
-| beta:[ This field is beta and subject to change. ]
-
-The number of bytes received (gauge) on all network interfaces by the container since the last metric collection.
+| The number of bytes received (gauge) on all network interfaces by the container since the last metric collection.
 
 type: long
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1057,7 +1057,6 @@ cloud.target.service.name:
   short: The cloud service name.
   type: keyword
 container.cpu.usage:
-  beta: This field is beta and subject to change.
   dashed_name: container-cpu-usage
   description: 'Percent CPU used which is normalized by the number of CPU cores and
     it ranges from 0 to 1. Scaling factor: 1000.'
@@ -1069,7 +1068,6 @@ container.cpu.usage:
   short: Percent CPU used, between 0 and 1.
   type: scaled_float
 container.disk.read.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-disk-read-bytes
   description: The total number of bytes (gauge) read successfully (aggregated from
     all disks) since the last metric collection.
@@ -1080,7 +1078,6 @@ container.disk.read.bytes:
   short: The number of bytes read by all disks.
   type: long
 container.disk.write.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-disk-write-bytes
   description: The total number of bytes (gauge) written successfully (aggregated
     from all disks) since the last metric collection.
@@ -1146,7 +1143,6 @@ container.labels:
   short: Image labels.
   type: object
 container.memory.usage:
-  beta: This field is beta and subject to change.
   dashed_name: container-memory-usage
   description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
     1000.'
@@ -1168,7 +1164,6 @@ container.name:
   short: Container name.
   type: keyword
 container.network.egress.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-network-egress-bytes
   description: The number of bytes (gauge) sent out on all network interfaces by the
     container since the last metric collection.
@@ -1179,7 +1174,6 @@ container.network.egress.bytes:
   short: The number of bytes sent on all network interfaces.
   type: long
 container.network.ingress.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-network-ingress-bytes
   description: The number of bytes received (gauge) on all network interfaces by the
     container since the last metric collection.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1437,7 +1437,6 @@ container:
     These fields help correlate data based containers from any runtime.'
   fields:
     container.cpu.usage:
-      beta: This field is beta and subject to change.
       dashed_name: container-cpu-usage
       description: 'Percent CPU used which is normalized by the number of CPU cores
         and it ranges from 0 to 1. Scaling factor: 1000.'
@@ -1449,7 +1448,6 @@ container:
       short: Percent CPU used, between 0 and 1.
       type: scaled_float
     container.disk.read.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-disk-read-bytes
       description: The total number of bytes (gauge) read successfully (aggregated
         from all disks) since the last metric collection.
@@ -1460,7 +1458,6 @@ container:
       short: The number of bytes read by all disks.
       type: long
     container.disk.write.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-disk-write-bytes
       description: The total number of bytes (gauge) written successfully (aggregated
         from all disks) since the last metric collection.
@@ -1526,7 +1523,6 @@ container:
       short: Image labels.
       type: object
     container.memory.usage:
-      beta: This field is beta and subject to change.
       dashed_name: container-memory-usage
       description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
         1000.'
@@ -1548,7 +1544,6 @@ container:
       short: Container name.
       type: keyword
     container.network.egress.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-network-egress-bytes
       description: The number of bytes (gauge) sent out on all network interfaces
         by the container since the last metric collection.
@@ -1559,7 +1554,6 @@ container:
       short: The number of bytes sent on all network interfaces.
       type: long
     container.network.ingress.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-network-ingress-bytes
       description: The number of bytes received (gauge) on all network interfaces
         by the container since the last metric collection.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -988,7 +988,6 @@ cloud.target.service.name:
   short: The cloud service name.
   type: keyword
 container.cpu.usage:
-  beta: This field is beta and subject to change.
   dashed_name: container-cpu-usage
   description: 'Percent CPU used which is normalized by the number of CPU cores and
     it ranges from 0 to 1. Scaling factor: 1000.'
@@ -1000,7 +999,6 @@ container.cpu.usage:
   short: Percent CPU used, between 0 and 1.
   type: scaled_float
 container.disk.read.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-disk-read-bytes
   description: The total number of bytes (gauge) read successfully (aggregated from
     all disks) since the last metric collection.
@@ -1011,7 +1009,6 @@ container.disk.read.bytes:
   short: The number of bytes read by all disks.
   type: long
 container.disk.write.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-disk-write-bytes
   description: The total number of bytes (gauge) written successfully (aggregated
     from all disks) since the last metric collection.
@@ -1077,7 +1074,6 @@ container.labels:
   short: Image labels.
   type: object
 container.memory.usage:
-  beta: This field is beta and subject to change.
   dashed_name: container-memory-usage
   description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
     1000.'
@@ -1099,7 +1095,6 @@ container.name:
   short: Container name.
   type: keyword
 container.network.egress.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-network-egress-bytes
   description: The number of bytes (gauge) sent out on all network interfaces by the
     container since the last metric collection.
@@ -1110,7 +1105,6 @@ container.network.egress.bytes:
   short: The number of bytes sent on all network interfaces.
   type: long
 container.network.ingress.bytes:
-  beta: This field is beta and subject to change.
   dashed_name: container-network-ingress-bytes
   description: The number of bytes received (gauge) on all network interfaces by the
     container since the last metric collection.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1357,7 +1357,6 @@ container:
     These fields help correlate data based containers from any runtime.'
   fields:
     container.cpu.usage:
-      beta: This field is beta and subject to change.
       dashed_name: container-cpu-usage
       description: 'Percent CPU used which is normalized by the number of CPU cores
         and it ranges from 0 to 1. Scaling factor: 1000.'
@@ -1369,7 +1368,6 @@ container:
       short: Percent CPU used, between 0 and 1.
       type: scaled_float
     container.disk.read.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-disk-read-bytes
       description: The total number of bytes (gauge) read successfully (aggregated
         from all disks) since the last metric collection.
@@ -1380,7 +1378,6 @@ container:
       short: The number of bytes read by all disks.
       type: long
     container.disk.write.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-disk-write-bytes
       description: The total number of bytes (gauge) written successfully (aggregated
         from all disks) since the last metric collection.
@@ -1446,7 +1443,6 @@ container:
       short: Image labels.
       type: object
     container.memory.usage:
-      beta: This field is beta and subject to change.
       dashed_name: container-memory-usage
       description: 'Memory usage percentage and it ranges from 0 to 1. Scaling factor:
         1000.'
@@ -1468,7 +1464,6 @@ container:
       short: Container name.
       type: keyword
     container.network.egress.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-network-egress-bytes
       description: The number of bytes (gauge) sent out on all network interfaces
         by the container since the last metric collection.
@@ -1479,7 +1474,6 @@ container:
       short: The number of bytes sent on all network interfaces.
       type: long
     container.network.ingress.bytes:
-      beta: This field is beta and subject to change.
       dashed_name: container-network-ingress-bytes
       description: The number of bytes received (gauge) on all network interfaces
         by the container since the last metric collection.

--- a/rfcs/text/0025-container-metric-fields.md
+++ b/rfcs/text/0025-container-metric-fields.md
@@ -1,7 +1,7 @@
 # 0025: Container Metric Fields
 <!-- Leave this ID at 0000. The ECS team will assign a unique, contiguous RFC number upon merging the initial stage of this RFC. -->
 
-- Stage: **3 (draft)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
+- Stage: **3 (finished)** <!-- Update to reflect target stage. See https://elastic.github.io/ecs/stages.html -->
 - Date: **2022-03-03** <!-- The ECS team sets this date at merge time. This is the date of the latest stage advancement. -->
 
 <!--

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -32,7 +32,6 @@
       scaling_factor: 1000
       level: extended
       short: Percent CPU used, between 0 and 1.
-      beta: This field is beta and subject to change.
       description: >
         Percent CPU used which is normalized by the number of CPU cores and it
         ranges from 0 to 1. Scaling factor: 1000.
@@ -41,7 +40,6 @@
       type: long
       level: extended
       short: The number of bytes read by all disks.
-      beta: This field is beta and subject to change.
       description: >
         The total number of bytes (gauge) read successfully (aggregated from all
         disks) since the last metric collection.
@@ -50,7 +48,6 @@
       type: long
       level: extended
       short: The number of bytes written on all disks.
-      beta: This field is beta and subject to change.
       description: >
         The total number of bytes (gauge) written successfully (aggregated from
         all disks) since the last metric collection.
@@ -99,7 +96,6 @@
       scaling_factor: 1000
       level: extended
       short: Percent memory used, between 0 and 1.
-      beta: This field is beta and subject to change.
       description: >
         Memory usage percentage and it ranges from 0 to 1. Scaling factor: 1000.
 
@@ -113,7 +109,6 @@
       type: long
       level: extended
       short: The number of bytes received on all network interfaces.
-      beta: This field is beta and subject to change.
       description: >
         The number of bytes received (gauge) on all network interfaces by the
         container since the last metric collection.
@@ -122,7 +117,6 @@
       type: long
       level: extended
       short: The number of bytes sent on all network interfaces.
-      beta: This field is beta and subject to change.
       description: >
         The number of bytes (gauge) sent out on all network interfaces by the
         container since the last metric collection.


### PR DESCRIPTION
Backports the following commits to 8.3:
 - Container metrics GA (#1927)