### PR TITLE
Process io subset fix

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7439,6 +7439,177 @@ example: `True`
 // ===============================================================
 
 |
+[[field-process-io]]
+<<field-process-io, process.io>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+A chunk of input or output (IO) from a single process.
+
+This field only appears on the top level process object, which is the process that wrote the output or read the input.
+
+type: object
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-bytes-skipped]]
+<<field-process-io-bytes-skipped, process.io.bytes_skipped>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+An array of byte offsets and lengths denoting where IO data has been skipped.
+
+type: object
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-bytes-skipped-length]]
+<<field-process-io-bytes-skipped-length, process.io.bytes_skipped.length>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+The length of bytes skipped.
+
+type: number
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-bytes-skipped-offset]]
+<<field-process-io-bytes-skipped-offset, process.io.bytes_skipped.offset>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+
+type: number
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-max-bytes-per-process-exceeded]]
+<<field-process-io-max-bytes-per-process-exceeded, process.io.max_bytes_per_process_exceeded>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting.
+
+type: boolean
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-text]]
+<<field-process-io-text, process.io.text>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+A chunk of output or input sanitized to UTF-8.
+
+Best efforts are made to ensure complete lines are captured in these events. Assumptions should NOT be made that multiple lines will appear in the same event. TTY output may contain terminal control codes such as for cursor movement, so some string queries may not match due to terminal codes inserted between characters of a word.
+
+type: wildcard
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-total-bytes-captured]]
+<<field-process-io-total-bytes-captured, process.io.total_bytes_captured>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+The total number of bytes captured in this event.
+
+type: number
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-total-bytes-skipped]]
+<<field-process-io-total-bytes-skipped, process.io.total_bytes_skipped>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
+
+type: number
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-io-type]]
+<<field-process-io-type, process.io.type>>
+
+a| beta:[ This field is beta and subject to change. ]
+
+The type of object on which the IO action (read or write) was taken.
+
+Currently only 'tty' is supported. Other types may be added in the future for 'file' and 'socket' support.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-process-name]]
 <<field-process-name, process.name>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5908,6 +5908,70 @@
         connected to the controlling TTY.'
       example: true
       default_field: false
+    - name: io
+      level: extended
+      type: object
+      description: 'A chunk of input or output (IO) from a single process.
+
+        This field only appears on the top level process object, which is the process
+        that wrote the output or read the input.'
+      default_field: false
+    - name: io.bytes_skipped
+      level: extended
+      type: object
+      description: An array of byte offsets and lengths denoting where IO data has
+        been skipped.
+      default_field: false
+    - name: io.bytes_skipped.length
+      level: extended
+      type: number
+      description: The length of bytes skipped.
+      default_field: false
+    - name: io.bytes_skipped.offset
+      level: extended
+      type: number
+      description: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      default_field: false
+    - name: io.max_bytes_per_process_exceeded
+      level: extended
+      type: boolean
+      description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      default_field: false
+    - name: io.text
+      level: extended
+      type: wildcard
+      description: 'A chunk of output or input sanitized to UTF-8.
+
+        Best efforts are made to ensure complete lines are captured in these events.
+        Assumptions should NOT be made that multiple lines will appear in the same
+        event. TTY output may contain terminal control codes such as for cursor movement,
+        so some string queries may not match due to terminal codes inserted between
+        characters of a word.'
+      default_field: false
+    - name: io.total_bytes_captured
+      level: extended
+      type: number
+      description: The total number of bytes captured in this event.
+      default_field: false
+    - name: io.total_bytes_skipped
+      level: extended
+      type: number
+      description: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits. Implementors should strive to ensure
+        this value is always zero
+      default_field: false
+    - name: io.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of object on which the IO action (read or write) was
+        taken.
+
+        Currently only ''tty'' is supported. Other types may be added in the future
+        for ''file'' and ''socket'' support.'
+      default_field: false
     - name: name
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -664,6 +664,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev+exp,true,process,process.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev+exp,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
+8.7.0-dev+exp,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped,object,extended,"a, r, r, a, y",,An array of byte offsets and lengths denoting where IO data has been skipped.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.7.0-dev+exp,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
+8.7.0-dev+exp,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
+8.7.0-dev+exp,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
+8.7.0-dev+exp,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.7.0-dev+exp,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.7.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8540,6 +8540,116 @@ process.interactive:
   normalize: []
   short: Whether the process is connected to an interactive shell.
   type: boolean
+process.io:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io
+  description: 'A chunk of input or output (IO) from a single process.
+
+    This field only appears on the top level process object, which is the process
+    that wrote the output or read the input.'
+  flat_name: process.io
+  level: extended
+  name: io
+  normalize: []
+  short: A chunk of input or output (IO) from a single process.
+  type: object
+process.io.bytes_skipped:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped
+  description: An array of byte offsets and lengths denoting where IO data has been
+    skipped.
+  flat_name: process.io.bytes_skipped
+  level: extended
+  name: io.bytes_skipped
+  normalize: array
+  short: An array of byte offsets and lengths denoting where IO data has been skipped.
+  type: object
+process.io.bytes_skipped.length:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped-length
+  description: The length of bytes skipped.
+  flat_name: process.io.bytes_skipped.length
+  level: extended
+  name: io.bytes_skipped.length
+  normalize: []
+  short: The length of bytes skipped.
+  type: number
+process.io.bytes_skipped.offset:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped-offset
+  description: The byte offset into this event's io.text (or io.bytes in the future)
+    where length bytes were skipped.
+  flat_name: process.io.bytes_skipped.offset
+  level: extended
+  name: io.bytes_skipped.offset
+  normalize: []
+  short: The byte offset into this event's io.text (or io.bytes in the future) where
+    length bytes were skipped.
+  type: number
+process.io.max_bytes_per_process_exceeded:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-max-bytes-per-process-exceeded
+  description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+    configuration setting.
+  flat_name: process.io.max_bytes_per_process_exceeded
+  level: extended
+  name: io.max_bytes_per_process_exceeded
+  normalize: []
+  short: If true, the process producing the output has exceeded the max_kilobytes_per_process
+    configuration setting.
+  type: boolean
+process.io.text:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-text
+  description: 'A chunk of output or input sanitized to UTF-8.
+
+    Best efforts are made to ensure complete lines are captured in these events. Assumptions
+    should NOT be made that multiple lines will appear in the same event. TTY output
+    may contain terminal control codes such as for cursor movement, so some string
+    queries may not match due to terminal codes inserted between characters of a word.'
+  flat_name: process.io.text
+  level: extended
+  name: io.text
+  normalize: []
+  short: A chunk of output or input sanitized to UTF-8.
+  type: wildcard
+process.io.total_bytes_captured:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-total-bytes-captured
+  description: The total number of bytes captured in this event.
+  flat_name: process.io.total_bytes_captured
+  level: extended
+  name: io.total_bytes_captured
+  normalize: []
+  short: The total number of bytes captured in this event.
+  type: number
+process.io.total_bytes_skipped:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-total-bytes-skipped
+  description: The total number of bytes that were not captured due to implementation
+    restrictions such as buffer size limits. Implementors should strive to ensure
+    this value is always zero
+  flat_name: process.io.total_bytes_skipped
+  level: extended
+  name: io.total_bytes_skipped
+  normalize: []
+  short: The total number of bytes that were not captured due to implementation restrictions
+    such as buffer size limits.
+  type: number
+process.io.type:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-type
+  description: 'The type of object on which the IO action (read or write) was taken.
+
+    Currently only ''tty'' is supported. Other types may be added in the future for
+    ''file'' and ''socket'' support.'
+  flat_name: process.io.type
+  ignore_above: 1024
+  level: extended
+  name: io.type
+  normalize: []
+  short: The type of object on which the IO action (read or write) was taken.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10269,6 +10269,119 @@ process:
       normalize: []
       short: Whether the process is connected to an interactive shell.
       type: boolean
+    process.io:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io
+      description: 'A chunk of input or output (IO) from a single process.
+
+        This field only appears on the top level process object, which is the process
+        that wrote the output or read the input.'
+      flat_name: process.io
+      level: extended
+      name: io
+      normalize: []
+      short: A chunk of input or output (IO) from a single process.
+      type: object
+    process.io.bytes_skipped:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped
+      description: An array of byte offsets and lengths denoting where IO data has
+        been skipped.
+      flat_name: process.io.bytes_skipped
+      level: extended
+      name: io.bytes_skipped
+      normalize: array
+      short: An array of byte offsets and lengths denoting where IO data has been
+        skipped.
+      type: object
+    process.io.bytes_skipped.length:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped-length
+      description: The length of bytes skipped.
+      flat_name: process.io.bytes_skipped.length
+      level: extended
+      name: io.bytes_skipped.length
+      normalize: []
+      short: The length of bytes skipped.
+      type: number
+    process.io.bytes_skipped.offset:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped-offset
+      description: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      flat_name: process.io.bytes_skipped.offset
+      level: extended
+      name: io.bytes_skipped.offset
+      normalize: []
+      short: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      type: number
+    process.io.max_bytes_per_process_exceeded:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-max-bytes-per-process-exceeded
+      description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      flat_name: process.io.max_bytes_per_process_exceeded
+      level: extended
+      name: io.max_bytes_per_process_exceeded
+      normalize: []
+      short: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      type: boolean
+    process.io.text:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-text
+      description: 'A chunk of output or input sanitized to UTF-8.
+
+        Best efforts are made to ensure complete lines are captured in these events.
+        Assumptions should NOT be made that multiple lines will appear in the same
+        event. TTY output may contain terminal control codes such as for cursor movement,
+        so some string queries may not match due to terminal codes inserted between
+        characters of a word.'
+      flat_name: process.io.text
+      level: extended
+      name: io.text
+      normalize: []
+      short: A chunk of output or input sanitized to UTF-8.
+      type: wildcard
+    process.io.total_bytes_captured:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-total-bytes-captured
+      description: The total number of bytes captured in this event.
+      flat_name: process.io.total_bytes_captured
+      level: extended
+      name: io.total_bytes_captured
+      normalize: []
+      short: The total number of bytes captured in this event.
+      type: number
+    process.io.total_bytes_skipped:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-total-bytes-skipped
+      description: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits. Implementors should strive to ensure
+        this value is always zero
+      flat_name: process.io.total_bytes_skipped
+      level: extended
+      name: io.total_bytes_skipped
+      normalize: []
+      short: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits.
+      type: number
+    process.io.type:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-type
+      description: 'The type of object on which the IO action (read or write) was
+        taken.
+
+        Currently only ''tty'' is supported. Other types may be added in the future
+        for ''file'' and ''socket'' support.'
+      flat_name: process.io.type
+      ignore_above: 1024
+      level: extended
+      name: io.type
+      normalize: []
+      short: The type of object on which the IO action (read or write) was taken.
+      type: keyword
     process.name:
       dashed_name: process-name
       description: 'Process name.

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -654,6 +654,38 @@
             "interactive": {
               "type": "boolean"
             },
+            "io": {
+              "properties": {
+                "bytes_skipped": {
+                  "properties": {
+                    "length": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "max_bytes_per_process_exceeded": {
+                  "type": "boolean"
+                },
+                "text": {
+                  "type": "wildcard"
+                },
+                "total_bytes_captured": {
+                  "type": "number"
+                },
+                "total_bytes_skipped": {
+                  "type": "number"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
             "name": {
               "fields": {
                 "text": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -3174,6 +3174,38 @@
           "interactive": {
             "type": "boolean"
           },
+          "io": {
+            "properties": {
+              "bytes_skipped": {
+                "properties": {
+                  "length": {
+                    "type": "number"
+                  },
+                  "offset": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "max_bytes_per_process_exceeded": {
+                "type": "boolean"
+              },
+              "text": {
+                "type": "wildcard"
+              },
+              "total_bytes_captured": {
+                "type": "number"
+              },
+              "total_bytes_skipped": {
+                "type": "number"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            },
+            "type": "object"
+          },
           "name": {
             "fields": {
               "text": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5858,6 +5858,70 @@
         connected to the controlling TTY.'
       example: true
       default_field: false
+    - name: io
+      level: extended
+      type: object
+      description: 'A chunk of input or output (IO) from a single process.
+
+        This field only appears on the top level process object, which is the process
+        that wrote the output or read the input.'
+      default_field: false
+    - name: io.bytes_skipped
+      level: extended
+      type: object
+      description: An array of byte offsets and lengths denoting where IO data has
+        been skipped.
+      default_field: false
+    - name: io.bytes_skipped.length
+      level: extended
+      type: number
+      description: The length of bytes skipped.
+      default_field: false
+    - name: io.bytes_skipped.offset
+      level: extended
+      type: number
+      description: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      default_field: false
+    - name: io.max_bytes_per_process_exceeded
+      level: extended
+      type: boolean
+      description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      default_field: false
+    - name: io.text
+      level: extended
+      type: wildcard
+      description: 'A chunk of output or input sanitized to UTF-8.
+
+        Best efforts are made to ensure complete lines are captured in these events.
+        Assumptions should NOT be made that multiple lines will appear in the same
+        event. TTY output may contain terminal control codes such as for cursor movement,
+        so some string queries may not match due to terminal codes inserted between
+        characters of a word.'
+      default_field: false
+    - name: io.total_bytes_captured
+      level: extended
+      type: number
+      description: The total number of bytes captured in this event.
+      default_field: false
+    - name: io.total_bytes_skipped
+      level: extended
+      type: number
+      description: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits. Implementors should strive to ensure
+        this value is always zero
+      default_field: false
+    - name: io.type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The type of object on which the IO action (read or write) was
+        taken.
+
+        Currently only ''tty'' is supported. Other types may be added in the future
+        for ''file'' and ''socket'' support.'
+      default_field: false
     - name: name
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -657,6 +657,15 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev,true,process,process.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
+8.7.0-dev,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
+8.7.0-dev,true,process,process.io.bytes_skipped,object,extended,"a, r, r, a, y",,An array of byte offsets and lengths denoting where IO data has been skipped.
+8.7.0-dev,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
+8.7.0-dev,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.7.0-dev,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
+8.7.0-dev,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
+8.7.0-dev,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
+8.7.0-dev,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.7.0-dev,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.7.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8471,6 +8471,116 @@ process.interactive:
   normalize: []
   short: Whether the process is connected to an interactive shell.
   type: boolean
+process.io:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io
+  description: 'A chunk of input or output (IO) from a single process.
+
+    This field only appears on the top level process object, which is the process
+    that wrote the output or read the input.'
+  flat_name: process.io
+  level: extended
+  name: io
+  normalize: []
+  short: A chunk of input or output (IO) from a single process.
+  type: object
+process.io.bytes_skipped:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped
+  description: An array of byte offsets and lengths denoting where IO data has been
+    skipped.
+  flat_name: process.io.bytes_skipped
+  level: extended
+  name: io.bytes_skipped
+  normalize: array
+  short: An array of byte offsets and lengths denoting where IO data has been skipped.
+  type: object
+process.io.bytes_skipped.length:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped-length
+  description: The length of bytes skipped.
+  flat_name: process.io.bytes_skipped.length
+  level: extended
+  name: io.bytes_skipped.length
+  normalize: []
+  short: The length of bytes skipped.
+  type: number
+process.io.bytes_skipped.offset:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-bytes-skipped-offset
+  description: The byte offset into this event's io.text (or io.bytes in the future)
+    where length bytes were skipped.
+  flat_name: process.io.bytes_skipped.offset
+  level: extended
+  name: io.bytes_skipped.offset
+  normalize: []
+  short: The byte offset into this event's io.text (or io.bytes in the future) where
+    length bytes were skipped.
+  type: number
+process.io.max_bytes_per_process_exceeded:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-max-bytes-per-process-exceeded
+  description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+    configuration setting.
+  flat_name: process.io.max_bytes_per_process_exceeded
+  level: extended
+  name: io.max_bytes_per_process_exceeded
+  normalize: []
+  short: If true, the process producing the output has exceeded the max_kilobytes_per_process
+    configuration setting.
+  type: boolean
+process.io.text:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-text
+  description: 'A chunk of output or input sanitized to UTF-8.
+
+    Best efforts are made to ensure complete lines are captured in these events. Assumptions
+    should NOT be made that multiple lines will appear in the same event. TTY output
+    may contain terminal control codes such as for cursor movement, so some string
+    queries may not match due to terminal codes inserted between characters of a word.'
+  flat_name: process.io.text
+  level: extended
+  name: io.text
+  normalize: []
+  short: A chunk of output or input sanitized to UTF-8.
+  type: wildcard
+process.io.total_bytes_captured:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-total-bytes-captured
+  description: The total number of bytes captured in this event.
+  flat_name: process.io.total_bytes_captured
+  level: extended
+  name: io.total_bytes_captured
+  normalize: []
+  short: The total number of bytes captured in this event.
+  type: number
+process.io.total_bytes_skipped:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-total-bytes-skipped
+  description: The total number of bytes that were not captured due to implementation
+    restrictions such as buffer size limits. Implementors should strive to ensure
+    this value is always zero
+  flat_name: process.io.total_bytes_skipped
+  level: extended
+  name: io.total_bytes_skipped
+  normalize: []
+  short: The total number of bytes that were not captured due to implementation restrictions
+    such as buffer size limits.
+  type: number
+process.io.type:
+  beta: This field is beta and subject to change.
+  dashed_name: process-io-type
+  description: 'The type of object on which the IO action (read or write) was taken.
+
+    Currently only ''tty'' is supported. Other types may be added in the future for
+    ''file'' and ''socket'' support.'
+  flat_name: process.io.type
+  ignore_above: 1024
+  level: extended
+  name: io.type
+  normalize: []
+  short: The type of object on which the IO action (read or write) was taken.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10189,6 +10189,119 @@ process:
       normalize: []
       short: Whether the process is connected to an interactive shell.
       type: boolean
+    process.io:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io
+      description: 'A chunk of input or output (IO) from a single process.
+
+        This field only appears on the top level process object, which is the process
+        that wrote the output or read the input.'
+      flat_name: process.io
+      level: extended
+      name: io
+      normalize: []
+      short: A chunk of input or output (IO) from a single process.
+      type: object
+    process.io.bytes_skipped:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped
+      description: An array of byte offsets and lengths denoting where IO data has
+        been skipped.
+      flat_name: process.io.bytes_skipped
+      level: extended
+      name: io.bytes_skipped
+      normalize: array
+      short: An array of byte offsets and lengths denoting where IO data has been
+        skipped.
+      type: object
+    process.io.bytes_skipped.length:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped-length
+      description: The length of bytes skipped.
+      flat_name: process.io.bytes_skipped.length
+      level: extended
+      name: io.bytes_skipped.length
+      normalize: []
+      short: The length of bytes skipped.
+      type: number
+    process.io.bytes_skipped.offset:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-bytes-skipped-offset
+      description: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      flat_name: process.io.bytes_skipped.offset
+      level: extended
+      name: io.bytes_skipped.offset
+      normalize: []
+      short: The byte offset into this event's io.text (or io.bytes in the future)
+        where length bytes were skipped.
+      type: number
+    process.io.max_bytes_per_process_exceeded:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-max-bytes-per-process-exceeded
+      description: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      flat_name: process.io.max_bytes_per_process_exceeded
+      level: extended
+      name: io.max_bytes_per_process_exceeded
+      normalize: []
+      short: If true, the process producing the output has exceeded the max_kilobytes_per_process
+        configuration setting.
+      type: boolean
+    process.io.text:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-text
+      description: 'A chunk of output or input sanitized to UTF-8.
+
+        Best efforts are made to ensure complete lines are captured in these events.
+        Assumptions should NOT be made that multiple lines will appear in the same
+        event. TTY output may contain terminal control codes such as for cursor movement,
+        so some string queries may not match due to terminal codes inserted between
+        characters of a word.'
+      flat_name: process.io.text
+      level: extended
+      name: io.text
+      normalize: []
+      short: A chunk of output or input sanitized to UTF-8.
+      type: wildcard
+    process.io.total_bytes_captured:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-total-bytes-captured
+      description: The total number of bytes captured in this event.
+      flat_name: process.io.total_bytes_captured
+      level: extended
+      name: io.total_bytes_captured
+      normalize: []
+      short: The total number of bytes captured in this event.
+      type: number
+    process.io.total_bytes_skipped:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-total-bytes-skipped
+      description: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits. Implementors should strive to ensure
+        this value is always zero
+      flat_name: process.io.total_bytes_skipped
+      level: extended
+      name: io.total_bytes_skipped
+      normalize: []
+      short: The total number of bytes that were not captured due to implementation
+        restrictions such as buffer size limits.
+      type: number
+    process.io.type:
+      beta: This field is beta and subject to change.
+      dashed_name: process-io-type
+      description: 'The type of object on which the IO action (read or write) was
+        taken.
+
+        Currently only ''tty'' is supported. Other types may be added in the future
+        for ''file'' and ''socket'' support.'
+      flat_name: process.io.type
+      ignore_above: 1024
+      level: extended
+      name: io.type
+      normalize: []
+      short: The type of object on which the IO action (read or write) was taken.
+      type: keyword
     process.name:
       dashed_name: process-name
       description: 'Process name.

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -654,6 +654,38 @@
             "interactive": {
               "type": "boolean"
             },
+            "io": {
+              "properties": {
+                "bytes_skipped": {
+                  "properties": {
+                    "length": {
+                      "type": "number"
+                    },
+                    "offset": {
+                      "type": "number"
+                    }
+                  },
+                  "type": "object"
+                },
+                "max_bytes_per_process_exceeded": {
+                  "type": "boolean"
+                },
+                "text": {
+                  "type": "wildcard"
+                },
+                "total_bytes_captured": {
+                  "type": "number"
+                },
+                "total_bytes_skipped": {
+                  "type": "number"
+                },
+                "type": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              },
+              "type": "object"
+            },
             "name": {
               "fields": {
                 "text": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -3132,6 +3132,38 @@
           "interactive": {
             "type": "boolean"
           },
+          "io": {
+            "properties": {
+              "bytes_skipped": {
+                "properties": {
+                  "length": {
+                    "type": "number"
+                  },
+                  "offset": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "max_bytes_per_process_exceeded": {
+                "type": "boolean"
+              },
+              "text": {
+                "type": "wildcard"
+              },
+              "total_bytes_captured": {
+                "type": "number"
+              },
+              "total_bytes_skipped": {
+                "type": "number"
+              },
+              "type": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            },
+            "type": "object"
+          },
           "name": {
             "fields": {
               "text": {

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -263,6 +263,8 @@ fields:
       hash:
         fields: "*"
       interactive: {}
+      io: 
+        fields: "*"
       name: {}
       parent:
         fields:


### PR DESCRIPTION
Followup to https://github.com/elastic/ecs/pull/2031 

Adding `io.*` fields to the subset file at top-level process

cc @mitodrummer 