### PR TITLE
[8.5] Add attested user and groups to process (#2050)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -46,6 +46,7 @@ Thanks, you're awesome :-) -->
 * Adding `process.io.*` as beta fields. #1956, #2031
 * Adding `process.tty.rows` and `process.tty.columns` as beta fields. #2031
 * Changed `process.env_vars` field type to be an array of keywords. #2038
+* `process.attested_user` and `process.attested_groups` as beta fields. #2050
 * Added `risk.*` fieldset to beta. #2051
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -4532,6 +4532,8 @@ type: keyword
 The `group` fields are expected to be nested at:
 
 
+* `process.attested_groups`
+
 * `process.group`
 
 * `process.real_group`
@@ -7673,6 +7675,24 @@ Note also that the `process` fields may be used directly at the root of the even
 [options="header"]
 |=====
 | Location | Field Set | Description
+
+// ===============================================================
+
+
+| `process.attested_groups.*`
+| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
+
+The externally attested groups based on an external source such as the Kube API.
+
+Note: this reuse should contain an array of group field set objects.
+
+// ===============================================================
+
+
+| `process.attested_user.*`
+| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
+
+The externally attested user based on an external source such as the Kube API.
 
 // ===============================================================
 
@@ -11539,6 +11559,8 @@ The `user` fields are expected to be nested at:
 * `client.user`
 
 * `destination.user`
+
+* `process.attested_user`
 
 * `process.real_user`
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5287,6 +5287,29 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: entry_leader.attested_groups.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: entry_leader.attested_user.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      default_field: false
+    - name: entry_leader.attested_user.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: match_only_text
+      description: Short name or login of the user.
+      example: a.einstein
+      default_field: false
     - name: entry_leader.command_line
       level: extended
       type: wildcard

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -580,6 +580,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev+exp,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.5.0-dev+exp,true,process,process.entry_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.5.0-dev+exp,true,process,process.entry_leader.args_count,long,extended,,4,Length of the process.args array.
+8.5.0-dev+exp,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
+8.5.0-dev+exp,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
+8.5.0-dev+exp,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
+8.5.0-dev+exp,true,process,process.entry_leader.attested_user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev+exp,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.5.0-dev+exp,true,process,process.entry_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.5.0-dev+exp,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7565,6 +7565,45 @@ process.entry_leader.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.entry_leader.attested_groups.name:
+  dashed_name: process-entry-leader-attested-groups-name
+  description: Name of the group.
+  flat_name: process.entry_leader.attested_groups.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+process.entry_leader.attested_user.id:
+  dashed_name: process-entry-leader-attested-user-id
+  description: Unique identifier of the user.
+  example: S-1-5-21-202424912787-2692429404-2351956786-1000
+  flat_name: process.entry_leader.attested_user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.entry_leader.attested_user.name:
+  dashed_name: process-entry-leader-attested-user-name
+  description: Short name or login of the user.
+  example: a.einstein
+  flat_name: process.entry_leader.attested_user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.entry_leader.attested_user.name.text
+    name: text
+    type: match_only_text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.entry_leader.command_line:
   dashed_name: process-entry-leader-command-line
   description: 'Full command line that started the process, including the absolute

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6122,6 +6122,14 @@ group:
       normalize:
       - array
       short_override: An array of supplemental groups.
+    - as: attested_groups
+      at: process
+      beta: Reusing the `group` fields in this location is currently considered beta.
+      full: process.attested_groups
+      normalize:
+      - array
+      short_override: The externally attested groups based on an external source such
+        as the Kube API.
     top_level: true
   short: User's group relevant to the event.
   title: Group
@@ -9269,6 +9277,45 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.entry_leader.attested_groups.name:
+      dashed_name: process-entry-leader-attested-groups-name
+      description: Name of the group.
+      flat_name: process.entry_leader.attested_groups.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
+    process.entry_leader.attested_user.id:
+      dashed_name: process-entry-leader-attested-user-id
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      flat_name: process.entry_leader.attested_user.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: user
+      short: Unique identifier of the user.
+      type: keyword
+    process.entry_leader.attested_user.name:
+      dashed_name: process-entry-leader-attested-user-name
+      description: Short name or login of the user.
+      example: a.einstein
+      flat_name: process.entry_leader.attested_user.name
+      ignore_above: 1024
+      level: core
+      multi_fields:
+      - flat_name: process.entry_leader.attested_user.name.text
+        name: text
+        type: match_only_text
+      name: name
+      normalize: []
+      original_fieldset: user
+      short: Short name or login of the user.
+      type: keyword
     process.entry_leader.command_line:
       dashed_name: process-entry-leader-command-line
       description: 'Full command line that started the process, including the absolute
@@ -12437,6 +12484,8 @@ process:
   group: 2
   name: process
   nestings:
+  - process.attested_groups
+  - process.attested_user
   - process.code_signature
   - process.elf
   - process.entry_leader
@@ -12551,6 +12600,13 @@ process:
     - array
     schema_name: group
     short: An array of supplemental groups.
+  - beta: Reusing the `group` fields in this location is currently considered beta.
+    full: process.attested_groups
+    normalize:
+    - array
+    schema_name: group
+    short: The externally attested groups based on an external source such as the
+      Kube API.
   - full: process.hash
     schema_name: hash
     short: Hashes, usually file hashes.
@@ -12580,6 +12636,11 @@ process:
     full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
+  - beta: Reusing the `user` fields in this location is currently considered beta.
+    full: process.attested_user
+    schema_name: user
+    short: The externally attested user based on an external source such as the Kube
+      API.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
@@ -21922,6 +21983,12 @@ user:
       beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
+    - as: attested_user
+      at: process
+      beta: Reusing the `user` fields in this location is currently considered beta.
+      full: process.attested_user
+      short_override: The externally attested user based on an external source such
+        as the Kube API.
     top_level: true
   reused_here:
   - full: user.group

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -192,6 +192,31 @@
                 "args_count": {
                   "type": "long"
                 },
+                "attested_groups": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "attested_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "command_line": {
                   "fields": {
                     "text": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -2736,6 +2736,31 @@
               "args_count": {
                 "type": "long"
               },
+              "attested_groups": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "attested_user": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "fields": {
+                      "text": {
+                        "type": "match_only_text"
+                      }
+                    },
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "command_line": {
                 "fields": {
                   "text": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5237,6 +5237,29 @@
         indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: entry_leader.attested_groups.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: entry_leader.attested_user.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      default_field: false
+    - name: entry_leader.attested_user.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+      - name: text
+        type: match_only_text
+      description: Short name or login of the user.
+      example: a.einstein
+      default_field: false
     - name: entry_leader.command_line
       level: extended
       type: wildcard

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -573,6 +573,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.0-dev,true,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
 8.5.0-dev,true,process,process.entry_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.5.0-dev,true,process,process.entry_leader.args_count,long,extended,,4,Length of the process.args array.
+8.5.0-dev,true,process,process.entry_leader.attested_groups.name,keyword,extended,,,Name of the group.
+8.5.0-dev,true,process,process.entry_leader.attested_user.id,keyword,core,,S-1-5-21-202424912787-2692429404-2351956786-1000,Unique identifier of the user.
+8.5.0-dev,true,process,process.entry_leader.attested_user.name,keyword,core,,a.einstein,Short name or login of the user.
+8.5.0-dev,true,process,process.entry_leader.attested_user.name.text,match_only_text,core,,a.einstein,Short name or login of the user.
 8.5.0-dev,true,process,process.entry_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.5.0-dev,true,process,process.entry_leader.command_line.text,match_only_text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
 8.5.0-dev,true,process,process.entry_leader.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7496,6 +7496,45 @@ process.entry_leader.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.entry_leader.attested_groups.name:
+  dashed_name: process-entry-leader-attested-groups-name
+  description: Name of the group.
+  flat_name: process.entry_leader.attested_groups.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+process.entry_leader.attested_user.id:
+  dashed_name: process-entry-leader-attested-user-id
+  description: Unique identifier of the user.
+  example: S-1-5-21-202424912787-2692429404-2351956786-1000
+  flat_name: process.entry_leader.attested_user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.entry_leader.attested_user.name:
+  dashed_name: process-entry-leader-attested-user-name
+  description: Short name or login of the user.
+  example: a.einstein
+  flat_name: process.entry_leader.attested_user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.entry_leader.attested_user.name.text
+    name: text
+    type: match_only_text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.entry_leader.command_line:
   dashed_name: process-entry-leader-command-line
   description: 'Full command line that started the process, including the absolute

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -6042,6 +6042,14 @@ group:
       normalize:
       - array
       short_override: An array of supplemental groups.
+    - as: attested_groups
+      at: process
+      beta: Reusing the `group` fields in this location is currently considered beta.
+      full: process.attested_groups
+      normalize:
+      - array
+      short_override: The externally attested groups based on an external source such
+        as the Kube API.
     top_level: true
   short: User's group relevant to the event.
   title: Group
@@ -9189,6 +9197,45 @@ process:
       original_fieldset: process
       short: Length of the process.args array.
       type: long
+    process.entry_leader.attested_groups.name:
+      dashed_name: process-entry-leader-attested-groups-name
+      description: Name of the group.
+      flat_name: process.entry_leader.attested_groups.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
+    process.entry_leader.attested_user.id:
+      dashed_name: process-entry-leader-attested-user-id
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      flat_name: process.entry_leader.attested_user.id
+      ignore_above: 1024
+      level: core
+      name: id
+      normalize: []
+      original_fieldset: user
+      short: Unique identifier of the user.
+      type: keyword
+    process.entry_leader.attested_user.name:
+      dashed_name: process-entry-leader-attested-user-name
+      description: Short name or login of the user.
+      example: a.einstein
+      flat_name: process.entry_leader.attested_user.name
+      ignore_above: 1024
+      level: core
+      multi_fields:
+      - flat_name: process.entry_leader.attested_user.name.text
+        name: text
+        type: match_only_text
+      name: name
+      normalize: []
+      original_fieldset: user
+      short: Short name or login of the user.
+      type: keyword
     process.entry_leader.command_line:
       dashed_name: process-entry-leader-command-line
       description: 'Full command line that started the process, including the absolute
@@ -12357,6 +12404,8 @@ process:
   group: 2
   name: process
   nestings:
+  - process.attested_groups
+  - process.attested_user
   - process.code_signature
   - process.elf
   - process.entry_leader
@@ -12471,6 +12520,13 @@ process:
     - array
     schema_name: group
     short: An array of supplemental groups.
+  - beta: Reusing the `group` fields in this location is currently considered beta.
+    full: process.attested_groups
+    normalize:
+    - array
+    schema_name: group
+    short: The externally attested groups based on an external source such as the
+      Kube API.
   - full: process.hash
     schema_name: hash
     short: Hashes, usually file hashes.
@@ -12500,6 +12556,11 @@ process:
     full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
+  - beta: Reusing the `user` fields in this location is currently considered beta.
+    full: process.attested_user
+    schema_name: user
+    short: The externally attested user based on an external source such as the Kube
+      API.
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
@@ -21842,6 +21903,12 @@ user:
       beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
+    - as: attested_user
+      at: process
+      beta: Reusing the `user` fields in this location is currently considered beta.
+      full: process.attested_user
+      short_override: The externally attested user based on an external source such
+        as the Kube API.
     top_level: true
   reused_here:
   - full: user.group

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -192,6 +192,31 @@
                 "args_count": {
                   "type": "long"
                 },
+                "attested_groups": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "attested_user": {
+                  "properties": {
+                    "id": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "name": {
+                      "fields": {
+                        "text": {
+                          "type": "match_only_text"
+                        }
+                      },
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "command_line": {
                   "fields": {
                     "text": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -2694,6 +2694,31 @@
               "args_count": {
                 "type": "long"
               },
+              "attested_groups": {
+                "properties": {
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "attested_user": {
+                "properties": {
+                  "id": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "name": {
+                    "fields": {
+                      "text": {
+                        "type": "match_only_text"
+                      }
+                    },
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "command_line": {
                 "fields": {
                   "text": {

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -47,6 +47,12 @@
         beta: Reusing the `group` fields in this location is currently considered beta.
         normalize:
           - array
+      - at: process
+        as: attested_groups
+        short_override: The externally attested groups based on an external source such as the Kube API.
+        beta: Reusing the `group` fields in this location is currently considered beta.
+        normalize:
+          - array
 
   fields:
 

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -139,6 +139,13 @@ fields:
             fields:
               id: {}
               name: {}
+          attested_user:
+            fields:
+              id: {}
+              name: {}
+          attested_groups:
+            fields:
+              name: {}
       entry_meta:
         fields:
           type:

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -54,6 +54,10 @@
         as: real_user
         short_override: The real user (ruid). Identifies the real owner of the process.
         beta: Reusing the `user` fields in this location is currently considered beta.
+      - at: process
+        as: attested_user
+        short_override: The externally attested user based on an external source such as the Kube API.
+        beta: Reusing the `user` fields in this location is currently considered beta.
 
   type: group
   fields:


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Add attested user and groups to process (#2050)