### PR TITLE
[8.4] adding 8.4 release notes section (#1940)

### DIFF
--- a/docs/release-notes/8.4.asciidoc
+++ b/docs/release-notes/8.4.asciidoc
@@ -1,0 +1,4 @@
+[[ecs-release-notes-8.4.0]]
+=== 8.4.0
+
+coming[8.4.0]

--- a/docs/release-notes/index.asciidoc
+++ b/docs/release-notes/index.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<ecs-release-notes-8.4.0, {ecs} version 8.4.0>>
 * <<ecs-release-notes-8.3.0, {ecs} version 8.3.0>>
 * <<ecs-release-notes-8.2.0, {ecs} version 8.2.0>>
 * <<ecs-release-notes-8.1.0, {ecs} version 8.1.0>>
@@ -14,6 +15,7 @@ This section summarizes the changes in each release.
 :issue: https://github.com/elastic/ecs/issues/
 :pull: https://github.com/elastic/ecs/pull/
 
+include::8.4.asciidoc[]
 include::8.3.asciidoc[]
 include::8.2.asciidoc[]
 include::8.1.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.4:
 - adding 8.4 release notes section (#1940)