### PR TITLE
[8.5] Fixes a typo in the client schema (#2014)

### DIFF
--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -353,6 +353,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -398,7 +398,7 @@ client.mac:
   level: core
   name: mac
   normalize: []
-  patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the client.
   type: keyword
 client.nat.ip:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -561,7 +561,7 @@ client:
       level: core
       name: mac
       normalize: []
-      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the client.
       type: keyword
     client.nat.ip:

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -303,6 +303,7 @@
         of the octet as an unsigned integer. Successive octets are separated by a
         hyphen.'
       example: 00-00-5E-00-53-23
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
     - name: nat.ip
       level: extended
       type: ip

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -329,7 +329,7 @@ client.mac:
   level: core
   name: mac
   normalize: []
-  patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+  pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
   short: MAC address of the client.
   type: keyword
 client.nat.ip:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -481,7 +481,7 @@ client:
       level: core
       name: mac
       normalize: []
-      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       short: MAC address of the client.
       type: keyword
     client.nat.ip:

--- a/schemas/client.yml
+++ b/schemas/client.yml
@@ -65,7 +65,7 @@
       level: core
       type: keyword
       short: MAC address of the client.
-      patther: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
+      pattern: ^[A-F0-9]{2}(-[A-F0-9]{2}){5,}$
       example: 00-00-5E-00-53-23
       description: >
         MAC address of the client.


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fixes a typo in the client schema (#2014)