### PR TITLE
[8.5] rectify changelog 1999 (#2012)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -47,6 +47,7 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Advances `threat.enrichments.indicator` to GA. #1928
+* Added `ios` and `android` as valid values for `os.type` #1999
 
 #### Deprecated
 


### PR DESCRIPTION
Backports the following commits to 8.5:
 - rectify changelog 1999 (#2012)