### PR TITLE
Added `ios` and `android` as valid values for `os.type`

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -6682,6 +6682,8 @@ Expected values for this field:
 * `macos`
 * `unix`
 * `windows`
+* `ios`
+* `android`
 
 type: keyword
 

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -390,7 +390,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev+exp,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev+exp,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev+exp,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev+exp,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev+exp,true,host,host.pid_ns_ino,keyword,extended,,256383,Pid namespace inode
 8.6.0-dev+exp,true,host,host.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
@@ -486,7 +486,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev+exp,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev+exp,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev+exp,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev+exp,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev+exp,true,observer,observer.product,keyword,extended,,s200,The product name of the observer.
 8.6.0-dev+exp,true,observer,observer.serial_number,keyword,extended,,,Observer serial number.
@@ -1532,7 +1532,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev+exp,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev+exp,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev+exp,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev+exp,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev+exp,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev+exp,true,user_agent,user_agent.version,keyword,extended,,12.0,Version of the user agent.
 8.6.0-dev+exp,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5214,13 +5214,16 @@ host.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: host.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 host.os.version:
   dashed_name: host-os-version
@@ -6453,13 +6456,16 @@ observer.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: observer.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 observer.os.version:
   dashed_name: observer-os-version
@@ -19334,13 +19340,16 @@ user_agent.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: user_agent.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 user_agent.os.version:
   dashed_name: user-agent-os-version

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6483,13 +6483,16 @@ host:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: host.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     host.os.version:
       dashed_name: host-os-version
@@ -7844,13 +7847,16 @@ observer:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: observer.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     observer.os.version:
       dashed_name: observer-os-version
@@ -8222,12 +8228,15 @@ os:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     os.version:
       dashed_name: os-version
@@ -21729,13 +21738,16 @@ user_agent:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: user_agent.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     user_agent.os.version:
       dashed_name: user-agent-os-version

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -383,7 +383,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev,true,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,host,host.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev,true,host,host.pid_ns_ino,keyword,extended,,256383,Pid namespace inode
 8.6.0-dev,true,host,host.type,keyword,core,,,Type of host.
@@ -473,7 +473,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev,true,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,observer,observer.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev,true,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev,true,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev,true,observer,observer.product,keyword,extended,,s200,The product name of the observer.
 8.6.0-dev,true,observer,observer.serial_number,keyword,extended,,,Observer serial number.
@@ -1495,7 +1495,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0-dev,true,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,user_agent,user_agent.os.name.text,match_only_text,extended,,Mac OS X,"Operating system name, without the version."
 8.6.0-dev,true,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
-8.6.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+8.6.0-dev,true,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.6.0-dev,true,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.6.0-dev,true,user_agent,user_agent.version,keyword,extended,,12.0,Version of the user agent.
 8.6.0-dev,true,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -5145,13 +5145,16 @@ host.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: host.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 host.os.version:
   dashed_name: host-os-version
@@ -6301,13 +6304,16 @@ observer.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: observer.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 observer.os.version:
   dashed_name: observer-os-version
@@ -18850,13 +18856,16 @@ user_agent.os.type:
   - macos
   - unix
   - windows
+  - ios
+  - android
   flat_name: user_agent.os.type
   ignore_above: 1024
   level: extended
   name: type
   normalize: []
   original_fieldset: os
-  short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+  short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or
+    android).'
   type: keyword
 user_agent.os.version:
   dashed_name: user-agent-os-version

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6403,13 +6403,16 @@ host:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: host.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     host.os.version:
       dashed_name: host-os-version
@@ -7676,13 +7679,16 @@ observer:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: observer.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     observer.os.version:
       dashed_name: observer-os-version
@@ -8054,12 +8060,15 @@ os:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     os.version:
       dashed_name: os-version
@@ -21125,13 +21134,16 @@ user_agent:
       - macos
       - unix
       - windows
+      - ios
+      - android
       flat_name: user_agent.os.type
       ignore_above: 1024
       level: extended
       name: type
       normalize: []
       original_fieldset: os
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios
+        or android).'
       type: keyword
     user_agent.os.version:
       dashed_name: user-agent-os-version

--- a/schemas/os.yml
+++ b/schemas/os.yml
@@ -33,7 +33,7 @@
     - name: type
       level: extended
       type: keyword
-      short: 'Which commercial OS family (one of: linux, macos, unix or windows).'
+      short: 'Which commercial OS family (one of: linux, macos, unix, windows, ios or android).'
       description: >
         Use the `os.type` field to categorize the operating system into one of
         the broad commercial families.
@@ -45,6 +45,8 @@
         - macos
         - unix
         - windows
+        - ios
+        - android
       example: macos
 
     - name: platform


### PR DESCRIPTION
Closes #1995 

Adds `ios` and `android` as valid values for the `os.type` field to support mobile use cases (E.g. APM / distributed tracing in mobile devices).

/cc @simitt, @felixbarny 
