### PR TITLE
Add fields for executable object format metadata for ELF, Mach-O and PE

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -45,6 +45,7 @@ Thanks, you're awesome :-) -->
 * Adding `vulnerability` option for `event.catgeory`. #2029
 * Added `device.*` field set as beta. #2030
 * Added `tlp.version` to threat #2074
+* Added fields for executable object format metadata for ELF, Mach-O and PE #2083
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2266,7 +2266,9 @@ Note: this field should contain an array of values.
 [[field-elf-go-import-hash]]
 <<field-elf-go-import-hash, elf.go_import_hash>>
 
-a| A hash of the Go language imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+a| A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
 
 type: keyword
 
@@ -5977,7 +5979,9 @@ beta::[ These fields are in beta and are subject to change.]
 [[field-macho-go-import-hash]]
 <<field-macho-go-import-hash, macho.go_import_hash>>
 
-a| A hash of the Go language imports in an Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+a| A hash of the Go language imports in a Mach-O file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
 
 type: keyword
 
@@ -7590,7 +7594,9 @@ example: `6.3.9600.17415`
 [[field-pe-go-import-hash]]
 <<field-pe-go-import-hash, pe.go_import_hash>>
 
-a| A hash of the Go language imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+a| A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).
 
 type: keyword
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -2263,6 +2263,86 @@ Note: this field should contain an array of values.
 // ===============================================================
 
 |
+[[field-elf-go-import-hash]]
+<<field-elf-go-import-hash, elf.go_import_hash>>
+
+a| A hash of the Go language imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+type: keyword
+
+
+
+example: `10bddcb4cee42080f76c88d9ff964491`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-go-imports]]
+<<field-elf-go-imports, elf.go_imports>>
+
+a| List of imported Go language element names and types.
+
+type: flattened
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-go-imports-names-entropy]]
+<<field-elf-go-imports-names-entropy, elf.go_imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-go-imports-names-var-entropy]]
+<<field-elf-go-imports-names-var-entropy, elf.go_imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-go-stripped]]
+<<field-elf-go-stripped, elf.go_stripped>>
+
+a| Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+
+type: boolean
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-elf-header-abi-version]]
 <<field-elf-header-abi-version, elf.header.abi_version>>
 
@@ -2391,6 +2471,24 @@ type: keyword
 // ===============================================================
 
 |
+[[field-elf-import-hash]]
+<<field-elf-import-hash, elf.import_hash>>
+
+a| A hash of the imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+This is an ELF implementation of the Windows PE imphash.
+
+type: keyword
+
+
+
+example: `d41d8cd98f00b204e9800998ecf8427e`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-elf-imports]]
 <<field-elf-imports, elf.imports>>
 
@@ -2400,6 +2498,38 @@ type: flattened
 
 
 Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-imports-names-entropy]]
+<<field-elf-imports-names-entropy, elf.imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of imported element names and types.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-imports-names-var-entropy]]
+<<field-elf-imports-names-var-entropy, elf.imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of imported element names and types.
+
+type: long
 
 
 
@@ -2533,6 +2663,22 @@ type: long
 a| ELF Section List type.
 
 type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-elf-sections-var-entropy]]
+<<field-elf-sections-var-entropy, elf.sections.var_entropy>>
+
+a| Variance for Shannon entropy calculation from the section.
+
+type: long
 
 
 
@@ -4308,6 +4454,14 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 // ===============================================================
 
 
+| `file.macho.*`
+| <<ecs-macho,macho>>| beta:[ This field reuse is beta and subject to change.]
+
+These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+
+// ===============================================================
+
+
 | `file.pe.*`
 | <<ecs-pe,pe>>
 | These fields contain Windows Portable Executable (PE) metadata.
@@ -5803,6 +5957,304 @@ example: `1`
 |=====
 
 
+[[ecs-macho]]
+=== Mach-O Header Fields
+
+These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+
+beta::[ These fields are in beta and are subject to change.]
+
+[discrete]
+==== Mach-O Header Field Details
+
+[options="header"]
+|=====
+| Field  | Description | Level
+
+// ===============================================================
+
+|
+[[field-macho-go-import-hash]]
+<<field-macho-go-import-hash, macho.go_import_hash>>
+
+a| A hash of the Go language imports in an Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+type: keyword
+
+
+
+example: `10bddcb4cee42080f76c88d9ff964491`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-go-imports]]
+<<field-macho-go-imports, macho.go_imports>>
+
+a| List of imported Go language element names and types.
+
+type: flattened
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-go-imports-names-entropy]]
+<<field-macho-go-imports-names-entropy, macho.go_imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-go-imports-names-var-entropy]]
+<<field-macho-go-imports-names-var-entropy, macho.go_imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-go-stripped]]
+<<field-macho-go-stripped, macho.go_stripped>>
+
+a| Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+
+type: boolean
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-import-hash]]
+<<field-macho-import-hash, macho.import_hash>>
+
+a| A hash of the imports in an Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+This is a synonym for symhash.
+
+type: keyword
+
+
+
+example: `d41d8cd98f00b204e9800998ecf8427e`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-imports]]
+<<field-macho-imports, macho.imports>>
+
+a| List of imported element names and types.
+
+type: flattened
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-imports-names-entropy]]
+<<field-macho-imports-names-entropy, macho.imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of imported element names and types.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-imports-names-var-entropy]]
+<<field-macho-imports-names-var-entropy, macho.imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of imported element names and types.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections]]
+<<field-macho-sections, macho.sections>>
+
+a| An array containing an object for each section of the Mach-O file.
+
+The keys that should be present in these objects are defined by sub-fields underneath `macho.sections.*`.
+
+type: nested
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections-entropy]]
+<<field-macho-sections-entropy, macho.sections.entropy>>
+
+a| Shannon entropy calculation from the section.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections-name]]
+<<field-macho-sections-name, macho.sections.name>>
+
+a| Mach-O Section List name.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections-physical-size]]
+<<field-macho-sections-physical-size, macho.sections.physical_size>>
+
+a| Mach-O Section List physical size.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections-var-entropy]]
+<<field-macho-sections-var-entropy, macho.sections.var_entropy>>
+
+a| Variance for Shannon entropy calculation from the section.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-sections-virtual-size]]
+<<field-macho-sections-virtual-size, macho.sections.virtual_size>>
+
+a| Mach-O Section List virtual size. This is always the same as `physical_size`.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-macho-symhash]]
+<<field-macho-symhash, macho.symhash>>
+
+a| A hash of the imports in a Mach-O file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+This is a Mach-O implementation of the Windows PE imphash
+
+type: keyword
+
+
+
+example: `d3ccf195b62a9279c3c19af1080497ec`
+
+| extended
+
+// ===============================================================
+
+|=====
+
+[discrete]
+==== Field Reuse
+
+The `macho` fields are expected to be nested at:
+
+
+* `file.macho`
+
+* `process.macho`
+
+
+Note also that the `macho` fields are not expected to be used directly at the root of the events.
 [[ecs-network]]
 === Network Fields
 
@@ -7135,6 +7587,86 @@ example: `6.3.9600.17415`
 // ===============================================================
 
 |
+[[field-pe-go-import-hash]]
+<<field-pe-go-import-hash, pe.go_import_hash>>
+
+a| A hash of the Go language imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+type: keyword
+
+
+
+example: `10bddcb4cee42080f76c88d9ff964491`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-go-imports]]
+<<field-pe-go-imports, pe.go_imports>>
+
+a| List of imported Go language element names and types.
+
+type: flattened
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-go-imports-names-entropy]]
+<<field-pe-go-imports-names-entropy, pe.go_imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-go-imports-names-var-entropy]]
+<<field-pe-go-imports-names-var-entropy, pe.go_imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of Go imports.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-go-stripped]]
+<<field-pe-go-stripped, pe.go_stripped>>
+
+a| Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+
+type: boolean
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
 [[field-pe-imphash]]
 <<field-pe-imphash, pe.imphash>>
 
@@ -7147,6 +7679,75 @@ type: keyword
 
 
 example: `0c6803c4e922103c4dca5963aad36ddf`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-import-hash]]
+<<field-pe-import-hash, pe.import_hash>>
+
+a| A hash of the imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+This is a synonym for imphash.
+
+type: keyword
+
+
+
+example: `d41d8cd98f00b204e9800998ecf8427e`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-imports]]
+<<field-pe-imports, pe.imports>>
+
+a| List of imported element names and types.
+
+type: flattened
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-imports-names-entropy]]
+<<field-pe-imports-names-entropy, pe.imports_names_entropy>>
+
+a| Shannon entropy calculation from the list of imported element names and types.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-imports-names-var-entropy]]
+<<field-pe-imports-names-var-entropy, pe.imports_names_var_entropy>>
+
+a| Variance for Shannon entropy calculation from the list of imported element names and types.
+
+type: long
+
+
+
+
 
 | extended
 
@@ -7197,6 +7798,107 @@ type: keyword
 
 
 example: `Microsoft® Windows® Operating System`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections]]
+<<field-pe-sections, pe.sections>>
+
+a| An array containing an object for each section of the PE file.
+
+The keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.
+
+type: nested
+
+
+Note: this field should contain an array of values.
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections-entropy]]
+<<field-pe-sections-entropy, pe.sections.entropy>>
+
+a| Shannon entropy calculation from the section.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections-name]]
+<<field-pe-sections-name, pe.sections.name>>
+
+a| PE Section List name.
+
+type: keyword
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections-physical-size]]
+<<field-pe-sections-physical-size, pe.sections.physical_size>>
+
+a| PE Section List physical size.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections-var-entropy]]
+<<field-pe-sections-var-entropy, pe.sections.var_entropy>>
+
+a| Variance for Shannon entropy calculation from the section.
+
+type: long
+
+
+
+
+
+| extended
+
+// ===============================================================
+
+|
+[[field-pe-sections-virtual-size]]
+<<field-pe-sections-virtual-size, pe.sections.virtual_size>>
+
+a| PE Section List virtual size. This is always the same as `physical_size`.
+
+type: long
+
+
+
+
 
 | extended
 
@@ -8005,6 +8707,14 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 | `process.hash.*`
 | <<ecs-hash,hash>>
 | Hashes, usually file hashes.
+
+// ===============================================================
+
+
+| `process.macho.*`
+| <<ecs-macho,macho>>| beta:[ This field reuse is beta and subject to change.]
+
+These fields contain Mac OS Mach Object file format (Mach-O) metadata.
 
 // ===============================================================
 

--- a/docs/fields/fields.asciidoc
+++ b/docs/fields/fields.asciidoc
@@ -72,6 +72,8 @@ For a single page representation of all fields, please see the
 
 | <<ecs-log,Log>> | Details about the event's logging mechanism.
 
+| <<ecs-macho,Mach-O Header>> | These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+
 | <<ecs-network,Network>> | Fields describing the communication path over which the event happened.
 
 | <<ecs-observer,Observer>> | Fields describing an entity observing the event from outside the host.

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1515,6 +1515,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -1525,6 +1557,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -1550,6 +1612,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
   - name: dns
     title: DNS
@@ -1777,6 +1877,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: header.abi_version
       level: extended
       type: keyword
@@ -1825,10 +1957,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: sections
       level: extended
@@ -1879,6 +2036,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: sections.virtual_address
       level: extended
@@ -2728,6 +2891,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: elf.header.abi_version
       level: extended
       type: keyword
@@ -2776,10 +2971,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: elf.sections
       level: extended
@@ -2830,6 +3050,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: elf.sections.virtual_address
       level: extended
@@ -2959,6 +3185,118 @@
       ignore_above: 1024
       description: Inode representing the file in the filesystem.
       example: '256383'
+    - name: macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: mime_type
       level: extended
       type: keyword
@@ -3029,6 +3367,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -3039,6 +3409,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -3064,6 +3464,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: size
       level: extended
@@ -4070,6 +4508,125 @@
         for RFC 5424 messages.
       example: 1
       default_field: false
+  - name: macho
+    title: Mach-O Header
+    group: 2
+    description: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+    type: group
+    default_field: true
+    fields:
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
   - name: network
     title: Network
     group: 2
@@ -4866,6 +5423,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: imphash
       level: extended
       type: keyword
@@ -4876,6 +5465,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: original_file_name
       level: extended
@@ -4901,6 +5520,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
   - name: process
     title: Process
@@ -5054,6 +5711,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: elf.header.abi_version
       level: extended
       type: keyword
@@ -5102,10 +5791,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: elf.sections
       level: extended
@@ -5156,6 +5870,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: elf.sections.virtual_address
       level: extended
@@ -5972,6 +6692,118 @@
         Currently only ''tty'' is supported. Other types may be added in the future
         for ''file'' and ''socket'' support.'
       default_field: false
+    - name: macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: name
       level: extended
       type: keyword
@@ -6126,6 +6958,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: parent.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: parent.elf.header.abi_version
       level: extended
       type: keyword
@@ -6174,10 +7038,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: parent.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: parent.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: parent.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: parent.elf.sections
       level: extended
@@ -6228,6 +7117,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: parent.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: parent.elf.sections.virtual_address
       level: extended
@@ -6411,6 +7306,118 @@
         connected to the controlling TTY.'
       example: true
       default_field: false
+    - name: parent.macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: parent.macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: parent.macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: parent.macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: parent.macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: parent.macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: parent.macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: parent.macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: parent.macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: parent.name
       level: extended
       type: keyword
@@ -6451,6 +7458,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: parent.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: parent.pe.imphash
       level: extended
       type: keyword
@@ -6461,6 +7500,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: parent.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: parent.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: parent.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: parent.pe.original_file_name
       level: extended
@@ -6486,6 +7555,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: parent.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: parent.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: parent.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: parent.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: parent.pgid
       level: extended
@@ -6690,6 +7797,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -6700,6 +7839,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -6725,6 +7894,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: pgid
       level: extended
@@ -8764,6 +9971,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: enrichments.indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: enrichments.indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -8812,10 +10051,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: enrichments.indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: enrichments.indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: enrichments.indicator.file.elf.sections
       level: extended
@@ -8866,6 +10130,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: enrichments.indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: enrichments.indicator.file.elf.sections.virtual_address
       level: extended
@@ -9077,6 +10347,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: enrichments.indicator.file.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: enrichments.indicator.file.pe.imphash
       level: extended
       type: keyword
@@ -9087,6 +10389,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: enrichments.indicator.file.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: enrichments.indicator.file.pe.original_file_name
       level: extended
@@ -9112,6 +10444,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: enrichments.indicator.file.size
       level: extended
@@ -10183,6 +11553,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -10231,10 +11633,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: indicator.file.elf.sections
       level: extended
@@ -10285,6 +11712,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: indicator.file.elf.sections.virtual_address
       level: extended
@@ -10496,6 +11929,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: indicator.file.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: indicator.file.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: indicator.file.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: indicator.file.pe.imphash
       level: extended
       type: keyword
@@ -10506,6 +11971,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: indicator.file.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: indicator.file.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: indicator.file.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: indicator.file.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: indicator.file.pe.original_file_name
       level: extended
@@ -10531,6 +12026,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: indicator.file.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: indicator.file.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: indicator.file.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: indicator.file.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: indicator.file.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: indicator.file.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: indicator.file.size
       level: extended

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -1519,9 +1519,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1881,9 +1885,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -2895,9 +2903,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -3189,10 +3201,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3371,9 +3386,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4519,10 +4538,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -5427,9 +5449,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -5715,9 +5741,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -6696,10 +6726,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6962,9 +6995,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -7310,10 +7347,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -7462,9 +7502,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7801,9 +7845,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -9975,9 +10023,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -10351,9 +10403,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -11557,9 +11613,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11933,9 +11993,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -167,10 +167,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,dll,dll.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,dll,dll.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,dll,dll.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,dll,dll.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,dll,dll.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,dll,dll.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,dll,dll.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,dll,dll.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,dll,dll.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,dll,dll.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,dll,dll.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,dll,dll.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,dll,dll.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,dll,dll.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,dll,dll.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,dll,dll.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,dll,dll.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,dll,dll.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,dll,dll.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,dll,dll.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,dll,dll.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,dll,dll.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,dns,dns.answers,object,extended,array,,Array of DNS answers.
 8.7.0-dev+exp,true,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
 8.7.0-dev+exp,true,dns,dns.answers.data,keyword,extended,,10.10.10.10,The data describing the resource.
@@ -278,6 +293,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,file,file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev+exp,true,file,file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev+exp,true,file,file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev+exp,true,file,file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,file,file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,file,file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,file,file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev+exp,true,file,file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev+exp,true,file,file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -286,7 +306,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,file,file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev+exp,true,file,file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev+exp,true,file,file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev+exp,true,file,file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev+exp,true,file,file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,file,file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,file,file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,file,file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev+exp,true,file,file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev+exp,true,file,file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -295,6 +318,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,file,file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev+exp,true,file,file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev+exp,true,file,file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev+exp,true,file,file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev+exp,true,file,file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev+exp,true,file,file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev+exp,true,file,file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -314,6 +338,22 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,file,file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev+exp,true,file,file.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev+exp,true,file,file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
+8.7.0-dev+exp,true,file,file.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,file,file.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,file,file.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev+exp,true,file,file.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,file,file.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,file,file.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,file,file.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,file,file.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev+exp,true,file,file.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,file,file.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev+exp,true,file,file.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev+exp,true,file,file.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,file,file.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev+exp,true,file,file.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev+exp,true,file,file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 8.7.0-dev+exp,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.7.0-dev+exp,true,file,file.mtime,date,extended,,,Last time the file content was modified.
@@ -325,10 +365,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,file,file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,file,file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,file,file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,file,file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,file,file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,file,file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,file,file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,file,file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,file,file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,file,file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,file,file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,file,file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,file,file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,file,file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,file,file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,file,file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,file,file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,file,file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,file,file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,file,file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev+exp,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev+exp,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
@@ -544,6 +599,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev+exp,true,process,process.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev+exp,true,process,process.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev+exp,true,process,process.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,process,process.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev+exp,true,process,process.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev+exp,true,process,process.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -552,7 +612,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev+exp,true,process,process.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev+exp,true,process,process.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev+exp,true,process,process.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev+exp,true,process,process.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,process,process.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev+exp,true,process,process.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev+exp,true,process,process.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -561,6 +624,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev+exp,true,process,process.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev+exp,true,process,process.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev+exp,true,process,process.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev+exp,true,process,process.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev+exp,true,process,process.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev+exp,true,process,process.elf.segments,nested,extended,array,,ELF object segment list.
@@ -673,6 +737,22 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
 8.7.0-dev+exp,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.7.0-dev+exp,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
+8.7.0-dev+exp,true,process,process.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev+exp,true,process,process.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,process,process.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev+exp,true,process,process.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev+exp,true,process,process.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev+exp,true,process,process.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev+exp,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev+exp,true,process,process.name,keyword,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -693,6 +773,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev+exp,true,process,process.parent.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev+exp,true,process,process.parent.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev+exp,true,process,process.parent.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.parent.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.parent.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,process,process.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev+exp,true,process,process.parent.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev+exp,true,process,process.parent.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -701,7 +786,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.parent.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev+exp,true,process,process.parent.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev+exp,true,process,process.parent.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev+exp,true,process,process.parent.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev+exp,true,process,process.parent.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,process,process.parent.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -710,6 +798,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.parent.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev+exp,true,process,process.parent.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev+exp,true,process,process.parent.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev+exp,true,process,process.parent.elf.segments,nested,extended,array,,ELF object segment list.
@@ -735,16 +824,47 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev+exp,true,process,process.parent.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev+exp,true,process,process.parent.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
+8.7.0-dev+exp,true,process,process.parent.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.parent.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.parent.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev+exp,true,process,process.parent.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,process,process.parent.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev+exp,true,process,process.parent.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.parent.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev+exp,true,process,process.parent.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev+exp,true,process,process.parent.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev+exp,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev+exp,true,process,process.parent.name,keyword,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev+exp,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.7.0-dev+exp,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,process,process.parent.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.parent.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.parent.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.parent.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,process,process.parent.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,process,process.parent.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.parent.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.parent.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,process,process.parent.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,process,process.parent.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.parent.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,process,process.parent.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,process,process.parent.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.parent.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,process,process.parent.pgid,long,extended,,,Deprecated identifier of the group of processes the process belongs to.
 8.7.0-dev+exp,true,process,process.parent.pid,long,core,,4242,Process id.
 8.7.0-dev+exp,true,process,process.parent.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -777,10 +897,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,process,process.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,process,process.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,process,process.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,process,process.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,process,process.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,process,process.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,process,process.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,process,process.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,process,process.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,process,process.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,process,process.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,process,process.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,process,process.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,process,process.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,process,process.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,process,process.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,process,process.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,process,process.pgid,long,extended,,,Deprecated identifier of the group of processes the process belongs to.
 8.7.0-dev+exp,true,process,process.pid,long,core,,4242,Process id.
 8.7.0-dev+exp,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -1016,6 +1151,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -1024,7 +1164,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -1033,6 +1176,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -1063,10 +1207,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev+exp,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
@@ -1207,6 +1366,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -1215,7 +1379,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -1224,6 +1391,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev+exp,true,threat,threat.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -1254,10 +1422,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev+exp,true,threat,threat.indicator.file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev+exp,true,threat,threat.indicator.file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev+exp,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev+exp,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev+exp,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2023,6 +2023,63 @@ dll.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+dll.pe.go_import_hash:
+  dashed_name: dll-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: dll.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+dll.pe.go_imports:
+  dashed_name: dll-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: dll.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+dll.pe.go_imports_names_entropy:
+  dashed_name: dll-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: dll.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+dll.pe.go_imports_names_var_entropy:
+  dashed_name: dll-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: dll.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+dll.pe.go_stripped:
+  dashed_name: dll-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: dll.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 dll.pe.imphash:
   dashed_name: dll-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -2039,6 +2096,58 @@ dll.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+dll.pe.import_hash:
+  dashed_name: dll-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: dll.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+dll.pe.imports:
+  dashed_name: dll-pe-imports
+  description: List of imported element names and types.
+  flat_name: dll.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+dll.pe.imports_names_entropy:
+  dashed_name: dll-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: dll.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+dll.pe.imports_names_var_entropy:
+  dashed_name: dll-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: dll.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 dll.pe.original_file_name:
   dashed_name: dll-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -2079,6 +2188,75 @@ dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+dll.pe.sections:
+  dashed_name: dll-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: dll.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+dll.pe.sections.entropy:
+  dashed_name: dll-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: dll.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+dll.pe.sections.name:
+  dashed_name: dll-pe-sections-name
+  description: PE Section List name.
+  flat_name: dll.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+dll.pe.sections.physical_size:
+  dashed_name: dll-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: dll.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+dll.pe.sections.var_entropy:
+  dashed_name: dll-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: dll.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+dll.pe.sections.virtual_size:
+  dashed_name: dll-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: dll.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 dns.answers:
   dashed_name: dns-answers
   description: 'An array containing an object for each answer section returned by
@@ -3887,6 +4065,63 @@ file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+file.elf.go_import_hash:
+  dashed_name: file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.elf.go_imports:
+  dashed_name: file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+file.elf.go_imports_names_entropy:
+  dashed_name: file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.elf.go_imports_names_var_entropy:
+  dashed_name: file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.elf.go_stripped:
+  dashed_name: file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 file.elf.header.abi_version:
   dashed_name: file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -3975,6 +4210,22 @@ file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+file.elf.import_hash:
+  dashed_name: file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 file.elf.imports:
   dashed_name: file-elf-imports
   description: List of imported element names and types.
@@ -3986,6 +4237,31 @@ file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+file.elf.imports_names_entropy:
+  dashed_name: file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.elf.imports_names_var_entropy:
+  dashed_name: file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 file.elf.sections:
   dashed_name: file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -4077,6 +4353,17 @@ file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+file.elf.sections.var_entropy:
+  dashed_name: file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 file.elf.sections.virtual_address:
   dashed_name: file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -4305,6 +4592,200 @@ file.inode:
   normalize: []
   short: Inode representing the file in the filesystem.
   type: keyword
+file.macho.go_import_hash:
+  dashed_name: file-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.macho.go_imports:
+  dashed_name: file-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+file.macho.go_imports_names_entropy:
+  dashed_name: file-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.macho.go_imports_names_var_entropy:
+  dashed_name: file-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.macho.go_stripped:
+  dashed_name: file-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+file.macho.import_hash:
+  dashed_name: file-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+file.macho.imports:
+  dashed_name: file-macho-imports
+  description: List of imported element names and types.
+  flat_name: file.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+file.macho.imports_names_entropy:
+  dashed_name: file-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.macho.imports_names_var_entropy:
+  dashed_name: file-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+file.macho.sections:
+  dashed_name: file-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: file.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+file.macho.sections.entropy:
+  dashed_name: file-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: file.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+file.macho.sections.name:
+  dashed_name: file-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: file.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+file.macho.sections.physical_size:
+  dashed_name: file-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: file.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+file.macho.sections.var_entropy:
+  dashed_name: file-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+file.macho.sections.virtual_size:
+  dashed_name: file-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: file.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+file.macho.symhash:
+  dashed_name: file-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: file.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 file.mime_type:
   dashed_name: file-mime-type
   description: MIME type should identify the format of the file or stream of bytes
@@ -4424,6 +4905,63 @@ file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+file.pe.go_import_hash:
+  dashed_name: file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.pe.go_imports:
+  dashed_name: file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+file.pe.go_imports_names_entropy:
+  dashed_name: file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.pe.go_imports_names_var_entropy:
+  dashed_name: file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.pe.go_stripped:
+  dashed_name: file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 file.pe.imphash:
   dashed_name: file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -4440,6 +4978,58 @@ file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+file.pe.import_hash:
+  dashed_name: file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+file.pe.imports:
+  dashed_name: file-pe-imports
+  description: List of imported element names and types.
+  flat_name: file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+file.pe.imports_names_entropy:
+  dashed_name: file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.pe.imports_names_var_entropy:
+  dashed_name: file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 file.pe.original_file_name:
   dashed_name: file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -4480,6 +5070,75 @@ file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+file.pe.sections:
+  dashed_name: file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+file.pe.sections.entropy:
+  dashed_name: file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+file.pe.sections.name:
+  dashed_name: file-pe-sections-name
+  description: PE Section List name.
+  flat_name: file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+file.pe.sections.physical_size:
+  dashed_name: file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+file.pe.sections.var_entropy:
+  dashed_name: file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+file.pe.sections.virtual_size:
+  dashed_name: file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 file.size:
   dashed_name: file-size
   description: 'File size in bytes.
@@ -7130,6 +7789,63 @@ process.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+process.elf.go_import_hash:
+  dashed_name: process-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.elf.go_imports:
+  dashed_name: process-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+process.elf.go_imports_names_entropy:
+  dashed_name: process-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.elf.go_imports_names_var_entropy:
+  dashed_name: process-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.elf.go_stripped:
+  dashed_name: process-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.elf.header.abi_version:
   dashed_name: process-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -7218,6 +7934,22 @@ process.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+process.elf.import_hash:
+  dashed_name: process-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 process.elf.imports:
   dashed_name: process-elf-imports
   description: List of imported element names and types.
@@ -7229,6 +7961,31 @@ process.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+process.elf.imports_names_entropy:
+  dashed_name: process-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.elf.imports_names_var_entropy:
+  dashed_name: process-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.elf.sections:
   dashed_name: process-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -7320,6 +8077,17 @@ process.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+process.elf.sections.var_entropy:
+  dashed_name: process-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 process.elf.sections.virtual_address:
   dashed_name: process-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -8638,6 +9406,200 @@ process.io.type:
   normalize: []
   short: The type of object on which the IO action (read or write) was taken.
   type: keyword
+process.macho.go_import_hash:
+  dashed_name: process-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.macho.go_imports:
+  dashed_name: process-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+process.macho.go_imports_names_entropy:
+  dashed_name: process-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.macho.go_imports_names_var_entropy:
+  dashed_name: process-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.macho.go_stripped:
+  dashed_name: process-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.macho.import_hash:
+  dashed_name: process-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.macho.imports:
+  dashed_name: process-macho-imports
+  description: List of imported element names and types.
+  flat_name: process.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+process.macho.imports_names_entropy:
+  dashed_name: process-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.macho.imports_names_var_entropy:
+  dashed_name: process-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.macho.sections:
+  dashed_name: process-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: process.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+process.macho.sections.entropy:
+  dashed_name: process-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+process.macho.sections.name:
+  dashed_name: process-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: process.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+process.macho.sections.physical_size:
+  dashed_name: process-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: process.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+process.macho.sections.var_entropy:
+  dashed_name: process-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.macho.sections.virtual_size:
+  dashed_name: process-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.macho.symhash:
+  dashed_name: process-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: process.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.
@@ -8886,6 +9848,63 @@ process.parent.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+process.parent.elf.go_import_hash:
+  dashed_name: process-parent-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.elf.go_imports:
+  dashed_name: process-parent-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.elf.go_imports_names_entropy:
+  dashed_name: process-parent-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.elf.go_imports_names_var_entropy:
+  dashed_name: process-parent-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.elf.go_stripped:
+  dashed_name: process-parent-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.parent.elf.header.abi_version:
   dashed_name: process-parent-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -8974,6 +9993,22 @@ process.parent.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+process.parent.elf.import_hash:
+  dashed_name: process-parent-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 process.parent.elf.imports:
   dashed_name: process-parent-elf-imports
   description: List of imported element names and types.
@@ -8985,6 +10020,31 @@ process.parent.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+process.parent.elf.imports_names_entropy:
+  dashed_name: process-parent-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.elf.imports_names_var_entropy:
+  dashed_name: process-parent-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.parent.elf.sections:
   dashed_name: process-parent-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -9076,6 +10136,17 @@ process.parent.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+process.parent.elf.sections.var_entropy:
+  dashed_name: process-parent-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 process.parent.elf.sections.virtual_address:
   dashed_name: process-parent-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -9381,6 +10452,200 @@ process.parent.interactive:
   original_fieldset: process
   short: Whether the process is connected to an interactive shell.
   type: boolean
+process.parent.macho.go_import_hash:
+  dashed_name: process-parent-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.macho.go_imports:
+  dashed_name: process-parent-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.macho.go_imports_names_entropy:
+  dashed_name: process-parent-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.macho.go_imports_names_var_entropy:
+  dashed_name: process-parent-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.macho.go_stripped:
+  dashed_name: process-parent-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.parent.macho.import_hash:
+  dashed_name: process-parent-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.parent.macho.imports:
+  dashed_name: process-parent-macho-imports
+  description: List of imported element names and types.
+  flat_name: process.parent.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+process.parent.macho.imports_names_entropy:
+  dashed_name: process-parent-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.macho.imports_names_var_entropy:
+  dashed_name: process-parent-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.parent.macho.sections:
+  dashed_name: process-parent-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: process.parent.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+process.parent.macho.sections.entropy:
+  dashed_name: process-parent-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.parent.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+process.parent.macho.sections.name:
+  dashed_name: process-parent-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: process.parent.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+process.parent.macho.sections.physical_size:
+  dashed_name: process-parent-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: process.parent.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+process.parent.macho.sections.var_entropy:
+  dashed_name: process-parent-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.parent.macho.sections.virtual_size:
+  dashed_name: process-parent-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.parent.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.parent.macho.symhash:
+  dashed_name: process-parent-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: process.parent.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 process.parent.name:
   dashed_name: process-parent-name
   description: 'Process name.
@@ -9447,6 +10712,63 @@ process.parent.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+process.parent.pe.go_import_hash:
+  dashed_name: process-parent-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.pe.go_imports:
+  dashed_name: process-parent-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.pe.go_imports_names_entropy:
+  dashed_name: process-parent-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.pe.go_imports_names_var_entropy:
+  dashed_name: process-parent-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.pe.go_stripped:
+  dashed_name: process-parent-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.parent.pe.imphash:
   dashed_name: process-parent-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -9463,6 +10785,58 @@ process.parent.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+process.parent.pe.import_hash:
+  dashed_name: process-parent-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.parent.pe.imports:
+  dashed_name: process-parent-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.parent.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.parent.pe.imports_names_entropy:
+  dashed_name: process-parent-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.pe.imports_names_var_entropy:
+  dashed_name: process-parent-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.parent.pe.original_file_name:
   dashed_name: process-parent-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -9503,6 +10877,75 @@ process.parent.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.parent.pe.sections:
+  dashed_name: process-parent-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.parent.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.parent.pe.sections.entropy:
+  dashed_name: process-parent-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.parent.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.parent.pe.sections.name:
+  dashed_name: process-parent-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.parent.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.parent.pe.sections.physical_size:
+  dashed_name: process-parent-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.parent.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.parent.pe.sections.var_entropy:
+  dashed_name: process-parent-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.parent.pe.sections.virtual_size:
+  dashed_name: process-parent-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.parent.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 process.parent.pgid:
   dashed_name: process-parent-pgid
   description: 'Deprecated for removal in next major version release. This field is
@@ -9846,6 +11289,63 @@ process.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+process.pe.go_import_hash:
+  dashed_name: process-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.pe.go_imports:
+  dashed_name: process-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.pe.go_imports_names_entropy:
+  dashed_name: process-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.pe.go_imports_names_var_entropy:
+  dashed_name: process-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.pe.go_stripped:
+  dashed_name: process-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.pe.imphash:
   dashed_name: process-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -9862,6 +11362,58 @@ process.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+process.pe.import_hash:
+  dashed_name: process-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.pe.imports:
+  dashed_name: process-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.pe.imports_names_entropy:
+  dashed_name: process-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.pe.imports_names_var_entropy:
+  dashed_name: process-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.pe.original_file_name:
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -9902,6 +11454,75 @@ process.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.pe.sections:
+  dashed_name: process-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.pe.sections.entropy:
+  dashed_name: process-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.pe.sections.name:
+  dashed_name: process-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.pe.sections.physical_size:
+  dashed_name: process-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.pe.sections.var_entropy:
+  dashed_name: process-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.pe.sections.virtual_size:
+  dashed_name: process-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 process.pgid:
   dashed_name: process-pgid
   description: 'Deprecated for removal in next major version release. This field is
@@ -12907,6 +14528,63 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -12995,6 +14673,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -13006,6 +14700,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -13097,6 +14816,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -13455,6 +15185,63 @@ threat.enrichments.indicator.file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+threat.enrichments.indicator.file.pe.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.pe.go_imports:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.pe.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.pe.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.pe.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.pe.imphash:
   dashed_name: threat-enrichments-indicator-file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -13471,6 +15258,58 @@ threat.enrichments.indicator.file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+threat.enrichments.indicator.file.pe.import_hash:
+  dashed_name: threat-enrichments-indicator-file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.pe.imports:
+  dashed_name: threat-enrichments-indicator-file-pe-imports
+  description: List of imported element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+threat.enrichments.indicator.file.pe.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.pe.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.pe.original_file_name:
   dashed_name: threat-enrichments-indicator-file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -13511,6 +15350,75 @@ threat.enrichments.indicator.file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+threat.enrichments.indicator.file.pe.sections:
+  dashed_name: threat-enrichments-indicator-file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: threat.enrichments.indicator.file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+threat.enrichments.indicator.file.pe.sections.entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+threat.enrichments.indicator.file.pe.sections.name:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-name
+  description: PE Section List name.
+  flat_name: threat.enrichments.indicator.file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+threat.enrichments.indicator.file.pe.sections.physical_size:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: threat.enrichments.indicator.file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+threat.enrichments.indicator.file.pe.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+threat.enrichments.indicator.file.pe.sections.virtual_size:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: threat.enrichments.indicator.file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 threat.enrichments.indicator.file.size:
   dashed_name: threat-enrichments-indicator-file-size
   description: 'File size in bytes.
@@ -15290,6 +17198,63 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -15378,6 +17343,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -15389,6 +17370,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -15480,6 +17486,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -15838,6 +17855,63 @@ threat.indicator.file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+threat.indicator.file.pe.go_import_hash:
+  dashed_name: threat-indicator-file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.pe.go_imports:
+  dashed_name: threat-indicator-file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.pe.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.pe.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.pe.go_stripped:
+  dashed_name: threat-indicator-file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.pe.imphash:
   dashed_name: threat-indicator-file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -15854,6 +17928,58 @@ threat.indicator.file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+threat.indicator.file.pe.import_hash:
+  dashed_name: threat-indicator-file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+threat.indicator.file.pe.imports:
+  dashed_name: threat-indicator-file-pe-imports
+  description: List of imported element names and types.
+  flat_name: threat.indicator.file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+threat.indicator.file.pe.imports_names_entropy:
+  dashed_name: threat-indicator-file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.pe.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.pe.original_file_name:
   dashed_name: threat-indicator-file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -15894,6 +18020,75 @@ threat.indicator.file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+threat.indicator.file.pe.sections:
+  dashed_name: threat-indicator-file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: threat.indicator.file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+threat.indicator.file.pe.sections.entropy:
+  dashed_name: threat-indicator-file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+threat.indicator.file.pe.sections.name:
+  dashed_name: threat-indicator-file-pe-sections-name
+  description: PE Section List name.
+  flat_name: threat.indicator.file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+threat.indicator.file.pe.sections.physical_size:
+  dashed_name: threat-indicator-file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: threat.indicator.file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+threat.indicator.file.pe.sections.var_entropy:
+  dashed_name: threat-indicator-file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+threat.indicator.file.pe.sections.virtual_size:
+  dashed_name: threat-indicator-file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: threat.indicator.file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 threat.indicator.file.size:
   dashed_name: threat-indicator-file-size
   description: 'File size in bytes.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2025,9 +2025,13 @@ dll.pe.file_version:
   type: keyword
 dll.pe.go_import_hash:
   dashed_name: dll-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -4067,9 +4071,13 @@ file.elf.exports:
   type: flattened
 file.elf.go_import_hash:
   dashed_name: file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4594,9 +4602,13 @@ file.inode:
   type: keyword
 file.macho.go_import_hash:
   dashed_name: file-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -4907,9 +4919,13 @@ file.pe.file_version:
   type: keyword
 file.pe.go_import_hash:
   dashed_name: file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -7791,9 +7807,13 @@ process.elf.exports:
   type: flattened
 process.elf.go_import_hash:
   dashed_name: process-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9408,9 +9428,13 @@ process.io.type:
   type: keyword
 process.macho.go_import_hash:
   dashed_name: process-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -9850,9 +9874,13 @@ process.parent.elf.exports:
   type: flattened
 process.parent.elf.go_import_hash:
   dashed_name: process-parent-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -10454,9 +10482,13 @@ process.parent.interactive:
   type: boolean
 process.parent.macho.go_import_hash:
   dashed_name: process-parent-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -10714,9 +10746,13 @@ process.parent.pe.file_version:
   type: keyword
 process.parent.pe.go_import_hash:
   dashed_name: process-parent-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11291,9 +11327,13 @@ process.pe.file_version:
   type: keyword
 process.pe.go_import_hash:
   dashed_name: process-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -14530,9 +14570,13 @@ threat.enrichments.indicator.file.elf.exports:
   type: flattened
 threat.enrichments.indicator.file.elf.go_import_hash:
   dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -15187,9 +15231,13 @@ threat.enrichments.indicator.file.pe.file_version:
   type: keyword
 threat.enrichments.indicator.file.pe.go_import_hash:
   dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -17200,9 +17248,13 @@ threat.indicator.file.elf.exports:
   type: flattened
 threat.indicator.file.elf.go_import_hash:
   dashed_name: threat-indicator-file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -17857,9 +17909,13 @@ threat.indicator.file.pe.file_version:
   type: keyword
 threat.indicator.file.pe.go_import_hash:
   dashed_name: threat-indicator-file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2498,9 +2498,13 @@ dll:
       type: keyword
     dll.pe.go_import_hash:
       dashed_name: dll-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3109,9 +3113,13 @@ elf:
       type: flattened
     elf.go_import_hash:
       dashed_name: elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5097,9 +5105,13 @@ file:
       type: flattened
     file.elf.go_import_hash:
       dashed_name: file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5625,10 +5637,13 @@ file:
       type: keyword
     file.macho.go_import_hash:
       dashed_name: file-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -5940,9 +5955,13 @@ file:
       type: keyword
     file.pe.go_import_hash:
       dashed_name: file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -7978,10 +7997,13 @@ macho:
   fields:
     macho.go_import_hash:
       dashed_name: macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9523,9 +9545,13 @@ pe:
       type: keyword
     pe.go_import_hash:
       dashed_name: pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -9992,9 +10018,13 @@ process:
       type: flattened
     process.elf.go_import_hash:
       dashed_name: process-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -11613,10 +11643,13 @@ process:
       type: keyword
     process.macho.go_import_hash:
       dashed_name: process-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -12057,9 +12090,13 @@ process:
       type: flattened
     process.parent.elf.go_import_hash:
       dashed_name: process-parent-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -12662,10 +12699,13 @@ process:
       type: boolean
     process.parent.macho.go_import_hash:
       dashed_name: process-parent-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -12924,9 +12964,13 @@ process:
       type: keyword
     process.parent.pe.go_import_hash:
       dashed_name: process-parent-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -13502,9 +13546,13 @@ process:
       type: keyword
     process.pe.go_import_hash:
       dashed_name: process-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -17188,9 +17236,13 @@ threat:
       type: flattened
     threat.enrichments.indicator.file.elf.go_import_hash:
       dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -17846,9 +17898,13 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.pe.go_import_hash:
       dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19864,9 +19920,13 @@ threat:
       type: flattened
     threat.indicator.file.elf.go_import_hash:
       dashed_name: threat-indicator-file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -20522,9 +20582,13 @@ threat:
       type: keyword
     threat.indicator.file.pe.go_import_hash:
       dashed_name: threat-indicator-file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -2496,6 +2496,63 @@ dll:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    dll.pe.go_import_hash:
+      dashed_name: dll-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: dll.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    dll.pe.go_imports:
+      dashed_name: dll-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: dll.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    dll.pe.go_imports_names_entropy:
+      dashed_name: dll-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: dll.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    dll.pe.go_imports_names_var_entropy:
+      dashed_name: dll-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: dll.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    dll.pe.go_stripped:
+      dashed_name: dll-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: dll.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     dll.pe.imphash:
       dashed_name: dll-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -2512,6 +2569,59 @@ dll:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    dll.pe.import_hash:
+      dashed_name: dll-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: dll.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    dll.pe.imports:
+      dashed_name: dll-pe-imports
+      description: List of imported element names and types.
+      flat_name: dll.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    dll.pe.imports_names_entropy:
+      dashed_name: dll-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: dll.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    dll.pe.imports_names_var_entropy:
+      dashed_name: dll-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: dll.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     dll.pe.original_file_name:
       dashed_name: dll-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -2552,6 +2662,75 @@ dll:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    dll.pe.sections:
+      dashed_name: dll-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: dll.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    dll.pe.sections.entropy:
+      dashed_name: dll-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: dll.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    dll.pe.sections.name:
+      dashed_name: dll-pe-sections-name
+      description: PE Section List name.
+      flat_name: dll.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    dll.pe.sections.physical_size:
+      dashed_name: dll-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: dll.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    dll.pe.sections.var_entropy:
+      dashed_name: dll-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: dll.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    dll.pe.sections.virtual_size:
+      dashed_name: dll-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: dll.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
   group: 2
   name: dll
   nestings:
@@ -2928,6 +3107,58 @@ elf:
       - array
       short: List of exported element names and types.
       type: flattened
+    elf.go_import_hash:
+      dashed_name: elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    elf.go_imports:
+      dashed_name: elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    elf.go_imports_names_entropy:
+      dashed_name: elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    elf.go_imports_names_var_entropy:
+      dashed_name: elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    elf.go_stripped:
+      dashed_name: elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     elf.header.abi_version:
       dashed_name: elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -3008,6 +3239,21 @@ elf:
       normalize: []
       short: Version of the ELF header.
       type: keyword
+    elf.import_hash:
+      dashed_name: elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
     elf.imports:
       dashed_name: elf-imports
       description: List of imported element names and types.
@@ -3018,6 +3264,30 @@ elf:
       - array
       short: List of imported element names and types.
       type: flattened
+    elf.imports_names_entropy:
+      dashed_name: elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    elf.imports_names_var_entropy:
+      dashed_name: elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     elf.sections:
       dashed_name: elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -3101,6 +3371,16 @@ elf:
       normalize: []
       short: ELF Section List type.
       type: keyword
+    elf.sections.var_entropy:
+      dashed_name: elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     elf.sections.virtual_address:
       dashed_name: elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -4815,6 +5095,63 @@ file:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    file.elf.go_import_hash:
+      dashed_name: file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.elf.go_imports:
+      dashed_name: file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.elf.go_imports_names_entropy:
+      dashed_name: file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.elf.go_imports_names_var_entropy:
+      dashed_name: file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.elf.go_stripped:
+      dashed_name: file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     file.elf.header.abi_version:
       dashed_name: file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -4903,6 +5240,22 @@ file:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    file.elf.import_hash:
+      dashed_name: file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     file.elf.imports:
       dashed_name: file-elf-imports
       description: List of imported element names and types.
@@ -4914,6 +5267,32 @@ file:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    file.elf.imports_names_entropy:
+      dashed_name: file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.elf.imports_names_var_entropy:
+      dashed_name: file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     file.elf.sections:
       dashed_name: file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -5005,6 +5384,17 @@ file:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    file.elf.sections.var_entropy:
+      dashed_name: file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     file.elf.sections.virtual_address:
       dashed_name: file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -5233,6 +5623,202 @@ file:
       normalize: []
       short: Inode representing the file in the filesystem.
       type: keyword
+    file.macho.go_import_hash:
+      dashed_name: file-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.macho.go_imports:
+      dashed_name: file-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.macho.go_imports_names_entropy:
+      dashed_name: file-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.macho.go_imports_names_var_entropy:
+      dashed_name: file-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.macho.go_stripped:
+      dashed_name: file-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    file.macho.import_hash:
+      dashed_name: file-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    file.macho.imports:
+      dashed_name: file-macho-imports
+      description: List of imported element names and types.
+      flat_name: file.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    file.macho.imports_names_entropy:
+      dashed_name: file-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.macho.imports_names_var_entropy:
+      dashed_name: file-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    file.macho.sections:
+      dashed_name: file-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: file.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    file.macho.sections.entropy:
+      dashed_name: file-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: file.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    file.macho.sections.name:
+      dashed_name: file-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: file.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    file.macho.sections.physical_size:
+      dashed_name: file-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: file.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    file.macho.sections.var_entropy:
+      dashed_name: file-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    file.macho.sections.virtual_size:
+      dashed_name: file-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: file.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    file.macho.symhash:
+      dashed_name: file-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: file.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     file.mime_type:
       dashed_name: file-mime-type
       description: MIME type should identify the format of the file or stream of bytes
@@ -5352,6 +5938,63 @@ file:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    file.pe.go_import_hash:
+      dashed_name: file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.pe.go_imports:
+      dashed_name: file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.pe.go_imports_names_entropy:
+      dashed_name: file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.pe.go_imports_names_var_entropy:
+      dashed_name: file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.pe.go_stripped:
+      dashed_name: file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     file.pe.imphash:
       dashed_name: file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -5368,6 +6011,59 @@ file:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    file.pe.import_hash:
+      dashed_name: file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    file.pe.imports:
+      dashed_name: file-pe-imports
+      description: List of imported element names and types.
+      flat_name: file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    file.pe.imports_names_entropy:
+      dashed_name: file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.pe.imports_names_var_entropy:
+      dashed_name: file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     file.pe.original_file_name:
       dashed_name: file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -5408,6 +6104,75 @@ file:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    file.pe.sections:
+      dashed_name: file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    file.pe.sections.entropy:
+      dashed_name: file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    file.pe.sections.name:
+      dashed_name: file-pe-sections-name
+      description: PE Section List name.
+      flat_name: file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    file.pe.sections.physical_size:
+      dashed_name: file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    file.pe.sections.var_entropy:
+      dashed_name: file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    file.pe.sections.virtual_size:
+      dashed_name: file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     file.size:
       dashed_name: file-size
       description: 'File size in bytes.
@@ -5768,6 +6533,7 @@ file:
   - file.code_signature
   - file.elf
   - file.hash
+  - file.macho
   - file.pe
   - file.x509
   prefix: file.
@@ -5797,6 +6563,10 @@ file:
     full: file.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  - beta: This field reuse is beta and subject to change.
+    full: file.macho
+    schema_name: macho
+    short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
   short: Fields describing files.
   title: File
   type: group
@@ -7202,6 +7972,207 @@ log:
   short: Details about the event's logging mechanism.
   title: Log
   type: group
+macho:
+  beta: These fields are in beta and are subject to change.
+  description: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+  fields:
+    macho.go_import_hash:
+      dashed_name: macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    macho.go_imports:
+      dashed_name: macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    macho.go_imports_names_entropy:
+      dashed_name: macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    macho.go_imports_names_var_entropy:
+      dashed_name: macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    macho.go_stripped:
+      dashed_name: macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    macho.import_hash:
+      dashed_name: macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    macho.imports:
+      dashed_name: macho-imports
+      description: List of imported element names and types.
+      flat_name: macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      short: List of imported element names and types.
+      type: flattened
+    macho.imports_names_entropy:
+      dashed_name: macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    macho.imports_names_var_entropy:
+      dashed_name: macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    macho.sections:
+      dashed_name: macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      short: Section information of the Mach-O file.
+      type: nested
+    macho.sections.entropy:
+      dashed_name: macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      short: Shannon entropy calculation from the section.
+      type: long
+    macho.sections.name:
+      dashed_name: macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      short: Mach-O Section List name.
+      type: keyword
+    macho.sections.physical_size:
+      dashed_name: macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      short: Mach-O Section List physical size.
+      type: long
+    macho.sections.var_entropy:
+      dashed_name: macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    macho.sections.virtual_size:
+      dashed_name: macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    macho.symhash:
+      dashed_name: macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
+  group: 2
+  name: macho
+  prefix: macho.
+  reusable:
+    expected:
+    - as: macho
+      at: file
+      beta: This field reuse is beta and subject to change.
+      full: file.macho
+    - as: macho
+      at: process
+      beta: This field reuse is beta and subject to change.
+      full: process.macho
+    top_level: false
+  short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+  title: Mach-O Header
+  type: group
 network:
   description: 'The network is defined as the communication path over which a host
     or network event happens.
@@ -8550,6 +9521,58 @@ pe:
       normalize: []
       short: Process name.
       type: keyword
+    pe.go_import_hash:
+      dashed_name: pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    pe.go_imports:
+      dashed_name: pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    pe.go_imports_names_entropy:
+      dashed_name: pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    pe.go_imports_names_var_entropy:
+      dashed_name: pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    pe.go_stripped:
+      dashed_name: pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     pe.imphash:
       dashed_name: pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -8565,6 +9588,55 @@ pe:
       normalize: []
       short: A hash of the imports in a PE file.
       type: keyword
+    pe.import_hash:
+      dashed_name: pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    pe.imports:
+      dashed_name: pe-imports
+      description: List of imported element names and types.
+      flat_name: pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      short: List of imported element names and types.
+      type: flattened
+    pe.imports_names_entropy:
+      dashed_name: pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    pe.imports_names_var_entropy:
+      dashed_name: pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     pe.original_file_name:
       dashed_name: pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -8602,6 +9674,69 @@ pe:
       normalize: []
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    pe.sections:
+      dashed_name: pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      short: Section information of the PE file.
+      type: nested
+    pe.sections.entropy:
+      dashed_name: pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      short: Shannon entropy calculation from the section.
+      type: long
+    pe.sections.name:
+      dashed_name: pe-sections-name
+      description: PE Section List name.
+      flat_name: pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      short: PE Section List name.
+      type: keyword
+    pe.sections.physical_size:
+      dashed_name: pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      short: PE Section List physical size.
+      type: long
+    pe.sections.var_entropy:
+      dashed_name: pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    pe.sections.virtual_size:
+      dashed_name: pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
   group: 2
   name: pe
   prefix: pe.
@@ -8855,6 +9990,63 @@ process:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    process.elf.go_import_hash:
+      dashed_name: process-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.elf.go_imports:
+      dashed_name: process-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.elf.go_imports_names_entropy:
+      dashed_name: process-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.elf.go_imports_names_var_entropy:
+      dashed_name: process-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.elf.go_stripped:
+      dashed_name: process-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.elf.header.abi_version:
       dashed_name: process-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -8943,6 +10135,22 @@ process:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    process.elf.import_hash:
+      dashed_name: process-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     process.elf.imports:
       dashed_name: process-elf-imports
       description: List of imported element names and types.
@@ -8954,6 +10162,32 @@ process:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    process.elf.imports_names_entropy:
+      dashed_name: process-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.elf.imports_names_var_entropy:
+      dashed_name: process-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.elf.sections:
       dashed_name: process-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -9045,6 +10279,17 @@ process:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    process.elf.sections.var_entropy:
+      dashed_name: process-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     process.elf.sections.virtual_address:
       dashed_name: process-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -10366,6 +11611,202 @@ process:
       normalize: []
       short: The type of object on which the IO action (read or write) was taken.
       type: keyword
+    process.macho.go_import_hash:
+      dashed_name: process-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.macho.go_imports:
+      dashed_name: process-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.macho.go_imports_names_entropy:
+      dashed_name: process-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.macho.go_imports_names_var_entropy:
+      dashed_name: process-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.macho.go_stripped:
+      dashed_name: process-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    process.macho.import_hash:
+      dashed_name: process-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.macho.imports:
+      dashed_name: process-macho-imports
+      description: List of imported element names and types.
+      flat_name: process.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    process.macho.imports_names_entropy:
+      dashed_name: process-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.macho.imports_names_var_entropy:
+      dashed_name: process-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    process.macho.sections:
+      dashed_name: process-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: process.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    process.macho.sections.entropy:
+      dashed_name: process-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.macho.sections.name:
+      dashed_name: process-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: process.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    process.macho.sections.physical_size:
+      dashed_name: process-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: process.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    process.macho.sections.var_entropy:
+      dashed_name: process-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.macho.sections.virtual_size:
+      dashed_name: process-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    process.macho.symhash:
+      dashed_name: process-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: process.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     process.name:
       dashed_name: process-name
       description: 'Process name.
@@ -10614,6 +12055,63 @@ process:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    process.parent.elf.go_import_hash:
+      dashed_name: process-parent-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.elf.go_imports:
+      dashed_name: process-parent-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.elf.go_imports_names_entropy:
+      dashed_name: process-parent-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.elf.go_imports_names_var_entropy:
+      dashed_name: process-parent-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.elf.go_stripped:
+      dashed_name: process-parent-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.parent.elf.header.abi_version:
       dashed_name: process-parent-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -10702,6 +12200,22 @@ process:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    process.parent.elf.import_hash:
+      dashed_name: process-parent-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     process.parent.elf.imports:
       dashed_name: process-parent-elf-imports
       description: List of imported element names and types.
@@ -10713,6 +12227,32 @@ process:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    process.parent.elf.imports_names_entropy:
+      dashed_name: process-parent-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.elf.imports_names_var_entropy:
+      dashed_name: process-parent-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.parent.elf.sections:
       dashed_name: process-parent-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -10804,6 +12344,17 @@ process:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    process.parent.elf.sections.var_entropy:
+      dashed_name: process-parent-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     process.parent.elf.sections.virtual_address:
       dashed_name: process-parent-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -11109,6 +12660,202 @@ process:
       original_fieldset: process
       short: Whether the process is connected to an interactive shell.
       type: boolean
+    process.parent.macho.go_import_hash:
+      dashed_name: process-parent-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.macho.go_imports:
+      dashed_name: process-parent-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.macho.go_imports_names_entropy:
+      dashed_name: process-parent-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.macho.go_imports_names_var_entropy:
+      dashed_name: process-parent-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.macho.go_stripped:
+      dashed_name: process-parent-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    process.parent.macho.import_hash:
+      dashed_name: process-parent-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.parent.macho.imports:
+      dashed_name: process-parent-macho-imports
+      description: List of imported element names and types.
+      flat_name: process.parent.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    process.parent.macho.imports_names_entropy:
+      dashed_name: process-parent-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.macho.imports_names_var_entropy:
+      dashed_name: process-parent-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    process.parent.macho.sections:
+      dashed_name: process-parent-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: process.parent.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    process.parent.macho.sections.entropy:
+      dashed_name: process-parent-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.parent.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.parent.macho.sections.name:
+      dashed_name: process-parent-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: process.parent.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    process.parent.macho.sections.physical_size:
+      dashed_name: process-parent-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: process.parent.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    process.parent.macho.sections.var_entropy:
+      dashed_name: process-parent-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.parent.macho.sections.virtual_size:
+      dashed_name: process-parent-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.parent.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    process.parent.macho.symhash:
+      dashed_name: process-parent-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: process.parent.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     process.parent.name:
       dashed_name: process-parent-name
       description: 'Process name.
@@ -11175,6 +12922,63 @@ process:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    process.parent.pe.go_import_hash:
+      dashed_name: process-parent-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.pe.go_imports:
+      dashed_name: process-parent-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.pe.go_imports_names_entropy:
+      dashed_name: process-parent-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.pe.go_imports_names_var_entropy:
+      dashed_name: process-parent-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.pe.go_stripped:
+      dashed_name: process-parent-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.parent.pe.imphash:
       dashed_name: process-parent-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -11191,6 +12995,59 @@ process:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    process.parent.pe.import_hash:
+      dashed_name: process-parent-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.parent.pe.imports:
+      dashed_name: process-parent-pe-imports
+      description: List of imported element names and types.
+      flat_name: process.parent.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    process.parent.pe.imports_names_entropy:
+      dashed_name: process-parent-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.pe.imports_names_var_entropy:
+      dashed_name: process-parent-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.parent.pe.original_file_name:
       dashed_name: process-parent-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -11231,6 +13088,75 @@ process:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    process.parent.pe.sections:
+      dashed_name: process-parent-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: process.parent.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    process.parent.pe.sections.entropy:
+      dashed_name: process-parent-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.parent.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.parent.pe.sections.name:
+      dashed_name: process-parent-pe-sections-name
+      description: PE Section List name.
+      flat_name: process.parent.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    process.parent.pe.sections.physical_size:
+      dashed_name: process-parent-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: process.parent.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    process.parent.pe.sections.var_entropy:
+      dashed_name: process-parent-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.parent.pe.sections.virtual_size:
+      dashed_name: process-parent-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.parent.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     process.parent.pgid:
       dashed_name: process-parent-pgid
       description: 'Deprecated for removal in next major version release. This field
@@ -11574,6 +13500,63 @@ process:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    process.pe.go_import_hash:
+      dashed_name: process-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.pe.go_imports:
+      dashed_name: process-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.pe.go_imports_names_entropy:
+      dashed_name: process-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.pe.go_imports_names_var_entropy:
+      dashed_name: process-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.pe.go_stripped:
+      dashed_name: process-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.pe.imphash:
       dashed_name: process-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -11590,6 +13573,59 @@ process:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    process.pe.import_hash:
+      dashed_name: process-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.pe.imports:
+      dashed_name: process-pe-imports
+      description: List of imported element names and types.
+      flat_name: process.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    process.pe.imports_names_entropy:
+      dashed_name: process-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.pe.imports_names_var_entropy:
+      dashed_name: process-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.pe.original_file_name:
       dashed_name: process-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -11630,6 +13666,75 @@ process:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    process.pe.sections:
+      dashed_name: process-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: process.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    process.pe.sections.entropy:
+      dashed_name: process-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.pe.sections.name:
+      dashed_name: process-pe-sections-name
+      description: PE Section List name.
+      flat_name: process.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    process.pe.sections.physical_size:
+      dashed_name: process-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: process.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    process.pe.sections.var_entropy:
+      dashed_name: process-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.pe.sections.virtual_size:
+      dashed_name: process-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     process.pgid:
       dashed_name: process-pgid
       description: 'Deprecated for removal in next major version release. This field
@@ -12493,6 +14598,7 @@ process:
   - process.group
   - process.group_leader
   - process.hash
+  - process.macho
   - process.parent
   - process.parent.group_leader
   - process.pe
@@ -12596,6 +14702,10 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  - beta: This field reuse is beta and subject to change.
+    full: process.macho
+    schema_name: macho
+    short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
   - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
@@ -15076,6 +17186,63 @@ threat:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    threat.enrichments.indicator.file.elf.go_import_hash:
+      dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.elf.go_imports:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.elf.go_stripped:
+      dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.enrichments.indicator.file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.enrichments.indicator.file.elf.header.abi_version:
       dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -15164,6 +17331,22 @@ threat:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    threat.enrichments.indicator.file.elf.import_hash:
+      dashed_name: threat-enrichments-indicator-file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.enrichments.indicator.file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     threat.enrichments.indicator.file.elf.imports:
       dashed_name: threat-enrichments-indicator-file-elf-imports
       description: List of imported element names and types.
@@ -15175,6 +17358,32 @@ threat:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    threat.enrichments.indicator.file.elf.imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.enrichments.indicator.file.elf.sections:
       dashed_name: threat-enrichments-indicator-file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -15266,6 +17475,17 @@ threat:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    threat.enrichments.indicator.file.elf.sections.var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     threat.enrichments.indicator.file.elf.sections.virtual_address:
       dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -15624,6 +17844,63 @@ threat:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    threat.enrichments.indicator.file.pe.go_import_hash:
+      dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.enrichments.indicator.file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.pe.go_imports:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.pe.go_imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.pe.go_imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.pe.go_stripped:
+      dashed_name: threat-enrichments-indicator-file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.enrichments.indicator.file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.enrichments.indicator.file.pe.imphash:
       dashed_name: threat-enrichments-indicator-file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -15640,6 +17917,59 @@ threat:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    threat.enrichments.indicator.file.pe.import_hash:
+      dashed_name: threat-enrichments-indicator-file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.enrichments.indicator.file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.pe.imports:
+      dashed_name: threat-enrichments-indicator-file-pe-imports
+      description: List of imported element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.pe.imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.enrichments.indicator.file.pe.imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.enrichments.indicator.file.pe.original_file_name:
       dashed_name: threat-enrichments-indicator-file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -15680,6 +18010,75 @@ threat:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    threat.enrichments.indicator.file.pe.sections:
+      dashed_name: threat-enrichments-indicator-file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: threat.enrichments.indicator.file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    threat.enrichments.indicator.file.pe.sections.entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.name:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-name
+      description: PE Section List name.
+      flat_name: threat.enrichments.indicator.file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    threat.enrichments.indicator.file.pe.sections.physical_size:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: threat.enrichments.indicator.file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.virtual_size:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: threat.enrichments.indicator.file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     threat.enrichments.indicator.file.size:
       dashed_name: threat-enrichments-indicator-file-size
       description: 'File size in bytes.
@@ -17463,6 +19862,63 @@ threat:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    threat.indicator.file.elf.go_import_hash:
+      dashed_name: threat-indicator-file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.indicator.file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.indicator.file.elf.go_imports:
+      dashed_name: threat-indicator-file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.indicator.file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.indicator.file.elf.go_imports_names_entropy:
+      dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.elf.go_imports_names_var_entropy:
+      dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.elf.go_stripped:
+      dashed_name: threat-indicator-file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.indicator.file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.indicator.file.elf.header.abi_version:
       dashed_name: threat-indicator-file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -17551,6 +20007,22 @@ threat:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    threat.indicator.file.elf.import_hash:
+      dashed_name: threat-indicator-file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.indicator.file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     threat.indicator.file.elf.imports:
       dashed_name: threat-indicator-file-elf-imports
       description: List of imported element names and types.
@@ -17562,6 +20034,32 @@ threat:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    threat.indicator.file.elf.imports_names_entropy:
+      dashed_name: threat-indicator-file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.indicator.file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.indicator.file.elf.imports_names_var_entropy:
+      dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.indicator.file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.indicator.file.elf.sections:
       dashed_name: threat-indicator-file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -17653,6 +20151,17 @@ threat:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    threat.indicator.file.elf.sections.var_entropy:
+      dashed_name: threat-indicator-file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     threat.indicator.file.elf.sections.virtual_address:
       dashed_name: threat-indicator-file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -18011,6 +20520,63 @@ threat:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    threat.indicator.file.pe.go_import_hash:
+      dashed_name: threat-indicator-file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.indicator.file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.indicator.file.pe.go_imports:
+      dashed_name: threat-indicator-file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.indicator.file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.indicator.file.pe.go_imports_names_entropy:
+      dashed_name: threat-indicator-file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.pe.go_imports_names_var_entropy:
+      dashed_name: threat-indicator-file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.pe.go_stripped:
+      dashed_name: threat-indicator-file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.indicator.file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.indicator.file.pe.imphash:
       dashed_name: threat-indicator-file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -18027,6 +20593,59 @@ threat:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    threat.indicator.file.pe.import_hash:
+      dashed_name: threat-indicator-file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.indicator.file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    threat.indicator.file.pe.imports:
+      dashed_name: threat-indicator-file-pe-imports
+      description: List of imported element names and types.
+      flat_name: threat.indicator.file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    threat.indicator.file.pe.imports_names_entropy:
+      dashed_name: threat-indicator-file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.indicator.file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.indicator.file.pe.imports_names_var_entropy:
+      dashed_name: threat-indicator-file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.indicator.file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.indicator.file.pe.original_file_name:
       dashed_name: threat-indicator-file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -18067,6 +20686,75 @@ threat:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    threat.indicator.file.pe.sections:
+      dashed_name: threat-indicator-file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: threat.indicator.file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    threat.indicator.file.pe.sections.entropy:
+      dashed_name: threat-indicator-file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    threat.indicator.file.pe.sections.name:
+      dashed_name: threat-indicator-file-pe-sections-name
+      description: PE Section List name.
+      flat_name: threat.indicator.file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    threat.indicator.file.pe.sections.physical_size:
+      dashed_name: threat-indicator-file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: threat.indicator.file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    threat.indicator.file.pe.sections.var_entropy:
+      dashed_name: threat-indicator-file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    threat.indicator.file.pe.sections.virtual_size:
+      dashed_name: threat-indicator-file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: threat.indicator.file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     threat.indicator.file.size:
       dashed_name: threat-indicator-file-size
       description: 'File size in bytes.

--- a/experimental/generated/elasticsearch/composable/component/dll.json
+++ b/experimental/generated/elasticsearch/composable/component/dll.json
@@ -102,9 +102,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -117,6 +146,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             }

--- a/experimental/generated/elasticsearch/composable/component/file.json
+++ b/experimental/generated/elasticsearch/composable/component/file.json
@@ -89,6 +89,22 @@
                 "exports": {
                   "type": "flattened"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "header": {
                   "properties": {
                     "abi_version": {
@@ -124,8 +140,18 @@
                     }
                   }
                 },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "imports": {
                   "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "sections": {
                   "properties": {
@@ -153,6 +179,9 @@
                     "type": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
                     },
                     "virtual_address": {
                       "type": "long"
@@ -238,6 +267,64 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "macho": {
+              "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "mime_type": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -284,9 +371,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -299,6 +415,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -79,6 +79,22 @@
                 "exports": {
                   "type": "flattened"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "header": {
                   "properties": {
                     "abi_version": {
@@ -114,8 +130,18 @@
                     }
                   }
                 },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "imports": {
                   "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "sections": {
                   "properties": {
@@ -143,6 +169,9 @@
                     "type": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
                     },
                     "virtual_address": {
                       "type": "long"
@@ -686,6 +715,64 @@
               },
               "type": "object"
             },
+            "macho": {
+              "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "name": {
               "fields": {
                 "text": {
@@ -768,6 +855,22 @@
                     "exports": {
                       "type": "flattened"
                     },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
                     "header": {
                       "properties": {
                         "abi_version": {
@@ -803,8 +906,18 @@
                         }
                       }
                     },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "imports": {
                       "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
                     },
                     "sections": {
                       "properties": {
@@ -832,6 +945,9 @@
                         "type": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "var_entropy": {
+                          "type": "long"
                         },
                         "virtual_address": {
                           "type": "long"
@@ -945,6 +1061,64 @@
                 "interactive": {
                   "type": "boolean"
                 },
+                "macho": {
+                  "properties": {
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "sections": {
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "symhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "name": {
                   "fields": {
                     "text": {
@@ -972,9 +1146,38 @@
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
                     "imphash": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
                     },
                     "original_file_name": {
                       "ignore_above": 1024,
@@ -987,6 +1190,27 @@
                     "product": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "sections": {
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
                     }
                   }
                 },
@@ -1153,9 +1377,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -1168,6 +1421,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -131,6 +131,22 @@
                             "exports": {
                               "type": "flattened"
                             },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flattened"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "header": {
                               "properties": {
                                 "abi_version": {
@@ -166,8 +182,18 @@
                                 }
                               }
                             },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "imports": {
                               "type": "flattened"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "sections": {
                               "properties": {
@@ -195,6 +221,9 @@
                                 "type": {
                                   "ignore_above": 1024,
                                   "type": "keyword"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
                                 },
                                 "virtual_address": {
                                   "type": "long"
@@ -326,9 +355,38 @@
                               "ignore_above": 1024,
                               "type": "keyword"
                             },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flattened"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "imphash": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flattened"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "original_file_name": {
                               "ignore_above": 1024,
@@ -341,6 +399,27 @@
                             "product": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "sections": {
+                              "properties": {
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             }
                           }
                         },
@@ -969,6 +1048,22 @@
                         "exports": {
                           "type": "flattened"
                         },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flattened"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
                         "header": {
                           "properties": {
                             "abi_version": {
@@ -1004,8 +1099,18 @@
                             }
                           }
                         },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "imports": {
                           "type": "flattened"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
                         },
                         "sections": {
                           "properties": {
@@ -1033,6 +1138,9 @@
                             "type": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "var_entropy": {
+                              "type": "long"
                             },
                             "virtual_address": {
                               "type": "long"
@@ -1164,9 +1272,38 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flattened"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
                         "imphash": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imports": {
+                          "type": "flattened"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
                         },
                         "original_file_name": {
                           "ignore_above": 1024,
@@ -1179,6 +1316,27 @@
                         "product": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "sections": {
+                          "properties": {
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "var_entropy": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
                         }
                       }
                     },

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -874,9 +874,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -889,6 +918,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           }
@@ -1369,6 +1419,22 @@
               "exports": {
                 "type": "flattened"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "header": {
                 "properties": {
                   "abi_version": {
@@ -1404,8 +1470,18 @@
                   }
                 }
               },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "imports": {
                 "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "sections": {
                 "properties": {
@@ -1433,6 +1509,9 @@
                   "type": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "var_entropy": {
+                    "type": "long"
                   },
                   "virtual_address": {
                     "type": "long"
@@ -1518,6 +1597,64 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "macho": {
+            "properties": {
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "symhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "mime_type": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -1564,9 +1701,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -1579,6 +1745,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           },
@@ -2599,6 +2786,22 @@
               "exports": {
                 "type": "flattened"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "header": {
                 "properties": {
                   "abi_version": {
@@ -2634,8 +2837,18 @@
                   }
                 }
               },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "imports": {
                 "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "sections": {
                 "properties": {
@@ -2663,6 +2876,9 @@
                   "type": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "var_entropy": {
+                    "type": "long"
                   },
                   "virtual_address": {
                     "type": "long"
@@ -3206,6 +3422,64 @@
             },
             "type": "object"
           },
+          "macho": {
+            "properties": {
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "symhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "name": {
             "fields": {
               "text": {
@@ -3288,6 +3562,22 @@
                   "exports": {
                     "type": "flattened"
                   },
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
                   "header": {
                     "properties": {
                       "abi_version": {
@@ -3323,8 +3613,18 @@
                       }
                     }
                   },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "imports": {
                     "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
                   },
                   "sections": {
                     "properties": {
@@ -3352,6 +3652,9 @@
                       "type": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "var_entropy": {
+                        "type": "long"
                       },
                       "virtual_address": {
                         "type": "long"
@@ -3465,6 +3768,64 @@
               "interactive": {
                 "type": "boolean"
               },
+              "macho": {
+                "properties": {
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "sections": {
+                    "properties": {
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "var_entropy": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "symhash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "name": {
                 "fields": {
                   "text": {
@@ -3492,9 +3853,38 @@
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
                   "imphash": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
                   },
                   "original_file_name": {
                     "ignore_above": 1024,
@@ -3507,6 +3897,27 @@
                   "product": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "sections": {
+                    "properties": {
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "var_entropy": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
                   }
                 }
               },
@@ -3673,9 +4084,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -3688,6 +4128,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           },
@@ -4807,6 +5268,22 @@
                           "exports": {
                             "type": "flattened"
                           },
+                          "go_import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "go_imports": {
+                            "type": "flattened"
+                          },
+                          "go_imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "go_imports_names_var_entropy": {
+                            "type": "long"
+                          },
+                          "go_stripped": {
+                            "type": "boolean"
+                          },
                           "header": {
                             "properties": {
                               "abi_version": {
@@ -4842,8 +5319,18 @@
                               }
                             }
                           },
+                          "import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "imports": {
                             "type": "flattened"
+                          },
+                          "imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "imports_names_var_entropy": {
+                            "type": "long"
                           },
                           "sections": {
                             "properties": {
@@ -4871,6 +5358,9 @@
                               "type": {
                                 "ignore_above": 1024,
                                 "type": "keyword"
+                              },
+                              "var_entropy": {
+                                "type": "long"
                               },
                               "virtual_address": {
                                 "type": "long"
@@ -5002,9 +5492,38 @@
                             "ignore_above": 1024,
                             "type": "keyword"
                           },
+                          "go_import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "go_imports": {
+                            "type": "flattened"
+                          },
+                          "go_imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "go_imports_names_var_entropy": {
+                            "type": "long"
+                          },
+                          "go_stripped": {
+                            "type": "boolean"
+                          },
                           "imphash": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "imports": {
+                            "type": "flattened"
+                          },
+                          "imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "imports_names_var_entropy": {
+                            "type": "long"
                           },
                           "original_file_name": {
                             "ignore_above": 1024,
@@ -5017,6 +5536,27 @@
                           "product": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "sections": {
+                            "properties": {
+                              "entropy": {
+                                "type": "long"
+                              },
+                              "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              },
+                              "physical_size": {
+                                "type": "long"
+                              },
+                              "var_entropy": {
+                                "type": "long"
+                              },
+                              "virtual_size": {
+                                "type": "long"
+                              }
+                            },
+                            "type": "nested"
                           }
                         }
                       },
@@ -5645,6 +6185,22 @@
                       "exports": {
                         "type": "flattened"
                       },
+                      "go_import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "go_imports": {
+                        "type": "flattened"
+                      },
+                      "go_imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "go_imports_names_var_entropy": {
+                        "type": "long"
+                      },
+                      "go_stripped": {
+                        "type": "boolean"
+                      },
                       "header": {
                         "properties": {
                           "abi_version": {
@@ -5680,8 +6236,18 @@
                           }
                         }
                       },
+                      "import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "imports": {
                         "type": "flattened"
+                      },
+                      "imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "imports_names_var_entropy": {
+                        "type": "long"
                       },
                       "sections": {
                         "properties": {
@@ -5709,6 +6275,9 @@
                           "type": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "var_entropy": {
+                            "type": "long"
                           },
                           "virtual_address": {
                             "type": "long"
@@ -5840,9 +6409,38 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "go_import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "go_imports": {
+                        "type": "flattened"
+                      },
+                      "go_imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "go_imports_names_var_entropy": {
+                        "type": "long"
+                      },
+                      "go_stripped": {
+                        "type": "boolean"
+                      },
                       "imphash": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "imports": {
+                        "type": "flattened"
+                      },
+                      "imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "imports_names_var_entropy": {
+                        "type": "long"
                       },
                       "original_file_name": {
                         "ignore_above": 1024,
@@ -5855,6 +6453,27 @@
                       "product": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "sections": {
+                        "properties": {
+                          "entropy": {
+                            "type": "long"
+                          },
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "physical_size": {
+                            "type": "long"
+                          },
+                          "var_entropy": {
+                            "type": "long"
+                          },
+                          "virtual_size": {
+                            "type": "long"
+                          }
+                        },
+                        "type": "nested"
                       }
                     }
                   },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1469,9 +1469,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -1831,9 +1835,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -2845,9 +2853,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -3139,10 +3151,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -3321,9 +3336,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -4469,10 +4488,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -5377,9 +5399,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: go_imports
@@ -5665,9 +5691,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: elf.go_imports
@@ -6646,10 +6676,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: macho.go_imports
@@ -6912,9 +6945,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.elf.go_imports
@@ -7260,10 +7297,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.macho.go_imports
@@ -7412,9 +7452,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: parent.pe.go_imports
@@ -7751,9 +7795,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: pe.go_imports
@@ -9925,9 +9973,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.elf.go_imports
@@ -10301,9 +10353,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: enrichments.indicator.file.pe.go_imports
@@ -11507,9 +11563,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.elf.go_imports
@@ -11883,9 +11943,13 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       default_field: false
     - name: indicator.file.pe.go_imports

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -1465,6 +1465,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -1475,6 +1507,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -1500,6 +1562,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
   - name: dns
     title: DNS
@@ -1727,6 +1827,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: header.abi_version
       level: extended
       type: keyword
@@ -1775,10 +1907,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: sections
       level: extended
@@ -1829,6 +1986,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: sections.virtual_address
       level: extended
@@ -2678,6 +2841,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: elf.header.abi_version
       level: extended
       type: keyword
@@ -2726,10 +2921,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: elf.sections
       level: extended
@@ -2780,6 +3000,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: elf.sections.virtual_address
       level: extended
@@ -2909,6 +3135,118 @@
       ignore_above: 1024
       description: Inode representing the file in the filesystem.
       example: '256383'
+    - name: macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: mime_type
       level: extended
       type: keyword
@@ -2979,6 +3317,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -2989,6 +3359,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -3014,6 +3414,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: size
       level: extended
@@ -4020,6 +4458,125 @@
         for RFC 5424 messages.
       example: 1
       default_field: false
+  - name: macho
+    title: Mach-O Header
+    group: 2
+    description: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+    type: group
+    default_field: true
+    fields:
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
   - name: network
     title: Network
     group: 2
@@ -4816,6 +5373,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: imphash
       level: extended
       type: keyword
@@ -4826,6 +5415,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: original_file_name
       level: extended
@@ -4851,6 +5470,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
   - name: process
     title: Process
@@ -5004,6 +5661,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: elf.header.abi_version
       level: extended
       type: keyword
@@ -5052,10 +5741,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: elf.sections
       level: extended
@@ -5106,6 +5820,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: elf.sections.virtual_address
       level: extended
@@ -5922,6 +6642,118 @@
         Currently only ''tty'' is supported. Other types may be added in the future
         for ''file'' and ''socket'' support.'
       default_field: false
+    - name: macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: name
       level: extended
       type: keyword
@@ -6076,6 +6908,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: parent.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: parent.elf.header.abi_version
       level: extended
       type: keyword
@@ -6124,10 +6988,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: parent.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: parent.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: parent.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: parent.elf.sections
       level: extended
@@ -6178,6 +7067,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: parent.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: parent.elf.sections.virtual_address
       level: extended
@@ -6361,6 +7256,118 @@
         connected to the controlling TTY.'
       example: true
       default_field: false
+    - name: parent.macho.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.macho.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.macho.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.macho.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.macho.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: parent.macho.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: parent.macho.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: parent.macho.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.macho.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      default_field: false
+    - name: parent.macho.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      default_field: false
+    - name: parent.macho.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.macho.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Mach-O Section List name.
+      default_field: false
+    - name: parent.macho.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: Mach-O Section List physical size.
+      default_field: false
+    - name: parent.macho.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.macho.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: parent.macho.symhash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      default_field: false
     - name: parent.name
       level: extended
       type: keyword
@@ -6401,6 +7408,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: parent.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: parent.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: parent.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: parent.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: parent.pe.imphash
       level: extended
       type: keyword
@@ -6411,6 +7450,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: parent.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: parent.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: parent.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: parent.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: parent.pe.original_file_name
       level: extended
@@ -6436,6 +7505,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: parent.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: parent.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: parent.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: parent.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: parent.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: parent.pgid
       level: extended
@@ -6640,6 +7747,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: pe.imphash
       level: extended
       type: keyword
@@ -6650,6 +7789,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -6675,6 +7844,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: pgid
       level: extended
@@ -8714,6 +9921,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: enrichments.indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: enrichments.indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -8762,10 +10001,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: enrichments.indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: enrichments.indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: enrichments.indicator.file.elf.sections
       level: extended
@@ -8816,6 +10080,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: enrichments.indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: enrichments.indicator.file.elf.sections.virtual_address
       level: extended
@@ -9027,6 +10297,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: enrichments.indicator.file.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: enrichments.indicator.file.pe.imphash
       level: extended
       type: keyword
@@ -9037,6 +10339,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: enrichments.indicator.file.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: enrichments.indicator.file.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: enrichments.indicator.file.pe.original_file_name
       level: extended
@@ -9062,6 +10394,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: enrichments.indicator.file.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: enrichments.indicator.file.size
       level: extended
@@ -10133,6 +11503,38 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -10181,10 +11583,35 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: indicator.file.elf.sections
       level: extended
@@ -10235,6 +11662,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: indicator.file.elf.sections.virtual_address
       level: extended
@@ -10446,6 +11879,38 @@
       description: Internal version of the file, provided at compile-time.
       example: 6.3.9600.17415
       default_field: false
+    - name: indicator.file.pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: indicator.file.pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: indicator.file.pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: indicator.file.pe.imphash
       level: extended
       type: keyword
@@ -10456,6 +11921,36 @@
 
         Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
       example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: indicator.file.pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: indicator.file.pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: indicator.file.pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      default_field: false
+    - name: indicator.file.pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
       default_field: false
     - name: indicator.file.pe.original_file_name
       level: extended
@@ -10481,6 +11976,44 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft\xAE Windows\xAE Operating System"
+      default_field: false
+    - name: indicator.file.pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      default_field: false
+    - name: indicator.file.pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: indicator.file.pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: indicator.file.pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: indicator.file.pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: indicator.file.pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
       default_field: false
     - name: indicator.file.size
       level: extended

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -160,10 +160,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,dll,dll.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,dll,dll.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,dll,dll.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,dll,dll.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,dll,dll.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,dll,dll.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,dll,dll.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,dll,dll.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,dll,dll.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,dll,dll.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,dll,dll.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,dll,dll.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,dll,dll.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,dll,dll.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,dll,dll.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,dll,dll.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,dll,dll.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,dll,dll.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,dll,dll.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,dll,dll.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,dll,dll.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,dll,dll.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,dns,dns.answers,object,extended,array,,Array of DNS answers.
 8.7.0-dev,true,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
 8.7.0-dev,true,dns,dns.answers.data,keyword,extended,,10.10.10.10,The data describing the resource.
@@ -271,6 +286,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,file,file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev,true,file,file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev,true,file,file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev,true,file,file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,file,file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,file,file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,file,file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev,true,file,file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev,true,file,file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -279,7 +299,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,file,file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev,true,file,file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev,true,file,file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev,true,file,file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev,true,file,file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,file,file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,file,file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,file,file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev,true,file,file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev,true,file,file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -288,6 +311,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,file,file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev,true,file,file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev,true,file,file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev,true,file,file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev,true,file,file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev,true,file,file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev,true,file,file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -307,6 +331,22 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,file,file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev,true,file,file.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev,true,file,file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
+8.7.0-dev,true,file,file.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,file,file.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,file,file.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev,true,file,file.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,file,file.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,file,file.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,file,file.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,file,file.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev,true,file,file.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,file,file.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev,true,file,file.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev,true,file,file.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,file,file.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev,true,file,file.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev,true,file,file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
 8.7.0-dev,true,file,file.mode,keyword,extended,,0640,Mode of the file in octal representation.
 8.7.0-dev,true,file,file.mtime,date,extended,,,Last time the file content was modified.
@@ -318,10 +358,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,file,file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,file,file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,file,file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,file,file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,file,file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,file,file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,file,file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,file,file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,file,file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,file,file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,file,file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,file,file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,file,file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,file,file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,file,file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,file,file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,file,file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,file,file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,file,file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,file,file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev,true,file,file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev,true,file,file.target_path.text,match_only_text,extended,,,Target path for symlinks.
@@ -537,6 +592,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev,true,process,process.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev,true,process,process.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev,true,process,process.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,process,process.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev,true,process,process.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev,true,process,process.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -545,7 +605,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev,true,process,process.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev,true,process,process.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev,true,process,process.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev,true,process,process.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,process,process.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev,true,process,process.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev,true,process,process.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -554,6 +617,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev,true,process,process.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev,true,process,process.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev,true,process,process.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev,true,process,process.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev,true,process,process.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev,true,process,process.elf.segments,nested,extended,array,,ELF object segment list.
@@ -666,6 +730,22 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
 8.7.0-dev,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.7.0-dev,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
+8.7.0-dev,true,process,process.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev,true,process,process.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,process,process.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev,true,process,process.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev,true,process,process.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev,true,process,process.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev,true,process,process.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev,true,process,process.name,keyword,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -686,6 +766,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev,true,process,process.parent.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev,true,process,process.parent.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev,true,process,process.parent.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.parent.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.parent.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,process,process.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev,true,process,process.parent.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev,true,process,process.parent.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -694,7 +779,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.parent.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev,true,process,process.parent.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev,true,process,process.parent.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev,true,process,process.parent.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev,true,process,process.parent.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.parent.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.parent.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,process,process.parent.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev,true,process,process.parent.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev,true,process,process.parent.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -703,6 +791,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.parent.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev,true,process,process.parent.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev,true,process,process.parent.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev,true,process,process.parent.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev,true,process,process.parent.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev,true,process,process.parent.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev,true,process,process.parent.elf.segments,nested,extended,array,,ELF object segment list.
@@ -728,16 +817,47 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
 8.7.0-dev,true,process,process.parent.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev,true,process,process.parent.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
+8.7.0-dev,true,process,process.parent.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.parent.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.parent.macho.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.macho.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.macho.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
+8.7.0-dev,true,process,process.parent.macho.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,process,process.parent.macho.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.parent.macho.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.parent.macho.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.parent.macho.sections,nested,extended,array,,Section information of the Mach-O file.
+8.7.0-dev,true,process,process.parent.macho.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.parent.macho.sections.name,keyword,extended,,,Mach-O Section List name.
+8.7.0-dev,true,process,process.parent.macho.sections.physical_size,long,extended,,,Mach-O Section List physical size.
+8.7.0-dev,true,process,process.parent.macho.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.parent.macho.sections.virtual_size,long,extended,,,Mach-O Section List virtual size. This is always the same as `physical_size`.
+8.7.0-dev,true,process,process.parent.macho.symhash,keyword,extended,,d3ccf195b62a9279c3c19af1080497ec,A hash of the imports in a Mach-O file.
 8.7.0-dev,true,process,process.parent.name,keyword,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.parent.name.text,match_only_text,extended,,ssh,Process name.
 8.7.0-dev,true,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
 8.7.0-dev,true,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,process,process.parent.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.parent.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.parent.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.parent.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,process,process.parent.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,process,process.parent.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.parent.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.parent.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,process,process.parent.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,process,process.parent.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,process,process.parent.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,process,process.parent.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.parent.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,process,process.parent.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,process,process.parent.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.parent.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,process,process.parent.pgid,long,extended,,,Deprecated identifier of the group of processes the process belongs to.
 8.7.0-dev,true,process,process.parent.pid,long,core,,4242,Process id.
 8.7.0-dev,true,process,process.parent.real_group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
@@ -770,10 +890,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,process,process.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,process,process.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,process,process.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,process,process.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,process,process.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,process,process.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,process,process.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,process,process.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,process,process.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,process,process.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,process,process.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,process,process.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,process,process.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,process,process.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,process,process.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,process,process.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,process,process.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,process,process.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,process,process.pgid,long,extended,,,Deprecated identifier of the group of processes the process belongs to.
 8.7.0-dev,true,process,process.pid,long,core,,4242,Process id.
 8.7.0-dev,true,process,process.previous.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
@@ -1009,6 +1144,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -1017,7 +1157,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -1026,6 +1169,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -1056,10 +1200,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,threat,threat.enrichments.indicator.file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev,true,threat,threat.enrichments.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.
@@ -1200,6 +1359,11 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
 8.7.0-dev,true,threat,threat.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
 8.7.0-dev,true,threat,threat.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.elf.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,threat,threat.indicator.file.elf.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.elf.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.indicator.file.elf.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.indicator.file.elf.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
@@ -1208,7 +1372,10 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
 8.7.0-dev,true,threat,threat.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+8.7.0-dev,true,threat,threat.indicator.file.elf.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
 8.7.0-dev,true,threat,threat.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.elf.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.elf.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
@@ -1217,6 +1384,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+8.7.0-dev,true,threat,threat.indicator.file.elf.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
 8.7.0-dev,true,threat,threat.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
 8.7.0-dev,true,threat,threat.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
@@ -1247,10 +1415,25 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,threat,threat.indicator.file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.indicator.file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.indicator.file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+8.7.0-dev,true,threat,threat.indicator.file.pe.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in an ELF file.
+8.7.0-dev,true,threat,threat.indicator.file.pe.go_imports,flattened,extended,,,List of imported Go language element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.pe.go_imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.indicator.file.pe.go_imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of Go imports.
+8.7.0-dev,true,threat,threat.indicator.file.pe.go_stripped,boolean,extended,,,Whether the file is a stripped or obfuscated Go executable.
 8.7.0-dev,true,threat,threat.indicator.file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+8.7.0-dev,true,threat,threat.indicator.file.pe.import_hash,keyword,extended,,d41d8cd98f00b204e9800998ecf8427e,A hash of the imports in an ELF file.
+8.7.0-dev,true,threat,threat.indicator.file.pe.imports,flattened,extended,array,,List of imported element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.pe.imports_names_entropy,long,extended,,,Shannon entropy calculation from the list of imported element names and types.
+8.7.0-dev,true,threat,threat.indicator.file.pe.imports_names_var_entropy,long,extended,,,Variance for Shannon entropy calculation from the list of imported element names and types.
 8.7.0-dev,true,threat,threat.indicator.file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
 8.7.0-dev,true,threat,threat.indicator.file.pe.pehash,keyword,extended,,73ff189b63cd6be375a7ff25179a38d347651975,A hash of the PE header and data from one or more PE sections.
 8.7.0-dev,true,threat,threat.indicator.file.pe.product,keyword,extended,,Microsoft® Windows® Operating System,"Internal product name of the file, provided at compile-time."
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections,nested,extended,array,,Section information of the PE file.
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections.name,keyword,extended,,,PE Section List name.
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections.physical_size,long,extended,,,PE Section List physical size.
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections.var_entropy,long,extended,,,Variance for Shannon entropy calculation from the section.
+8.7.0-dev,true,threat,threat.indicator.file.pe.sections.virtual_size,long,extended,,,PE Section List virtual size. This is always the same as `physical_size`.
 8.7.0-dev,true,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
 8.7.0-dev,true,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
 8.7.0-dev,true,threat,threat.indicator.file.target_path.text,match_only_text,extended,,,Target path for symlinks.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1956,9 +1956,13 @@ dll.pe.file_version:
   type: keyword
 dll.pe.go_import_hash:
   dashed_name: dll-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: dll.pe.go_import_hash
   ignore_above: 1024
@@ -3998,9 +4002,13 @@ file.elf.exports:
   type: flattened
 file.elf.go_import_hash:
   dashed_name: file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.elf.go_import_hash
   ignore_above: 1024
@@ -4525,9 +4533,13 @@ file.inode:
   type: keyword
 file.macho.go_import_hash:
   dashed_name: file-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.macho.go_import_hash
   ignore_above: 1024
@@ -4838,9 +4850,13 @@ file.pe.file_version:
   type: keyword
 file.pe.go_import_hash:
   dashed_name: file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: file.pe.go_import_hash
   ignore_above: 1024
@@ -7722,9 +7738,13 @@ process.elf.exports:
   type: flattened
 process.elf.go_import_hash:
   dashed_name: process-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.elf.go_import_hash
   ignore_above: 1024
@@ -9339,9 +9359,13 @@ process.io.type:
   type: keyword
 process.macho.go_import_hash:
   dashed_name: process-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.macho.go_import_hash
   ignore_above: 1024
@@ -9781,9 +9805,13 @@ process.parent.elf.exports:
   type: flattened
 process.parent.elf.go_import_hash:
   dashed_name: process-parent-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.elf.go_import_hash
   ignore_above: 1024
@@ -10385,9 +10413,13 @@ process.parent.interactive:
   type: boolean
 process.parent.macho.go_import_hash:
   dashed_name: process-parent-macho-go-import-hash
-  description: A hash of the Go language imports in an Mach-O file. An import hash
-    can be used to fingerprint binaries even after recompilation or other code-level
-    transformations have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a Mach-O file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.macho.go_import_hash
   ignore_above: 1024
@@ -10645,9 +10677,13 @@ process.parent.pe.file_version:
   type: keyword
 process.parent.pe.go_import_hash:
   dashed_name: process-parent-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.parent.pe.go_import_hash
   ignore_above: 1024
@@ -11222,9 +11258,13 @@ process.pe.file_version:
   type: keyword
 process.pe.go_import_hash:
   dashed_name: process-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: process.pe.go_import_hash
   ignore_above: 1024
@@ -14461,9 +14501,13 @@ threat.enrichments.indicator.file.elf.exports:
   type: flattened
 threat.enrichments.indicator.file.elf.go_import_hash:
   dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -15118,9 +15162,13 @@ threat.enrichments.indicator.file.pe.file_version:
   type: keyword
 threat.enrichments.indicator.file.pe.go_import_hash:
   dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.enrichments.indicator.file.pe.go_import_hash
   ignore_above: 1024
@@ -17131,9 +17179,13 @@ threat.indicator.file.elf.exports:
   type: flattened
 threat.indicator.file.elf.go_import_hash:
   dashed_name: threat-indicator-file-elf-go-import-hash
-  description: A hash of the Go language imports in an ELF file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.elf.go_import_hash
   ignore_above: 1024
@@ -17788,9 +17840,13 @@ threat.indicator.file.pe.file_version:
   type: keyword
 threat.indicator.file.pe.go_import_hash:
   dashed_name: threat-indicator-file-pe-go-import-hash
-  description: A hash of the Go language imports in a PE file. An import hash can
-    be used to fingerprint binaries even after recompilation or other code-level transformations
-    have occurred, which would change more traditional hash values.
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
   example: 10bddcb4cee42080f76c88d9ff964491
   flat_name: threat.indicator.file.pe.go_import_hash
   ignore_above: 1024

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1954,6 +1954,63 @@ dll.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+dll.pe.go_import_hash:
+  dashed_name: dll-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: dll.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+dll.pe.go_imports:
+  dashed_name: dll-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: dll.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+dll.pe.go_imports_names_entropy:
+  dashed_name: dll-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: dll.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+dll.pe.go_imports_names_var_entropy:
+  dashed_name: dll-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: dll.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+dll.pe.go_stripped:
+  dashed_name: dll-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: dll.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 dll.pe.imphash:
   dashed_name: dll-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -1970,6 +2027,58 @@ dll.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+dll.pe.import_hash:
+  dashed_name: dll-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: dll.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+dll.pe.imports:
+  dashed_name: dll-pe-imports
+  description: List of imported element names and types.
+  flat_name: dll.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+dll.pe.imports_names_entropy:
+  dashed_name: dll-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: dll.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+dll.pe.imports_names_var_entropy:
+  dashed_name: dll-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: dll.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 dll.pe.original_file_name:
   dashed_name: dll-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -2010,6 +2119,75 @@ dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+dll.pe.sections:
+  dashed_name: dll-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: dll.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+dll.pe.sections.entropy:
+  dashed_name: dll-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: dll.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+dll.pe.sections.name:
+  dashed_name: dll-pe-sections-name
+  description: PE Section List name.
+  flat_name: dll.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+dll.pe.sections.physical_size:
+  dashed_name: dll-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: dll.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+dll.pe.sections.var_entropy:
+  dashed_name: dll-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: dll.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+dll.pe.sections.virtual_size:
+  dashed_name: dll-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: dll.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 dns.answers:
   dashed_name: dns-answers
   description: 'An array containing an object for each answer section returned by
@@ -3818,6 +3996,63 @@ file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+file.elf.go_import_hash:
+  dashed_name: file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.elf.go_imports:
+  dashed_name: file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+file.elf.go_imports_names_entropy:
+  dashed_name: file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.elf.go_imports_names_var_entropy:
+  dashed_name: file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.elf.go_stripped:
+  dashed_name: file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 file.elf.header.abi_version:
   dashed_name: file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -3906,6 +4141,22 @@ file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+file.elf.import_hash:
+  dashed_name: file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 file.elf.imports:
   dashed_name: file-elf-imports
   description: List of imported element names and types.
@@ -3917,6 +4168,31 @@ file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+file.elf.imports_names_entropy:
+  dashed_name: file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.elf.imports_names_var_entropy:
+  dashed_name: file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 file.elf.sections:
   dashed_name: file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -4008,6 +4284,17 @@ file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+file.elf.sections.var_entropy:
+  dashed_name: file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 file.elf.sections.virtual_address:
   dashed_name: file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -4236,6 +4523,200 @@ file.inode:
   normalize: []
   short: Inode representing the file in the filesystem.
   type: keyword
+file.macho.go_import_hash:
+  dashed_name: file-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.macho.go_imports:
+  dashed_name: file-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+file.macho.go_imports_names_entropy:
+  dashed_name: file-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.macho.go_imports_names_var_entropy:
+  dashed_name: file-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.macho.go_stripped:
+  dashed_name: file-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+file.macho.import_hash:
+  dashed_name: file-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+file.macho.imports:
+  dashed_name: file-macho-imports
+  description: List of imported element names and types.
+  flat_name: file.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+file.macho.imports_names_entropy:
+  dashed_name: file-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.macho.imports_names_var_entropy:
+  dashed_name: file-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+file.macho.sections:
+  dashed_name: file-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: file.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+file.macho.sections.entropy:
+  dashed_name: file-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: file.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+file.macho.sections.name:
+  dashed_name: file-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: file.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+file.macho.sections.physical_size:
+  dashed_name: file-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: file.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+file.macho.sections.var_entropy:
+  dashed_name: file-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+file.macho.sections.virtual_size:
+  dashed_name: file-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: file.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+file.macho.symhash:
+  dashed_name: file-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: file.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 file.mime_type:
   dashed_name: file-mime-type
   description: MIME type should identify the format of the file or stream of bytes
@@ -4355,6 +4836,63 @@ file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+file.pe.go_import_hash:
+  dashed_name: file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+file.pe.go_imports:
+  dashed_name: file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+file.pe.go_imports_names_entropy:
+  dashed_name: file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+file.pe.go_imports_names_var_entropy:
+  dashed_name: file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+file.pe.go_stripped:
+  dashed_name: file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 file.pe.imphash:
   dashed_name: file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -4371,6 +4909,58 @@ file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+file.pe.import_hash:
+  dashed_name: file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+file.pe.imports:
+  dashed_name: file-pe-imports
+  description: List of imported element names and types.
+  flat_name: file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+file.pe.imports_names_entropy:
+  dashed_name: file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+file.pe.imports_names_var_entropy:
+  dashed_name: file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 file.pe.original_file_name:
   dashed_name: file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -4411,6 +5001,75 @@ file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+file.pe.sections:
+  dashed_name: file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+file.pe.sections.entropy:
+  dashed_name: file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+file.pe.sections.name:
+  dashed_name: file-pe-sections-name
+  description: PE Section List name.
+  flat_name: file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+file.pe.sections.physical_size:
+  dashed_name: file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+file.pe.sections.var_entropy:
+  dashed_name: file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+file.pe.sections.virtual_size:
+  dashed_name: file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 file.size:
   dashed_name: file-size
   description: 'File size in bytes.
@@ -7061,6 +7720,63 @@ process.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+process.elf.go_import_hash:
+  dashed_name: process-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.elf.go_imports:
+  dashed_name: process-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+process.elf.go_imports_names_entropy:
+  dashed_name: process-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.elf.go_imports_names_var_entropy:
+  dashed_name: process-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.elf.go_stripped:
+  dashed_name: process-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.elf.header.abi_version:
   dashed_name: process-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -7149,6 +7865,22 @@ process.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+process.elf.import_hash:
+  dashed_name: process-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 process.elf.imports:
   dashed_name: process-elf-imports
   description: List of imported element names and types.
@@ -7160,6 +7892,31 @@ process.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+process.elf.imports_names_entropy:
+  dashed_name: process-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.elf.imports_names_var_entropy:
+  dashed_name: process-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.elf.sections:
   dashed_name: process-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -7251,6 +8008,17 @@ process.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+process.elf.sections.var_entropy:
+  dashed_name: process-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 process.elf.sections.virtual_address:
   dashed_name: process-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -8569,6 +9337,200 @@ process.io.type:
   normalize: []
   short: The type of object on which the IO action (read or write) was taken.
   type: keyword
+process.macho.go_import_hash:
+  dashed_name: process-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.macho.go_imports:
+  dashed_name: process-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+process.macho.go_imports_names_entropy:
+  dashed_name: process-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.macho.go_imports_names_var_entropy:
+  dashed_name: process-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.macho.go_stripped:
+  dashed_name: process-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.macho.import_hash:
+  dashed_name: process-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.macho.imports:
+  dashed_name: process-macho-imports
+  description: List of imported element names and types.
+  flat_name: process.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+process.macho.imports_names_entropy:
+  dashed_name: process-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.macho.imports_names_var_entropy:
+  dashed_name: process-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.macho.sections:
+  dashed_name: process-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: process.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+process.macho.sections.entropy:
+  dashed_name: process-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+process.macho.sections.name:
+  dashed_name: process-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: process.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+process.macho.sections.physical_size:
+  dashed_name: process-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: process.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+process.macho.sections.var_entropy:
+  dashed_name: process-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.macho.sections.virtual_size:
+  dashed_name: process-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.macho.symhash:
+  dashed_name: process-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: process.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.
@@ -8817,6 +9779,63 @@ process.parent.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+process.parent.elf.go_import_hash:
+  dashed_name: process-parent-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.elf.go_imports:
+  dashed_name: process-parent-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.elf.go_imports_names_entropy:
+  dashed_name: process-parent-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.elf.go_imports_names_var_entropy:
+  dashed_name: process-parent-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.elf.go_stripped:
+  dashed_name: process-parent-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.parent.elf.header.abi_version:
   dashed_name: process-parent-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -8905,6 +9924,22 @@ process.parent.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+process.parent.elf.import_hash:
+  dashed_name: process-parent-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 process.parent.elf.imports:
   dashed_name: process-parent-elf-imports
   description: List of imported element names and types.
@@ -8916,6 +9951,31 @@ process.parent.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+process.parent.elf.imports_names_entropy:
+  dashed_name: process-parent-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.elf.imports_names_var_entropy:
+  dashed_name: process-parent-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.parent.elf.sections:
   dashed_name: process-parent-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -9007,6 +10067,17 @@ process.parent.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+process.parent.elf.sections.var_entropy:
+  dashed_name: process-parent-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 process.parent.elf.sections.virtual_address:
   dashed_name: process-parent-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -9312,6 +10383,200 @@ process.parent.interactive:
   original_fieldset: process
   short: Whether the process is connected to an interactive shell.
   type: boolean
+process.parent.macho.go_import_hash:
+  dashed_name: process-parent-macho-go-import-hash
+  description: A hash of the Go language imports in an Mach-O file. An import hash
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.macho.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.macho.go_imports:
+  dashed_name: process-parent-macho-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.macho.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: macho
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.macho.go_imports_names_entropy:
+  dashed_name: process-parent-macho-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.macho.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.macho.go_imports_names_var_entropy:
+  dashed_name: process-parent-macho-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.macho.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.macho.go_stripped:
+  dashed_name: process-parent-macho-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.macho.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: macho
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.parent.macho.import_hash:
+  dashed_name: process-parent-macho-import-hash
+  description: 'A hash of the imports in an Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for symhash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.macho.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.parent.macho.imports:
+  dashed_name: process-parent-macho-imports
+  description: List of imported element names and types.
+  flat_name: process.parent.macho.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: macho
+  short: List of imported element names and types.
+  type: flattened
+process.parent.macho.imports_names_entropy:
+  dashed_name: process-parent-macho-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.macho.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.macho.imports_names_var_entropy:
+  dashed_name: process-parent-macho-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.macho.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.parent.macho.sections:
+  dashed_name: process-parent-macho-sections
+  description: 'An array containing an object for each section of the Mach-O file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `macho.sections.*`.'
+  flat_name: process.parent.macho.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: macho
+  short: Section information of the Mach-O file.
+  type: nested
+process.parent.macho.sections.entropy:
+  dashed_name: process-parent-macho-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.parent.macho.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: macho
+  short: Shannon entropy calculation from the section.
+  type: long
+process.parent.macho.sections.name:
+  dashed_name: process-parent-macho-sections-name
+  description: Mach-O Section List name.
+  flat_name: process.parent.macho.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List name.
+  type: keyword
+process.parent.macho.sections.physical_size:
+  dashed_name: process-parent-macho-sections-physical-size
+  description: Mach-O Section List physical size.
+  flat_name: process.parent.macho.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List physical size.
+  type: long
+process.parent.macho.sections.var_entropy:
+  dashed_name: process-parent-macho-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.macho.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: macho
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.parent.macho.sections.virtual_size:
+  dashed_name: process-parent-macho-sections-virtual-size
+  description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.parent.macho.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: macho
+  short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.parent.macho.symhash:
+  dashed_name: process-parent-macho-symhash
+  description: 'A hash of the imports in a Mach-O file. An import hash can be used
+    to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a Mach-O implementation of the Windows PE imphash'
+  example: d3ccf195b62a9279c3c19af1080497ec
+  flat_name: process.parent.macho.symhash
+  ignore_above: 1024
+  level: extended
+  name: symhash
+  normalize: []
+  original_fieldset: macho
+  short: A hash of the imports in a Mach-O file.
+  type: keyword
 process.parent.name:
   dashed_name: process-parent-name
   description: 'Process name.
@@ -9378,6 +10643,63 @@ process.parent.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+process.parent.pe.go_import_hash:
+  dashed_name: process-parent-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.parent.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.parent.pe.go_imports:
+  dashed_name: process-parent-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.parent.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.parent.pe.go_imports_names_entropy:
+  dashed_name: process-parent-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.pe.go_imports_names_var_entropy:
+  dashed_name: process-parent-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.parent.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.parent.pe.go_stripped:
+  dashed_name: process-parent-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.parent.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.parent.pe.imphash:
   dashed_name: process-parent-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -9394,6 +10716,58 @@ process.parent.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+process.parent.pe.import_hash:
+  dashed_name: process-parent-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.parent.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.parent.pe.imports:
+  dashed_name: process-parent-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.parent.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.parent.pe.imports_names_entropy:
+  dashed_name: process-parent-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.parent.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.parent.pe.imports_names_var_entropy:
+  dashed_name: process-parent-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.parent.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.parent.pe.original_file_name:
   dashed_name: process-parent-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -9434,6 +10808,75 @@ process.parent.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.parent.pe.sections:
+  dashed_name: process-parent-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.parent.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.parent.pe.sections.entropy:
+  dashed_name: process-parent-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.parent.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.parent.pe.sections.name:
+  dashed_name: process-parent-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.parent.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.parent.pe.sections.physical_size:
+  dashed_name: process-parent-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.parent.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.parent.pe.sections.var_entropy:
+  dashed_name: process-parent-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.parent.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.parent.pe.sections.virtual_size:
+  dashed_name: process-parent-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.parent.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 process.parent.pgid:
   dashed_name: process-parent-pgid
   description: 'Deprecated for removal in next major version release. This field is
@@ -9777,6 +11220,63 @@ process.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+process.pe.go_import_hash:
+  dashed_name: process-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+process.pe.go_imports:
+  dashed_name: process-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.pe.go_imports_names_entropy:
+  dashed_name: process-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.pe.go_imports_names_var_entropy:
+  dashed_name: process-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.pe.go_stripped:
+  dashed_name: process-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 process.pe.imphash:
   dashed_name: process-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -9793,6 +11293,58 @@ process.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+process.pe.import_hash:
+  dashed_name: process-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+process.pe.imports:
+  dashed_name: process-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.pe.imports_names_entropy:
+  dashed_name: process-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.pe.imports_names_var_entropy:
+  dashed_name: process-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 process.pe.original_file_name:
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -9833,6 +11385,75 @@ process.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.pe.sections:
+  dashed_name: process-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.pe.sections.entropy:
+  dashed_name: process-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.pe.sections.name:
+  dashed_name: process-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.pe.sections.physical_size:
+  dashed_name: process-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.pe.sections.var_entropy:
+  dashed_name: process-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.pe.sections.virtual_size:
+  dashed_name: process-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 process.pgid:
   dashed_name: process-pgid
   description: 'Deprecated for removal in next major version release. This field is
@@ -12838,6 +14459,63 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -12926,6 +14604,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -12937,6 +14631,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -13028,6 +14747,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -13386,6 +15116,63 @@ threat.enrichments.indicator.file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+threat.enrichments.indicator.file.pe.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.pe.go_imports:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.pe.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.pe.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.pe.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.pe.imphash:
   dashed_name: threat-enrichments-indicator-file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -13402,6 +15189,58 @@ threat.enrichments.indicator.file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+threat.enrichments.indicator.file.pe.import_hash:
+  dashed_name: threat-enrichments-indicator-file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.pe.imports:
+  dashed_name: threat-enrichments-indicator-file-pe-imports
+  description: List of imported element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+threat.enrichments.indicator.file.pe.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.pe.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.pe.original_file_name:
   dashed_name: threat-enrichments-indicator-file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -13442,6 +15281,75 @@ threat.enrichments.indicator.file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+threat.enrichments.indicator.file.pe.sections:
+  dashed_name: threat-enrichments-indicator-file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: threat.enrichments.indicator.file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+threat.enrichments.indicator.file.pe.sections.entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+threat.enrichments.indicator.file.pe.sections.name:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-name
+  description: PE Section List name.
+  flat_name: threat.enrichments.indicator.file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+threat.enrichments.indicator.file.pe.sections.physical_size:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: threat.enrichments.indicator.file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+threat.enrichments.indicator.file.pe.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+threat.enrichments.indicator.file.pe.sections.virtual_size:
+  dashed_name: threat-enrichments-indicator-file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: threat.enrichments.indicator.file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 threat.enrichments.indicator.file.size:
   dashed_name: threat-enrichments-indicator-file-size
   description: 'File size in bytes.
@@ -15221,6 +17129,63 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: A hash of the Go language imports in an ELF file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -15309,6 +17274,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -15320,6 +17301,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -15411,6 +17417,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -15769,6 +17786,63 @@ threat.indicator.file.pe.file_version:
   original_fieldset: pe
   short: Process name.
   type: keyword
+threat.indicator.file.pe.go_import_hash:
+  dashed_name: threat-indicator-file-pe-go-import-hash
+  description: A hash of the Go language imports in a PE file. An import hash can
+    be used to fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.pe.go_imports:
+  dashed_name: threat-indicator-file-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.pe.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.pe.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.pe.go_stripped:
+  dashed_name: threat-indicator-file-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.pe.imphash:
   dashed_name: threat-indicator-file-pe-imphash
   description: 'A hash of the imports in a PE file. An imphash -- or import hash --
@@ -15785,6 +17859,58 @@ threat.indicator.file.pe.imphash:
   original_fieldset: pe
   short: A hash of the imports in a PE file.
   type: keyword
+threat.indicator.file.pe.import_hash:
+  dashed_name: threat-indicator-file-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in an ELF file.
+  type: keyword
+threat.indicator.file.pe.imports:
+  dashed_name: threat-indicator-file-pe-imports
+  description: List of imported element names and types.
+  flat_name: threat.indicator.file.pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+threat.indicator.file.pe.imports_names_entropy:
+  dashed_name: threat-indicator-file-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.pe.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.pe.original_file_name:
   dashed_name: threat-indicator-file-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -15825,6 +17951,75 @@ threat.indicator.file.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+threat.indicator.file.pe.sections:
+  dashed_name: threat-indicator-file-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: threat.indicator.file.pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+threat.indicator.file.pe.sections.entropy:
+  dashed_name: threat-indicator-file-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+threat.indicator.file.pe.sections.name:
+  dashed_name: threat-indicator-file-pe-sections-name
+  description: PE Section List name.
+  flat_name: threat.indicator.file.pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+threat.indicator.file.pe.sections.physical_size:
+  dashed_name: threat-indicator-file-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: threat.indicator.file.pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+threat.indicator.file.pe.sections.var_entropy:
+  dashed_name: threat-indicator-file-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+threat.indicator.file.pe.sections.virtual_size:
+  dashed_name: threat-indicator-file-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: threat.indicator.file.pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
 threat.indicator.file.size:
   dashed_name: threat-indicator-file-size
   description: 'File size in bytes.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2418,9 +2418,13 @@ dll:
       type: keyword
     dll.pe.go_import_hash:
       dashed_name: dll-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: dll.pe.go_import_hash
       ignore_above: 1024
@@ -3029,9 +3033,13 @@ elf:
       type: flattened
     elf.go_import_hash:
       dashed_name: elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: elf.go_import_hash
       ignore_above: 1024
@@ -5017,9 +5025,13 @@ file:
       type: flattened
     file.elf.go_import_hash:
       dashed_name: file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.elf.go_import_hash
       ignore_above: 1024
@@ -5545,10 +5557,13 @@ file:
       type: keyword
     file.macho.go_import_hash:
       dashed_name: file-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.macho.go_import_hash
       ignore_above: 1024
@@ -5860,9 +5875,13 @@ file:
       type: keyword
     file.pe.go_import_hash:
       dashed_name: file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: file.pe.go_import_hash
       ignore_above: 1024
@@ -7898,10 +7917,13 @@ macho:
   fields:
     macho.go_import_hash:
       dashed_name: macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: macho.go_import_hash
       ignore_above: 1024
@@ -9443,9 +9465,13 @@ pe:
       type: keyword
     pe.go_import_hash:
       dashed_name: pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: pe.go_import_hash
       ignore_above: 1024
@@ -9912,9 +9938,13 @@ process:
       type: flattened
     process.elf.go_import_hash:
       dashed_name: process-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.elf.go_import_hash
       ignore_above: 1024
@@ -11533,10 +11563,13 @@ process:
       type: keyword
     process.macho.go_import_hash:
       dashed_name: process-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.macho.go_import_hash
       ignore_above: 1024
@@ -11977,9 +12010,13 @@ process:
       type: flattened
     process.parent.elf.go_import_hash:
       dashed_name: process-parent-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.elf.go_import_hash
       ignore_above: 1024
@@ -12582,10 +12619,13 @@ process:
       type: boolean
     process.parent.macho.go_import_hash:
       dashed_name: process-parent-macho-go-import-hash
-      description: A hash of the Go language imports in an Mach-O file. An import
-        hash can be used to fingerprint binaries even after recompilation or other
-        code-level transformations have occurred, which would change more traditional
-        hash values.
+      description: 'A hash of the Go language imports in a Mach-O file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.macho.go_import_hash
       ignore_above: 1024
@@ -12844,9 +12884,13 @@ process:
       type: keyword
     process.parent.pe.go_import_hash:
       dashed_name: process-parent-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.parent.pe.go_import_hash
       ignore_above: 1024
@@ -13422,9 +13466,13 @@ process:
       type: keyword
     process.pe.go_import_hash:
       dashed_name: process-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: process.pe.go_import_hash
       ignore_above: 1024
@@ -17108,9 +17156,13 @@ threat:
       type: flattened
     threat.enrichments.indicator.file.elf.go_import_hash:
       dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -17766,9 +17818,13 @@ threat:
       type: keyword
     threat.enrichments.indicator.file.pe.go_import_hash:
       dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.enrichments.indicator.file.pe.go_import_hash
       ignore_above: 1024
@@ -19784,9 +19840,13 @@ threat:
       type: flattened
     threat.indicator.file.elf.go_import_hash:
       dashed_name: threat-indicator-file-elf-go-import-hash
-      description: A hash of the Go language imports in an ELF file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in an ELF file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.elf.go_import_hash
       ignore_above: 1024
@@ -20442,9 +20502,13 @@ threat:
       type: keyword
     threat.indicator.file.pe.go_import_hash:
       dashed_name: threat-indicator-file-pe-go-import-hash
-      description: A hash of the Go language imports in a PE file. An import hash
-        can be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+      description: 'A hash of the Go language imports in a PE file excluding standard
+        library imports. An import hash can be used to fingerprint binaries even after
+        recompilation or other code-level transformations have occurred, which would
+        change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).'
       example: 10bddcb4cee42080f76c88d9ff964491
       flat_name: threat.indicator.file.pe.go_import_hash
       ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -2416,6 +2416,63 @@ dll:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    dll.pe.go_import_hash:
+      dashed_name: dll-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: dll.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    dll.pe.go_imports:
+      dashed_name: dll-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: dll.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    dll.pe.go_imports_names_entropy:
+      dashed_name: dll-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: dll.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    dll.pe.go_imports_names_var_entropy:
+      dashed_name: dll-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: dll.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    dll.pe.go_stripped:
+      dashed_name: dll-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: dll.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     dll.pe.imphash:
       dashed_name: dll-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -2432,6 +2489,59 @@ dll:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    dll.pe.import_hash:
+      dashed_name: dll-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: dll.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    dll.pe.imports:
+      dashed_name: dll-pe-imports
+      description: List of imported element names and types.
+      flat_name: dll.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    dll.pe.imports_names_entropy:
+      dashed_name: dll-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: dll.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    dll.pe.imports_names_var_entropy:
+      dashed_name: dll-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: dll.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     dll.pe.original_file_name:
       dashed_name: dll-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -2472,6 +2582,75 @@ dll:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    dll.pe.sections:
+      dashed_name: dll-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: dll.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    dll.pe.sections.entropy:
+      dashed_name: dll-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: dll.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    dll.pe.sections.name:
+      dashed_name: dll-pe-sections-name
+      description: PE Section List name.
+      flat_name: dll.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    dll.pe.sections.physical_size:
+      dashed_name: dll-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: dll.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    dll.pe.sections.var_entropy:
+      dashed_name: dll-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: dll.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    dll.pe.sections.virtual_size:
+      dashed_name: dll-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: dll.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
   group: 2
   name: dll
   nestings:
@@ -2848,6 +3027,58 @@ elf:
       - array
       short: List of exported element names and types.
       type: flattened
+    elf.go_import_hash:
+      dashed_name: elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    elf.go_imports:
+      dashed_name: elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    elf.go_imports_names_entropy:
+      dashed_name: elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    elf.go_imports_names_var_entropy:
+      dashed_name: elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    elf.go_stripped:
+      dashed_name: elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     elf.header.abi_version:
       dashed_name: elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -2928,6 +3159,21 @@ elf:
       normalize: []
       short: Version of the ELF header.
       type: keyword
+    elf.import_hash:
+      dashed_name: elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
     elf.imports:
       dashed_name: elf-imports
       description: List of imported element names and types.
@@ -2938,6 +3184,30 @@ elf:
       - array
       short: List of imported element names and types.
       type: flattened
+    elf.imports_names_entropy:
+      dashed_name: elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    elf.imports_names_var_entropy:
+      dashed_name: elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     elf.sections:
       dashed_name: elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -3021,6 +3291,16 @@ elf:
       normalize: []
       short: ELF Section List type.
       type: keyword
+    elf.sections.var_entropy:
+      dashed_name: elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     elf.sections.virtual_address:
       dashed_name: elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -4735,6 +5015,63 @@ file:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    file.elf.go_import_hash:
+      dashed_name: file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.elf.go_imports:
+      dashed_name: file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.elf.go_imports_names_entropy:
+      dashed_name: file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.elf.go_imports_names_var_entropy:
+      dashed_name: file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.elf.go_stripped:
+      dashed_name: file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     file.elf.header.abi_version:
       dashed_name: file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -4823,6 +5160,22 @@ file:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    file.elf.import_hash:
+      dashed_name: file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     file.elf.imports:
       dashed_name: file-elf-imports
       description: List of imported element names and types.
@@ -4834,6 +5187,32 @@ file:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    file.elf.imports_names_entropy:
+      dashed_name: file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.elf.imports_names_var_entropy:
+      dashed_name: file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     file.elf.sections:
       dashed_name: file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -4925,6 +5304,17 @@ file:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    file.elf.sections.var_entropy:
+      dashed_name: file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     file.elf.sections.virtual_address:
       dashed_name: file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -5153,6 +5543,202 @@ file:
       normalize: []
       short: Inode representing the file in the filesystem.
       type: keyword
+    file.macho.go_import_hash:
+      dashed_name: file-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.macho.go_imports:
+      dashed_name: file-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.macho.go_imports_names_entropy:
+      dashed_name: file-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.macho.go_imports_names_var_entropy:
+      dashed_name: file-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.macho.go_stripped:
+      dashed_name: file-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    file.macho.import_hash:
+      dashed_name: file-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    file.macho.imports:
+      dashed_name: file-macho-imports
+      description: List of imported element names and types.
+      flat_name: file.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    file.macho.imports_names_entropy:
+      dashed_name: file-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.macho.imports_names_var_entropy:
+      dashed_name: file-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    file.macho.sections:
+      dashed_name: file-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: file.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    file.macho.sections.entropy:
+      dashed_name: file-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: file.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    file.macho.sections.name:
+      dashed_name: file-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: file.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    file.macho.sections.physical_size:
+      dashed_name: file-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: file.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    file.macho.sections.var_entropy:
+      dashed_name: file-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    file.macho.sections.virtual_size:
+      dashed_name: file-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: file.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    file.macho.symhash:
+      dashed_name: file-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: file.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     file.mime_type:
       dashed_name: file-mime-type
       description: MIME type should identify the format of the file or stream of bytes
@@ -5272,6 +5858,63 @@ file:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    file.pe.go_import_hash:
+      dashed_name: file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    file.pe.go_imports:
+      dashed_name: file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    file.pe.go_imports_names_entropy:
+      dashed_name: file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.pe.go_imports_names_var_entropy:
+      dashed_name: file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    file.pe.go_stripped:
+      dashed_name: file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     file.pe.imphash:
       dashed_name: file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -5288,6 +5931,59 @@ file:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    file.pe.import_hash:
+      dashed_name: file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    file.pe.imports:
+      dashed_name: file-pe-imports
+      description: List of imported element names and types.
+      flat_name: file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    file.pe.imports_names_entropy:
+      dashed_name: file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    file.pe.imports_names_var_entropy:
+      dashed_name: file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     file.pe.original_file_name:
       dashed_name: file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -5328,6 +6024,75 @@ file:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    file.pe.sections:
+      dashed_name: file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    file.pe.sections.entropy:
+      dashed_name: file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    file.pe.sections.name:
+      dashed_name: file-pe-sections-name
+      description: PE Section List name.
+      flat_name: file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    file.pe.sections.physical_size:
+      dashed_name: file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    file.pe.sections.var_entropy:
+      dashed_name: file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    file.pe.sections.virtual_size:
+      dashed_name: file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     file.size:
       dashed_name: file-size
       description: 'File size in bytes.
@@ -5688,6 +6453,7 @@ file:
   - file.code_signature
   - file.elf
   - file.hash
+  - file.macho
   - file.pe
   - file.x509
   prefix: file.
@@ -5717,6 +6483,10 @@ file:
     full: file.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  - beta: This field reuse is beta and subject to change.
+    full: file.macho
+    schema_name: macho
+    short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
   short: Fields describing files.
   title: File
   type: group
@@ -7122,6 +7892,207 @@ log:
   short: Details about the event's logging mechanism.
   title: Log
   type: group
+macho:
+  beta: These fields are in beta and are subject to change.
+  description: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+  fields:
+    macho.go_import_hash:
+      dashed_name: macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    macho.go_imports:
+      dashed_name: macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    macho.go_imports_names_entropy:
+      dashed_name: macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    macho.go_imports_names_var_entropy:
+      dashed_name: macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    macho.go_stripped:
+      dashed_name: macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    macho.import_hash:
+      dashed_name: macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    macho.imports:
+      dashed_name: macho-imports
+      description: List of imported element names and types.
+      flat_name: macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      short: List of imported element names and types.
+      type: flattened
+    macho.imports_names_entropy:
+      dashed_name: macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    macho.imports_names_var_entropy:
+      dashed_name: macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    macho.sections:
+      dashed_name: macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      short: Section information of the Mach-O file.
+      type: nested
+    macho.sections.entropy:
+      dashed_name: macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      short: Shannon entropy calculation from the section.
+      type: long
+    macho.sections.name:
+      dashed_name: macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      short: Mach-O Section List name.
+      type: keyword
+    macho.sections.physical_size:
+      dashed_name: macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      short: Mach-O Section List physical size.
+      type: long
+    macho.sections.var_entropy:
+      dashed_name: macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    macho.sections.virtual_size:
+      dashed_name: macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    macho.symhash:
+      dashed_name: macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
+  group: 2
+  name: macho
+  prefix: macho.
+  reusable:
+    expected:
+    - as: macho
+      at: file
+      beta: This field reuse is beta and subject to change.
+      full: file.macho
+    - as: macho
+      at: process
+      beta: This field reuse is beta and subject to change.
+      full: process.macho
+    top_level: false
+  short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+  title: Mach-O Header
+  type: group
 network:
   description: 'The network is defined as the communication path over which a host
     or network event happens.
@@ -8470,6 +9441,58 @@ pe:
       normalize: []
       short: Process name.
       type: keyword
+    pe.go_import_hash:
+      dashed_name: pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    pe.go_imports:
+      dashed_name: pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      short: List of imported Go language element names and types.
+      type: flattened
+    pe.go_imports_names_entropy:
+      dashed_name: pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    pe.go_imports_names_var_entropy:
+      dashed_name: pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    pe.go_stripped:
+      dashed_name: pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     pe.imphash:
       dashed_name: pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -8485,6 +9508,55 @@ pe:
       normalize: []
       short: A hash of the imports in a PE file.
       type: keyword
+    pe.import_hash:
+      dashed_name: pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    pe.imports:
+      dashed_name: pe-imports
+      description: List of imported element names and types.
+      flat_name: pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      short: List of imported element names and types.
+      type: flattened
+    pe.imports_names_entropy:
+      dashed_name: pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    pe.imports_names_var_entropy:
+      dashed_name: pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     pe.original_file_name:
       dashed_name: pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -8522,6 +9594,69 @@ pe:
       normalize: []
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    pe.sections:
+      dashed_name: pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      short: Section information of the PE file.
+      type: nested
+    pe.sections.entropy:
+      dashed_name: pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      short: Shannon entropy calculation from the section.
+      type: long
+    pe.sections.name:
+      dashed_name: pe-sections-name
+      description: PE Section List name.
+      flat_name: pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      short: PE Section List name.
+      type: keyword
+    pe.sections.physical_size:
+      dashed_name: pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      short: PE Section List physical size.
+      type: long
+    pe.sections.var_entropy:
+      dashed_name: pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    pe.sections.virtual_size:
+      dashed_name: pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
   group: 2
   name: pe
   prefix: pe.
@@ -8775,6 +9910,63 @@ process:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    process.elf.go_import_hash:
+      dashed_name: process-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.elf.go_imports:
+      dashed_name: process-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.elf.go_imports_names_entropy:
+      dashed_name: process-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.elf.go_imports_names_var_entropy:
+      dashed_name: process-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.elf.go_stripped:
+      dashed_name: process-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.elf.header.abi_version:
       dashed_name: process-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -8863,6 +10055,22 @@ process:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    process.elf.import_hash:
+      dashed_name: process-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     process.elf.imports:
       dashed_name: process-elf-imports
       description: List of imported element names and types.
@@ -8874,6 +10082,32 @@ process:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    process.elf.imports_names_entropy:
+      dashed_name: process-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.elf.imports_names_var_entropy:
+      dashed_name: process-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.elf.sections:
       dashed_name: process-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -8965,6 +10199,17 @@ process:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    process.elf.sections.var_entropy:
+      dashed_name: process-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     process.elf.sections.virtual_address:
       dashed_name: process-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -10286,6 +11531,202 @@ process:
       normalize: []
       short: The type of object on which the IO action (read or write) was taken.
       type: keyword
+    process.macho.go_import_hash:
+      dashed_name: process-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.macho.go_imports:
+      dashed_name: process-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.macho.go_imports_names_entropy:
+      dashed_name: process-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.macho.go_imports_names_var_entropy:
+      dashed_name: process-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.macho.go_stripped:
+      dashed_name: process-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    process.macho.import_hash:
+      dashed_name: process-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.macho.imports:
+      dashed_name: process-macho-imports
+      description: List of imported element names and types.
+      flat_name: process.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    process.macho.imports_names_entropy:
+      dashed_name: process-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.macho.imports_names_var_entropy:
+      dashed_name: process-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    process.macho.sections:
+      dashed_name: process-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: process.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    process.macho.sections.entropy:
+      dashed_name: process-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.macho.sections.name:
+      dashed_name: process-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: process.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    process.macho.sections.physical_size:
+      dashed_name: process-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: process.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    process.macho.sections.var_entropy:
+      dashed_name: process-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.macho.sections.virtual_size:
+      dashed_name: process-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    process.macho.symhash:
+      dashed_name: process-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: process.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     process.name:
       dashed_name: process-name
       description: 'Process name.
@@ -10534,6 +11975,63 @@ process:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    process.parent.elf.go_import_hash:
+      dashed_name: process-parent-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.elf.go_imports:
+      dashed_name: process-parent-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.elf.go_imports_names_entropy:
+      dashed_name: process-parent-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.elf.go_imports_names_var_entropy:
+      dashed_name: process-parent-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.elf.go_stripped:
+      dashed_name: process-parent-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.parent.elf.header.abi_version:
       dashed_name: process-parent-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -10622,6 +12120,22 @@ process:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    process.parent.elf.import_hash:
+      dashed_name: process-parent-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     process.parent.elf.imports:
       dashed_name: process-parent-elf-imports
       description: List of imported element names and types.
@@ -10633,6 +12147,32 @@ process:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    process.parent.elf.imports_names_entropy:
+      dashed_name: process-parent-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.elf.imports_names_var_entropy:
+      dashed_name: process-parent-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.parent.elf.sections:
       dashed_name: process-parent-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -10724,6 +12264,17 @@ process:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    process.parent.elf.sections.var_entropy:
+      dashed_name: process-parent-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     process.parent.elf.sections.virtual_address:
       dashed_name: process-parent-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -11029,6 +12580,202 @@ process:
       original_fieldset: process
       short: Whether the process is connected to an interactive shell.
       type: boolean
+    process.parent.macho.go_import_hash:
+      dashed_name: process-parent-macho-go-import-hash
+      description: A hash of the Go language imports in an Mach-O file. An import
+        hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional
+        hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.macho.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.macho.go_imports:
+      dashed_name: process-parent-macho-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.macho.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: macho
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.macho.go_imports_names_entropy:
+      dashed_name: process-parent-macho-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.macho.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.macho.go_imports_names_var_entropy:
+      dashed_name: process-parent-macho-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.macho.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.macho.go_stripped:
+      dashed_name: process-parent-macho-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.macho.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: macho
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
+    process.parent.macho.import_hash:
+      dashed_name: process-parent-macho-import-hash
+      description: 'A hash of the imports in an Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for symhash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.macho.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.parent.macho.imports:
+      dashed_name: process-parent-macho-imports
+      description: List of imported element names and types.
+      flat_name: process.parent.macho.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: macho
+      short: List of imported element names and types.
+      type: flattened
+    process.parent.macho.imports_names_entropy:
+      dashed_name: process-parent-macho-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.macho.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.macho.imports_names_var_entropy:
+      dashed_name: process-parent-macho-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.macho.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
+    process.parent.macho.sections:
+      dashed_name: process-parent-macho-sections
+      description: 'An array containing an object for each section of the Mach-O file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `macho.sections.*`.'
+      flat_name: process.parent.macho.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: macho
+      short: Section information of the Mach-O file.
+      type: nested
+    process.parent.macho.sections.entropy:
+      dashed_name: process-parent-macho-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.parent.macho.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: macho
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.parent.macho.sections.name:
+      dashed_name: process-parent-macho-sections-name
+      description: Mach-O Section List name.
+      flat_name: process.parent.macho.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List name.
+      type: keyword
+    process.parent.macho.sections.physical_size:
+      dashed_name: process-parent-macho-sections-physical-size
+      description: Mach-O Section List physical size.
+      flat_name: process.parent.macho.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List physical size.
+      type: long
+    process.parent.macho.sections.var_entropy:
+      dashed_name: process-parent-macho-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.macho.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: macho
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.parent.macho.sections.virtual_size:
+      dashed_name: process-parent-macho-sections-virtual-size
+      description: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.parent.macho.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: macho
+      short: Mach-O Section List virtual size. This is always the same as `physical_size`.
+      type: long
+    process.parent.macho.symhash:
+      dashed_name: process-parent-macho-symhash
+      description: 'A hash of the imports in a Mach-O file. An import hash can be
+        used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash'
+      example: d3ccf195b62a9279c3c19af1080497ec
+      flat_name: process.parent.macho.symhash
+      ignore_above: 1024
+      level: extended
+      name: symhash
+      normalize: []
+      original_fieldset: macho
+      short: A hash of the imports in a Mach-O file.
+      type: keyword
     process.parent.name:
       dashed_name: process-parent-name
       description: 'Process name.
@@ -11095,6 +12842,63 @@ process:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    process.parent.pe.go_import_hash:
+      dashed_name: process-parent-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.parent.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.parent.pe.go_imports:
+      dashed_name: process-parent-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.parent.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.parent.pe.go_imports_names_entropy:
+      dashed_name: process-parent-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.pe.go_imports_names_var_entropy:
+      dashed_name: process-parent-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.parent.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.parent.pe.go_stripped:
+      dashed_name: process-parent-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.parent.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.parent.pe.imphash:
       dashed_name: process-parent-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -11111,6 +12915,59 @@ process:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    process.parent.pe.import_hash:
+      dashed_name: process-parent-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.parent.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.parent.pe.imports:
+      dashed_name: process-parent-pe-imports
+      description: List of imported element names and types.
+      flat_name: process.parent.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    process.parent.pe.imports_names_entropy:
+      dashed_name: process-parent-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.parent.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.parent.pe.imports_names_var_entropy:
+      dashed_name: process-parent-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.parent.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.parent.pe.original_file_name:
       dashed_name: process-parent-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -11151,6 +13008,75 @@ process:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    process.parent.pe.sections:
+      dashed_name: process-parent-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: process.parent.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    process.parent.pe.sections.entropy:
+      dashed_name: process-parent-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.parent.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.parent.pe.sections.name:
+      dashed_name: process-parent-pe-sections-name
+      description: PE Section List name.
+      flat_name: process.parent.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    process.parent.pe.sections.physical_size:
+      dashed_name: process-parent-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: process.parent.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    process.parent.pe.sections.var_entropy:
+      dashed_name: process-parent-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.parent.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.parent.pe.sections.virtual_size:
+      dashed_name: process-parent-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.parent.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     process.parent.pgid:
       dashed_name: process-parent-pgid
       description: 'Deprecated for removal in next major version release. This field
@@ -11494,6 +13420,63 @@ process:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    process.pe.go_import_hash:
+      dashed_name: process-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: process.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    process.pe.go_imports:
+      dashed_name: process-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: process.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    process.pe.go_imports_names_entropy:
+      dashed_name: process-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: process.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.pe.go_imports_names_var_entropy:
+      dashed_name: process-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: process.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    process.pe.go_stripped:
+      dashed_name: process-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: process.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     process.pe.imphash:
       dashed_name: process-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -11510,6 +13493,59 @@ process:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    process.pe.import_hash:
+      dashed_name: process-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: process.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    process.pe.imports:
+      dashed_name: process-pe-imports
+      description: List of imported element names and types.
+      flat_name: process.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    process.pe.imports_names_entropy:
+      dashed_name: process-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: process.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    process.pe.imports_names_var_entropy:
+      dashed_name: process-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: process.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     process.pe.original_file_name:
       dashed_name: process-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -11550,6 +13586,75 @@ process:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    process.pe.sections:
+      dashed_name: process-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: process.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    process.pe.sections.entropy:
+      dashed_name: process-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: process.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    process.pe.sections.name:
+      dashed_name: process-pe-sections-name
+      description: PE Section List name.
+      flat_name: process.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    process.pe.sections.physical_size:
+      dashed_name: process-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: process.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    process.pe.sections.var_entropy:
+      dashed_name: process-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: process.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    process.pe.sections.virtual_size:
+      dashed_name: process-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: process.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     process.pgid:
       dashed_name: process-pgid
       description: 'Deprecated for removal in next major version release. This field
@@ -12413,6 +14518,7 @@ process:
   - process.group
   - process.group_leader
   - process.hash
+  - process.macho
   - process.parent
   - process.parent.group_leader
   - process.pe
@@ -12516,6 +14622,10 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
+  - beta: This field reuse is beta and subject to change.
+    full: process.macho
+    schema_name: macho
+    short: These fields contain Mac OS Mach Object file format (Mach-O) metadata.
   - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
@@ -14996,6 +17106,63 @@ threat:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    threat.enrichments.indicator.file.elf.go_import_hash:
+      dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.elf.go_imports:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.elf.go_stripped:
+      dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.enrichments.indicator.file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.enrichments.indicator.file.elf.header.abi_version:
       dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -15084,6 +17251,22 @@ threat:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    threat.enrichments.indicator.file.elf.import_hash:
+      dashed_name: threat-enrichments-indicator-file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.enrichments.indicator.file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     threat.enrichments.indicator.file.elf.imports:
       dashed_name: threat-enrichments-indicator-file-elf-imports
       description: List of imported element names and types.
@@ -15095,6 +17278,32 @@ threat:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    threat.enrichments.indicator.file.elf.imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.enrichments.indicator.file.elf.sections:
       dashed_name: threat-enrichments-indicator-file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -15186,6 +17395,17 @@ threat:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    threat.enrichments.indicator.file.elf.sections.var_entropy:
+      dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     threat.enrichments.indicator.file.elf.sections.virtual_address:
       dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -15544,6 +17764,63 @@ threat:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    threat.enrichments.indicator.file.pe.go_import_hash:
+      dashed_name: threat-enrichments-indicator-file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.enrichments.indicator.file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.pe.go_imports:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.pe.go_imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.pe.go_imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.enrichments.indicator.file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.enrichments.indicator.file.pe.go_stripped:
+      dashed_name: threat-enrichments-indicator-file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.enrichments.indicator.file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.enrichments.indicator.file.pe.imphash:
       dashed_name: threat-enrichments-indicator-file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -15560,6 +17837,59 @@ threat:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    threat.enrichments.indicator.file.pe.import_hash:
+      dashed_name: threat-enrichments-indicator-file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.enrichments.indicator.file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    threat.enrichments.indicator.file.pe.imports:
+      dashed_name: threat-enrichments-indicator-file-pe-imports
+      description: List of imported element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    threat.enrichments.indicator.file.pe.imports_names_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.enrichments.indicator.file.pe.imports_names_var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.enrichments.indicator.file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.enrichments.indicator.file.pe.original_file_name:
       dashed_name: threat-enrichments-indicator-file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -15600,6 +17930,75 @@ threat:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    threat.enrichments.indicator.file.pe.sections:
+      dashed_name: threat-enrichments-indicator-file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: threat.enrichments.indicator.file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    threat.enrichments.indicator.file.pe.sections.entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.name:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-name
+      description: PE Section List name.
+      flat_name: threat.enrichments.indicator.file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    threat.enrichments.indicator.file.pe.sections.physical_size:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: threat.enrichments.indicator.file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.var_entropy:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.enrichments.indicator.file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    threat.enrichments.indicator.file.pe.sections.virtual_size:
+      dashed_name: threat-enrichments-indicator-file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: threat.enrichments.indicator.file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     threat.enrichments.indicator.file.size:
       dashed_name: threat-enrichments-indicator-file-size
       description: 'File size in bytes.
@@ -17383,6 +19782,63 @@ threat:
       original_fieldset: elf
       short: List of exported element names and types.
       type: flattened
+    threat.indicator.file.elf.go_import_hash:
+      dashed_name: threat-indicator-file-elf-go-import-hash
+      description: A hash of the Go language imports in an ELF file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.indicator.file.elf.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.indicator.file.elf.go_imports:
+      dashed_name: threat-indicator-file-elf-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.indicator.file.elf.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: elf
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.indicator.file.elf.go_imports_names_entropy:
+      dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.elf.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.elf.go_imports_names_var_entropy:
+      dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.elf.go_stripped:
+      dashed_name: threat-indicator-file-elf-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.indicator.file.elf.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: elf
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.indicator.file.elf.header.abi_version:
       dashed_name: threat-indicator-file-elf-header-abi-version
       description: Version of the ELF Application Binary Interface (ABI).
@@ -17471,6 +19927,22 @@ threat:
       original_fieldset: elf
       short: Version of the ELF header.
       type: keyword
+    threat.indicator.file.elf.import_hash:
+      dashed_name: threat-indicator-file-elf-import-hash
+      description: 'A hash of the imports in an ELF file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.indicator.file.elf.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: elf
+      short: A hash of the imports in an ELF file.
+      type: keyword
     threat.indicator.file.elf.imports:
       dashed_name: threat-indicator-file-elf-imports
       description: List of imported element names and types.
@@ -17482,6 +19954,32 @@ threat:
       original_fieldset: elf
       short: List of imported element names and types.
       type: flattened
+    threat.indicator.file.elf.imports_names_entropy:
+      dashed_name: threat-indicator-file-elf-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.indicator.file.elf.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.indicator.file.elf.imports_names_var_entropy:
+      dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.indicator.file.elf.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.indicator.file.elf.sections:
       dashed_name: threat-indicator-file-elf-sections
       description: 'An array containing an object for each section of the ELF file.
@@ -17573,6 +20071,17 @@ threat:
       original_fieldset: elf
       short: ELF Section List type.
       type: keyword
+    threat.indicator.file.elf.sections.var_entropy:
+      dashed_name: threat-indicator-file-elf-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.elf.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: elf
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
     threat.indicator.file.elf.sections.virtual_address:
       dashed_name: threat-indicator-file-elf-sections-virtual-address
       description: ELF Section List virtual address.
@@ -17931,6 +20440,63 @@ threat:
       original_fieldset: pe
       short: Process name.
       type: keyword
+    threat.indicator.file.pe.go_import_hash:
+      dashed_name: threat-indicator-file-pe-go-import-hash
+      description: A hash of the Go language imports in a PE file. An import hash
+        can be used to fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      flat_name: threat.indicator.file.pe.go_import_hash
+      ignore_above: 1024
+      level: extended
+      name: go_import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the Go language imports in an ELF file.
+      type: keyword
+    threat.indicator.file.pe.go_imports:
+      dashed_name: threat-indicator-file-pe-go-imports
+      description: List of imported Go language element names and types.
+      flat_name: threat.indicator.file.pe.go_imports
+      level: extended
+      name: go_imports
+      normalize: []
+      original_fieldset: pe
+      short: List of imported Go language element names and types.
+      type: flattened
+    threat.indicator.file.pe.go_imports_names_entropy:
+      dashed_name: threat-indicator-file-pe-go-imports-names-entropy
+      description: Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.pe.go_imports_names_entropy
+      format: number
+      level: extended
+      name: go_imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.pe.go_imports_names_var_entropy:
+      dashed_name: threat-indicator-file-pe-go-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      flat_name: threat.indicator.file.pe.go_imports_names_var_entropy
+      format: number
+      level: extended
+      name: go_imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+    threat.indicator.file.pe.go_stripped:
+      dashed_name: threat-indicator-file-pe-go-stripped
+      description: Set to true if the file is a Go executable that has had its symbols
+        stripped or obfuscated and false if an unobfuscated Go executable.
+      flat_name: threat.indicator.file.pe.go_stripped
+      level: extended
+      name: go_stripped
+      normalize: []
+      original_fieldset: pe
+      short: Whether the file is a stripped or obfuscated Go executable.
+      type: boolean
     threat.indicator.file.pe.imphash:
       dashed_name: threat-indicator-file-pe-imphash
       description: 'A hash of the imports in a PE file. An imphash -- or import hash
@@ -17947,6 +20513,59 @@ threat:
       original_fieldset: pe
       short: A hash of the imports in a PE file.
       type: keyword
+    threat.indicator.file.pe.import_hash:
+      dashed_name: threat-indicator-file-pe-import-hash
+      description: 'A hash of the imports in a PE file. An import hash can be used
+        to fingerprint binaries even after recompilation or other code-level transformations
+        have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      flat_name: threat.indicator.file.pe.import_hash
+      ignore_above: 1024
+      level: extended
+      name: import_hash
+      normalize: []
+      original_fieldset: pe
+      short: A hash of the imports in an ELF file.
+      type: keyword
+    threat.indicator.file.pe.imports:
+      dashed_name: threat-indicator-file-pe-imports
+      description: List of imported element names and types.
+      flat_name: threat.indicator.file.pe.imports
+      level: extended
+      name: imports
+      normalize:
+      - array
+      original_fieldset: pe
+      short: List of imported element names and types.
+      type: flattened
+    threat.indicator.file.pe.imports_names_entropy:
+      dashed_name: threat-indicator-file-pe-imports-names-entropy
+      description: Shannon entropy calculation from the list of imported element names
+        and types.
+      flat_name: threat.indicator.file.pe.imports_names_entropy
+      format: number
+      level: extended
+      name: imports_names_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the list of imported element names and
+        types.
+      type: long
+    threat.indicator.file.pe.imports_names_var_entropy:
+      dashed_name: threat-indicator-file-pe-imports-names-var-entropy
+      description: Variance for Shannon entropy calculation from the list of imported
+        element names and types.
+      flat_name: threat.indicator.file.pe.imports_names_var_entropy
+      format: number
+      level: extended
+      name: imports_names_var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the list of imported element
+        names and types.
+      type: long
     threat.indicator.file.pe.original_file_name:
       dashed_name: threat-indicator-file-pe-original-file-name
       description: Internal name of the file, provided at compile-time.
@@ -17987,6 +20606,75 @@ threat:
       original_fieldset: pe
       short: Internal product name of the file, provided at compile-time.
       type: keyword
+    threat.indicator.file.pe.sections:
+      dashed_name: threat-indicator-file-pe-sections
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields
+        underneath `pe.sections.*`.'
+      flat_name: threat.indicator.file.pe.sections
+      level: extended
+      name: sections
+      normalize:
+      - array
+      original_fieldset: pe
+      short: Section information of the PE file.
+      type: nested
+    threat.indicator.file.pe.sections.entropy:
+      dashed_name: threat-indicator-file-pe-sections-entropy
+      description: Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.pe.sections.entropy
+      format: number
+      level: extended
+      name: sections.entropy
+      normalize: []
+      original_fieldset: pe
+      short: Shannon entropy calculation from the section.
+      type: long
+    threat.indicator.file.pe.sections.name:
+      dashed_name: threat-indicator-file-pe-sections-name
+      description: PE Section List name.
+      flat_name: threat.indicator.file.pe.sections.name
+      ignore_above: 1024
+      level: extended
+      name: sections.name
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List name.
+      type: keyword
+    threat.indicator.file.pe.sections.physical_size:
+      dashed_name: threat-indicator-file-pe-sections-physical-size
+      description: PE Section List physical size.
+      flat_name: threat.indicator.file.pe.sections.physical_size
+      format: bytes
+      level: extended
+      name: sections.physical_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List physical size.
+      type: long
+    threat.indicator.file.pe.sections.var_entropy:
+      dashed_name: threat-indicator-file-pe-sections-var-entropy
+      description: Variance for Shannon entropy calculation from the section.
+      flat_name: threat.indicator.file.pe.sections.var_entropy
+      format: number
+      level: extended
+      name: sections.var_entropy
+      normalize: []
+      original_fieldset: pe
+      short: Variance for Shannon entropy calculation from the section.
+      type: long
+    threat.indicator.file.pe.sections.virtual_size:
+      dashed_name: threat-indicator-file-pe-sections-virtual-size
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      flat_name: threat.indicator.file.pe.sections.virtual_size
+      format: string
+      level: extended
+      name: sections.virtual_size
+      normalize: []
+      original_fieldset: pe
+      short: PE Section List virtual size. This is always the same as `physical_size`.
+      type: long
     threat.indicator.file.size:
       dashed_name: threat-indicator-file-size
       description: 'File size in bytes.

--- a/generated/elasticsearch/composable/component/dll.json
+++ b/generated/elasticsearch/composable/component/dll.json
@@ -102,9 +102,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -117,6 +146,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             }

--- a/generated/elasticsearch/composable/component/file.json
+++ b/generated/elasticsearch/composable/component/file.json
@@ -89,6 +89,22 @@
                 "exports": {
                   "type": "flattened"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "header": {
                   "properties": {
                     "abi_version": {
@@ -124,8 +140,18 @@
                     }
                   }
                 },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "imports": {
                   "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "sections": {
                   "properties": {
@@ -153,6 +179,9 @@
                     "type": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
                     },
                     "virtual_address": {
                       "type": "long"
@@ -238,6 +267,64 @@
               "ignore_above": 1024,
               "type": "keyword"
             },
+            "macho": {
+              "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "mime_type": {
               "ignore_above": 1024,
               "type": "keyword"
@@ -284,9 +371,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -299,6 +415,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -79,6 +79,22 @@
                 "exports": {
                   "type": "flattened"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "header": {
                   "properties": {
                     "abi_version": {
@@ -114,8 +130,18 @@
                     }
                   }
                 },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "imports": {
                   "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "sections": {
                   "properties": {
@@ -143,6 +169,9 @@
                     "type": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "var_entropy": {
+                      "type": "long"
                     },
                     "virtual_address": {
                       "type": "long"
@@ -686,6 +715,64 @@
               },
               "type": "object"
             },
+            "macho": {
+              "properties": {
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
+                },
+                "symhash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "name": {
               "fields": {
                 "text": {
@@ -768,6 +855,22 @@
                     "exports": {
                       "type": "flattened"
                     },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
                     "header": {
                       "properties": {
                         "abi_version": {
@@ -803,8 +906,18 @@
                         }
                       }
                     },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
                     "imports": {
                       "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
                     },
                     "sections": {
                       "properties": {
@@ -832,6 +945,9 @@
                         "type": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "var_entropy": {
+                          "type": "long"
                         },
                         "virtual_address": {
                           "type": "long"
@@ -945,6 +1061,64 @@
                 "interactive": {
                   "type": "boolean"
                 },
+                "macho": {
+                  "properties": {
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "sections": {
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
+                    },
+                    "symhash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "name": {
                   "fields": {
                     "text": {
@@ -972,9 +1146,38 @@
                       "ignore_above": 1024,
                       "type": "keyword"
                     },
+                    "go_import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "go_imports": {
+                      "type": "flattened"
+                    },
+                    "go_imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "go_imports_names_var_entropy": {
+                      "type": "long"
+                    },
+                    "go_stripped": {
+                      "type": "boolean"
+                    },
                     "imphash": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "import_hash": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "imports": {
+                      "type": "flattened"
+                    },
+                    "imports_names_entropy": {
+                      "type": "long"
+                    },
+                    "imports_names_var_entropy": {
+                      "type": "long"
                     },
                     "original_file_name": {
                       "ignore_above": 1024,
@@ -987,6 +1190,27 @@
                     "product": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "sections": {
+                      "properties": {
+                        "entropy": {
+                          "type": "long"
+                        },
+                        "name": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "physical_size": {
+                          "type": "long"
+                        },
+                        "var_entropy": {
+                          "type": "long"
+                        },
+                        "virtual_size": {
+                          "type": "long"
+                        }
+                      },
+                      "type": "nested"
                     }
                   }
                 },
@@ -1153,9 +1377,38 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
+                "go_import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "go_imports": {
+                  "type": "flattened"
+                },
+                "go_imports_names_entropy": {
+                  "type": "long"
+                },
+                "go_imports_names_var_entropy": {
+                  "type": "long"
+                },
+                "go_stripped": {
+                  "type": "boolean"
+                },
                 "imphash": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "import_hash": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "imports": {
+                  "type": "flattened"
+                },
+                "imports_names_entropy": {
+                  "type": "long"
+                },
+                "imports_names_var_entropy": {
+                  "type": "long"
                 },
                 "original_file_name": {
                   "ignore_above": 1024,
@@ -1168,6 +1421,27 @@
                 "product": {
                   "ignore_above": 1024,
                   "type": "keyword"
+                },
+                "sections": {
+                  "properties": {
+                    "entropy": {
+                      "type": "long"
+                    },
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "physical_size": {
+                      "type": "long"
+                    },
+                    "var_entropy": {
+                      "type": "long"
+                    },
+                    "virtual_size": {
+                      "type": "long"
+                    }
+                  },
+                  "type": "nested"
                 }
               }
             },

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -131,6 +131,22 @@
                             "exports": {
                               "type": "flattened"
                             },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flattened"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "header": {
                               "properties": {
                                 "abi_version": {
@@ -166,8 +182,18 @@
                                 }
                               }
                             },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
                             "imports": {
                               "type": "flattened"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "sections": {
                               "properties": {
@@ -195,6 +221,9 @@
                                 "type": {
                                   "ignore_above": 1024,
                                   "type": "keyword"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
                                 },
                                 "virtual_address": {
                                   "type": "long"
@@ -326,9 +355,38 @@
                               "ignore_above": 1024,
                               "type": "keyword"
                             },
+                            "go_import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "go_imports": {
+                              "type": "flattened"
+                            },
+                            "go_imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "go_imports_names_var_entropy": {
+                              "type": "long"
+                            },
+                            "go_stripped": {
+                              "type": "boolean"
+                            },
                             "imphash": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "import_hash": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "imports": {
+                              "type": "flattened"
+                            },
+                            "imports_names_entropy": {
+                              "type": "long"
+                            },
+                            "imports_names_var_entropy": {
+                              "type": "long"
                             },
                             "original_file_name": {
                               "ignore_above": 1024,
@@ -341,6 +399,27 @@
                             "product": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "sections": {
+                              "properties": {
+                                "entropy": {
+                                  "type": "long"
+                                },
+                                "name": {
+                                  "ignore_above": 1024,
+                                  "type": "keyword"
+                                },
+                                "physical_size": {
+                                  "type": "long"
+                                },
+                                "var_entropy": {
+                                  "type": "long"
+                                },
+                                "virtual_size": {
+                                  "type": "long"
+                                }
+                              },
+                              "type": "nested"
                             }
                           }
                         },
@@ -969,6 +1048,22 @@
                         "exports": {
                           "type": "flattened"
                         },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flattened"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
                         "header": {
                           "properties": {
                             "abi_version": {
@@ -1004,8 +1099,18 @@
                             }
                           }
                         },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
                         "imports": {
                           "type": "flattened"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
                         },
                         "sections": {
                           "properties": {
@@ -1033,6 +1138,9 @@
                             "type": {
                               "ignore_above": 1024,
                               "type": "keyword"
+                            },
+                            "var_entropy": {
+                              "type": "long"
                             },
                             "virtual_address": {
                               "type": "long"
@@ -1164,9 +1272,38 @@
                           "ignore_above": 1024,
                           "type": "keyword"
                         },
+                        "go_import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "go_imports": {
+                          "type": "flattened"
+                        },
+                        "go_imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "go_imports_names_var_entropy": {
+                          "type": "long"
+                        },
+                        "go_stripped": {
+                          "type": "boolean"
+                        },
                         "imphash": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "import_hash": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "imports": {
+                          "type": "flattened"
+                        },
+                        "imports_names_entropy": {
+                          "type": "long"
+                        },
+                        "imports_names_var_entropy": {
+                          "type": "long"
                         },
                         "original_file_name": {
                           "ignore_above": 1024,
@@ -1179,6 +1316,27 @@
                         "product": {
                           "ignore_above": 1024,
                           "type": "keyword"
+                        },
+                        "sections": {
+                          "properties": {
+                            "entropy": {
+                              "type": "long"
+                            },
+                            "name": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "physical_size": {
+                              "type": "long"
+                            },
+                            "var_entropy": {
+                              "type": "long"
+                            },
+                            "virtual_size": {
+                              "type": "long"
+                            }
+                          },
+                          "type": "nested"
                         }
                       }
                     },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -832,9 +832,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -847,6 +876,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           }
@@ -1327,6 +1377,22 @@
               "exports": {
                 "type": "flattened"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "header": {
                 "properties": {
                   "abi_version": {
@@ -1362,8 +1428,18 @@
                   }
                 }
               },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "imports": {
                 "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "sections": {
                 "properties": {
@@ -1391,6 +1467,9 @@
                   "type": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "var_entropy": {
+                    "type": "long"
                   },
                   "virtual_address": {
                     "type": "long"
@@ -1476,6 +1555,64 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "macho": {
+            "properties": {
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "symhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "mime_type": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -1522,9 +1659,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -1537,6 +1703,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           },
@@ -2557,6 +2744,22 @@
               "exports": {
                 "type": "flattened"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "header": {
                 "properties": {
                   "abi_version": {
@@ -2592,8 +2795,18 @@
                   }
                 }
               },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "imports": {
                 "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "sections": {
                 "properties": {
@@ -2621,6 +2834,9 @@
                   "type": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "var_entropy": {
+                    "type": "long"
                   },
                   "virtual_address": {
                     "type": "long"
@@ -3164,6 +3380,64 @@
             },
             "type": "object"
           },
+          "macho": {
+            "properties": {
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
+              },
+              "symhash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "name": {
             "fields": {
               "text": {
@@ -3246,6 +3520,22 @@
                   "exports": {
                     "type": "flattened"
                   },
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
                   "header": {
                     "properties": {
                       "abi_version": {
@@ -3281,8 +3571,18 @@
                       }
                     }
                   },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "imports": {
                     "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
                   },
                   "sections": {
                     "properties": {
@@ -3310,6 +3610,9 @@
                       "type": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "var_entropy": {
+                        "type": "long"
                       },
                       "virtual_address": {
                         "type": "long"
@@ -3423,6 +3726,64 @@
               "interactive": {
                 "type": "boolean"
               },
+              "macho": {
+                "properties": {
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "sections": {
+                    "properties": {
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "var_entropy": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "symhash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "name": {
                 "fields": {
                   "text": {
@@ -3450,9 +3811,38 @@
                     "ignore_above": 1024,
                     "type": "keyword"
                   },
+                  "go_import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "go_imports": {
+                    "type": "flattened"
+                  },
+                  "go_imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "go_imports_names_var_entropy": {
+                    "type": "long"
+                  },
+                  "go_stripped": {
+                    "type": "boolean"
+                  },
                   "imphash": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "import_hash": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "imports": {
+                    "type": "flattened"
+                  },
+                  "imports_names_entropy": {
+                    "type": "long"
+                  },
+                  "imports_names_var_entropy": {
+                    "type": "long"
                   },
                   "original_file_name": {
                     "ignore_above": 1024,
@@ -3465,6 +3855,27 @@
                   "product": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "sections": {
+                    "properties": {
+                      "entropy": {
+                        "type": "long"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "physical_size": {
+                        "type": "long"
+                      },
+                      "var_entropy": {
+                        "type": "long"
+                      },
+                      "virtual_size": {
+                        "type": "long"
+                      }
+                    },
+                    "type": "nested"
                   }
                 }
               },
@@ -3631,9 +4042,38 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "go_import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "go_imports": {
+                "type": "flattened"
+              },
+              "go_imports_names_entropy": {
+                "type": "long"
+              },
+              "go_imports_names_var_entropy": {
+                "type": "long"
+              },
+              "go_stripped": {
+                "type": "boolean"
+              },
               "imphash": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "import_hash": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "imports": {
+                "type": "flattened"
+              },
+              "imports_names_entropy": {
+                "type": "long"
+              },
+              "imports_names_var_entropy": {
+                "type": "long"
               },
               "original_file_name": {
                 "ignore_above": 1024,
@@ -3646,6 +4086,27 @@
               "product": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sections": {
+                "properties": {
+                  "entropy": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "physical_size": {
+                    "type": "long"
+                  },
+                  "var_entropy": {
+                    "type": "long"
+                  },
+                  "virtual_size": {
+                    "type": "long"
+                  }
+                },
+                "type": "nested"
               }
             }
           },
@@ -4765,6 +5226,22 @@
                           "exports": {
                             "type": "flattened"
                           },
+                          "go_import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "go_imports": {
+                            "type": "flattened"
+                          },
+                          "go_imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "go_imports_names_var_entropy": {
+                            "type": "long"
+                          },
+                          "go_stripped": {
+                            "type": "boolean"
+                          },
                           "header": {
                             "properties": {
                               "abi_version": {
@@ -4800,8 +5277,18 @@
                               }
                             }
                           },
+                          "import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
                           "imports": {
                             "type": "flattened"
+                          },
+                          "imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "imports_names_var_entropy": {
+                            "type": "long"
                           },
                           "sections": {
                             "properties": {
@@ -4829,6 +5316,9 @@
                               "type": {
                                 "ignore_above": 1024,
                                 "type": "keyword"
+                              },
+                              "var_entropy": {
+                                "type": "long"
                               },
                               "virtual_address": {
                                 "type": "long"
@@ -4960,9 +5450,38 @@
                             "ignore_above": 1024,
                             "type": "keyword"
                           },
+                          "go_import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "go_imports": {
+                            "type": "flattened"
+                          },
+                          "go_imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "go_imports_names_var_entropy": {
+                            "type": "long"
+                          },
+                          "go_stripped": {
+                            "type": "boolean"
+                          },
                           "imphash": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "import_hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "imports": {
+                            "type": "flattened"
+                          },
+                          "imports_names_entropy": {
+                            "type": "long"
+                          },
+                          "imports_names_var_entropy": {
+                            "type": "long"
                           },
                           "original_file_name": {
                             "ignore_above": 1024,
@@ -4975,6 +5494,27 @@
                           "product": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "sections": {
+                            "properties": {
+                              "entropy": {
+                                "type": "long"
+                              },
+                              "name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              },
+                              "physical_size": {
+                                "type": "long"
+                              },
+                              "var_entropy": {
+                                "type": "long"
+                              },
+                              "virtual_size": {
+                                "type": "long"
+                              }
+                            },
+                            "type": "nested"
                           }
                         }
                       },
@@ -5603,6 +6143,22 @@
                       "exports": {
                         "type": "flattened"
                       },
+                      "go_import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "go_imports": {
+                        "type": "flattened"
+                      },
+                      "go_imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "go_imports_names_var_entropy": {
+                        "type": "long"
+                      },
+                      "go_stripped": {
+                        "type": "boolean"
+                      },
                       "header": {
                         "properties": {
                           "abi_version": {
@@ -5638,8 +6194,18 @@
                           }
                         }
                       },
+                      "import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "imports": {
                         "type": "flattened"
+                      },
+                      "imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "imports_names_var_entropy": {
+                        "type": "long"
                       },
                       "sections": {
                         "properties": {
@@ -5667,6 +6233,9 @@
                           "type": {
                             "ignore_above": 1024,
                             "type": "keyword"
+                          },
+                          "var_entropy": {
+                            "type": "long"
                           },
                           "virtual_address": {
                             "type": "long"
@@ -5798,9 +6367,38 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       },
+                      "go_import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "go_imports": {
+                        "type": "flattened"
+                      },
+                      "go_imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "go_imports_names_var_entropy": {
+                        "type": "long"
+                      },
+                      "go_stripped": {
+                        "type": "boolean"
+                      },
                       "imphash": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "import_hash": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "imports": {
+                        "type": "flattened"
+                      },
+                      "imports_names_entropy": {
+                        "type": "long"
+                      },
+                      "imports_names_var_entropy": {
+                        "type": "long"
                       },
                       "original_file_name": {
                         "ignore_above": 1024,
@@ -5813,6 +6411,27 @@
                       "product": {
                         "ignore_above": 1024,
                         "type": "keyword"
+                      },
+                      "sections": {
+                        "properties": {
+                          "entropy": {
+                            "type": "long"
+                          },
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "physical_size": {
+                            "type": "long"
+                          },
+                          "var_entropy": {
+                            "type": "long"
+                          },
+                          "virtual_size": {
+                            "type": "long"
+                          }
+                        },
+                        "type": "nested"
                       }
                     }
                   },

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -65,9 +65,12 @@
     - name: go_import_hash
       short: A hash of the Go language imports in an ELF file.
       description: >
-        A hash of the Go language imports in an ELF file. An import hash can be used to
-        fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+        A hash of the Go language imports in an ELF file excluding standard library imports.
+        An import hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/elf.yml
+++ b/schemas/elf.yml
@@ -62,6 +62,43 @@
       level: extended
       example: Intel
 
+    - name: go_import_hash
+      short: A hash of the Go language imports in an ELF file.
+      description: >
+        A hash of the Go language imports in an ELF file. An import hash can be used to
+        fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+      example: 10bddcb4cee42080f76c88d9ff964491
+      type: keyword
+      level: extended
+
+    - name: go_imports_names_entropy
+      description: >
+        Shannon entropy calculation from the list of Go imports.
+      type: long
+      format: number
+      level: extended
+
+    - name: go_imports_names_var_entropy
+      description: >
+        Variance for Shannon entropy calculation from the list of Go imports.
+      type: long
+      format: number
+      level: extended
+
+    - name: go_imports
+      description: >
+        List of imported Go language element names and types.
+      type: flattened
+      level: extended
+
+    - name: go_stripped
+      short: Whether the file is a stripped or obfuscated Go executable.
+      description: >
+        Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      type: boolean
+      level: extended
+
     - name: header.class
       description: >
         Header class of the ELF file.
@@ -111,6 +148,32 @@
       description: >
         "0x1" for original ELF files.
 
+    - name: import_hash
+      short: A hash of the imports in an ELF file.
+      description: >
+        A hash of the imports in an ELF file. An import hash can be used to
+        fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.
+      example: d41d8cd98f00b204e9800998ecf8427e
+      type: keyword
+      level: extended
+
+    - name: imports_names_entropy
+      description: >
+        Shannon entropy calculation from the list of imported element names and types.
+      format: number
+      type: long
+      level: extended
+
+    - name: imports_names_var_entropy
+      description: >
+        Variance for Shannon entropy calculation from the list of imported element names and types.
+      format: number
+      type: long
+      level: extended
+
     - name: sections
       short: Section information of the ELF file.
       description: >
@@ -151,6 +214,13 @@
       description: >
         ELF Section List physical size.
       format: bytes
+      type: long
+      level: extended
+
+    - name: sections.var_entropy
+      description: >
+        Variance for Shannon entropy calculation from the section.
+      format: number
       type: long
       level: extended
 

--- a/schemas/macho.yml
+++ b/schemas/macho.yml
@@ -36,9 +36,12 @@
     - name: go_import_hash
       short: A hash of the Go language imports in an ELF file.
       description: >
-        A hash of the Go language imports in an Mach-O file. An import hash can be used to
-        fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+        A hash of the Go language imports in a Mach-O file excluding standard library imports.
+        An import hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/macho.yml
+++ b/schemas/macho.yml
@@ -15,83 +15,32 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-- name: pe
-  title: PE Header
+- name: macho
+  title: Mach-O Header
   group: 2
-  description: These fields contain Windows Portable Executable (PE) metadata.
+  description: >
+    These fields contain Mac OS Mach Object file format (Mach-O) metadata.
+  beta: >
+    These fields are in beta and are subject to change.
   type: group
   reusable:
     top_level: false
-    order: 1
     expected:
-      - file
-      - dll
-      - process
-
+      - at: file
+        as: macho
+        beta: This field reuse is beta and subject to change.
+      - at: process
+        as: macho
+        beta: This field reuse is beta and subject to change.
   fields:
-    - name: original_file_name
-      level: extended
-      type: keyword
-      description: Internal name of the file, provided at compile-time.
-      example: MSPAINT.EXE
-
-    - name: file_version
-      level: extended
-      type: keyword
-      short: Process name.
-      description: Internal version of the file, provided at compile-time.
-      example: 6.3.9600.17415
-
-    - name: description
-      level: extended
-      type: keyword
-      description: Internal description of the file, provided at compile-time.
-      example: Paint
-
-    - name: product
-      level: extended
-      type: keyword
-      description: Internal product name of the file, provided at compile-time.
-      example: Microsoft® Windows® Operating System
-
-    - name: company
-      level: extended
-      type: keyword
-      description: Internal company name of the file, provided at compile-time.
-      example: Microsoft Corporation
-
-    - name: imphash
-      level: extended
-      type: keyword
-      short: A hash of the imports in a PE file.
-      description: >
-        A hash of the imports in a PE file. An imphash -- or import hash -- can
-        be used to fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
-
-        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.
-      example: 0c6803c4e922103c4dca5963aad36ddf
-
-    - name: architecture
-      level: extended
-      type: keyword
-      description: CPU architecture target for the file.
-      example: x64
-
     - name: go_import_hash
       short: A hash of the Go language imports in an ELF file.
       description: >
-        A hash of the Go language imports in a PE file. An import hash can be used to
+        A hash of the Go language imports in an Mach-O file. An import hash can be used to
         fingerprint binaries even after recompilation or other code-level
         transformations have occurred, which would change more traditional hash values.
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
-      level: extended
-
-    - name: go_imports
-      description: >
-        List of imported Go language element names and types.
-      type: flattened
       level: extended
 
     - name: go_imports_names_entropy
@@ -108,6 +57,12 @@
       format: number
       level: extended
 
+    - name: go_imports
+      description: >
+        List of imported Go language element names and types.
+      type: flattened
+      level: extended
+
     - name: go_stripped
       short: Whether the file is a stripped or obfuscated Go executable.
       description: >
@@ -118,11 +73,11 @@
     - name: import_hash
       short: A hash of the imports in an ELF file.
       description: >
-        A hash of the imports in a PE file. An import hash can be used to
+        A hash of the imports in an Mach-O file. An import hash can be used to
         fingerprint binaries even after recompilation or other code-level
         transformations have occurred, which would change more traditional hash values.
 
-        This is a synonym for imphash.
+        This is a synonym for symhash.
       example: d41d8cd98f00b204e9800998ecf8427e
       type: keyword
       level: extended
@@ -149,24 +104,13 @@
       type: long
       level: extended
 
-    - name: pehash
-      level: extended
-      type: keyword
-      short: A hash of the PE header and data from one or more PE sections.
-      description: >
-        A hash of the PE header and data from one or more PE sections. An pehash can
-        be used to cluster files by transforming structural information about a file into a hash value.
-
-        Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.
-      example: 73ff189b63cd6be375a7ff25179a38d347651975
-
     - name: sections
-      short: Section information of the PE file.
+      short: Section information of the Mach-O file.
       description: >
-        An array containing an object for each section of the PE file.
+        An array containing an object for each section of the Mach-O file.
 
         The keys that should be present in these objects are defined by sub-fields
-        underneath `pe.sections.*`.
+        underneath `macho.sections.*`.
       type: nested
       level: extended
       normalize:
@@ -181,13 +125,13 @@
 
     - name: sections.name
       description: >
-        PE Section List name.
+        Mach-O Section List name.
       type: keyword
       level: extended
 
     - name: sections.physical_size
       description: >
-        PE Section List physical size.
+        Mach-O Section List physical size.
       format: bytes
       type: long
       level: extended
@@ -201,8 +145,19 @@
 
     - name: sections.virtual_size
       description: >
-        PE Section List virtual size. This is always the same as `physical_size`.
+        Mach-O Section List virtual size. This is always the same as `physical_size`.
       format: string
       type: long
       level: extended
 
+    - name: symhash
+      short: A hash of the imports in a Mach-O file.
+      description: >
+        A hash of the imports in a Mach-O file. An import hash can be used to
+        fingerprint binaries even after recompilation or other code-level
+        transformations have occurred, which would change more traditional hash values.
+
+        This is a Mach-O implementation of the Windows PE imphash
+      example: d3ccf195b62a9279c3c19af1080497ec
+      type: keyword
+      level: extended

--- a/schemas/pe.yml
+++ b/schemas/pe.yml
@@ -81,9 +81,12 @@
     - name: go_import_hash
       short: A hash of the Go language imports in an ELF file.
       description: >
-        A hash of the Go language imports in a PE file. An import hash can be used to
-        fingerprint binaries even after recompilation or other code-level
-        transformations have occurred, which would change more traditional hash values.
+        A hash of the Go language imports in a PE file excluding standard library imports.
+        An import hash can be used to fingerprint binaries even after recompilation or other
+        code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation
+        are available [here](https://github.com/elastic/toutoumomoma).
       example: 10bddcb4cee42080f76c88d9ff964491
       type: keyword
       level: extended

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -111,6 +111,8 @@ fields:
     fields: "*"
   log:
     fields: "*"
+  macho:
+    fields: "*"
   network:
     fields: "*"
   observer:
@@ -265,6 +267,8 @@ fields:
       interactive: {}
       io: 
         fields: "*"
+      macho:
+        fields: "*"
       name: {}
       parent:
         fields:
@@ -287,6 +291,8 @@ fields:
           hash:
             fields: "*"
           interactive: {}
+          macho:
+            fields: "*"
           name: {}
           pe:
             fields: "*"


### PR DESCRIPTION
Fields are added to ELF for malware detection signatures and fields in ELF for this are reflected in PE. A new Mac OS Mach-O field group is added. Not all possible fields are added to Mach-O.

Specific Go executable fields are added because the import structure of Go executables is not described in standard dynamic library imports and Go is a reasonably popular language both generally, and significantly, in malware.

See discussion at https://github.com/elastic/beats/pull/28802#discussion_r990525302.

Optimistically putting in 8.6, but happy to bump to 8.7 if this is too tight. If this needs an RFC will do that.

ELF:

- [x] `file.elf.go_import_hash`
- [x] `file.elf.go_imports`
- [x] `file.elf.go_imports_names_entropy`
- [x] `file.elf.go_imports_names_var_entropy`
- [x] `file.elf.go_stripped`
- [x] `file.elf.import_hash` — alias for ELF equivalent of imphash to simplify cross-platform searches
- [x] `file.elf.imports_names_entropy`
- [x] `file.elf.imports_names_var_entropy`
- [x] `file.elf.sections.var_entropy`

PE:

- [x] `file.pe.go_import_hash`
- [x] `file.pe.go_imports`
- [x] `file.pe.go_imports_names_entropy`
- [x] `file.pe.go_imports_names_var_entropy`
- [x] `file.pe.go_stripped`
- [x] `file.pe.imports_names_entropy`
- [x] `file.pe.imports_names_var_entropy`
- [x] `file.pe.sections.var_entropy`

The following are added to PE as analogous to the existing ELF fields. All bar virtual_size are strictly informative (`virtual_size` is always equal to `physical_size` since only ELF has compressed sections)

- [x] `file.pe.import_hash` — alias for imphash to simplify cross-platform searches
- [x] `file.pe.imports`
- [x] `file.pe.sections`
- [x] `file.pe.sections.entropy`
- [x] `file.pe.sections.name`
- [x] `file.pe.sections.physical_size`
- [x] `file.pe.sections.virtual_size` — always the same as `physical_size` on PE (meaningful on ELF as a potential marker for evasive ELF)

ECS doesn't have any fields for Mach-O so all the following are new:

- [x] `file.macho.go_import_hash`
- [x] `file.macho.go_imports_names_entropy`
- [x] `file.macho.go_imports_names_var_entropy`
- [x] `file.macho.go_imports`
- [x] `file.macho.go_stripped`
- [x] `file.macho.import_hash` — alias for Mach-O equivalent of imphash
- [x] `file.macho.imports`
- [x] `file.macho.imports_names_entropy`
- [x] `file.macho.imports_names_var_entropy`
- [x] `file.macho.sections`
- [x] `file.macho.sections.entropy`
- [x] `file.macho.sections.name`
- [x] `file.macho.sections.physical_size`
- [x] `file.macho.sections.var_entropy`
- [x] `file.macho.sections.virtual_size` — always the same as `physical_size` on Mach-O (meaningful on ELF as a potential marker for evasive ELF)
- [x] `file.macho.symhash` — alias for Mach-O equivalent of for imphash

For elastic/beats#28802

Please take a look.