### PR TITLE
Define initial set of field `expected_values`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -43,6 +43,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Add `service.node.role` #1916
+* Initial set of `expected_values`. #1962
 
 #### Improvements
 
@@ -57,6 +58,8 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 #### Added
+
+* Introduce `expected_values` attribute. #1952
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -1818,7 +1818,15 @@ example: `CNAME`
 
 a| Array of 2 letter DNS header flags.
 
-Expected values are: AA, TC, RD, RA, AD, CD, DO.
+Expected values for this field:
+
+* `AA`
+* `TC`
+* `RD`
+* `RA`
+* `AD`
+* `CD`
+* `DO`
 
 type: keyword
 
@@ -3725,17 +3733,13 @@ example: `123456789`
 
 a| The trigger for the function execution.
 
-Expected values are:
+Expected values for this field:
 
-  * http
-
-  * pubsub
-
-  * datasource
-
-  * timer
-
-  * other
+* `http`
+* `pubsub`
+* `datasource`
+* `timer`
+* `other`
 
 type: keyword
 
@@ -5779,29 +5783,21 @@ example: `1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=`
 
 a| Direction of the network traffic.
 
-Recommended values are:
-
-  * ingress
-
-  * egress
-
-  * inbound
-
-  * outbound
-
-  * internal
-
-  * external
-
-  * unknown
-
-
-
 When mapping events from a host-based monitoring context, populate this field from the host's point of view, using the values "ingress" or "egress".
 
 When mapping events from a network or perimeter-based monitoring context, populate this field from the point of view of the network perimeter, using the values "inbound", "outbound", "internal" or "external".
 
 Note that "internal" is not crossing perimeter boundaries, and is meant to describe communication between two hosts within the perimeter. Note also that "external" is meant to describe traffic between two hosts that are external to the perimeter. This could for example be useful for ISPs or VPN service providers.
+
+Expected values for this field:
+
+* `ingress`
+* `egress`
+* `inbound`
+* `outbound`
+* `internal`
+* `external`
+* `unknown`
 
 type: keyword
 
@@ -6678,9 +6674,14 @@ example: `darwin`
 
 a| Use the `os.type` field to categorize the operating system into one of the broad commercial families.
 
-One of these following values should be used (lowercase): linux, macos, unix, windows.
+If the OS you're dealing with is not listed as an expected value, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition.
 
-If the OS you're dealing with is not in the list, the field should not be populated. Please let us know by opening an issue with ECS, to propose its addition.
+Expected values for this field:
+
+* `linux`
+* `macos`
+* `unix`
+* `windows`
 
 type: keyword
 
@@ -9100,19 +9101,15 @@ type: object
 
 a| beta:[ This field is beta and subject to change. ]
 
-Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
+Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
 
-Expected values are:
+Expected values for this field:
 
-  * Not Specified
-
-  * None
-
-  * Low
-
-  * Medium
-
-  * High
+* `Not Specified`
+* `None`
+* `Low`
+* `Medium`
+* `High`
 
 type: keyword
 
@@ -9220,21 +9217,20 @@ example: `2020-11-05T17:25:47.000Z`
 
 a| beta:[ This field is beta and subject to change. ]
 
-Traffic Light Protocol sharing markings. Recommended values are:
+Traffic Light Protocol sharing markings.
 
-  * WHITE
+Expected values for this field:
 
-  * GREEN
-
-  * AMBER
-
-  * RED
+* `WHITE`
+* `GREEN`
+* `AMBER`
+* `RED`
 
 type: keyword
 
 
 
-example: `White`
+example: `WHITE`
 
 | extended
 
@@ -9354,41 +9350,27 @@ example: `20`
 
 a| beta:[ This field is beta and subject to change. ]
 
-Type of indicator as represented by Cyber Observable in STIX 2.0. Recommended values:
+Type of indicator as represented by Cyber Observable in STIX 2.0.
 
-  * autonomous-system
+Expected values for this field:
 
-  * artifact
-
-  * directory
-
-  * domain-name
-
-  * email-addr
-
-  * file
-
-  * ipv4-addr
-
-  * ipv6-addr
-
-  * mac-addr
-
-  * mutex
-
-  * port
-
-  * process
-
-  * software
-
-  * url
-
-  * user-account
-
-  * windows-registry-key
-
-  * x509-certificate
+* `autonomous-system`
+* `artifact`
+* `directory`
+* `domain-name`
+* `email-addr`
+* `file`
+* `ipv4-addr`
+* `ipv6-addr`
+* `mac-addr`
+* `mutex`
+* `port`
+* `process`
+* `software`
+* `url`
+* `user-account`
+* `windows-registry-key`
+* `x509-certificate`
 
 type: keyword
 
@@ -9665,19 +9647,15 @@ example: `https://attack.mitre.org/groups/G0037/`
 [[field-threat-indicator-confidence]]
 <<field-threat-indicator-confidence, threat.indicator.confidence>>
 
-a| Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
+a| Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence scales may be added as custom fields.
 
-Expected values are:
+Expected values for this field:
 
-  * Not Specified
-
-  * None
-
-  * Low
-
-  * Medium
-
-  * High
+* `Not Specified`
+* `None`
+* `Low`
+* `Medium`
+* `High`
 
 type: keyword
 
@@ -9775,15 +9753,12 @@ example: `2020-11-05T17:25:47.000Z`
 
 a| Traffic Light Protocol sharing markings.
 
-Recommended values are:
+Expected values for this field:
 
-  * WHITE
-
-  * GREEN
-
-  * AMBER
-
-  * RED
+* `WHITE`
+* `GREEN`
+* `AMBER`
+* `RED`
 
 type: keyword
 
@@ -9897,41 +9872,25 @@ example: `20`
 
 a| Type of indicator as represented by Cyber Observable in STIX 2.0.
 
-Recommended values:
+Expected values for this field:
 
-  * autonomous-system
-
-  * artifact
-
-  * directory
-
-  * domain-name
-
-  * email-addr
-
-  * file
-
-  * ipv4-addr
-
-  * ipv6-addr
-
-  * mac-addr
-
-  * mutex
-
-  * port
-
-  * process
-
-  * software
-
-  * url
-
-  * user-account
-
-  * windows-registry-key
-
-  * x509-certificate
+* `autonomous-system`
+* `artifact`
+* `directory`
+* `domain-name`
+* `email-addr`
+* `file`
+* `ipv4-addr`
+* `ipv6-addr`
+* `mac-addr`
+* `mutex`
+* `port`
+* `process`
+* `software`
+* `url`
+* `user-account`
+* `windows-registry-key`
+* `x509-certificate`
 
 type: keyword
 
@@ -10006,31 +9965,20 @@ example: `AdFind`
 
 a| The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-Recommended Values:
+While not required, you can use MITRE ATT&CK® software platform values.
 
-  * AWS
+Expected values for this field:
 
-  * Azure
-
-  * Azure AD
-
-  * GCP
-
-  * Linux
-
-  * macOS
-
-  * Network
-
-  * Office 365
-
-  * SaaS
-
-  * Windows
-
-
-
-While not required, you can use a MITRE ATT&CK® software platforms.
+* `AWS`
+* `Azure`
+* `Azure AD`
+* `GCP`
+* `Linux`
+* `macOS`
+* `Network`
+* `Office 365`
+* `SaaS`
+* `Windows`
 
 type: keyword
 
@@ -10069,15 +10017,12 @@ example: `https://attack.mitre.org/software/S0552/`
 
 a| The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-Recommended values
+While not required, you can use a MITRE ATT&CK® software type.
 
-  * Malware
+Expected values for this field:
 
-  * Tool
-
-
-
- While not required, you can use a MITRE ATT&CK® software type.
+* `Malware`
+* `Tool`
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1569,9 +1569,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of 2 letter DNS header flags.
-
-        Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+      description: Array of 2 letter DNS header flags.
       example: '["RD", "RA"]'
     - name: id
       level: extended
@@ -2496,8 +2494,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The trigger for the function execution.\nExpected values are:\n\
-        \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+      description: The trigger for the function execution.
       example: http
       default_field: false
     - name: version
@@ -3636,12 +3633,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version
@@ -4030,18 +4024,20 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
-        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values \"ingress\"\
-        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of the network perimeter,\
-        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
-        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
-        \ to describe communication between two hosts within the perimeter. Note also\
-        \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to the perimeter. This could for example be useful for ISPs or\
-        \ VPN service providers."
+      description: 'Direction of the network traffic.
+
+        When mapping events from a host-based monitoring context, populate this field
+        from the host''s point of view, using the values "ingress" or "egress".
+
+        When mapping events from a network or perimeter-based monitoring context,
+        populate this field from the point of view of the network perimeter, using
+        the values "inbound", "outbound", "internal" or "external".
+
+        Note that "internal" is not crossing perimeter boundaries, and is meant to
+        describe communication between two hosts within the perimeter. Note also that
+        "external" is meant to describe traffic between two hosts that are external
+        to the perimeter. This could for example be useful for ISPs or VPN service
+        providers.'
       example: inbound
     - name: forwarded_ip
       level: core
@@ -4414,12 +4410,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version
@@ -4634,12 +4627,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: version
@@ -8267,10 +8257,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
       default_field: false
     - name: enrichments.indicator.description
@@ -9118,9 +9107,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-      example: White
+      description: Traffic Light Protocol sharing markings.
+      example: WHITE
       default_field: false
     - name: enrichments.indicator.modified_at
       level: extended
@@ -9226,11 +9214,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-        \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
       default_field: false
     - name: enrichments.indicator.url.domain
@@ -9692,10 +9676,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
       default_field: false
     - name: indicator.description
@@ -10543,8 +10526,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+      description: Traffic Light Protocol sharing markings.
       example: WHITE
       default_field: false
     - name: indicator.modified_at
@@ -10651,11 +10633,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-        Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
       default_field: false
     - name: indicator.url.domain
@@ -11010,10 +10988,8 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
-        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
-        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software platforms."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -11030,8 +11006,8 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-        \n While not required, you can use a MITRE ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id
@@ -12258,12 +12234,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1082,7 +1082,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
-8.5.0-dev+exp,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,White,Indicator TLP marking
+8.5.0-dev+exp,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,WHITE,Indicator TLP marking
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.port,long,extended,,443,Indicator port
 8.5.0-dev+exp,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2112,10 +2112,16 @@ dns.answers.type:
   type: keyword
 dns.header_flags:
   dashed_name: dns-header-flags
-  description: 'Array of 2 letter DNS header flags.
-
-    Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+  description: Array of 2 letter DNS header flags.
   example: '["RD", "RA"]'
+  expected_values:
+  - AA
+  - TC
+  - RD
+  - RA
+  - AD
+  - CD
+  - DO
   flat_name: dns.header_flags
   ignore_above: 1024
   level: extended
@@ -3530,9 +3536,14 @@ faas.trigger.request_id:
   type: keyword
 faas.trigger.type:
   dashed_name: faas-trigger-type
-  description: "The trigger for the function execution.\nExpected values are:\n  *\
-    \ http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+  description: The trigger for the function execution.
   example: http
+  expected_values:
+  - http
+  - pubsub
+  - datasource
+  - timer
+  - other
   flat_name: faas.trigger.type
   ignore_above: 1024
   level: extended
@@ -5194,12 +5205,15 @@ host.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: host.os.type
   ignore_above: 1024
   level: extended
@@ -5731,18 +5745,28 @@ network.community_id:
   type: keyword
 network.direction:
   dashed_name: network-direction
-  description: "Direction of the network traffic.\nRecommended values are:\n  * ingress\n\
-    \  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\
-    \nWhen mapping events from a host-based monitoring context, populate this field\
-    \ from the host's point of view, using the values \"ingress\" or \"egress\".\n\
-    When mapping events from a network or perimeter-based monitoring context, populate\
-    \ this field from the point of view of the network perimeter, using the values\
-    \ \"inbound\", \"outbound\", \"internal\" or \"external\".\nNote that \"internal\"\
-    \ is not crossing perimeter boundaries, and is meant to describe communication\
-    \ between two hosts within the perimeter. Note also that \"external\" is meant\
-    \ to describe traffic between two hosts that are external to the perimeter. This\
-    \ could for example be useful for ISPs or VPN service providers."
+  description: 'Direction of the network traffic.
+
+    When mapping events from a host-based monitoring context, populate this field
+    from the host''s point of view, using the values "ingress" or "egress".
+
+    When mapping events from a network or perimeter-based monitoring context, populate
+    this field from the point of view of the network perimeter, using the values "inbound",
+    "outbound", "internal" or "external".
+
+    Note that "internal" is not crossing perimeter boundaries, and is meant to describe
+    communication between two hosts within the perimeter. Note also that "external"
+    is meant to describe traffic between two hosts that are external to the perimeter.
+    This could for example be useful for ISPs or VPN service providers.'
   example: inbound
+  expected_values:
+  - ingress
+  - egress
+  - inbound
+  - outbound
+  - internal
+  - external
+  - unknown
   flat_name: network.direction
   ignore_above: 1024
   level: core
@@ -6337,12 +6361,15 @@ observer.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: observer.os.type
   ignore_above: 1024
   level: extended
@@ -12190,11 +12217,16 @@ threat.enrichments.indicator.as.organization.name:
 threat.enrichments.indicator.confidence:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-confidence
-  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
-    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
-    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
-    \  * None\n  * Low\n  * Medium\n  * High"
+  description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+    scales may be added as custom fields.
   example: Medium
+  expected_values:
+  - Not Specified
+  - None
+  - Low
+  - Medium
+  - High
   flat_name: threat.enrichments.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -13643,9 +13675,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-marking-tlp
-  description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-    \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-  example: White
+  description: Traffic Light Protocol sharing markings.
+  example: WHITE
+  expected_values:
+  - WHITE
+  - GREEN
+  - AMBER
+  - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
   level: extended
@@ -13821,12 +13857,26 @@ threat.enrichments.indicator.sightings:
 threat.enrichments.indicator.type:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-type
-  description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-    \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  *\
-    \ domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n  * mac-addr\n\
-    \  * mutex\n  * port\n  * process\n  * software\n  * url\n  * user-account\n \
-    \ * windows-registry-key\n  * x509-certificate"
+  description: Type of indicator as represented by Cyber Observable in STIX 2.0.
   example: ipv4-addr
+  expected_values:
+  - autonomous-system
+  - artifact
+  - directory
+  - domain-name
+  - email-addr
+  - file
+  - ipv4-addr
+  - ipv6-addr
+  - mac-addr
+  - mutex
+  - port
+  - process
+  - software
+  - url
+  - user-account
+  - windows-registry-key
+  - x509-certificate
   flat_name: threat.enrichments.indicator.type
   ignore_above: 1024
   level: extended
@@ -14573,11 +14623,16 @@ threat.indicator.as.organization.name:
   type: keyword
 threat.indicator.confidence:
   dashed_name: threat-indicator-confidence
-  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
-    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
-    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
-    \  * None\n  * Low\n  * Medium\n  * High"
+  description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+    scales may be added as custom fields.
   example: Medium
+  expected_values:
+  - Not Specified
+  - None
+  - Low
+  - Medium
+  - High
   flat_name: threat.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -16020,9 +16075,13 @@ threat.indicator.last_seen:
   type: date
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
-  description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-    \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+  description: Traffic Light Protocol sharing markings.
   example: WHITE
+  expected_values:
+  - WHITE
+  - GREEN
+  - AMBER
+  - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024
   level: extended
@@ -16191,12 +16250,26 @@ threat.indicator.sightings:
   type: long
 threat.indicator.type:
   dashed_name: threat-indicator-type
-  description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-    Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  * domain-name\n\
-    \  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n  * mac-addr\n  * mutex\n\
-    \  * port\n  * process\n  * software\n  * url\n  * user-account\n  * windows-registry-key\n\
-    \  * x509-certificate"
+  description: Type of indicator as represented by Cyber Observable in STIX 2.0.
   example: ipv4-addr
+  expected_values:
+  - autonomous-system
+  - artifact
+  - directory
+  - domain-name
+  - email-addr
+  - file
+  - ipv4-addr
+  - ipv6-addr
+  - mac-addr
+  - mutex
+  - port
+  - process
+  - software
+  - url
+  - user-account
+  - windows-registry-key
+  - x509-certificate
   flat_name: threat.indicator.type
   ignore_above: 1024
   level: extended
@@ -16771,11 +16844,20 @@ threat.software.name:
 threat.software.platforms:
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n  *\
-    \ Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-    \ 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE ATT&CK\xAE\
-    \ software platforms."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use MITRE\
+    \ ATT&CK\xAE software platform values."
   example: '[ "Windows" ]'
+  expected_values:
+  - AWS
+  - Azure
+  - Azure AD
+  - GCP
+  - Linux
+  - macOS
+  - Network
+  - Office 365
+  - SaaS
+  - Windows
   flat_name: threat.software.platforms
   ignore_above: 1024
   level: extended
@@ -16800,9 +16882,12 @@ threat.software.reference:
 threat.software.type:
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-    \n While not required, you can use a MITRE ATT&CK\xAE software type."
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software type."
   example: Tool
+  expected_values:
+  - Malware
+  - Tool
   flat_name: threat.software.type
   ignore_above: 1024
   level: extended
@@ -18766,12 +18851,15 @@ user_agent.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: user_agent.os.type
   ignore_above: 1024
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2598,10 +2598,16 @@ dns:
       type: keyword
     dns.header_flags:
       dashed_name: dns-header-flags
-      description: 'Array of 2 letter DNS header flags.
-
-        Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+      description: Array of 2 letter DNS header flags.
       example: '["RD", "RA"]'
+      expected_values:
+      - AA
+      - TC
+      - RD
+      - RA
+      - AD
+      - CD
+      - DO
       flat_name: dns.header_flags
       ignore_above: 1024
       level: extended
@@ -4427,9 +4433,14 @@ faas:
       type: keyword
     faas.trigger.type:
       dashed_name: faas-trigger-type
-      description: "The trigger for the function execution.\nExpected values are:\n\
-        \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+      description: The trigger for the function execution.
       example: http
+      expected_values:
+      - http
+      - pubsub
+      - datasource
+      - timer
+      - other
       flat_name: faas.trigger.type
       ignore_above: 1024
       level: extended
@@ -6466,13 +6477,15 @@ host:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: host.os.type
       ignore_above: 1024
       level: extended
@@ -7085,19 +7098,29 @@ network:
       type: keyword
     network.direction:
       dashed_name: network-direction
-      description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
-        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values \"ingress\"\
-        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of the network perimeter,\
-        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
-        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
-        \ to describe communication between two hosts within the perimeter. Note also\
-        \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to the perimeter. This could for example be useful for ISPs or\
-        \ VPN service providers."
+      description: 'Direction of the network traffic.
+
+        When mapping events from a host-based monitoring context, populate this field
+        from the host''s point of view, using the values "ingress" or "egress".
+
+        When mapping events from a network or perimeter-based monitoring context,
+        populate this field from the point of view of the network perimeter, using
+        the values "inbound", "outbound", "internal" or "external".
+
+        Note that "internal" is not crossing perimeter boundaries, and is meant to
+        describe communication between two hosts within the perimeter. Note also that
+        "external" is meant to describe traffic between two hosts that are external
+        to the perimeter. This could for example be useful for ISPs or VPN service
+        providers.'
       example: inbound
+      expected_values:
+      - ingress
+      - egress
+      - inbound
+      - outbound
+      - internal
+      - external
+      - unknown
       flat_name: network.direction
       ignore_above: 1024
       level: core
@@ -7727,13 +7750,15 @@ observer:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: observer.os.type
       ignore_above: 1024
       level: extended
@@ -8103,13 +8128,15 @@ os:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: os.type
       ignore_above: 1024
       level: extended
@@ -14260,11 +14287,16 @@ threat:
     threat.enrichments.indicator.confidence:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-confidence
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
+      expected_values:
+      - Not Specified
+      - None
+      - Low
+      - Medium
+      - High
       flat_name: threat.enrichments.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -15714,9 +15746,13 @@ threat:
     threat.enrichments.indicator.marking.tlp:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-marking-tlp
-      description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-      example: White
+      description: Traffic Light Protocol sharing markings.
+      example: WHITE
+      expected_values:
+      - WHITE
+      - GREEN
+      - AMBER
+      - RED
       flat_name: threat.enrichments.indicator.marking.tlp
       ignore_above: 1024
       level: extended
@@ -15893,12 +15929,26 @@ threat:
     threat.enrichments.indicator.type:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-type
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-        \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
+      expected_values:
+      - autonomous-system
+      - artifact
+      - directory
+      - domain-name
+      - email-addr
+      - file
+      - ipv4-addr
+      - ipv6-addr
+      - mac-addr
+      - mutex
+      - port
+      - process
+      - software
+      - url
+      - user-account
+      - windows-registry-key
+      - x509-certificate
       flat_name: threat.enrichments.indicator.type
       ignore_above: 1024
       level: extended
@@ -16647,11 +16697,16 @@ threat:
       type: keyword
     threat.indicator.confidence:
       dashed_name: threat-indicator-confidence
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
+      expected_values:
+      - Not Specified
+      - None
+      - Low
+      - Medium
+      - High
       flat_name: threat.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -18095,9 +18150,13 @@ threat:
       type: date
     threat.indicator.marking.tlp:
       dashed_name: threat-indicator-marking-tlp
-      description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+      description: Traffic Light Protocol sharing markings.
       example: WHITE
+      expected_values:
+      - WHITE
+      - GREEN
+      - AMBER
+      - RED
       flat_name: threat.indicator.marking.tlp
       ignore_above: 1024
       level: extended
@@ -18267,12 +18326,26 @@ threat:
       type: long
     threat.indicator.type:
       dashed_name: threat-indicator-type
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-        Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
+      expected_values:
+      - autonomous-system
+      - artifact
+      - directory
+      - domain-name
+      - email-addr
+      - file
+      - ipv4-addr
+      - ipv6-addr
+      - mac-addr
+      - mutex
+      - port
+      - process
+      - software
+      - url
+      - user-account
+      - windows-registry-key
+      - x509-certificate
       flat_name: threat.indicator.type
       ignore_above: 1024
       level: extended
@@ -18849,11 +18922,20 @@ threat:
     threat.software.platforms:
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
-        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
-        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software platforms."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
+      expected_values:
+      - AWS
+      - Azure
+      - Azure AD
+      - GCP
+      - Linux
+      - macOS
+      - Network
+      - Office 365
+      - SaaS
+      - Windows
       flat_name: threat.software.platforms
       ignore_above: 1024
       level: extended
@@ -18878,9 +18960,12 @@ threat:
     threat.software.type:
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-        \n While not required, you can use a MITRE ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
+      expected_values:
+      - Malware
+      - Tool
       flat_name: threat.software.type
       ignore_above: 1024
       level: extended
@@ -21064,13 +21149,15 @@ user_agent:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: user_agent.os.type
       ignore_above: 1024
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1519,9 +1519,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Array of 2 letter DNS header flags.
-
-        Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+      description: Array of 2 letter DNS header flags.
       example: '["RD", "RA"]'
     - name: id
       level: extended
@@ -2446,8 +2444,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "The trigger for the function execution.\nExpected values are:\n\
-        \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+      description: The trigger for the function execution.
       example: http
       default_field: false
     - name: version
@@ -3586,12 +3583,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version
@@ -3980,18 +3974,20 @@
       level: core
       type: keyword
       ignore_above: 1024
-      description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
-        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values \"ingress\"\
-        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of the network perimeter,\
-        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
-        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
-        \ to describe communication between two hosts within the perimeter. Note also\
-        \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to the perimeter. This could for example be useful for ISPs or\
-        \ VPN service providers."
+      description: 'Direction of the network traffic.
+
+        When mapping events from a host-based monitoring context, populate this field
+        from the host''s point of view, using the values "ingress" or "egress".
+
+        When mapping events from a network or perimeter-based monitoring context,
+        populate this field from the point of view of the network perimeter, using
+        the values "inbound", "outbound", "internal" or "external".
+
+        Note that "internal" is not crossing perimeter boundaries, and is meant to
+        describe communication between two hosts within the perimeter. Note also that
+        "external" is meant to describe traffic between two hosts that are external
+        to the perimeter. This could for example be useful for ISPs or VPN service
+        providers.'
       example: inbound
     - name: forwarded_ip
       level: core
@@ -4364,12 +4360,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version
@@ -4584,12 +4577,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: version
@@ -8217,10 +8207,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
       default_field: false
     - name: enrichments.indicator.description
@@ -9068,9 +9057,8 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-      example: White
+      description: Traffic Light Protocol sharing markings.
+      example: WHITE
       default_field: false
     - name: enrichments.indicator.modified_at
       level: extended
@@ -9176,11 +9164,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-        \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
       default_field: false
     - name: enrichments.indicator.url.domain
@@ -9642,10 +9626,9 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
       default_field: false
     - name: indicator.description
@@ -10493,8 +10476,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+      description: Traffic Light Protocol sharing markings.
       example: WHITE
       default_field: false
     - name: indicator.modified_at
@@ -10601,11 +10583,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-        Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
       default_field: false
     - name: indicator.url.domain
@@ -10960,10 +10938,8 @@
       type: keyword
       ignore_above: 1024
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
-        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
-        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software platforms."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
       default_field: false
     - name: software.reference
@@ -10980,8 +10956,8 @@
       type: keyword
       ignore_above: 1024
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-        \n While not required, you can use a MITRE ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
       default_field: false
     - name: tactic.id
@@ -12208,12 +12184,9 @@
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
       default_field: false
     - name: os.version

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1075,7 +1075,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,threat,threat.enrichments.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 8.5.0-dev,true,threat,threat.enrichments.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.5.0-dev,true,threat,threat.enrichments.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
-8.5.0-dev,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,White,Indicator TLP marking
+8.5.0-dev,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,WHITE,Indicator TLP marking
 8.5.0-dev,true,threat,threat.enrichments.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.5.0-dev,true,threat,threat.enrichments.indicator.port,long,extended,,443,Indicator port
 8.5.0-dev,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2043,10 +2043,16 @@ dns.answers.type:
   type: keyword
 dns.header_flags:
   dashed_name: dns-header-flags
-  description: 'Array of 2 letter DNS header flags.
-
-    Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+  description: Array of 2 letter DNS header flags.
   example: '["RD", "RA"]'
+  expected_values:
+  - AA
+  - TC
+  - RD
+  - RA
+  - AD
+  - CD
+  - DO
   flat_name: dns.header_flags
   ignore_above: 1024
   level: extended
@@ -3461,9 +3467,14 @@ faas.trigger.request_id:
   type: keyword
 faas.trigger.type:
   dashed_name: faas-trigger-type
-  description: "The trigger for the function execution.\nExpected values are:\n  *\
-    \ http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+  description: The trigger for the function execution.
   example: http
+  expected_values:
+  - http
+  - pubsub
+  - datasource
+  - timer
+  - other
   flat_name: faas.trigger.type
   ignore_above: 1024
   level: extended
@@ -5125,12 +5136,15 @@ host.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: host.os.type
   ignore_above: 1024
   level: extended
@@ -5662,18 +5676,28 @@ network.community_id:
   type: keyword
 network.direction:
   dashed_name: network-direction
-  description: "Direction of the network traffic.\nRecommended values are:\n  * ingress\n\
-    \  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n  * unknown\n\
-    \nWhen mapping events from a host-based monitoring context, populate this field\
-    \ from the host's point of view, using the values \"ingress\" or \"egress\".\n\
-    When mapping events from a network or perimeter-based monitoring context, populate\
-    \ this field from the point of view of the network perimeter, using the values\
-    \ \"inbound\", \"outbound\", \"internal\" or \"external\".\nNote that \"internal\"\
-    \ is not crossing perimeter boundaries, and is meant to describe communication\
-    \ between two hosts within the perimeter. Note also that \"external\" is meant\
-    \ to describe traffic between two hosts that are external to the perimeter. This\
-    \ could for example be useful for ISPs or VPN service providers."
+  description: 'Direction of the network traffic.
+
+    When mapping events from a host-based monitoring context, populate this field
+    from the host''s point of view, using the values "ingress" or "egress".
+
+    When mapping events from a network or perimeter-based monitoring context, populate
+    this field from the point of view of the network perimeter, using the values "inbound",
+    "outbound", "internal" or "external".
+
+    Note that "internal" is not crossing perimeter boundaries, and is meant to describe
+    communication between two hosts within the perimeter. Note also that "external"
+    is meant to describe traffic between two hosts that are external to the perimeter.
+    This could for example be useful for ISPs or VPN service providers.'
   example: inbound
+  expected_values:
+  - ingress
+  - egress
+  - inbound
+  - outbound
+  - internal
+  - external
+  - unknown
   flat_name: network.direction
   ignore_above: 1024
   level: core
@@ -6268,12 +6292,15 @@ observer.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: observer.os.type
   ignore_above: 1024
   level: extended
@@ -12121,11 +12148,16 @@ threat.enrichments.indicator.as.organization.name:
 threat.enrichments.indicator.confidence:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-confidence
-  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
-    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
-    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
-    \  * None\n  * Low\n  * Medium\n  * High"
+  description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+    scales may be added as custom fields.
   example: Medium
+  expected_values:
+  - Not Specified
+  - None
+  - Low
+  - Medium
+  - High
   flat_name: threat.enrichments.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -13574,9 +13606,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-marking-tlp
-  description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-    \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-  example: White
+  description: Traffic Light Protocol sharing markings.
+  example: WHITE
+  expected_values:
+  - WHITE
+  - GREEN
+  - AMBER
+  - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
   level: extended
@@ -13752,12 +13788,26 @@ threat.enrichments.indicator.sightings:
 threat.enrichments.indicator.type:
   beta: This field is beta and subject to change.
   dashed_name: threat-enrichments-indicator-type
-  description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-    \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  *\
-    \ domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n  * mac-addr\n\
-    \  * mutex\n  * port\n  * process\n  * software\n  * url\n  * user-account\n \
-    \ * windows-registry-key\n  * x509-certificate"
+  description: Type of indicator as represented by Cyber Observable in STIX 2.0.
   example: ipv4-addr
+  expected_values:
+  - autonomous-system
+  - artifact
+  - directory
+  - domain-name
+  - email-addr
+  - file
+  - ipv4-addr
+  - ipv6-addr
+  - mac-addr
+  - mutex
+  - port
+  - process
+  - software
+  - url
+  - user-account
+  - windows-registry-key
+  - x509-certificate
   flat_name: threat.enrichments.indicator.type
   ignore_above: 1024
   level: extended
@@ -14504,11 +14554,16 @@ threat.indicator.as.organization.name:
   type: keyword
 threat.indicator.confidence:
   dashed_name: threat-indicator-confidence
-  description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the None/Low/Medium/High\_\
-    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence\
-    \ scales may be added as custom fields.\nExpected values are:\n  * Not Specified\n\
-    \  * None\n  * Low\n  * Medium\n  * High"
+  description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+    scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+    scales may be added as custom fields.
   example: Medium
+  expected_values:
+  - Not Specified
+  - None
+  - Low
+  - Medium
+  - High
   flat_name: threat.indicator.confidence
   ignore_above: 1024
   level: extended
@@ -15951,9 +16006,13 @@ threat.indicator.last_seen:
   type: date
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
-  description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-    \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+  description: Traffic Light Protocol sharing markings.
   example: WHITE
+  expected_values:
+  - WHITE
+  - GREEN
+  - AMBER
+  - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024
   level: extended
@@ -16122,12 +16181,26 @@ threat.indicator.sightings:
   type: long
 threat.indicator.type:
   dashed_name: threat-indicator-type
-  description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-    Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n  * domain-name\n\
-    \  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n  * mac-addr\n  * mutex\n\
-    \  * port\n  * process\n  * software\n  * url\n  * user-account\n  * windows-registry-key\n\
-    \  * x509-certificate"
+  description: Type of indicator as represented by Cyber Observable in STIX 2.0.
   example: ipv4-addr
+  expected_values:
+  - autonomous-system
+  - artifact
+  - directory
+  - domain-name
+  - email-addr
+  - file
+  - ipv4-addr
+  - ipv6-addr
+  - mac-addr
+  - mutex
+  - port
+  - process
+  - software
+  - url
+  - user-account
+  - windows-registry-key
+  - x509-certificate
   flat_name: threat.indicator.type
   ignore_above: 1024
   level: extended
@@ -16702,11 +16775,20 @@ threat.software.name:
 threat.software.platforms:
   dashed_name: threat-software-platforms
   description: "The platforms of the software used by this threat to conduct behavior\
-    \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n  *\
-    \ Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  * Office\
-    \ 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE ATT&CK\xAE\
-    \ software platforms."
+    \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use MITRE\
+    \ ATT&CK\xAE software platform values."
   example: '[ "Windows" ]'
+  expected_values:
+  - AWS
+  - Azure
+  - Azure AD
+  - GCP
+  - Linux
+  - macOS
+  - Network
+  - Office 365
+  - SaaS
+  - Windows
   flat_name: threat.software.platforms
   ignore_above: 1024
   level: extended
@@ -16731,9 +16813,12 @@ threat.software.reference:
 threat.software.type:
   dashed_name: threat-software-type
   description: "The type of software used by this threat to conduct behavior commonly\
-    \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-    \n While not required, you can use a MITRE ATT&CK\xAE software type."
+    \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE ATT&CK\xAE\
+    \ software type."
   example: Tool
+  expected_values:
+  - Malware
+  - Tool
   flat_name: threat.software.type
   ignore_above: 1024
   level: extended
@@ -18697,12 +18782,15 @@ user_agent.os.type:
   description: 'Use the `os.type` field to categorize the operating system into one
     of the broad commercial families.
 
-    One of these following values should be used (lowercase): linux, macos, unix,
-    windows.
-
-    If the OS you''re dealing with is not in the list, the field should not be populated.
-    Please let us know by opening an issue with ECS, to propose its addition.'
+    If the OS you''re dealing with is not listed as an expected value, the field should
+    not be populated. Please let us know by opening an issue with ECS, to propose
+    its addition.'
   example: macos
+  expected_values:
+  - linux
+  - macos
+  - unix
+  - windows
   flat_name: user_agent.os.type
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2518,10 +2518,16 @@ dns:
       type: keyword
     dns.header_flags:
       dashed_name: dns-header-flags
-      description: 'Array of 2 letter DNS header flags.
-
-        Expected values are: AA, TC, RD, RA, AD, CD, DO.'
+      description: Array of 2 letter DNS header flags.
       example: '["RD", "RA"]'
+      expected_values:
+      - AA
+      - TC
+      - RD
+      - RA
+      - AD
+      - CD
+      - DO
       flat_name: dns.header_flags
       ignore_above: 1024
       level: extended
@@ -4347,9 +4353,14 @@ faas:
       type: keyword
     faas.trigger.type:
       dashed_name: faas-trigger-type
-      description: "The trigger for the function execution.\nExpected values are:\n\
-        \  * http\n  * pubsub\n  * datasource\n  * timer\n  * other"
+      description: The trigger for the function execution.
       example: http
+      expected_values:
+      - http
+      - pubsub
+      - datasource
+      - timer
+      - other
       flat_name: faas.trigger.type
       ignore_above: 1024
       level: extended
@@ -6386,13 +6397,15 @@ host:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: host.os.type
       ignore_above: 1024
       level: extended
@@ -7005,19 +7018,29 @@ network:
       type: keyword
     network.direction:
       dashed_name: network-direction
-      description: "Direction of the network traffic.\nRecommended values are:\n \
-        \ * ingress\n  * egress\n  * inbound\n  * outbound\n  * internal\n  * external\n\
-        \  * unknown\n\nWhen mapping events from a host-based monitoring context,\
-        \ populate this field from the host's point of view, using the values \"ingress\"\
-        \ or \"egress\".\nWhen mapping events from a network or perimeter-based monitoring\
-        \ context, populate this field from the point of view of the network perimeter,\
-        \ using the values \"inbound\", \"outbound\", \"internal\" or \"external\"\
-        .\nNote that \"internal\" is not crossing perimeter boundaries, and is meant\
-        \ to describe communication between two hosts within the perimeter. Note also\
-        \ that \"external\" is meant to describe traffic between two hosts that are\
-        \ external to the perimeter. This could for example be useful for ISPs or\
-        \ VPN service providers."
+      description: 'Direction of the network traffic.
+
+        When mapping events from a host-based monitoring context, populate this field
+        from the host''s point of view, using the values "ingress" or "egress".
+
+        When mapping events from a network or perimeter-based monitoring context,
+        populate this field from the point of view of the network perimeter, using
+        the values "inbound", "outbound", "internal" or "external".
+
+        Note that "internal" is not crossing perimeter boundaries, and is meant to
+        describe communication between two hosts within the perimeter. Note also that
+        "external" is meant to describe traffic between two hosts that are external
+        to the perimeter. This could for example be useful for ISPs or VPN service
+        providers.'
       example: inbound
+      expected_values:
+      - ingress
+      - egress
+      - inbound
+      - outbound
+      - internal
+      - external
+      - unknown
       flat_name: network.direction
       ignore_above: 1024
       level: core
@@ -7647,13 +7670,15 @@ observer:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: observer.os.type
       ignore_above: 1024
       level: extended
@@ -8023,13 +8048,15 @@ os:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: os.type
       ignore_above: 1024
       level: extended
@@ -14180,11 +14207,16 @@ threat:
     threat.enrichments.indicator.confidence:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-confidence
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
+      expected_values:
+      - Not Specified
+      - None
+      - Low
+      - Medium
+      - High
       flat_name: threat.enrichments.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -15634,9 +15666,13 @@ threat:
     threat.enrichments.indicator.marking.tlp:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-marking-tlp
-      description: "Traffic Light Protocol sharing markings. Recommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
-      example: White
+      description: Traffic Light Protocol sharing markings.
+      example: WHITE
+      expected_values:
+      - WHITE
+      - GREEN
+      - AMBER
+      - RED
       flat_name: threat.enrichments.indicator.marking.tlp
       ignore_above: 1024
       level: extended
@@ -15813,12 +15849,26 @@ threat:
     threat.enrichments.indicator.type:
       beta: This field is beta and subject to change.
       dashed_name: threat-enrichments-indicator-type
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\
-        \ Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
+      expected_values:
+      - autonomous-system
+      - artifact
+      - directory
+      - domain-name
+      - email-addr
+      - file
+      - ipv4-addr
+      - ipv6-addr
+      - mac-addr
+      - mutex
+      - port
+      - process
+      - software
+      - url
+      - user-account
+      - windows-registry-key
+      - x509-certificate
       flat_name: threat.enrichments.indicator.type
       ignore_above: 1024
       level: extended
@@ -16567,11 +16617,16 @@ threat:
       type: keyword
     threat.indicator.confidence:
       dashed_name: threat-indicator-confidence
-      description: "Identifies\_the\_vendor-neutral confidence\_rating\_using\_the\
-        \ None/Low/Medium/High\_scale defined in Appendix A of the STIX 2.1 framework.\
-        \ Vendor-specific confidence scales may be added as custom fields.\nExpected\
-        \ values are:\n  * Not Specified\n  * None\n  * Low\n  * Medium\n  * High"
+      description: Identifies the vendor-neutral confidence rating using the None/Low/Medium/High
+        scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific confidence
+        scales may be added as custom fields.
       example: Medium
+      expected_values:
+      - Not Specified
+      - None
+      - Low
+      - Medium
+      - High
       flat_name: threat.indicator.confidence
       ignore_above: 1024
       level: extended
@@ -18015,9 +18070,13 @@ threat:
       type: date
     threat.indicator.marking.tlp:
       dashed_name: threat-indicator-marking-tlp
-      description: "Traffic Light Protocol sharing markings.\nRecommended values are:\n\
-        \  * WHITE\n  * GREEN\n  * AMBER\n  * RED"
+      description: Traffic Light Protocol sharing markings.
       example: WHITE
+      expected_values:
+      - WHITE
+      - GREEN
+      - AMBER
+      - RED
       flat_name: threat.indicator.marking.tlp
       ignore_above: 1024
       level: extended
@@ -18187,12 +18246,26 @@ threat:
       type: long
     threat.indicator.type:
       dashed_name: threat-indicator-type
-      description: "Type of indicator as represented by Cyber Observable in STIX 2.0.\n\
-        Recommended values:\n  * autonomous-system\n  * artifact\n  * directory\n\
-        \  * domain-name\n  * email-addr\n  * file\n  * ipv4-addr\n  * ipv6-addr\n\
-        \  * mac-addr\n  * mutex\n  * port\n  * process\n  * software\n  * url\n \
-        \ * user-account\n  * windows-registry-key\n  * x509-certificate"
+      description: Type of indicator as represented by Cyber Observable in STIX 2.0.
       example: ipv4-addr
+      expected_values:
+      - autonomous-system
+      - artifact
+      - directory
+      - domain-name
+      - email-addr
+      - file
+      - ipv4-addr
+      - ipv6-addr
+      - mac-addr
+      - mutex
+      - port
+      - process
+      - software
+      - url
+      - user-account
+      - windows-registry-key
+      - x509-certificate
       flat_name: threat.indicator.type
       ignore_above: 1024
       level: extended
@@ -18769,11 +18842,20 @@ threat:
     threat.software.platforms:
       dashed_name: threat-software-platforms
       description: "The platforms of the software used by this threat to conduct behavior\
-        \ commonly modeled using MITRE ATT&CK\xAE.\nRecommended Values:\n  * AWS\n\
-        \  * Azure\n  * Azure AD\n  * GCP\n  * Linux\n  * macOS\n  * Network\n  *\
-        \ Office 365\n  * SaaS\n  * Windows\n\nWhile not required, you can use a MITRE\
-        \ ATT&CK\xAE software platforms."
+        \ commonly modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use\
+        \ MITRE ATT&CK\xAE software platform values."
       example: '[ "Windows" ]'
+      expected_values:
+      - AWS
+      - Azure
+      - Azure AD
+      - GCP
+      - Linux
+      - macOS
+      - Network
+      - Office 365
+      - SaaS
+      - Windows
       flat_name: threat.software.platforms
       ignore_above: 1024
       level: extended
@@ -18798,9 +18880,12 @@ threat:
     threat.software.type:
       dashed_name: threat-software-type
       description: "The type of software used by this threat to conduct behavior commonly\
-        \ modeled using MITRE ATT&CK\xAE.\nRecommended values\n  * Malware\n  * Tool\n\
-        \n While not required, you can use a MITRE ATT&CK\xAE software type."
+        \ modeled using MITRE ATT&CK\xAE.\nWhile not required, you can use a MITRE\
+        \ ATT&CK\xAE software type."
       example: Tool
+      expected_values:
+      - Malware
+      - Tool
       flat_name: threat.software.type
       ignore_above: 1024
       level: extended
@@ -20984,13 +21069,15 @@ user_agent:
       description: 'Use the `os.type` field to categorize the operating system into
         one of the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix,
-        windows.
-
-        If the OS you''re dealing with is not in the list, the field should not be
-        populated. Please let us know by opening an issue with ECS, to propose its
-        addition.'
+        If the OS you''re dealing with is not listed as an expected value, the field
+        should not be populated. Please let us know by opening an issue with ECS,
+        to propose its addition.'
       example: macos
+      expected_values:
+      - linux
+      - macos
+      - unix
+      - windows
       flat_name: user_agent.os.type
       ignore_above: 1024
       level: extended

--- a/schemas/dns.yml
+++ b/schemas/dns.yml
@@ -68,8 +68,14 @@
       short: Array of DNS header flags.
       description: >
         Array of 2 letter DNS header flags.
-
-        Expected values are: AA, TC, RD, RA, AD, CD, DO.
+      expected_values:
+        - AA
+        - TC
+        - RD
+        - RA
+        - AD
+        - CD
+        - DO
       example: "[\"RD\", \"RA\"]"
       normalize:
         - array

--- a/schemas/faas.yml
+++ b/schemas/faas.yml
@@ -69,13 +69,12 @@
       short: The trigger for the function execution.
       description: >
         The trigger for the function execution.
-
-        Expected values are:
-          * http
-          * pubsub
-          * datasource
-          * timer
-          * other
+      expected_values:
+        - http
+        - pubsub
+        - datasource
+        - timer
+        - other
       example: http
     - name: trigger.request_id
       level: extended

--- a/schemas/network.yml
+++ b/schemas/network.yml
@@ -99,15 +99,6 @@
       description: >
         Direction of the network traffic.
 
-        Recommended values are:
-          * ingress
-          * egress
-          * inbound
-          * outbound
-          * internal
-          * external
-          * unknown
-
         When mapping events from a host-based monitoring context, populate this
         field from the host's point of view, using the values "ingress" or "egress".
 
@@ -120,6 +111,14 @@
         that "external" is meant to describe traffic between two hosts that are
         external to the perimeter. This could for example be useful for ISPs or
         VPN service providers.
+      expected_values:
+        - ingress
+        - egress
+        - inbound
+        - outbound
+        - internal
+        - external
+        - unknown
       example: inbound
 
     - name: forwarded_ip

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -38,10 +38,13 @@
         Use the `os.type` field to categorize the operating system into one of
         the broad commercial families.
 
-        One of these following values should be used (lowercase): linux, macos, unix, windows.
-
-        If the OS you're dealing with is not in the list, the field should not be populated.
+        If the OS you're dealing with is not listed as an expected value, the field should not be populated.
         Please let us know by opening an issue with ECS, to propose its addition.
+      expected_values:
+        - linux
+        - macos
+        - unix
+        - windows
       example: macos
 
     - name: platform

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -92,24 +92,24 @@
       beta: This field is beta and subject to change.
       description: >
         Type of indicator as represented by Cyber Observable in STIX 2.0.
-        Recommended values:
-          * autonomous-system
-          * artifact
-          * directory
-          * domain-name
-          * email-addr
-          * file
-          * ipv4-addr
-          * ipv6-addr
-          * mac-addr
-          * mutex
-          * port
-          * process
-          * software
-          * url
-          * user-account
-          * windows-registry-key
-          * x509-certificate
+      expected_values:
+        - autonomous-system
+        - artifact
+        - directory
+        - domain-name
+        - email-addr
+        - file
+        - ipv4-addr
+        - ipv6-addr
+        - mac-addr
+        - mutex
+        - port
+        - process
+        - software
+        - url
+        - user-account
+        - windows-registry-key
+        - x509-certificate
       example: ipv4-addr
 
     - name: enrichments.indicator.description
@@ -136,15 +136,14 @@
       short: Indicator confidence rating
       beta: This field is beta and subject to change.
       description: >
-        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
+        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
         confidence scales may be added as custom fields.
-
-        Expected values are:
-          * Not Specified
-          * None
-          * Low
-          * Medium
-          * High
+      expected_values:
+        - Not Specified
+        - None
+        - Low
+        - Medium
+        - High
       example: Medium
 
     - name: enrichments.indicator.ip
@@ -181,12 +180,12 @@
       beta: This field is beta and subject to change.
       description: >
         Traffic Light Protocol sharing markings.
-        Recommended values are:
-          * WHITE
-          * GREEN
-          * AMBER
-          * RED
-      example: White
+      expected_values:
+        - WHITE
+        - GREEN
+        - AMBER
+        - RED
+      example: WHITE
 
     - name: enrichments.indicator.reference
       level: extended
@@ -385,26 +384,24 @@
       short: Type of indicator
       description: >
         Type of indicator as represented by Cyber Observable in STIX 2.0.
-
-        Recommended values:
-          * autonomous-system
-          * artifact
-          * directory
-          * domain-name
-          * email-addr
-          * file
-          * ipv4-addr
-          * ipv6-addr
-          * mac-addr
-          * mutex
-          * port
-          * process
-          * software
-          * url
-          * user-account
-          * windows-registry-key
-          * x509-certificate
-
+      expected_values:
+        - autonomous-system
+        - artifact
+        - directory
+        - domain-name
+        - email-addr
+        - file
+        - ipv4-addr
+        - ipv6-addr
+        - mac-addr
+        - mutex
+        - port
+        - process
+        - software
+        - url
+        - user-account
+        - windows-registry-key
+        - x509-certificate
       example: ipv4-addr
 
     - name: indicator.description
@@ -430,15 +427,14 @@
       type: keyword
       short: Indicator confidence rating
       description: >
-        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
+        Identifies the vendor-neutral confidence rating using the None/Low/Medium/High scale defined in Appendix A of the STIX 2.1 framework. Vendor-specific
         confidence scales may be added as custom fields.
-
-        Expected values are:
-          * Not Specified
-          * None
-          * Low
-          * Medium
-          * High
+      expected_values:
+        - Not Specified
+        - None
+        - Low
+        - Medium
+        - High
       example: Medium
 
     - name: indicator.ip
@@ -474,13 +470,11 @@
       short: Indicator TLP marking
       description: >
         Traffic Light Protocol sharing markings.
-
-        Recommended values are:
-          * WHITE
-          * GREEN
-          * AMBER
-          * RED
-
+      expected_values:
+        - WHITE
+        - GREEN
+        - AMBER
+        - RED
       example: WHITE
 
     - name: indicator.reference
@@ -539,19 +533,18 @@
       description: >
         The platforms of the software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-        Recommended Values:
-          * AWS
-          * Azure
-          * Azure AD
-          * GCP
-          * Linux
-          * macOS
-          * Network
-          * Office 365
-          * SaaS
-          * Windows
-
-        While not required, you can use a MITRE ATT&CK® software platforms.
+        While not required, you can use MITRE ATT&CK® software platform values.
+      expected_values:
+        - AWS
+        - Azure
+        - Azure AD
+        - GCP
+        - Linux
+        - macOS
+        - Network
+        - Office 365
+        - SaaS
+        - Windows
       example: '[ "Windows" ]'
       normalize:
         - array
@@ -573,11 +566,10 @@
       description: >
         The type of software used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
 
-        Recommended values
-          * Malware
-          * Tool
-
-         While not required, you can use a MITRE ATT&CK® software type.
+        While not required, you can use a MITRE ATT&CK® software type.
+      expected_values:
+        - Malware
+        - Tool
       example: "Tool"
 
     - name: tactic.id
@@ -604,7 +596,6 @@
       normalize:
         - array
 
-
     - name: tactic.reference
       level: extended
       type: keyword
@@ -616,7 +607,6 @@
       example: https://attack.mitre.org/tactics/TA0002/
       normalize:
         - array
-
 
     - name: technique.id
       level: extended


### PR DESCRIPTION
### Summary

Define the `expected_values` parameter added in #1952.

This set of fields already defined expected or recommended values in the field descriptions.

### Updated fields

* `dns.header_flags`
* `faas.trigger.type`
* `network.direction`
* `os.type`
* `threat.enrichments.indicator.type`
* `threat.enrichments.indicator.confidence`
* `threat.enrichments.indicator.marking.tlp`
* `threat.indicator.type`
* `threat.indicator.confidence`
* `threat.indicator.marking.tlp`
* `threat.software.platforms`
* `threat.software.type`

### Other changes

* Correct example from `White` to `WHITE` on `threat.enrichments.indicator.marking.tlp`.