### PR TITLE
Adding service.node.roles

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8661,6 +8661,33 @@ example: `background-tasks`
 // ===============================================================
 
 |
+[[field-service-node-roles]]
+<<field-service-node-roles, service.node.roles>>
+
+a| Roles of a service node.
+
+This allows for distinction between different running roles of the same service.
+
+In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks` or both.
+
+In the case of Elasticsearch, the `service.node.role` could be `master` or `data or both`.
+
+Other services could use this to distinguish between a `web` and `worker` role running as part of the service.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `["ui", "background-tasks"]`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-service-state]]
 <<field-service-state, service.state>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -7660,6 +7660,24 @@
         role running as part of the service.'
       example: background-tasks
       default_field: false
+    - name: node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      default_field: false
     - name: origin.address
       level: extended
       type: keyword
@@ -7757,6 +7775,24 @@
         Other services could use this to distinguish between a `web` and `worker`
         role running as part of the service.'
       example: background-tasks
+      default_field: false
+    - name: origin.node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
       default_field: false
     - name: origin.state
       level: core
@@ -7888,6 +7924,24 @@
         Other services could use this to distinguish between a `web` and `worker`
         role running as part of the service.'
       example: background-tasks
+      default_field: false
+    - name: target.node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
       default_field: false
     - name: target.state
       level: core

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -897,6 +897,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev+exp,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev+exp,true,service,service.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev+exp,true,service,service.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev+exp,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.5.0-dev+exp,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.5.0-dev+exp,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -904,6 +905,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev+exp,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev+exp,true,service,service.origin.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev+exp,true,service,service.origin.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev+exp,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.5.0-dev+exp,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.5.0-dev+exp,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -915,6 +917,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev+exp,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev+exp,true,service,service.target.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev+exp,true,service,service.target.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev+exp,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.5.0-dev+exp,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.5.0-dev+exp,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11296,6 +11296,29 @@ service.node.role:
   normalize: []
   short: Deprecated role (singular) of the service node.
   type: keyword
+service.node.roles:
+  dashed_name: service-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  short: Roles of the service node.
+  type: keyword
 service.origin.address:
   dashed_name: service-origin-address
   description: 'Address where data about this service was collected from.
@@ -11427,6 +11450,30 @@ service.origin.node.role:
   normalize: []
   original_fieldset: service
   short: Deprecated role (singular) of the service node.
+  type: keyword
+service.origin.node.roles:
+  dashed_name: service-origin-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.origin.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  original_fieldset: service
+  short: Roles of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11612,6 +11659,30 @@ service.target.node.role:
   normalize: []
   original_fieldset: service
   short: Deprecated role (singular) of the service node.
+  type: keyword
+service.target.node.roles:
+  dashed_name: service-target-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.target.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  original_fieldset: service
+  short: Roles of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13295,6 +13295,29 @@ service:
       normalize: []
       short: Deprecated role (singular) of the service node.
       type: keyword
+    service.node.roles:
+      dashed_name: service-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      short: Roles of the service node.
+      type: keyword
     service.origin.address:
       dashed_name: service-origin-address
       description: 'Address where data about this service was collected from.
@@ -13428,6 +13451,30 @@ service:
       normalize: []
       original_fieldset: service
       short: Deprecated role (singular) of the service node.
+      type: keyword
+    service.origin.node.roles:
+      dashed_name: service-origin-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.origin.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      original_fieldset: service
+      short: Roles of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13615,6 +13662,30 @@ service:
       normalize: []
       original_fieldset: service
       short: Deprecated role (singular) of the service node.
+      type: keyword
+    service.target.node.roles:
+      dashed_name: service-target-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.target.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      original_fieldset: service
+      short: Roles of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/experimental/generated/elasticsearch/composable/component/service.json
+++ b/experimental/generated/elasticsearch/composable/component/service.json
@@ -37,6 +37,10 @@
                 "role": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -69,6 +73,10 @@
                       "type": "keyword"
                     },
                     "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }
@@ -121,6 +129,10 @@
                       "type": "keyword"
                     },
                     "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -4258,6 +4258,10 @@
               "role": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "roles": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -4290,6 +4294,10 @@
                     "type": "keyword"
                   },
                   "role": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "roles": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }
@@ -4342,6 +4350,10 @@
                     "type": "keyword"
                   },
                   "role": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "roles": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -7610,6 +7610,24 @@
         role running as part of the service.'
       example: background-tasks
       default_field: false
+    - name: node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      default_field: false
     - name: origin.address
       level: extended
       type: keyword
@@ -7707,6 +7725,24 @@
         Other services could use this to distinguish between a `web` and `worker`
         role running as part of the service.'
       example: background-tasks
+      default_field: false
+    - name: origin.node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
       default_field: false
     - name: origin.state
       level: core
@@ -7838,6 +7874,24 @@
         Other services could use this to distinguish between a `web` and `worker`
         role running as part of the service.'
       example: background-tasks
+      default_field: false
+    - name: target.node.roles
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
       default_field: false
     - name: target.state
       level: core

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -890,6 +890,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev,true,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev,true,service,service.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev,true,service,service.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev,true,service,service.origin.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.5.0-dev,true,service,service.origin.environment,keyword,extended,,production,Environment of the service.
 8.5.0-dev,true,service,service.origin.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
@@ -897,6 +898,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,service,service.origin.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev,true,service,service.origin.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev,true,service,service.origin.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev,true,service,service.origin.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev,true,service,service.origin.state,keyword,core,,,Current state of the service.
 8.5.0-dev,true,service,service.origin.type,keyword,core,,elasticsearch,The type of the service.
 8.5.0-dev,true,service,service.origin.version,keyword,core,,3.2.4,Version of the service.
@@ -908,6 +910,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,service,service.target.name,keyword,core,,elasticsearch-metrics,Name of the service.
 8.5.0-dev,true,service,service.target.node.name,keyword,extended,,instance-0000000016,Name of the service node.
 8.5.0-dev,true,service,service.target.node.role,keyword,extended,,background-tasks,Deprecated role (singular) of the service node.
+8.5.0-dev,true,service,service.target.node.roles,keyword,extended,array,"[""ui"", ""background-tasks""]",Roles of the service node.
 8.5.0-dev,true,service,service.target.state,keyword,core,,,Current state of the service.
 8.5.0-dev,true,service,service.target.type,keyword,core,,elasticsearch,The type of the service.
 8.5.0-dev,true,service,service.target.version,keyword,core,,3.2.4,Version of the service.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -11227,6 +11227,29 @@ service.node.role:
   normalize: []
   short: Deprecated role (singular) of the service node.
   type: keyword
+service.node.roles:
+  dashed_name: service-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  short: Roles of the service node.
+  type: keyword
 service.origin.address:
   dashed_name: service-origin-address
   description: 'Address where data about this service was collected from.
@@ -11358,6 +11381,30 @@ service.origin.node.role:
   normalize: []
   original_fieldset: service
   short: Deprecated role (singular) of the service node.
+  type: keyword
+service.origin.node.roles:
+  dashed_name: service-origin-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.origin.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  original_fieldset: service
+  short: Roles of the service node.
   type: keyword
 service.origin.state:
   dashed_name: service-origin-state
@@ -11543,6 +11590,30 @@ service.target.node.role:
   normalize: []
   original_fieldset: service
   short: Deprecated role (singular) of the service node.
+  type: keyword
+service.target.node.roles:
+  dashed_name: service-target-node-roles
+  description: 'Roles of a service node.
+
+    This allows for distinction between different running roles of the same service.
+
+    In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+    or both.
+
+    In the case of Elasticsearch, the `service.node.role` could be `master` or `data
+    or both`.
+
+    Other services could use this to distinguish between a `web` and `worker` role
+    running as part of the service.'
+  example: '["ui", "background-tasks"]'
+  flat_name: service.target.node.roles
+  ignore_above: 1024
+  level: extended
+  name: node.roles
+  normalize:
+  - array
+  original_fieldset: service
+  short: Roles of the service node.
   type: keyword
 service.target.state:
   dashed_name: service-target-state

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -13215,6 +13215,29 @@ service:
       normalize: []
       short: Deprecated role (singular) of the service node.
       type: keyword
+    service.node.roles:
+      dashed_name: service-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      short: Roles of the service node.
+      type: keyword
     service.origin.address:
       dashed_name: service-origin-address
       description: 'Address where data about this service was collected from.
@@ -13348,6 +13371,30 @@ service:
       normalize: []
       original_fieldset: service
       short: Deprecated role (singular) of the service node.
+      type: keyword
+    service.origin.node.roles:
+      dashed_name: service-origin-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.origin.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      original_fieldset: service
+      short: Roles of the service node.
       type: keyword
     service.origin.state:
       dashed_name: service-origin-state
@@ -13535,6 +13582,30 @@ service:
       normalize: []
       original_fieldset: service
       short: Deprecated role (singular) of the service node.
+      type: keyword
+    service.target.node.roles:
+      dashed_name: service-target-node-roles
+      description: 'Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks`
+        or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or
+        `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker`
+        role running as part of the service.'
+      example: '["ui", "background-tasks"]'
+      flat_name: service.target.node.roles
+      ignore_above: 1024
+      level: extended
+      name: node.roles
+      normalize:
+      - array
+      original_fieldset: service
+      short: Roles of the service node.
       type: keyword
     service.target.state:
       dashed_name: service-target-state

--- a/generated/elasticsearch/composable/component/service.json
+++ b/generated/elasticsearch/composable/component/service.json
@@ -37,6 +37,10 @@
                 "role": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "roles": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
                 }
               }
             },
@@ -69,6 +73,10 @@
                       "type": "keyword"
                     },
                     "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }
@@ -121,6 +129,10 @@
                       "type": "keyword"
                     },
                     "role": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "roles": {
                       "ignore_above": 1024,
                       "type": "keyword"
                     }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -4216,6 +4216,10 @@
               "role": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "roles": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -4248,6 +4252,10 @@
                     "type": "keyword"
                   },
                   "role": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "roles": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }
@@ -4300,6 +4308,10 @@
                     "type": "keyword"
                   },
                   "role": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "roles": {
                     "ignore_above": 1024,
                     "type": "keyword"
                   }

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -135,6 +135,22 @@
 
         Other services could use this to distinguish between a `web` and `worker` role running as part of the service.
 
+    - name: node.roles
+      level: extended
+      type: keyword
+      example: ['ui', 'background-tasks']
+      short: Roles of the service node.
+      description: >
+        Roles of a service node.
+
+        This allows for distinction between different running roles of the same service.
+
+        In the case of Kibana, the `service.node.role` could be `ui` or `background-tasks` or both.
+
+        In the case of Elasticsearch, the `service.node.role` could be `master` or `data or both`.
+
+        Other services could use this to distinguish between a `web` and `worker` role running as part of the service.
+
     - name: type
       level: core
       type: keyword

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -138,7 +138,7 @@
     - name: node.roles
       level: extended
       type: keyword
-      example: ['ui', 'background-tasks']
+      example: ["ui", "background-tasks"]
       normalize:
         - array
       short: Roles of the service node.

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -138,7 +138,7 @@
     - name: node.roles
       level: extended
       type: keyword
-      example: ["ui", "background-tasks"]
+      example: "[\"ui\", \"background-tasks\"]"
       normalize:
         - array
       short: Roles of the service node.

--- a/schemas/service.yml
+++ b/schemas/service.yml
@@ -139,6 +139,8 @@
       level: extended
       type: keyword
       example: ['ui', 'background-tasks']
+      normalize:
+        - array
       short: Roles of the service node.
       description: >
         Roles of a service node.


### PR DESCRIPTION
Adding the _plural_ `service.node.roles` field per https://github.com/elastic/ecs/issues/1965

@lukeelmers / @matschaffer let me know if you want any tweaks to the description. I mostly kept what you had for the singlular.