### PR TITLE
[8.6] [8.5] Linux event model GA (#2082)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -68,10 +68,6 @@ Thanks, you're awesome :-) -->
 
 ### Schema Changes
 
-#### Breaking changes
-
-#### Bugfixes
-
 #### Added
 
 * Adding `risk.*` fields as experimental. #1994, #2010
@@ -85,6 +81,7 @@ Thanks, you're awesome :-) -->
 
 * Advances `threat.enrichments.indicator` to GA. #1928
 * Added `ios` and `android` as valid values for `os.type` #1999
+* Advances linux event model fields and fieldsets under process, user and group to GA. #2082
 
 #### Deprecated
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7337,9 +7337,7 @@ example: `c2c455d9f99375d`
 [[field-process-entry-meta-type]]
 <<field-process-entry-meta-type, process.entry_meta.type>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
+a| The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
 
 Note: This field is only set on process.session_leader.
 
@@ -7420,9 +7418,7 @@ example: `137`
 [[field-process-interactive]]
 <<field-process-interactive, process.interactive>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-Whether the process is connected to an interactive shell.
+a| Whether the process is connected to an interactive shell.
 
 Process interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.
 
@@ -7671,9 +7667,7 @@ example: `4242`
 [[field-process-same-as-process]]
 <<field-process-same-as-process, process.same_as_process>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-This boolean is used to identify if a leader process is the same as the top level process.
+a| This boolean is used to identify if a leader process is the same as the top level process.
 
 For example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.
 
@@ -7769,9 +7763,7 @@ Multi-fields:
 [[field-process-tty]]
 <<field-process-tty, process.tty>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-Information about the controlling TTY device. If set, the process belongs to an interactive session.
+a| Information about the controlling TTY device. If set, the process belongs to an interactive session.
 
 type: object
 
@@ -7787,9 +7779,7 @@ type: object
 [[field-process-tty-char-device-major]]
 <<field-process-tty-char-device-major, process.tty.char_device.major>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
+a| The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
 
 type: long
 
@@ -7805,9 +7795,7 @@ example: `4`
 [[field-process-tty-char-device-minor]]
 <<field-process-tty-char-device-minor, process.tty.char_device.minor>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
+a| The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
 
 type: long
 
@@ -7973,49 +7961,43 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 
 | `process.entry_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
+| <<ecs-process,process>>
+| First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.entry_meta.source.*`
-| <<ecs-source,source>>| beta:[ Reusing the `source` fields in this location is currently considered beta.]
-
-Remote client information such as ip, port and geo location.
+| <<ecs-source,source>>
+| Remote client information such as ip, port and geo location.
 
 // ===============================================================
 
 
 | `process.group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The effective group (egid).
+| <<ecs-group,group>>
+| The effective group (egid).
 
 // ===============================================================
 
 
 | `process.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the process group leader. In some cases this may be the same as the top level process.
+| <<ecs-process,process>>
+| Information about the process group leader. In some cases this may be the same as the top level process.
 
 // ===============================================================
 
@@ -8035,9 +8017,8 @@ Information about the process group leader. In some cases this may be the same a
 
 
 | `process.parent.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent's process group leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent's process group leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
@@ -8050,9 +8031,8 @@ Information about the parent's process group leader. Only pid, start and entity_
 
 
 | `process.previous.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-An array of previous executions for the process, including the initial fork. Only executable and args are set.
+| <<ecs-process,process>>
+| An array of previous executions for the process, including the initial fork. Only executable and args are set.
 
 Note: this reuse should contain an array of process field set objects.
 
@@ -8060,65 +8040,57 @@ Note: this reuse should contain an array of process field set objects.
 
 
 | `process.real_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The real group (rgid).
+| <<ecs-group,group>>
+| The real group (rgid).
 
 // ===============================================================
 
 
 | `process.real_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The real user (ruid). Identifies the real owner of the process.
+| <<ecs-user,user>>
+| The real user (ruid). Identifies the real owner of the process.
 
 // ===============================================================
 
 
 | `process.saved_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The saved group (sgid).
+| <<ecs-group,group>>
+| The saved group (sgid).
 
 // ===============================================================
 
 
 | `process.saved_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The saved user (suid).
+| <<ecs-user,user>>
+| The saved user (suid).
 
 // ===============================================================
 
 
 | `process.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
+| <<ecs-process,process>>
+| Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
 
 // ===============================================================
 
 
 | `process.session_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the session leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the session leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.session_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.supplemental_groups.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-An array of supplemental groups.
+| <<ecs-group,group>>
+| An array of supplemental groups.
 
 Note: this reuse should contain an array of group field set objects.
 
@@ -8126,9 +8098,8 @@ Note: this reuse should contain an array of group field set objects.
 
 
 | `process.user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The effective user (euid).
+| <<ecs-user,user>>
+| The effective user (euid).
 
 // ===============================================================
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7549,7 +7549,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -7602,7 +7601,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7790,7 +7788,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7904,7 +7901,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7916,7 +7912,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7931,7 +7926,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8141,7 +8135,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8243,7 +8236,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8357,7 +8349,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8369,7 +8360,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8384,7 +8374,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8520,7 +8509,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9373,7 +9361,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9718,7 +9705,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9730,7 +9716,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9745,7 +9730,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10197,7 +10181,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10385,7 +10368,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10499,7 +10481,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10511,7 +10492,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10526,7 +10506,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10656,7 +10635,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10667,7 +10645,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10681,7 +10658,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -6015,22 +6015,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -9278,7 +9274,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -9331,7 +9326,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9519,7 +9513,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9633,7 +9626,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9645,7 +9637,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9660,7 +9651,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9870,7 +9860,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9972,7 +9961,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -10086,7 +10074,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -10098,7 +10085,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -10113,7 +10099,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -10249,7 +10234,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11105,7 +11089,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11450,7 +11433,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11462,7 +11444,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11477,7 +11458,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11929,7 +11909,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -12117,7 +12096,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -12231,7 +12209,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12243,7 +12220,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12258,7 +12234,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12388,7 +12363,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12399,7 +12373,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12413,7 +12386,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12543,64 +12515,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12608,20 +12562,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12646,20 +12596,16 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - beta: Reusing the `user` fields in this location is currently considered beta.
@@ -12670,48 +12616,39 @@ process:
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -14748,7 +14685,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true
@@ -21604,17 +21540,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     - as: attested_user

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7480,7 +7480,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -7533,7 +7532,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7721,7 +7719,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7835,7 +7832,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7847,7 +7843,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7862,7 +7857,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8072,7 +8066,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8174,7 +8167,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8288,7 +8280,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8300,7 +8291,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8315,7 +8305,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8451,7 +8440,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9304,7 +9292,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9649,7 +9636,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9661,7 +9647,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9676,7 +9661,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10128,7 +10112,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10316,7 +10299,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10430,7 +10412,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10442,7 +10423,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10457,7 +10437,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10587,7 +10566,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10598,7 +10576,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10612,7 +10589,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5935,22 +5935,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -9198,7 +9194,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -9251,7 +9246,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9439,7 +9433,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9553,7 +9546,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9565,7 +9557,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9580,7 +9571,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9790,7 +9780,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9892,7 +9881,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -10006,7 +9994,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -10018,7 +10005,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -10033,7 +10019,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -10169,7 +10154,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11025,7 +11009,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11370,7 +11353,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11382,7 +11364,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11397,7 +11378,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11849,7 +11829,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -12037,7 +12016,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -12151,7 +12129,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12163,7 +12140,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12178,7 +12154,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12308,7 +12283,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12319,7 +12293,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12333,7 +12306,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12463,64 +12435,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12528,20 +12482,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12566,20 +12516,16 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - beta: Reusing the `user` fields in this location is currently considered beta.
@@ -12590,48 +12536,39 @@ process:
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -14668,7 +14605,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true
@@ -21524,17 +21460,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     - as: attested_user

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -32,19 +32,15 @@
       - at: process
         as: group
         short_override: The effective group (egid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: real_group
         short_override: The real group (rgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: saved_group
         short_override: The saved group (sgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: supplemental_groups
         short_override: An array of supplemental groups.
-        beta: Reusing the `group` fields in this location is currently considered beta.
         normalize:
           - array
       - at: process

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -35,39 +35,30 @@
       - at: process
         as: entry_leader
         short_override: First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: session_leader
         short_override: Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: group_leader
         short_override: Information about the process group leader. In some cases this may be the same as the top level process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.parent
         as: group_leader
         short_override: Information about the parent's process group leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader
         as: parent
         short_override: Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader
         as: parent
         short_override: Information about the session leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader.parent
         as: session_leader
         short_override: Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader.parent
         as: session_leader
         short_override: Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: previous
         short_override: An array of previous executions for the process, including the initial fork. Only executable and args are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
         normalize:
           - array
 
@@ -244,7 +235,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: Whether the process is connected to an interactive shell.
       description: >
         Whether the process is connected to an interactive shell.
@@ -257,7 +247,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: This boolean is used to identify if a leader process is the same as the top level process.
       description: >
         This boolean is used to identify if a leader process is the same as the top level process.
@@ -295,7 +284,6 @@
     - name: entry_meta.type
       level: extended
       type: keyword
-      beta: This field is beta and subject to change.
       short: The entry type for the entry session leader.
       description: >
         The entry type for the entry session leader.
@@ -306,7 +294,6 @@
     - name: entry_meta.source
       level: extended
       type: source
-      beta: This field is beta and subject to change.
       short: Entry point information for a session.
       description: >
         Entry point information for a session.
@@ -315,7 +302,6 @@
     - name: tty
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       short: Information about the controlling TTY device.
       description: >
         Information about the controlling TTY device. If set, the process belongs to an interactive session.
@@ -323,7 +309,6 @@
     - name: tty.char_device.major
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's major number.
       description: >
         The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
@@ -332,7 +317,6 @@
     - name: tty.char_device.minor
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's minor number.
       description: >
         The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -34,7 +34,6 @@
       - at: process.entry_meta
         as: source
         short_override: Remote client information such as ip, port and geo location.
-        beta: Reusing the `source` fields in this location is currently considered beta.
 
   fields:
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -45,15 +45,12 @@
       - at: process
         as: user
         short_override: The effective user (euid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: saved_user
         short_override: The saved user (suid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: real_user
         short_override: The real user (ruid). Identifies the real owner of the process.
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: attested_user
         short_override: The externally attested user based on an external source such as the Kube API.


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [8.5] Linux event model GA (#2082)