### PR TITLE
Forward Port cut 8.6 SFF Changelog (#2071)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,32 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+#### Improvements
+
+#### Deprecated
+
+### Tooling and Artifact Changes
+
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
+#### Improvements
+
+#### Deprecated
+
+## 8.6.0 (Soft Feature Freeze)
+
+### Schema Changes
+
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
 * Adding `vulnerability` option for `event.catgeory`. #2029
 * Added `device.*` field set as beta. #2030
 


### PR DESCRIPTION
Forward Port SFF 8.6 `CHANGELOG.next.md` to `main`