### PR TITLE
Mapping parameters

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -30,6 +30,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Add `parameters` property for field definitions, to provide any mapping parameter. #2084
+
 #### Improvements
 
 * Bump `gitpython` from `3.1.27` to `3.1.30` in `/scripts`. #2139

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -211,6 +211,8 @@ def entry_for(field: Field) -> Dict:
                     ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['normalizer', 'ignore_above'])
                 elif mf_type == 'text':
                     ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['norms', 'analyzer'])
+                if 'parameters' in mf:
+                    mf_entry.update(mf['parameters'])
                 field_entry['fields'][mf['name']] = mf_entry
 
         if 'parameters' in field:

--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -213,6 +213,9 @@ def entry_for(field: Field) -> Dict:
                     ecs_helpers.dict_copy_existing_keys(mf, mf_entry, ['norms', 'analyzer'])
                 field_entry['fields'][mf['name']] = mf_entry
 
+        if 'parameters' in field:
+            field_entry.update(field['parameters'])
+
     except KeyError as ex:
         print("Exception {} occurred for field {}".format(ex, field))
         raise ex

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -174,6 +174,21 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         exp = {'type': 'constant_keyword'}
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_parameters(self):
+        test_map = {
+            'name': 'field_with_parameters',
+            'type': 'date',
+            'parameters': {
+                'format': 'strict_date_optional_time||epoch_seconds',
+            }
+        }
+
+        exp = {
+            'type': 'date',
+            'format': 'strict_date_optional_time||epoch_seconds'
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
     def test_component_composable_template_name(self):
         version = "1.8"
         test_map = {

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -189,6 +189,54 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         }
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_multi_fields(self):
+        test_map = {
+            'name': 'field_with_multi_fields',
+            'type': 'keyword',
+            'multi_fields': [
+                {
+                    'name': 'text',
+                    'type': 'match_only_text'
+                }
+            ]
+        }
+
+        exp = {
+            'type': 'keyword',
+            'fields': {
+                'text': {
+                    'type': 'match_only_text'
+                }
+            }
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+    def test_multi_fields_parameters(self):
+        test_map = {
+            'name': 'field_with_multi_fields_with_parameters',
+            'type': 'keyword',
+            'multi_fields': [
+                {
+                    'name': 'text',
+                    'type': 'match_only_text',
+                    'parameters': {
+                        'analyzer': 'english'
+                    }
+                }
+            ]
+        }
+
+        exp = {
+            'type': 'keyword',
+            'fields': {
+                'text': {
+                    'type': 'match_only_text',
+                    'analyzer': 'english'
+                }
+            }
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
     def test_component_composable_template_name(self):
         version = "1.8"
         test_map = {


### PR DESCRIPTION
When attempting to create a custom mapping for a `date` (multi-)field, I found that the ECS tooling doesn't currently support providing the `ignore_malformed` and `format` mapping parameters. Even though there is some limited support for certain parameters, these are not consistent between the main field mapping and the multi-field mapping. E.g. the `normalizer` parameter is only available for multi-fields.

Instead of implementing specific parameters for my use case, this PR adds a new property `parameters` to provide any mapping parameter, both for the main field and for multi-fields, along with a minimal test for the multi-field generation code. The existing code can remain as-is, with the minimal sanity checking that is in place, for backwards compatibility.