### PR TITLE
Deprecate service.node.role

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -40,7 +40,7 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-* Deprecate `service.node.role` in favor of upcoming `service.node.roles`. #XXXX
+* Deprecate `service.node.role` in favor of upcoming `service.node.roles`. #1976
 
 <!-- All empty sections:
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -34,6 +34,14 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
+## 8.3.1
+
+### Schema Changes
+
+#### Deprecated
+
+* Deprecate `service.node.role` in favor of upcoming `service.node.roles`. #XXXX
+
 <!-- All empty sections:
 
 ## Unreleased

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8637,7 +8637,9 @@ example: `instance-0000000016`
 [[field-service-node-role]]
 <<field-service-node-role, service.node.role>>
 
-| Role of a service node.
+| Deprecated for removal in next major version release. This field will be superseded by `node.roles`.
+
+Role of a service node.
 
 This allows for distinction between different running roles of the same service.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -7654,7 +7654,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -7749,7 +7752,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -7877,7 +7883,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -896,14 +896,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0+exp,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0+exp,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0+exp,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0+exp,true,service,service.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0+exp,true,service,service.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0+exp,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.3.0+exp,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.3.0+exp,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.3.0+exp,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0+exp,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0+exp,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0+exp,true,service,service.origin.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0+exp,true,service,service.origin.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0+exp,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.3.0+exp,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0+exp,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -914,7 +914,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0+exp,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0+exp,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0+exp,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0+exp,true,service,service.target.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0+exp,true,service,service.target.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0+exp,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.3.0+exp,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0+exp,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11248,7 +11248,10 @@ service.node.name:
   type: keyword
 service.node.role:
   dashed_name: service-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11264,7 +11267,7 @@ service.node.role:
   level: extended
   name: node.role
   normalize: []
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -11376,7 +11379,10 @@ service.origin.node.name:
   type: keyword
 service.origin.node.role:
   dashed_name: service-origin-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11393,7 +11399,7 @@ service.origin.node.role:
   name: node.role
   normalize: []
   original_fieldset: service
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11558,7 +11564,10 @@ service.target.node.name:
   type: keyword
 service.target.node.role:
   dashed_name: service-target-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11575,7 +11584,7 @@ service.target.node.role:
   name: node.role
   normalize: []
   original_fieldset: service
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13246,7 +13246,10 @@ service:
       type: keyword
     service.node.role:
       dashed_name: service-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13263,7 +13266,7 @@ service:
       level: extended
       name: node.role
       normalize: []
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -13376,7 +13379,10 @@ service:
       type: keyword
     service.origin.node.role:
       dashed_name: service-origin-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13394,7 +13400,7 @@ service:
       name: node.role
       normalize: []
       original_fieldset: service
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13560,7 +13566,10 @@ service:
       type: keyword
     service.target.node.role:
       dashed_name: service-target-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13578,7 +13587,7 @@ service:
       name: node.role
       normalize: []
       original_fieldset: service
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -7604,7 +7604,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -7699,7 +7702,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -7827,7 +7833,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -889,14 +889,14 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0,true,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0,true,service,service.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0,true,service,service.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.3.0,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.3.0,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
 8.3.0,true,service,service.origin.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0,true,service,service.origin.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0,true,service,service.origin.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.3.0,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -907,7 +907,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.3.0,true,service,service.target.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
 8.3.0,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.3.0,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
-8.3.0,true,service,service.target.node.role,keyword,extended,,background-tasks,Role of the service node.
+8.3.0,true,service,service.target.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
 8.3.0,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.3.0,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.3.0,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -11179,7 +11179,10 @@ service.node.name:
   type: keyword
 service.node.role:
   dashed_name: service-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11195,7 +11198,7 @@ service.node.role:
   level: extended
   name: node.role
   normalize: []
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.origin.address:
   dashed_name: service-origin-address
@@ -11307,7 +11310,10 @@ service.origin.node.name:
   type: keyword
 service.origin.node.role:
   dashed_name: service-origin-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11324,7 +11330,7 @@ service.origin.node.role:
   name: node.role
   normalize: []
   original_fieldset: service
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11489,7 +11495,10 @@ service.target.node.name:
   type: keyword
 service.target.node.role:
   dashed_name: service-target-node-role
-  description: 'Role of a service node.
+  description: 'Deprecated for removal in next major version release. This field will
+    be superseded by `node.roles`.
+
+    Role of a service node.
 
     This allows for distinction between different running roles of the same service.
 
@@ -11506,7 +11515,7 @@ service.target.node.role:
   name: node.role
   normalize: []
   original_fieldset: service
-  short: Role of the service node.
+  short: Deprecated role (singular) of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -13166,7 +13166,10 @@ service:
       type: keyword
     service.node.role:
       dashed_name: service-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13183,7 +13186,7 @@ service:
       level: extended
       name: node.role
       normalize: []
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.origin.address:
       dashed_name: service-origin-address
@@ -13296,7 +13299,10 @@ service:
       type: keyword
     service.origin.node.role:
       dashed_name: service-origin-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13314,7 +13320,7 @@ service:
       name: node.role
       normalize: []
       original_fieldset: service
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13480,7 +13486,10 @@ service:
       type: keyword
     service.target.node.role:
       dashed_name: service-target-node-role
-      description: 'Role of a service node.
+      description: 'Deprecated for removal in next major version release. This field
+        will be superseded by `node.roles`.
+
+        Role of a service node.
 
         This allows for distinction between different running roles of the same service.
 
@@ -13498,7 +13507,7 @@ service:
       name: node.role
       normalize: []
       original_fieldset: service
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -120,8 +120,11 @@
       level: extended
       type: keyword
       example: "background-tasks"
-      short: Role of the service node.
+      short: Deprecated role (singular) of the service node.
       description: >
+        Deprecated for removal in next major version release. This field will be superseded by
+        `node.roles`.
+
         Role of a service node.
 
         This allows for distinction between different running roles of the same service.


### PR DESCRIPTION
As per https://github.com/elastic/ecs/issues/1965 , we are deprecating singular `service.node.role` in favor of upcoming plural `service.node.roles`. 