### PR TITLE
[8.5] Changed type of process.env_vars to show shadowing (#2038)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -34,6 +34,8 @@ Thanks, you're awesome :-) -->
 
 ## 8.5.0 (Soft Feature Freeze)
 
+* Changed `process.env_vars` field type to be an array of keywords. #2038
+
 ### Schema Changes
 
 #### Breaking changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7261,15 +7261,18 @@ type: keyword
 
 a| beta:[ This field is beta and subject to change. ]
 
-Environment variables (`env_vars`) set at the time of the event. May be filtered to protect sensitive information.
+Array of environment variable bindings. Captured from a snapshot of the environment at the time of execution.
 
-The field should not contain nested objects. All values should use `keyword`.
+May be filtered to protect sensitive information.
 
-type: object
+type: keyword
+
+
+Note: this field should contain an array of values.
 
 
 
-example: `{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}`
+example: `["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5502,12 +5502,13 @@
       default_field: false
     - name: env_vars
       level: extended
-      type: object
-      description: 'Environment variables (`env_vars`) set at the time of the event.
-        May be filtered to protect sensitive information.
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of environment variable bindings. Captured from a snapshot
+        of the environment at the time of execution.
 
-        The field should not contain nested objects. All values should use `keyword`.'
-      example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+        May be filtered to protect sensitive information.'
+      example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
       default_field: false
     - name: executable
       level: extended

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -609,7 +609,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,process,process.entry_leader.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,process,process.entry_leader.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 8.5.0-dev+exp,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
-8.5.0-dev+exp,true,process,process.env_vars,object,extended,,"{""USER"": ""elastic"",""LANG"": ""en_US.UTF-8"",""HOME"": ""/home/elastic""}",Environment variables set at the time of the event.
+8.5.0-dev+exp,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.5.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.5.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.5.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7897,17 +7897,19 @@ process.entry_leader.working_directory:
 process.env_vars:
   beta: This field is beta and subject to change.
   dashed_name: process-env-vars
-  description: 'Environment variables (`env_vars`) set at the time of the event. May
-    be filtered to protect sensitive information.
+  description: 'Array of environment variable bindings. Captured from a snapshot of
+    the environment at the time of execution.
 
-    The field should not contain nested objects. All values should use `keyword`.'
-  example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+    May be filtered to protect sensitive information.'
+  example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
   flat_name: process.env_vars
+  ignore_above: 1024
   level: extended
   name: env_vars
-  normalize: []
-  short: Environment variables set at the time of the event.
-  type: object
+  normalize:
+  - array
+  short: Array of environment variable bindings.
+  type: keyword
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -9601,17 +9601,19 @@ process:
     process.env_vars:
       beta: This field is beta and subject to change.
       dashed_name: process-env-vars
-      description: 'Environment variables (`env_vars`) set at the time of the event.
-        May be filtered to protect sensitive information.
+      description: 'Array of environment variable bindings. Captured from a snapshot
+        of the environment at the time of execution.
 
-        The field should not contain nested objects. All values should use `keyword`.'
-      example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+        May be filtered to protect sensitive information.'
+      example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
       flat_name: process.env_vars
+      ignore_above: 1024
       level: extended
       name: env_vars
-      normalize: []
-      short: Environment variables set at the time of the event.
-      type: object
+      normalize:
+      - array
+      short: Array of environment variable bindings.
+      type: keyword
     process.executable:
       dashed_name: process-executable
       description: Absolute path to the process executable.

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -403,7 +403,8 @@
               }
             },
             "env_vars": {
-              "type": "object"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "executable": {
               "fields": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2899,7 +2899,8 @@
             }
           },
           "env_vars": {
-            "type": "object"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "executable": {
             "fields": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5406,12 +5406,13 @@
       default_field: false
     - name: env_vars
       level: extended
-      type: object
-      description: 'Environment variables (`env_vars`) set at the time of the event.
-        May be filtered to protect sensitive information.
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of environment variable bindings. Captured from a snapshot
+        of the environment at the time of execution.
 
-        The field should not contain nested objects. All values should use `keyword`.'
-      example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+        May be filtered to protect sensitive information.'
+      example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
       default_field: false
     - name: executable
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -596,7 +596,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,process,process.entry_leader.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,process,process.entry_leader.working_directory,keyword,extended,,/home/alice,The working directory of the process.
 8.5.0-dev,true,process,process.entry_leader.working_directory.text,match_only_text,extended,,/home/alice,The working directory of the process.
-8.5.0-dev,true,process,process.env_vars,object,extended,,"{""USER"": ""elastic"",""LANG"": ""en_US.UTF-8"",""HOME"": ""/home/elastic""}",Environment variables set at the time of the event.
+8.5.0-dev,true,process,process.env_vars,keyword,extended,array,"[""PATH=/usr/local/bin:/usr/bin"", ""USER=ubuntu""]",Array of environment variable bindings.
 8.5.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.5.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.5.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7748,17 +7748,19 @@ process.entry_leader.working_directory:
 process.env_vars:
   beta: This field is beta and subject to change.
   dashed_name: process-env-vars
-  description: 'Environment variables (`env_vars`) set at the time of the event. May
-    be filtered to protect sensitive information.
+  description: 'Array of environment variable bindings. Captured from a snapshot of
+    the environment at the time of execution.
 
-    The field should not contain nested objects. All values should use `keyword`.'
-  example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+    May be filtered to protect sensitive information.'
+  example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
   flat_name: process.env_vars
+  ignore_above: 1024
   level: extended
   name: env_vars
-  normalize: []
-  short: Environment variables set at the time of the event.
-  type: object
+  normalize:
+  - array
+  short: Array of environment variable bindings.
+  type: keyword
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -9437,17 +9437,19 @@ process:
     process.env_vars:
       beta: This field is beta and subject to change.
       dashed_name: process-env-vars
-      description: 'Environment variables (`env_vars`) set at the time of the event.
-        May be filtered to protect sensitive information.
+      description: 'Array of environment variable bindings. Captured from a snapshot
+        of the environment at the time of execution.
 
-        The field should not contain nested objects. All values should use `keyword`.'
-      example: '{"USER": "elastic","LANG": "en_US.UTF-8","HOME": "/home/elastic"}'
+        May be filtered to protect sensitive information.'
+      example: '["PATH=/usr/local/bin:/usr/bin", "USER=ubuntu"]'
       flat_name: process.env_vars
+      ignore_above: 1024
       level: extended
       name: env_vars
-      normalize: []
-      short: Environment variables set at the time of the event.
-      type: object
+      normalize:
+      - array
+      short: Array of environment variable bindings.
+      type: keyword
     process.executable:
       dashed_name: process-executable
       description: Absolute path to the process executable.

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -403,7 +403,8 @@
               }
             },
             "env_vars": {
-              "type": "object"
+              "ignore_above": 1024,
+              "type": "keyword"
             },
             "executable": {
               "fields": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2833,7 +2833,8 @@
             }
           },
           "env_vars": {
-            "type": "object"
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "executable": {
             "fields": {

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -280,15 +280,17 @@
 
     - name: env_vars
       level: extended
-      type: object
+      type: keyword
       beta: This field is beta and subject to change.
-      short: Environment variables set at the time of the event.
+      short: Array of environment variable bindings.
       description: >
-        Environment variables (`env_vars`) set at the time of the event.
-        May be filtered to protect sensitive information.
+        Array of environment variable bindings.
+        Captured from a snapshot of the environment at the time of execution.
 
-        The field should not contain nested objects. All values should use `keyword`.
-      example: "{\"USER\": \"elastic\",\"LANG\": \"en_US.UTF-8\",\"HOME\": \"/home/elastic\"}"
+        May be filtered to protect sensitive information.
+      example: "[\"PATH=/usr/local/bin:/usr/bin\", \"USER=ubuntu\"]"
+      normalize:
+        - array
 
     - name: entry_meta.type
       level: extended


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Changed type of process.env_vars to show shadowing (#2038)