### PR TITLE
migrate sample index templates to datastream

### DIFF
--- a/generated/elasticsearch/composable/template.json
+++ b/generated/elasticsearch/composable/template.json
@@ -3,6 +3,7 @@
     "description": "Sample composable template that includes all ECS fields",
     "ecs_version": "8.5.0-dev"
   },
+  "data_stream": { },
   "composed_of": [
     "ecs_8.5.0-dev_base",
     "ecs_8.5.0-dev_agent",


### PR DESCRIPTION
Hi team,

I'm an Elastic SA, the main purpose of this PR is to migrate the example index template into data stream to align our example with our updated best practices. It's basically a minor change to the sample index template file, I haven't added any new fields. If this can be merged that's be really useful as It'd help share that with customers and improve ECS alignment.

Thanks in advance!  
