### PR TITLE
[8.5] Fixing risk short fields (#2010)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -42,7 +42,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
-* Adding `risk.*` fields as experimental. #1994
+* Adding `risk.*` fields as experimental. #1994, #2010
 
 #### Improvements
 

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -395,10 +395,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,host,host.pid_ns_ino,keyword,extended,,256383,Pid namespace inode
 8.5.0-dev+exp,true,host,host.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
 8.5.0-dev+exp,true,host,host.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
-8.5.0-dev+exp,true,host,host.risk.calculated_score_norm,float,extended,,88.73,"A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,host,host.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
 8.5.0-dev+exp,true,host,host.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
 8.5.0-dev+exp,true,host,host.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
-8.5.0-dev+exp,true,host,host.risk.static_score_norm,float,extended,,83.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,host,host.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,host,host.type,keyword,core,,,Type of host.
 8.5.0-dev+exp,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 8.5.0-dev+exp,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
@@ -1462,10 +1462,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,user,user.changes.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,user,user.changes.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
 8.5.0-dev+exp,true,user,user.changes.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
-8.5.0-dev+exp,true,user,user.changes.risk.calculated_score_norm,float,extended,,88.73,"A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.changes.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
 8.5.0-dev+exp,true,user,user.changes.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
 8.5.0-dev+exp,true,user,user.changes.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
-8.5.0-dev+exp,true,user,user.changes.risk.static_score_norm,float,extended,,83.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.changes.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.5.0-dev+exp,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
@@ -1481,10 +1481,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,user,user.effective.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,user,user.effective.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
 8.5.0-dev+exp,true,user,user.effective.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
-8.5.0-dev+exp,true,user,user.effective.risk.calculated_score_norm,float,extended,,88.73,"A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.effective.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
 8.5.0-dev+exp,true,user,user.effective.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
 8.5.0-dev+exp,true,user,user.effective.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
-8.5.0-dev+exp,true,user,user.effective.risk.static_score_norm,float,extended,,83.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.effective.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,user,user.email,keyword,extended,,,User email address.
 8.5.0-dev+exp,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
@@ -1498,10 +1498,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,user,user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,user,user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
 8.5.0-dev+exp,true,user,user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
-8.5.0-dev+exp,true,user,user.risk.calculated_score_norm,float,extended,,88.73,"A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
 8.5.0-dev+exp,true,user,user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
 8.5.0-dev+exp,true,user,user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
-8.5.0-dev+exp,true,user,user.risk.static_score_norm,float,extended,,83.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.5.0-dev+exp,true,user,user.target.email,keyword,extended,,,User email address.
@@ -1516,10 +1516,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,user,user.target.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,user,user.target.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
 8.5.0-dev+exp,true,user,user.target.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
-8.5.0-dev+exp,true,user,user.target.risk.calculated_score_norm,float,extended,,88.73,"A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.target.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
 8.5.0-dev+exp,true,user,user.target.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
 8.5.0-dev+exp,true,user,user.target.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
-8.5.0-dev+exp,true,user,user.target.risk.static_score_norm,float,extended,,83.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100."
+8.5.0-dev+exp,true,user,user.target.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 8.5.0-dev+exp,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -5285,8 +5285,7 @@ host.risk.calculated_score_norm:
   name: calculated_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score calculated by an internal system as part of entity
-    analytics and entity risk scoring, and normalized to a range of 0 to 100.
+  short: A normalized risk score calculated by an internal system.
   type: float
 host.risk.static_level:
   dashed_name: host-risk-static-level
@@ -5326,9 +5325,7 @@ host.risk.static_score_norm:
   name: static_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score obtained from outside the system, such as from
-    some external Threat Intelligence Platform, and normalized to a range of 0 to
-    100.
+  short: A normalized risk score calculated by an external system.
   type: float
 host.type:
   dashed_name: host-type
@@ -18521,8 +18518,7 @@ user.changes.risk.calculated_score_norm:
   name: calculated_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score calculated by an internal system as part of entity
-    analytics and entity risk scoring, and normalized to a range of 0 to 100.
+  short: A normalized risk score calculated by an internal system.
   type: float
 user.changes.risk.static_level:
   dashed_name: user-changes-risk-static-level
@@ -18562,9 +18558,7 @@ user.changes.risk.static_score_norm:
   name: static_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score obtained from outside the system, such as from
-    some external Threat Intelligence Platform, and normalized to a range of 0 to
-    100.
+  short: A normalized risk score calculated by an external system.
   type: float
 user.changes.roles:
   dashed_name: user-changes-roles
@@ -18747,8 +18741,7 @@ user.effective.risk.calculated_score_norm:
   name: calculated_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score calculated by an internal system as part of entity
-    analytics and entity risk scoring, and normalized to a range of 0 to 100.
+  short: A normalized risk score calculated by an internal system.
   type: float
 user.effective.risk.static_level:
   dashed_name: user-effective-risk-static-level
@@ -18788,9 +18781,7 @@ user.effective.risk.static_score_norm:
   name: static_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score obtained from outside the system, such as from
-    some external Threat Intelligence Platform, and normalized to a range of 0 to
-    100.
+  short: A normalized risk score calculated by an external system.
   type: float
 user.effective.roles:
   dashed_name: user-effective-roles
@@ -18943,8 +18934,7 @@ user.risk.calculated_score_norm:
   name: calculated_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score calculated by an internal system as part of entity
-    analytics and entity risk scoring, and normalized to a range of 0 to 100.
+  short: A normalized risk score calculated by an internal system.
   type: float
 user.risk.static_level:
   dashed_name: user-risk-static-level
@@ -18984,9 +18974,7 @@ user.risk.static_score_norm:
   name: static_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score obtained from outside the system, such as from
-    some external Threat Intelligence Platform, and normalized to a range of 0 to
-    100.
+  short: A normalized risk score calculated by an external system.
   type: float
 user.roles:
   dashed_name: user-roles
@@ -19156,8 +19144,7 @@ user.target.risk.calculated_score_norm:
   name: calculated_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score calculated by an internal system as part of entity
-    analytics and entity risk scoring, and normalized to a range of 0 to 100.
+  short: A normalized risk score calculated by an internal system.
   type: float
 user.target.risk.static_level:
   dashed_name: user-target-risk-static-level
@@ -19197,9 +19184,7 @@ user.target.risk.static_score_norm:
   name: static_score_norm
   normalize: []
   original_fieldset: risk
-  short: A risk classification score obtained from outside the system, such as from
-    some external Threat Intelligence Platform, and normalized to a range of 0 to
-    100.
+  short: A normalized risk score calculated by an external system.
   type: float
 user.target.roles:
   dashed_name: user-target-roles

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6554,9 +6554,7 @@ host:
       name: calculated_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     host.risk.static_level:
       dashed_name: host-risk-static-level
@@ -6596,9 +6594,7 @@ host:
       name: static_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
     host.type:
       dashed_name: host-type
@@ -12645,9 +12641,7 @@ risk:
       level: extended
       name: calculated_score_norm
       normalize: []
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     risk.static_level:
       dashed_name: risk-static-level
@@ -12684,9 +12678,7 @@ risk:
       level: extended
       name: static_score_norm
       normalize: []
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
   group: 2
   name: risk
@@ -20837,9 +20829,7 @@ user:
       name: calculated_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     user.changes.risk.static_level:
       dashed_name: user-changes-risk-static-level
@@ -20879,9 +20869,7 @@ user:
       name: static_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
     user.changes.roles:
       dashed_name: user-changes-roles
@@ -21064,9 +21052,7 @@ user:
       name: calculated_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     user.effective.risk.static_level:
       dashed_name: user-effective-risk-static-level
@@ -21106,9 +21092,7 @@ user:
       name: static_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
     user.effective.roles:
       dashed_name: user-effective-roles
@@ -21261,9 +21245,7 @@ user:
       name: calculated_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     user.risk.static_level:
       dashed_name: user-risk-static-level
@@ -21303,9 +21285,7 @@ user:
       name: static_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
     user.roles:
       dashed_name: user-roles
@@ -21475,9 +21455,7 @@ user:
       name: calculated_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score calculated by an internal system as part
-        of entity analytics and entity risk scoring, and normalized to a range of
-        0 to 100.
+      short: A normalized risk score calculated by an internal system.
       type: float
     user.target.risk.static_level:
       dashed_name: user-target-risk-static-level
@@ -21517,9 +21495,7 @@ user:
       name: static_score_norm
       normalize: []
       original_fieldset: risk
-      short: A risk classification score obtained from outside the system, such as
-        from some external Threat Intelligence Platform, and normalized to a range
-        of 0 to 100.
+      short: A normalized risk score calculated by an external system.
       type: float
     user.target.roles:
       dashed_name: user-target-roles

--- a/experimental/schemas/risk.yml
+++ b/experimental/schemas/risk.yml
@@ -23,6 +23,7 @@
       level: extended
       type: float
       example: 88.73
+      short: A normalized risk score calculated by an internal system.
       description: >
         A risk classification score calculated by an internal system as part of
         entity analytics and entity risk scoring, and normalized to a range of
@@ -38,6 +39,7 @@
       level: extended
       type: float
       example: 83.0
+      short: A normalized risk score calculated by an external system.
       description: >
         A risk classification score obtained from outside the system, such as
         from some external Threat Intelligence Platform, and normalized to a


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fixing risk short fields (#2010)