### PR TITLE
[8.5] Adding `risk.*` as beta (#2051)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -34,8 +34,6 @@ Thanks, you're awesome :-) -->
 
 ## 8.5.0 (Soft Feature Freeze)
 
-* Changed `process.env_vars` field type to be an array of keywords. #2038
-
 ### Schema Changes
 
 #### Breaking changes
@@ -47,6 +45,8 @@ Thanks, you're awesome :-) -->
 * Adding `risk.*` fields as experimental. #1994, #2010
 * Adding `process.io.*` as beta fields. #1956, #2031
 * Adding `process.tty.rows` and `process.tty.columns` as beta fields. #2031
+* Changed `process.env_vars` field type to be an array of keywords. #2038
+* Added `risk.*` fieldset to beta. #2051
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5056,6 +5056,13 @@ example: `1325`
 // ===============================================================
 
 
+| `host.risk.*`
+| <<ecs-risk,risk>>
+| Fields for describing risk score and level.
+
+// ===============================================================
+
+
 |=====
 
 
@@ -8095,6 +8102,132 @@ Note: this field should contain an array of values.
 |=====
 
 
+[[ecs-risk]]
+=== Risk information Fields
+
+Fields for describing risk score and risk level of entities such as hosts and users.  These fields are not allowed to be nested under `event.*`. Please continue to use  `event.risk_score` and `event.risk_score_norm` for event risk.
+
+beta::[ These fields are in beta and are subject to change.]
+
+[discrete]
+==== Risk information Field Details
+
+[options="header"]
+|=====
+| Field  | Description | Level
+
+// ===============================================================
+
+|
+[[field-risk-calculated-level]]
+<<field-risk-calculated-level, risk.calculated_level>>
+
+a| A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+
+type: keyword
+
+
+
+example: `High`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-risk-calculated-score]]
+<<field-risk-calculated-score, risk.calculated_score>>
+
+a| A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+
+type: float
+
+
+
+example: `880.73`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-risk-calculated-score-norm]]
+<<field-risk-calculated-score-norm, risk.calculated_score_norm>>
+
+a| A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring, and normalized to a range of 0 to 100.
+
+type: float
+
+
+
+example: `88.73`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-risk-static-level]]
+<<field-risk-static-level, risk.static_level>>
+
+a| A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform.
+
+type: keyword
+
+
+
+example: `High`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-risk-static-score]]
+<<field-risk-static-score, risk.static_score>>
+
+a| A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform.
+
+type: float
+
+
+
+example: `830.0`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-risk-static-score-norm]]
+<<field-risk-static-score-norm, risk.static_score_norm>>
+
+a| A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform, and normalized to a range of 0 to 100.
+
+type: float
+
+
+
+example: `83.0`
+
+| extended
+
+// ===============================================================
+
+|=====
+
+[discrete]
+==== Field Reuse
+
+The `risk` fields are expected to be nested at:
+
+
+* `host.risk`
+
+* `user.risk`
+
+
+Note also that the `risk` fields are not expected to be used directly at the root of the events.
 [[ecs-rule]]
 === Rule Fields
 
@@ -11454,6 +11587,13 @@ Note also that the `user` fields may be used directly at the root of the events.
 | `user.group.*`
 | <<ecs-group,group>>
 | User's group relevant to the event.
+
+// ===============================================================
+
+
+| `user.risk.*`
+| <<ecs-risk,risk>>
+| Fields for describing risk score and level.
 
 // ===============================================================
 

--- a/docs/fields/fields.asciidoc
+++ b/docs/fields/fields.asciidoc
@@ -90,6 +90,8 @@ For a single page representation of all fields, please see the
 
 | <<ecs-related,Related>> | Fields meant to facilitate pivoting around a piece of data.
 
+| <<ecs-risk,Risk information>> | Fields for describing risk score and level.
+
 | <<ecs-rule,Rule>> | Fields to capture details about rules used to generate alerts or other notable events.
 
 | <<ecs-server,Server>> | Fields about the server side of a network connection, used with client.

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -481,6 +481,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -1279,6 +1325,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -7229,9 +7321,12 @@
       description: All the user names or other user identifiers seen on the event.
       default_field: false
   - name: risk
-    title: Risk score information
+    title: Risk information
     group: 2
-    description: Fields for describing the risk score and level.
+    description: Fields for describing risk score and risk level of entities such
+      as hosts and users.  These fields are not allowed to be nested under `event.*`.
+      Please continue to use  `event.risk_score` and `event.risk_score_norm` for event
+      risk.
     type: group
     default_field: true
     fields:
@@ -7659,6 +7754,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -8387,6 +8528,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -53,6 +53,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,client,client.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev+exp,true,client,client.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,client,client.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev+exp,true,client,client.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,client,client.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,client,client.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev+exp,true,client,client.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,client,client.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,client,client.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 8.5.0-dev+exp,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -140,6 +146,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,destination,destination.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev+exp,true,destination,destination.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,destination,destination.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev+exp,true,destination,destination.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,destination,destination.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,destination,destination.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev+exp,true,destination,destination.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,destination,destination.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,destination,destination.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.5.0-dev+exp,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -897,6 +909,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,server,server.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev+exp,true,server,server.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,server,server.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev+exp,true,server,server.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,server,server.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,server,server.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev+exp,true,server,server.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,server,server.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,server,server.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.5.0-dev+exp,true,service,service.environment,keyword,extended,,production,Environment of the service.
@@ -968,6 +986,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,source,source.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev+exp,true,source,source.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,source,source.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev+exp,true,source,source.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,source,source.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev+exp,true,source,source.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev+exp,true,source,source.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,source,source.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev+exp,true,source,source.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev+exp,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev+exp,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 8.5.0-dev+exp,true,threat,threat.enrichments,nested,extended,array,,List of objects containing indicators enriching the event.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -616,6 +616,86 @@ client.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+client.user.risk.calculated_level:
+  dashed_name: client-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: client.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+client.user.risk.calculated_score:
+  dashed_name: client-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: client.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+client.user.risk.calculated_score_norm:
+  dashed_name: client-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: client.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+client.user.risk.static_level:
+  dashed_name: client-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: client.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+client.user.risk.static_score:
+  dashed_name: client-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: client.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+client.user.risk.static_score_norm:
+  dashed_name: client-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: client.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 client.user.roles:
   dashed_name: client-user-roles
   description: Array of user roles at the time of the event.
@@ -1687,6 +1767,86 @@ destination.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+destination.user.risk.calculated_level:
+  dashed_name: destination-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: destination.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+destination.user.risk.calculated_score:
+  dashed_name: destination-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: destination.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+destination.user.risk.calculated_score_norm:
+  dashed_name: destination-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: destination.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+destination.user.risk.static_level:
+  dashed_name: destination-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: destination.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+destination.user.risk.static_score:
+  dashed_name: destination-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: destination.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+destination.user.risk.static_score_norm:
+  dashed_name: destination-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: destination.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 destination.user.roles:
   dashed_name: destination-user-roles
   description: Array of user roles at the time of the event.
@@ -11274,6 +11434,86 @@ server.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+server.user.risk.calculated_level:
+  dashed_name: server-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: server.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+server.user.risk.calculated_score:
+  dashed_name: server-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: server.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+server.user.risk.calculated_score_norm:
+  dashed_name: server-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: server.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+server.user.risk.static_level:
+  dashed_name: server-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: server.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+server.user.risk.static_score:
+  dashed_name: server-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: server.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+server.user.risk.static_score_norm:
+  dashed_name: server-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: server.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 server.user.roles:
   dashed_name: server-user-roles
   description: Array of user roles at the time of the event.
@@ -12321,6 +12561,86 @@ source.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+source.user.risk.calculated_level:
+  dashed_name: source-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: source.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+source.user.risk.calculated_score:
+  dashed_name: source-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: source.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+source.user.risk.calculated_score_norm:
+  dashed_name: source-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: source.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+source.user.risk.static_level:
+  dashed_name: source-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: source.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+source.user.risk.static_score:
+  dashed_name: source-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: source.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+source.user.risk.static_score_norm:
+  dashed_name: source-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: source.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 source.user.roles:
   dashed_name: source-user-roles
   description: Array of user roles at the time of the event.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -779,6 +779,86 @@ client:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    client.user.risk.calculated_level:
+      dashed_name: client-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: client.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    client.user.risk.calculated_score:
+      dashed_name: client-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: client.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    client.user.risk.calculated_score_norm:
+      dashed_name: client-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: client.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    client.user.risk.static_level:
+      dashed_name: client-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: client.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    client.user.risk.static_score:
+      dashed_name: client-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: client.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    client.user.risk.static_score_norm:
+      dashed_name: client-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: client.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     client.user.roles:
       dashed_name: client-user-roles
       description: Array of user roles at the time of the event.
@@ -2109,6 +2189,86 @@ destination:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    destination.user.risk.calculated_level:
+      dashed_name: destination-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: destination.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    destination.user.risk.calculated_score:
+      dashed_name: destination-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: destination.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    destination.user.risk.calculated_score_norm:
+      dashed_name: destination-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: destination.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    destination.user.risk.static_level:
+      dashed_name: destination-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: destination.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    destination.user.risk.static_score:
+      dashed_name: destination-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: destination.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    destination.user.risk.static_score_norm:
+      dashed_name: destination-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: destination.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     destination.user.roles:
       dashed_name: destination-user-roles
       description: Array of user roles at the time of the event.
@@ -6639,7 +6799,7 @@ host:
     short: OS fields contain information about the operating system.
   - full: host.risk
     schema_name: risk
-    short: Fields for describing the risk score and level.
+    short: Fields for describing risk score and level.
   short: Fields describing the relevant computing instance.
   title: Host
   type: group
@@ -12643,7 +12803,10 @@ related:
   title: Related
   type: group
 risk:
-  description: Fields for describing the risk score and level.
+  beta: These fields are in beta and are subject to change.
+  description: Fields for describing risk score and risk level of entities such as
+    hosts and users.  These fields are not allowed to be nested under `event.*`. Please
+    continue to use  `event.risk_score` and `event.risk_score_norm` for event risk.
   fields:
     risk.calculated_level:
       dashed_name: risk-calculated-level
@@ -12731,8 +12894,8 @@ risk:
       at: user
       full: user.risk
     top_level: false
-  short: Fields for describing the risk score and level.
-  title: Risk score information
+  short: Fields for describing risk score and level.
+  title: Risk information
   type: group
 rule:
   description: 'Rule fields are used to capture the specifics of any observer or agent
@@ -13339,6 +13502,86 @@ server:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    server.user.risk.calculated_level:
+      dashed_name: server-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: server.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    server.user.risk.calculated_score:
+      dashed_name: server-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: server.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    server.user.risk.calculated_score_norm:
+      dashed_name: server-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: server.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    server.user.risk.static_level:
+      dashed_name: server-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: server.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    server.user.risk.static_score:
+      dashed_name: server-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: server.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    server.user.risk.static_score_norm:
+      dashed_name: server-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: server.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     server.user.roles:
       dashed_name: server-user-roles
       description: Array of user roles at the time of the event.
@@ -14474,6 +14717,86 @@ source:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    source.user.risk.calculated_level:
+      dashed_name: source-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: source.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    source.user.risk.calculated_score:
+      dashed_name: source-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: source.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    source.user.risk.calculated_score_norm:
+      dashed_name: source-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: source.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    source.user.risk.static_level:
+      dashed_name: source-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: source.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    source.user.risk.static_score:
+      dashed_name: source-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: source.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    source.user.risk.static_score_norm:
+      dashed_name: source-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: source.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     source.user.roles:
       dashed_name: source-user-roles
       description: Array of user roles at the time of the event.
@@ -21606,7 +21929,7 @@ user:
     short: User's group relevant to the event.
   - full: user.risk
     schema_name: risk
-    short: Fields for describing the risk score and level.
+    short: Fields for describing risk score and level.
   - full: user.target
     schema_name: user
     short: Targeted user of action taken.

--- a/experimental/generated/elasticsearch/composable/component/client.json
+++ b/experimental/generated/elasticsearch/composable/component/client.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/composable/component/destination.json
+++ b/experimental/generated/elasticsearch/composable/component/destination.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/composable/component/server.json
+++ b/experimental/generated/elasticsearch/composable/component/server.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/composable/component/source.json
+++ b/experimental/generated/elasticsearch/composable/component/source.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -263,6 +263,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -745,6 +769,30 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
               },
               "roles": {
                 "ignore_above": 1024,
@@ -4250,6 +4298,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -4580,6 +4652,30 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
               },
               "roles": {
                 "ignore_above": 1024,

--- a/experimental/schemas/subsets/experimental.yml
+++ b/experimental/schemas/subsets/experimental.yml
@@ -3,5 +3,3 @@ name: experimental
 fields:
   cgroup:
     fields: "*"
-  risk:
-    fields: "*"

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -431,6 +431,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -1229,6 +1275,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -3602,6 +3694,52 @@
       description: This is the inode number of the namespace in the namespace file
         system (nsfs). Unsigned int inum in include/linux/ns_common.h.
       example: 256383
+      default_field: false
+    - name: risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
       default_field: false
     - name: type
       level: core
@@ -7132,6 +7270,62 @@
       ignore_above: 1024
       description: All the user names or other user identifiers seen on the event.
       default_field: false
+  - name: risk
+    title: Risk information
+    group: 2
+    description: Fields for describing risk score and risk level of entities such
+      as hosts and users.  These fields are not allowed to be nested under `event.*`.
+      Please continue to use  `event.risk_score` and `event.risk_score_norm` for event
+      risk.
+    type: group
+    default_field: true
+    fields:
+    - name: calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
   - name: rule
     title: Rule
     group: 2
@@ -7510,6 +7704,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -8238,6 +8478,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: user.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: user.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: user.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: user.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: user.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: user.roles
       level: extended
       type: keyword
@@ -11957,6 +12243,52 @@
       description: Short name or login of the user.
       example: a.einstein
       default_field: false
+    - name: changes.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: changes.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: changes.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: changes.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: changes.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: changes.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: changes.roles
       level: extended
       type: keyword
@@ -12042,6 +12374,52 @@
       description: Short name or login of the user.
       example: a.einstein
       default_field: false
+    - name: effective.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: effective.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: effective.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: effective.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: effective.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: effective.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: effective.roles
       level: extended
       type: keyword
@@ -12106,6 +12484,52 @@
         default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      default_field: false
     - name: roles
       level: extended
       type: keyword
@@ -12183,6 +12607,52 @@
         type: match_only_text
       description: Short name or login of the user.
       example: a.einstein
+      default_field: false
+    - name: target.risk.calculated_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      default_field: false
+    - name: target.risk.calculated_score
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      default_field: false
+    - name: target.risk.calculated_score_norm
+      level: extended
+      type: float
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      default_field: false
+    - name: target.risk.static_level
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      default_field: false
+    - name: target.risk.static_score
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      default_field: false
+    - name: target.risk.static_score_norm
+      level: extended
+      type: float
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
       default_field: false
     - name: target.roles
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -46,6 +46,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,client,client.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,client,client.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,client,client.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,client,client.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,client,client.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,client,client.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,client,client.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,client,client.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,client,client.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,cloud,cloud.account.id,keyword,extended,,666777888999,The cloud account or organization id.
 8.5.0-dev,true,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
@@ -133,6 +139,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,destination,destination.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,destination,destination.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,destination,destination.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,destination,destination.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,destination,destination.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,destination,destination.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,destination,destination.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,destination,destination.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,destination,destination.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,dll,dll.code_signature.digest_algorithm,keyword,extended,,sha256,Hashing algorithm used to sign the process.
 8.5.0-dev,true,dll,dll.code_signature.exists,boolean,core,,true,Boolean to capture if a signature is present.
@@ -386,6 +398,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix, windows, ios or android)."
 8.5.0-dev,true,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
 8.5.0-dev,true,host,host.pid_ns_ino,keyword,extended,,256383,Pid namespace inode
+8.5.0-dev,true,host,host.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,host,host.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,host,host.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,host,host.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,host,host.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,host,host.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,host,host.type,keyword,core,,,Type of host.
 8.5.0-dev,true,host,host.uptime,long,extended,,1325,Seconds the host has been up.
 8.5.0-dev,true,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
@@ -884,6 +902,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,server,server.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,server,server.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,server,server.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,server,server.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,server,server.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,server,server.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,server,server.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,server,server.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,server,server.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,service,service.address,keyword,extended,,172.26.0.2:5432,Address of this service.
 8.5.0-dev,true,service,service.environment,keyword,extended,,production,Environment of the service.
@@ -955,6 +979,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,source,source.user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,source,source.user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,source,source.user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,source,source.user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,source,source.user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,source,source.user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,source,source.user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,source,source.user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,source,source.user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
 8.5.0-dev,true,threat,threat.enrichments,nested,extended,array,,List of objects containing indicators enriching the event.
@@ -1449,6 +1479,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,user,user.changes.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,user,user.changes.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,user,user.changes.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,user,user.changes.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.changes.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.changes.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,user,user.changes.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.changes.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.changes.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.5.0-dev,true,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
@@ -1462,6 +1498,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,user,user.effective.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,user,user.effective.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,user,user.effective.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,user,user.effective.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.effective.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.effective.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,user,user.effective.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.effective.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.effective.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,user,user.email,keyword,extended,,,User email address.
 8.5.0-dev,true,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
@@ -1473,6 +1515,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,user,user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,user,user.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,user,user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,user,user.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,user,user.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
 8.5.0-dev,true,user,user.target.email,keyword,extended,,,User email address.
@@ -1485,6 +1533,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,user,user.target.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
 8.5.0-dev,true,user,user.target.name,keyword,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,user,user.target.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,user,user.target.risk.calculated_level,keyword,extended,,High,A risk classification level calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.target.risk.calculated_score,float,extended,,880.73,A risk classification score calculated by an internal system as part of entity analytics and entity risk scoring.
+8.5.0-dev,true,user,user.target.risk.calculated_score_norm,float,extended,,88.73,A normalized risk score calculated by an internal system.
+8.5.0-dev,true,user,user.target.risk.static_level,keyword,extended,,High,"A risk classification level obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.target.risk.static_score,float,extended,,830.0,"A risk classification score obtained from outside the system, such as from some external Threat Intelligence Platform."
+8.5.0-dev,true,user,user.target.risk.static_score_norm,float,extended,,83.0,A normalized risk score calculated by an external system.
 8.5.0-dev,true,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
 8.5.0-dev,true,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
 8.5.0-dev,true,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -547,6 +547,86 @@ client.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+client.user.risk.calculated_level:
+  dashed_name: client-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: client.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+client.user.risk.calculated_score:
+  dashed_name: client-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: client.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+client.user.risk.calculated_score_norm:
+  dashed_name: client-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: client.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+client.user.risk.static_level:
+  dashed_name: client-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: client.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+client.user.risk.static_score:
+  dashed_name: client-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: client.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+client.user.risk.static_score_norm:
+  dashed_name: client-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: client.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 client.user.roles:
   dashed_name: client-user-roles
   description: Array of user roles at the time of the event.
@@ -1618,6 +1698,86 @@ destination.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+destination.user.risk.calculated_level:
+  dashed_name: destination-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: destination.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+destination.user.risk.calculated_score:
+  dashed_name: destination-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: destination.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+destination.user.risk.calculated_score_norm:
+  dashed_name: destination-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: destination.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+destination.user.risk.static_level:
+  dashed_name: destination-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: destination.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+destination.user.risk.static_score:
+  dashed_name: destination-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: destination.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+destination.user.risk.static_score_norm:
+  dashed_name: destination-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: destination.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 destination.user.roles:
   dashed_name: destination-user-roles
   description: Array of user roles at the time of the event.
@@ -5181,6 +5341,86 @@ host.pid_ns_ino:
   normalize: []
   short: Pid namespace inode
   type: keyword
+host.risk.calculated_level:
+  dashed_name: host-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: host.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+host.risk.calculated_score:
+  dashed_name: host-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: host.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+host.risk.calculated_score_norm:
+  dashed_name: host-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: host.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+host.risk.static_level:
+  dashed_name: host-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: host.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+host.risk.static_score:
+  dashed_name: host-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: host.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+host.risk.static_score_norm:
+  dashed_name: host-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: host.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 host.type:
   dashed_name: host-type
   description: 'Type of host.
@@ -11125,6 +11365,86 @@ server.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+server.user.risk.calculated_level:
+  dashed_name: server-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: server.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+server.user.risk.calculated_score:
+  dashed_name: server-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: server.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+server.user.risk.calculated_score_norm:
+  dashed_name: server-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: server.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+server.user.risk.static_level:
+  dashed_name: server-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: server.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+server.user.risk.static_score:
+  dashed_name: server-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: server.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+server.user.risk.static_score_norm:
+  dashed_name: server-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: server.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 server.user.roles:
   dashed_name: server-user-roles
   description: Array of user roles at the time of the event.
@@ -12172,6 +12492,86 @@ source.user.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+source.user.risk.calculated_level:
+  dashed_name: source-user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: source.user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+source.user.risk.calculated_score:
+  dashed_name: source-user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: source.user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+source.user.risk.calculated_score_norm:
+  dashed_name: source-user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: source.user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+source.user.risk.static_level:
+  dashed_name: source-user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: source.user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+source.user.risk.static_score:
+  dashed_name: source-user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: source.user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+source.user.risk.static_score_norm:
+  dashed_name: source-user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: source.user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 source.user.roles:
   dashed_name: source-user-roles
   description: Array of user roles at the time of the event.
@@ -18367,6 +18767,86 @@ user.changes.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+user.changes.risk.calculated_level:
+  dashed_name: user-changes-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: user.changes.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+user.changes.risk.calculated_score:
+  dashed_name: user-changes-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: user.changes.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+user.changes.risk.calculated_score_norm:
+  dashed_name: user-changes-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: user.changes.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+user.changes.risk.static_level:
+  dashed_name: user-changes-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: user.changes.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+user.changes.risk.static_score:
+  dashed_name: user-changes-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: user.changes.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+user.changes.risk.static_score_norm:
+  dashed_name: user-changes-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: user.changes.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 user.changes.roles:
   dashed_name: user-changes-roles
   description: Array of user roles at the time of the event.
@@ -18510,6 +18990,86 @@ user.effective.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+user.effective.risk.calculated_level:
+  dashed_name: user-effective-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: user.effective.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+user.effective.risk.calculated_score:
+  dashed_name: user-effective-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: user.effective.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+user.effective.risk.calculated_score_norm:
+  dashed_name: user-effective-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: user.effective.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+user.effective.risk.static_level:
+  dashed_name: user-effective-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: user.effective.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+user.effective.risk.static_score:
+  dashed_name: user-effective-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: user.effective.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+user.effective.risk.static_score_norm:
+  dashed_name: user-effective-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: user.effective.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 user.effective.roles:
   dashed_name: user-effective-roles
   description: Array of user roles at the time of the event.
@@ -18623,6 +19183,86 @@ user.name:
   normalize: []
   short: Short name or login of the user.
   type: keyword
+user.risk.calculated_level:
+  dashed_name: user-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: user.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+user.risk.calculated_score:
+  dashed_name: user-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: user.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+user.risk.calculated_score_norm:
+  dashed_name: user-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: user.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+user.risk.static_level:
+  dashed_name: user-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: user.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+user.risk.static_score:
+  dashed_name: user-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: user.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+user.risk.static_score_norm:
+  dashed_name: user-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: user.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 user.roles:
   dashed_name: user-roles
   description: Array of user roles at the time of the event.
@@ -18753,6 +19393,86 @@ user.target.name:
   original_fieldset: user
   short: Short name or login of the user.
   type: keyword
+user.target.risk.calculated_level:
+  dashed_name: user-target-risk-calculated-level
+  description: A risk classification level calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: High
+  flat_name: user.target.risk.calculated_level
+  ignore_above: 1024
+  level: extended
+  name: calculated_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: keyword
+user.target.risk.calculated_score:
+  dashed_name: user-target-risk-calculated-score
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring.
+  example: 880.73
+  flat_name: user.target.risk.calculated_score
+  level: extended
+  name: calculated_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score calculated by an internal system as part of entity
+    analytics and entity risk scoring.
+  type: float
+user.target.risk.calculated_score_norm:
+  dashed_name: user-target-risk-calculated-score-norm
+  description: A risk classification score calculated by an internal system as part
+    of entity analytics and entity risk scoring, and normalized to a range of 0 to
+    100.
+  example: 88.73
+  flat_name: user.target.risk.calculated_score_norm
+  level: extended
+  name: calculated_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an internal system.
+  type: float
+user.target.risk.static_level:
+  dashed_name: user-target-risk-static-level
+  description: A risk classification level obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: High
+  flat_name: user.target.risk.static_level
+  ignore_above: 1024
+  level: extended
+  name: static_level
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification level obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: keyword
+user.target.risk.static_score:
+  dashed_name: user-target-risk-static-score
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform.
+  example: 830.0
+  flat_name: user.target.risk.static_score
+  level: extended
+  name: static_score
+  normalize: []
+  original_fieldset: risk
+  short: A risk classification score obtained from outside the system, such as from
+    some external Threat Intelligence Platform.
+  type: float
+user.target.risk.static_score_norm:
+  dashed_name: user-target-risk-static-score-norm
+  description: A risk classification score obtained from outside the system, such
+    as from some external Threat Intelligence Platform, and normalized to a range
+    of 0 to 100.
+  example: 83.0
+  flat_name: user.target.risk.static_score_norm
+  level: extended
+  name: static_score_norm
+  normalize: []
+  original_fieldset: risk
+  short: A normalized risk score calculated by an external system.
+  type: float
 user.target.roles:
   dashed_name: user-target-roles
   description: Array of user roles at the time of the event.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -699,6 +699,86 @@ client:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    client.user.risk.calculated_level:
+      dashed_name: client-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: client.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    client.user.risk.calculated_score:
+      dashed_name: client-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: client.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    client.user.risk.calculated_score_norm:
+      dashed_name: client-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: client.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    client.user.risk.static_level:
+      dashed_name: client-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: client.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    client.user.risk.static_score:
+      dashed_name: client-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: client.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    client.user.risk.static_score_norm:
+      dashed_name: client-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: client.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     client.user.roles:
       dashed_name: client-user-roles
       description: Array of user roles at the time of the event.
@@ -2029,6 +2109,86 @@ destination:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    destination.user.risk.calculated_level:
+      dashed_name: destination-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: destination.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    destination.user.risk.calculated_score:
+      dashed_name: destination-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: destination.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    destination.user.risk.calculated_score_norm:
+      dashed_name: destination-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: destination.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    destination.user.risk.static_level:
+      dashed_name: destination-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: destination.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    destination.user.risk.static_score:
+      dashed_name: destination-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: destination.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    destination.user.risk.static_score_norm:
+      dashed_name: destination-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: destination.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     destination.user.roles:
       dashed_name: destination-user-roles
       description: Array of user roles at the time of the event.
@@ -6439,6 +6599,86 @@ host:
       normalize: []
       short: Pid namespace inode
       type: keyword
+    host.risk.calculated_level:
+      dashed_name: host-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: host.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    host.risk.calculated_score:
+      dashed_name: host-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: host.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    host.risk.calculated_score_norm:
+      dashed_name: host-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: host.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    host.risk.static_level:
+      dashed_name: host-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: host.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    host.risk.static_score:
+      dashed_name: host-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: host.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    host.risk.static_score_norm:
+      dashed_name: host-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: host.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     host.type:
       dashed_name: host-type
       description: 'Type of host.
@@ -6468,6 +6708,7 @@ host:
   nestings:
   - host.geo
   - host.os
+  - host.risk
   prefix: host.
   reused_here:
   - full: host.geo
@@ -6476,6 +6717,9 @@ host:
   - full: host.os
     schema_name: os
     short: OS fields contain information about the operating system.
+  - full: host.risk
+    schema_name: risk
+    short: Fields for describing risk score and level.
   short: Fields describing the relevant computing instance.
   title: Host
   type: group
@@ -12478,6 +12722,101 @@ related:
   short: Fields meant to facilitate pivoting around a piece of data.
   title: Related
   type: group
+risk:
+  beta: These fields are in beta and are subject to change.
+  description: Fields for describing risk score and risk level of entities such as
+    hosts and users.  These fields are not allowed to be nested under `event.*`. Please
+    continue to use  `event.risk_score` and `event.risk_score_norm` for event risk.
+  fields:
+    risk.calculated_level:
+      dashed_name: risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    risk.calculated_score:
+      dashed_name: risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    risk.calculated_score_norm:
+      dashed_name: risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    risk.static_level:
+      dashed_name: risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    risk.static_score:
+      dashed_name: risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    risk.static_score_norm:
+      dashed_name: risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      short: A normalized risk score calculated by an external system.
+      type: float
+  group: 2
+  name: risk
+  prefix: risk.
+  reusable:
+    expected:
+    - as: risk
+      at: host
+      full: host.risk
+    - as: risk
+      at: user
+      full: user.risk
+    top_level: false
+  short: Fields for describing risk score and level.
+  title: Risk information
+  type: group
 rule:
   description: 'Rule fields are used to capture the specifics of any observer or agent
     rules that generate alerts or other notable events.
@@ -13083,6 +13422,86 @@ server:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    server.user.risk.calculated_level:
+      dashed_name: server-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: server.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    server.user.risk.calculated_score:
+      dashed_name: server-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: server.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    server.user.risk.calculated_score_norm:
+      dashed_name: server-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: server.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    server.user.risk.static_level:
+      dashed_name: server-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: server.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    server.user.risk.static_score:
+      dashed_name: server-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: server.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    server.user.risk.static_score_norm:
+      dashed_name: server-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: server.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     server.user.roles:
       dashed_name: server-user-roles
       description: Array of user roles at the time of the event.
@@ -14218,6 +14637,86 @@ source:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    source.user.risk.calculated_level:
+      dashed_name: source-user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: source.user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    source.user.risk.calculated_score:
+      dashed_name: source-user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: source.user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    source.user.risk.calculated_score_norm:
+      dashed_name: source-user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: source.user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    source.user.risk.static_level:
+      dashed_name: source-user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: source.user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    source.user.risk.static_score:
+      dashed_name: source-user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: source.user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    source.user.risk.static_score_norm:
+      dashed_name: source-user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: source.user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     source.user.roles:
       dashed_name: source-user-roles
       description: Array of user roles at the time of the event.
@@ -20574,6 +21073,86 @@ user:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    user.changes.risk.calculated_level:
+      dashed_name: user-changes-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: user.changes.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    user.changes.risk.calculated_score:
+      dashed_name: user-changes-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: user.changes.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    user.changes.risk.calculated_score_norm:
+      dashed_name: user-changes-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: user.changes.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    user.changes.risk.static_level:
+      dashed_name: user-changes-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: user.changes.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    user.changes.risk.static_score:
+      dashed_name: user-changes-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: user.changes.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    user.changes.risk.static_score_norm:
+      dashed_name: user-changes-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: user.changes.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     user.changes.roles:
       dashed_name: user-changes-roles
       description: Array of user roles at the time of the event.
@@ -20717,6 +21296,86 @@ user:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    user.effective.risk.calculated_level:
+      dashed_name: user-effective-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: user.effective.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    user.effective.risk.calculated_score:
+      dashed_name: user-effective-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: user.effective.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    user.effective.risk.calculated_score_norm:
+      dashed_name: user-effective-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: user.effective.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    user.effective.risk.static_level:
+      dashed_name: user-effective-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: user.effective.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    user.effective.risk.static_score:
+      dashed_name: user-effective-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: user.effective.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    user.effective.risk.static_score_norm:
+      dashed_name: user-effective-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: user.effective.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     user.effective.roles:
       dashed_name: user-effective-roles
       description: Array of user roles at the time of the event.
@@ -20830,6 +21489,86 @@ user:
       normalize: []
       short: Short name or login of the user.
       type: keyword
+    user.risk.calculated_level:
+      dashed_name: user-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: user.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    user.risk.calculated_score:
+      dashed_name: user-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: user.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    user.risk.calculated_score_norm:
+      dashed_name: user-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: user.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    user.risk.static_level:
+      dashed_name: user-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: user.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    user.risk.static_score:
+      dashed_name: user-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: user.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    user.risk.static_score_norm:
+      dashed_name: user-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: user.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     user.roles:
       dashed_name: user-roles
       description: Array of user roles at the time of the event.
@@ -20960,6 +21699,86 @@ user:
       original_fieldset: user
       short: Short name or login of the user.
       type: keyword
+    user.target.risk.calculated_level:
+      dashed_name: user-target-risk-calculated-level
+      description: A risk classification level calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: High
+      flat_name: user.target.risk.calculated_level
+      ignore_above: 1024
+      level: extended
+      name: calculated_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: keyword
+    user.target.risk.calculated_score:
+      dashed_name: user-target-risk-calculated-score
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring.
+      example: 880.73
+      flat_name: user.target.risk.calculated_score
+      level: extended
+      name: calculated_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score calculated by an internal system as part
+        of entity analytics and entity risk scoring.
+      type: float
+    user.target.risk.calculated_score_norm:
+      dashed_name: user-target-risk-calculated-score-norm
+      description: A risk classification score calculated by an internal system as
+        part of entity analytics and entity risk scoring, and normalized to a range
+        of 0 to 100.
+      example: 88.73
+      flat_name: user.target.risk.calculated_score_norm
+      level: extended
+      name: calculated_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an internal system.
+      type: float
+    user.target.risk.static_level:
+      dashed_name: user-target-risk-static-level
+      description: A risk classification level obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: High
+      flat_name: user.target.risk.static_level
+      ignore_above: 1024
+      level: extended
+      name: static_level
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification level obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: keyword
+    user.target.risk.static_score:
+      dashed_name: user-target-risk-static-score
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform.
+      example: 830.0
+      flat_name: user.target.risk.static_score
+      level: extended
+      name: static_score
+      normalize: []
+      original_fieldset: risk
+      short: A risk classification score obtained from outside the system, such as
+        from some external Threat Intelligence Platform.
+      type: float
+    user.target.risk.static_score_norm:
+      dashed_name: user-target-risk-static-score-norm
+      description: A risk classification score obtained from outside the system, such
+        as from some external Threat Intelligence Platform, and normalized to a range
+        of 0 to 100.
+      example: 83.0
+      flat_name: user.target.risk.static_score_norm
+      level: extended
+      name: static_score_norm
+      normalize: []
+      original_fieldset: risk
+      short: A normalized risk score calculated by an external system.
+      type: float
     user.target.roles:
       dashed_name: user-target-roles
       description: Array of user roles at the time of the event.
@@ -20979,6 +21798,7 @@ user:
   - user.changes
   - user.effective
   - user.group
+  - user.risk
   - user.target
   prefix: user.
   reusable:
@@ -21027,6 +21847,9 @@ user:
   - full: user.group
     schema_name: group
     short: User's group relevant to the event.
+  - full: user.risk
+    schema_name: risk
+    short: Fields for describing risk score and level.
   - full: user.target
     schema_name: user
     short: Targeted user of action taken.

--- a/generated/elasticsearch/composable/component/client.json
+++ b/generated/elasticsearch/composable/component/client.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/composable/component/destination.json
+++ b/generated/elasticsearch/composable/component/destination.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/composable/component/host.json
+++ b/generated/elasticsearch/composable/component/host.json
@@ -186,6 +186,30 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "risk": {
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
+            },
             "type": {
               "ignore_above": 1024,
               "type": "keyword"

--- a/generated/elasticsearch/composable/component/server.json
+++ b/generated/elasticsearch/composable/component/server.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/composable/component/source.json
+++ b/generated/elasticsearch/composable/component/source.json
@@ -173,6 +173,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"

--- a/generated/elasticsearch/composable/component/user.json
+++ b/generated/elasticsearch/composable/component/user.json
@@ -60,6 +60,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -122,6 +146,30 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
+                },
                 "roles": {
                   "ignore_above": 1024,
                   "type": "keyword"
@@ -173,6 +221,30 @@
               },
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "risk": {
+              "properties": {
+                "calculated_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "calculated_score": {
+                  "type": "float"
+                },
+                "calculated_score_norm": {
+                  "type": "float"
+                },
+                "static_level": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "static_score": {
+                  "type": "float"
+                },
+                "static_score_norm": {
+                  "type": "float"
+                }
+              }
             },
             "roles": {
               "ignore_above": 1024,
@@ -229,6 +301,30 @@
                   },
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "risk": {
+                  "properties": {
+                    "calculated_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "calculated_score": {
+                      "type": "float"
+                    },
+                    "calculated_score_norm": {
+                      "type": "float"
+                    },
+                    "static_level": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "static_score": {
+                      "type": "float"
+                    },
+                    "static_score_norm": {
+                      "type": "float"
+                    }
+                  }
                 },
                 "roles": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -221,6 +221,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -703,6 +727,30 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
               },
               "roles": {
                 "ignore_above": 1024,
@@ -1839,6 +1887,30 @@
           "pid_ns_ino": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "risk": {
+            "properties": {
+              "calculated_level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "calculated_score": {
+                "type": "float"
+              },
+              "calculated_score_norm": {
+                "type": "float"
+              },
+              "static_level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "static_score": {
+                "type": "float"
+              },
+              "static_score_norm": {
+                "type": "float"
+              }
+            }
           },
           "type": {
             "ignore_above": 1024,
@@ -4184,6 +4256,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -4514,6 +4610,30 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
               },
               "roles": {
                 "ignore_above": 1024,
@@ -6698,6 +6818,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -6760,6 +6904,30 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
+              },
               "roles": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -6811,6 +6979,30 @@
             },
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "risk": {
+            "properties": {
+              "calculated_level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "calculated_score": {
+                "type": "float"
+              },
+              "calculated_score_norm": {
+                "type": "float"
+              },
+              "static_level": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "static_score": {
+                "type": "float"
+              },
+              "static_score_norm": {
+                "type": "float"
+              }
+            }
           },
           "roles": {
             "ignore_above": 1024,
@@ -6867,6 +7059,30 @@
                 },
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "risk": {
+                "properties": {
+                  "calculated_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "calculated_score": {
+                    "type": "float"
+                  },
+                  "calculated_score_norm": {
+                    "type": "float"
+                  },
+                  "static_level": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "static_score": {
+                    "type": "float"
+                  },
+                  "static_score_norm": {
+                    "type": "float"
+                  }
+                }
               },
               "roles": {
                 "ignore_above": 1024,

--- a/schemas/risk.yml
+++ b/schemas/risk.yml
@@ -1,10 +1,14 @@
 ---
 - name: risk
-  title: Risk score information
+  title: Risk information
   group: 2
-  short: Fields for describing the risk score and level.
+  short: Fields for describing risk score and level.
+  beta: >
+    These fields are in beta and are subject to change.
   description: >
-    Fields for describing the risk score and level.
+     Fields for describing risk score and risk level of entities such as hosts and users. 
+     These fields are not allowed to be nested under `event.*`. Please continue to use 
+     `event.risk_score` and `event.risk_score_norm` for event risk.
   reusable:
     top_level: false
     expected:

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -371,6 +371,8 @@ fields:
     fields: "*"
   related:
     fields: "*"
+  risk:
+    fields: "*"
   rule:
     fields: "*"
   server:


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Adding `risk.*` as beta (#2051)