### PR TITLE
[8.5] [8.5] Linux event model GA (#2082)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,8 +36,6 @@ Thanks, you're awesome :-) -->
 
 ### Schema Changes
 
-* Fields added to process, user and group fieldsets in RFC 0030 (Linux event model) are now GA. Beta removed.
-
 #### Added
 
 * Adding `risk.*` fields as experimental. #1994, #2010
@@ -51,6 +49,7 @@ Thanks, you're awesome :-) -->
 
 * Advances `threat.enrichments.indicator` to GA. #1928
 * Added `ios` and `android` as valid values for `os.type` #1999
+* Advances linux event model fields and fieldsets under process, user and group to GA. #2082
 
 ### Tooling and Artifact Changes
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -36,6 +36,8 @@ Thanks, you're awesome :-) -->
 
 ### Schema Changes
 
+* Fields added to process, user and group fieldsets in RFC 0030 (Linux event model) are now GA. Beta removed.
+
 #### Added
 
 * Adding `risk.*` fields as experimental. #1994, #2010

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7248,9 +7248,7 @@ example: `c2c455d9f99375d`
 [[field-process-entry-meta-type]]
 <<field-process-entry-meta-type, process.entry_meta.type>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
+a| The entry type for the entry session leader. Values include: init(e.g systemd), sshd, ssm, kubelet, teleport, terminal, console
 
 Note: This field is only set on process.session_leader.
 
@@ -7331,9 +7329,7 @@ example: `137`
 [[field-process-interactive]]
 <<field-process-interactive, process.interactive>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-Whether the process is connected to an interactive shell.
+a| Whether the process is connected to an interactive shell.
 
 Process interactivity is inferred from the processes file descriptors. If the character device for the controlling tty is the same as stdin and stderr for the process, the process is considered interactive.
 
@@ -7582,9 +7578,7 @@ example: `4242`
 [[field-process-same-as-process]]
 <<field-process-same-as-process, process.same_as_process>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-This boolean is used to identify if a leader process is the same as the top level process.
+a| This boolean is used to identify if a leader process is the same as the top level process.
 
 For example, if `process.group_leader.same_as_process = true`, it means the process event in question is the leader of its process group. Details under `process.*` like `pid` would be the same under `process.group_leader.*` The same applies for both `process.session_leader` and `process.entry_leader`.
 
@@ -7680,9 +7674,7 @@ Multi-fields:
 [[field-process-tty]]
 <<field-process-tty, process.tty>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-Information about the controlling TTY device. If set, the process belongs to an interactive session.
+a| Information about the controlling TTY device. If set, the process belongs to an interactive session.
 
 type: object
 
@@ -7698,9 +7690,7 @@ type: object
 [[field-process-tty-char-device-major]]
 <<field-process-tty-char-device-major, process.tty.char_device.major>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
+a| The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
 
 type: long
 
@@ -7716,9 +7706,7 @@ example: `4`
 [[field-process-tty-char-device-minor]]
 <<field-process-tty-char-device-minor, process.tty.char_device.minor>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
+a| The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.
 
 type: long
 
@@ -7884,49 +7872,43 @@ These fields contain Linux Executable Linkable Format (ELF) metadata.
 
 
 | `process.entry_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
+| <<ecs-process,process>>
+| First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.entry_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.entry_meta.source.*`
-| <<ecs-source,source>>| beta:[ Reusing the `source` fields in this location is currently considered beta.]
-
-Remote client information such as ip, port and geo location.
+| <<ecs-source,source>>
+| Remote client information such as ip, port and geo location.
 
 // ===============================================================
 
 
 | `process.group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The effective group (egid).
+| <<ecs-group,group>>
+| The effective group (egid).
 
 // ===============================================================
 
 
 | `process.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the process group leader. In some cases this may be the same as the top level process.
+| <<ecs-process,process>>
+| Information about the process group leader. In some cases this may be the same as the top level process.
 
 // ===============================================================
 
@@ -7946,9 +7928,8 @@ Information about the process group leader. In some cases this may be the same a
 
 
 | `process.parent.group_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent's process group leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent's process group leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
@@ -7961,9 +7942,8 @@ Information about the parent's process group leader. Only pid, start and entity_
 
 
 | `process.previous.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-An array of previous executions for the process, including the initial fork. Only executable and args are set.
+| <<ecs-process,process>>
+| An array of previous executions for the process, including the initial fork. Only executable and args are set.
 
 Note: this reuse should contain an array of process field set objects.
 
@@ -7971,65 +7951,57 @@ Note: this reuse should contain an array of process field set objects.
 
 
 | `process.real_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The real group (rgid).
+| <<ecs-group,group>>
+| The real group (rgid).
 
 // ===============================================================
 
 
 | `process.real_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The real user (ruid). Identifies the real owner of the process.
+| <<ecs-user,user>>
+| The real user (ruid). Identifies the real owner of the process.
 
 // ===============================================================
 
 
 | `process.saved_group.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-The saved group (sgid).
+| <<ecs-group,group>>
+| The saved group (sgid).
 
 // ===============================================================
 
 
 | `process.saved_user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The saved user (suid).
+| <<ecs-user,user>>
+| The saved user (suid).
 
 // ===============================================================
 
 
 | `process.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
+| <<ecs-process,process>>
+| Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
 
 // ===============================================================
 
 
 | `process.session_leader.parent.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the session leader's parent process. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the session leader's parent process. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.session_leader.parent.session_leader.*`
-| <<ecs-process,process>>| beta:[ Reusing the `process` fields in this location is currently considered beta.]
-
-Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
+| <<ecs-process,process>>
+| Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
 
 // ===============================================================
 
 
 | `process.supplemental_groups.*`
-| <<ecs-group,group>>| beta:[ Reusing the `group` fields in this location is currently considered beta.]
-
-An array of supplemental groups.
+| <<ecs-group,group>>
+| An array of supplemental groups.
 
 Note: this reuse should contain an array of group field set objects.
 
@@ -8037,9 +8009,8 @@ Note: this reuse should contain an array of group field set objects.
 
 
 | `process.user.*`
-| <<ecs-user,user>>| beta:[ Reusing the `user` fields in this location is currently considered beta.]
-
-The effective user (euid).
+| <<ecs-user,user>>
+| The effective user (euid).
 
 // ===============================================================
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -7493,7 +7493,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -7546,7 +7545,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7734,7 +7732,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7848,7 +7845,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7860,7 +7856,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7875,7 +7870,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8085,7 +8079,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8187,7 +8180,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8301,7 +8293,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8313,7 +8304,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8328,7 +8318,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8464,7 +8453,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9317,7 +9305,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9662,7 +9649,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9674,7 +9660,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9689,7 +9674,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10141,7 +10125,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10329,7 +10312,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10443,7 +10425,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10455,7 +10436,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10470,7 +10450,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10600,7 +10579,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10611,7 +10589,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10625,7 +10602,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -5942,22 +5942,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -9205,7 +9201,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -9258,7 +9253,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9446,7 +9440,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9560,7 +9553,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9572,7 +9564,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9587,7 +9578,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9797,7 +9787,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9899,7 +9888,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -10013,7 +10001,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -10025,7 +10012,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -10040,7 +10026,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -10176,7 +10161,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11032,7 +11016,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11377,7 +11360,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11389,7 +11371,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11404,7 +11385,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11856,7 +11836,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -12044,7 +12023,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -12158,7 +12136,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12170,7 +12147,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12185,7 +12161,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12315,7 +12290,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12326,7 +12300,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12340,7 +12313,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12470,64 +12442,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12535,20 +12489,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12573,20 +12523,16 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - beta: Reusing the `user` fields in this location is currently considered beta.
@@ -12597,48 +12543,39 @@ process:
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -14675,7 +14612,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true
@@ -21523,17 +21459,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     - as: attested_user

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -7424,7 +7424,6 @@ process.entry_leader.entry_meta.source.ip:
   short: IP address of the source.
   type: ip
 process.entry_leader.entry_meta.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-entry-meta-type
   description: 'The entry type for the entry session leader. Values include: init(e.g
     systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -7477,7 +7476,6 @@ process.entry_leader.group.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -7665,7 +7663,6 @@ process.entry_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.entry_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -7779,7 +7776,6 @@ process.entry_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.entry_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -7791,7 +7787,6 @@ process.entry_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.entry_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -7806,7 +7801,6 @@ process.entry_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.entry_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-entry-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8016,7 +8010,6 @@ process.group_leader.group.name:
   short: Name of the group.
   type: keyword
 process.group_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -8118,7 +8111,6 @@ process.group_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.group_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -8232,7 +8224,6 @@ process.group_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.group_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -8244,7 +8235,6 @@ process.group_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.group_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -8259,7 +8249,6 @@ process.group_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.group_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-group-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -8395,7 +8384,6 @@ process.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9248,7 +9236,6 @@ process.parent.hash.tlsh:
   short: TLSH hash.
   type: keyword
 process.parent.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -9593,7 +9580,6 @@ process.parent.title:
   short: Process title.
   type: keyword
 process.parent.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -9605,7 +9591,6 @@ process.parent.tty:
   short: Information about the controlling TTY device.
   type: object
 process.parent.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -9620,7 +9605,6 @@ process.parent.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.parent.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-parent-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10072,7 +10056,6 @@ process.session_leader.group.name:
   short: Name of the group.
   type: keyword
 process.session_leader.interactive:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-interactive
   description: 'Whether the process is connected to an interactive shell.
 
@@ -10260,7 +10243,6 @@ process.session_leader.real_user.name:
   short: Short name or login of the user.
   type: keyword
 process.session_leader.same_as_process:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-same-as-process
   description: 'This boolean is used to identify if a leader process is the same as
     the top level process.
@@ -10374,7 +10356,6 @@ process.session_leader.supplemental_groups.name:
   short: Name of the group.
   type: keyword
 process.session_leader.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10386,7 +10367,6 @@ process.session_leader.tty:
   short: Information about the controlling TTY device.
   type: object
 process.session_leader.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10401,7 +10381,6 @@ process.session_leader.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.session_leader.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-session-leader-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\
@@ -10531,7 +10510,6 @@ process.title:
   short: Process title.
   type: keyword
 process.tty:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty
   description: Information about the controlling TTY device. If set, the process belongs
     to an interactive session.
@@ -10542,7 +10520,6 @@ process.tty:
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-major
   description: The major number identifies the driver associated with the device.
     The character device's major and minor numbers can be algorithmically combined
@@ -10556,7 +10533,6 @@ process.tty.char_device.major:
   short: The TTY character device's major number.
   type: long
 process.tty.char_device.minor:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-char-device-minor
   description: "The minor number is used only by the driver specified by the major\
     \ number; other parts of the kernel don\u2019t use it, and merely pass it along\

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -5862,22 +5862,18 @@ group:
       full: user.group
     - as: group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.group
       short_override: The effective group (egid).
     - as: real_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.real_group
       short_override: The real group (rgid).
     - as: saved_group
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.saved_group
       short_override: The saved group (sgid).
     - as: supplemental_groups
       at: process
-      beta: Reusing the `group` fields in this location is currently considered beta.
       full: process.supplemental_groups
       normalize:
       - array
@@ -9125,7 +9121,6 @@ process:
       short: IP address of the source.
       type: ip
     process.entry_leader.entry_meta.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-entry-meta-type
       description: 'The entry type for the entry session leader. Values include: init(e.g
         systemd), sshd, ssm, kubelet, teleport, terminal, console
@@ -9178,7 +9173,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9366,7 +9360,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.entry_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9480,7 +9473,6 @@ process:
       short: Name of the group.
       type: keyword
     process.entry_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9492,7 +9484,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.entry_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9507,7 +9498,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.entry_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-entry-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -9717,7 +9707,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -9819,7 +9808,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.group_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -9933,7 +9921,6 @@ process:
       short: Name of the group.
       type: keyword
     process.group_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -9945,7 +9932,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.group_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -9960,7 +9946,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.group_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-group-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -10096,7 +10081,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -10952,7 +10936,6 @@ process:
       short: TLSH hash.
       type: keyword
     process.parent.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11297,7 +11280,6 @@ process:
       short: Process title.
       type: keyword
     process.parent.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -11309,7 +11291,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.parent.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -11324,7 +11305,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.parent.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-parent-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -11776,7 +11756,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.interactive:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-interactive
       description: 'Whether the process is connected to an interactive shell.
 
@@ -11964,7 +11943,6 @@ process:
       short: Short name or login of the user.
       type: keyword
     process.session_leader.same_as_process:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-same-as-process
       description: 'This boolean is used to identify if a leader process is the same
         as the top level process.
@@ -12078,7 +12056,6 @@ process:
       short: Name of the group.
       type: keyword
     process.session_leader.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12090,7 +12067,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.session_leader.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12105,7 +12081,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.session_leader.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-session-leader-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12235,7 +12210,6 @@ process:
       short: Process title.
       type: keyword
     process.tty:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty
       description: Information about the controlling TTY device. If set, the process
         belongs to an interactive session.
@@ -12246,7 +12220,6 @@ process:
       short: Information about the controlling TTY device.
       type: object
     process.tty.char_device.major:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-major
       description: The major number identifies the driver associated with the device.
         The character device's major and minor numbers can be algorithmically combined
@@ -12260,7 +12233,6 @@ process:
       short: The TTY character device's major number.
       type: long
     process.tty.char_device.minor:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-char-device-minor
       description: "The minor number is used only by the driver specified by the major\
         \ number; other parts of the kernel don\u2019t use it, and merely pass it\
@@ -12390,64 +12362,46 @@ process:
       short_override: Information about the parent process.
     - as: entry_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader
       short_override: First process from terminal or remote access via SSH, SSM, etc
         OR a service directly started by the init process.
     - as: session_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader
       short_override: Often the same as entry_leader. When it differs, it represents
         a session started within another session. e.g. using tmux
     - as: group_leader
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.group_leader
       short_override: Information about the process group leader. In some cases this
         may be the same as the top level process.
     - as: group_leader
       at: process.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.parent.group_leader
       short_override: Information about the parent's process group leader. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.entry_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent
       short_override: Information about the entry leader's parent process. Only pid,
         start and entity_id fields are set.
     - as: parent
       at: process.session_leader
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent
       short_override: Information about the session leader's parent process. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.entry_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.entry_leader.parent.session_leader
       short_override: Information about the parent session of the entry leader. Only
         pid, start and entity_id fields are set.
     - as: session_leader
       at: process.session_leader.parent
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.session_leader.parent.session_leader
       short_override: Information about the parent session of the session leader.
         Only pid, start and entity_id fields are set.
     - as: previous
       at: process
-      beta: Reusing the `process` fields in this location is currently considered
-        beta.
       full: process.previous
       normalize: &id001
       - array
@@ -12455,20 +12409,16 @@ process:
         initial fork. Only executable and args are set.
     top_level: true
   reused_here:
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.group
+  - full: process.group
     schema_name: group
     short: The effective group (egid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.real_group
+  - full: process.real_group
     schema_name: group
     short: The real group (rgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.saved_group
+  - full: process.saved_group
     schema_name: group
     short: The saved group (sgid).
-  - beta: Reusing the `group` fields in this location is currently considered beta.
-    full: process.supplemental_groups
+  - full: process.supplemental_groups
     normalize:
     - array
     schema_name: group
@@ -12493,20 +12443,16 @@ process:
     full: process.elf
     schema_name: elf
     short: These fields contain Linux Executable Linkable Format (ELF) metadata.
-  - beta: Reusing the `source` fields in this location is currently considered beta.
-    full: process.entry_meta.source
+  - full: process.entry_meta.source
     schema_name: source
     short: Remote client information such as ip, port and geo location.
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.user
+  - full: process.user
     schema_name: user
     short: The effective user (euid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.saved_user
+  - full: process.saved_user
     schema_name: user
     short: The saved user (suid).
-  - beta: Reusing the `user` fields in this location is currently considered beta.
-    full: process.real_user
+  - full: process.real_user
     schema_name: user
     short: The real user (ruid). Identifies the real owner of the process.
   - beta: Reusing the `user` fields in this location is currently considered beta.
@@ -12517,48 +12463,39 @@ process:
   - full: process.parent
     schema_name: process
     short: Information about the parent process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader
+  - full: process.entry_leader
     schema_name: process
     short: First process from terminal or remote access via SSH, SSM, etc OR a service
       directly started by the init process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader
+  - full: process.session_leader
     schema_name: process
     short: Often the same as entry_leader. When it differs, it represents a session
       started within another session. e.g. using tmux
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.group_leader
+  - full: process.group_leader
     schema_name: process
     short: Information about the process group leader. In some cases this may be the
       same as the top level process.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.parent.group_leader
+  - full: process.parent.group_leader
     schema_name: process
     short: Information about the parent's process group leader. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent
+  - full: process.entry_leader.parent
     schema_name: process
     short: Information about the entry leader's parent process. Only pid, start and
       entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent
+  - full: process.session_leader.parent
     schema_name: process
     short: Information about the session leader's parent process. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.entry_leader.parent.session_leader
+  - full: process.entry_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the entry leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.session_leader.parent.session_leader
+  - full: process.session_leader.parent.session_leader
     schema_name: process
     short: Information about the parent session of the session leader. Only pid, start
       and entity_id fields are set.
-  - beta: Reusing the `process` fields in this location is currently considered beta.
-    full: process.previous
+  - full: process.previous
     normalize: *id001
     schema_name: process
     short: An array of previous executions for the process, including the initial
@@ -14595,7 +14532,6 @@ source:
     expected:
     - as: source
       at: process.entry_meta
-      beta: Reusing the `source` fields in this location is currently considered beta.
       full: process.entry_meta.source
       short_override: Remote client information such as ip, port and geo location.
     top_level: true
@@ -21443,17 +21379,14 @@ user:
       short_override: Captures changes made to a user.
     - as: user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.user
       short_override: The effective user (euid).
     - as: saved_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.saved_user
       short_override: The saved user (suid).
     - as: real_user
       at: process
-      beta: Reusing the `user` fields in this location is currently considered beta.
       full: process.real_user
       short_override: The real user (ruid). Identifies the real owner of the process.
     - as: attested_user

--- a/schemas/group.yml
+++ b/schemas/group.yml
@@ -32,19 +32,15 @@
       - at: process
         as: group
         short_override: The effective group (egid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: real_group
         short_override: The real group (rgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: saved_group
         short_override: The saved group (sgid).
-        beta: Reusing the `group` fields in this location is currently considered beta.
       - at: process
         as: supplemental_groups
         short_override: An array of supplemental groups.
-        beta: Reusing the `group` fields in this location is currently considered beta.
         normalize:
           - array
       - at: process

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -35,39 +35,30 @@
       - at: process
         as: entry_leader
         short_override: First process from terminal or remote access via SSH, SSM, etc OR a service directly started by the init process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: session_leader
         short_override: Often the same as entry_leader. When it differs, it represents a session started within another session. e.g. using tmux
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: group_leader
         short_override: Information about the process group leader. In some cases this may be the same as the top level process.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.parent
         as: group_leader
         short_override: Information about the parent's process group leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader
         as: parent
         short_override: Information about the entry leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader
         as: parent
         short_override: Information about the session leader's parent process. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.entry_leader.parent
         as: session_leader
         short_override: Information about the parent session of the entry leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process.session_leader.parent
         as: session_leader
         short_override: Information about the parent session of the session leader. Only pid, start and entity_id fields are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
       - at: process
         as: previous
         short_override: An array of previous executions for the process, including the initial fork. Only executable and args are set.
-        beta: Reusing the `process` fields in this location is currently considered beta.
         normalize:
           - array
 
@@ -244,7 +235,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: Whether the process is connected to an interactive shell.
       description: >
         Whether the process is connected to an interactive shell.
@@ -257,7 +247,6 @@
       level: extended
       type: boolean
       example: true
-      beta: This field is beta and subject to change.
       short: This boolean is used to identify if a leader process is the same as the top level process.
       description: >
         This boolean is used to identify if a leader process is the same as the top level process.
@@ -295,7 +284,6 @@
     - name: entry_meta.type
       level: extended
       type: keyword
-      beta: This field is beta and subject to change.
       short: The entry type for the entry session leader.
       description: >
         The entry type for the entry session leader.
@@ -306,7 +294,6 @@
     - name: entry_meta.source
       level: extended
       type: source
-      beta: This field is beta and subject to change.
       short: Entry point information for a session.
       description: >
         Entry point information for a session.
@@ -315,7 +302,6 @@
     - name: tty
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       short: Information about the controlling TTY device.
       description: >
         Information about the controlling TTY device. If set, the process belongs to an interactive session.
@@ -323,7 +309,6 @@
     - name: tty.char_device.major
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's major number.
       description: >
         The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0". For more details, please refer to the Linux kernel documentation.
@@ -332,7 +317,6 @@
     - name: tty.char_device.minor
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The TTY character device's minor number.
       description: >
         The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them.

--- a/schemas/source.yml
+++ b/schemas/source.yml
@@ -34,7 +34,6 @@
       - at: process.entry_meta
         as: source
         short_override: Remote client information such as ip, port and geo location.
-        beta: Reusing the `source` fields in this location is currently considered beta.
 
   fields:
 

--- a/schemas/user.yml
+++ b/schemas/user.yml
@@ -45,15 +45,12 @@
       - at: process
         as: user
         short_override: The effective user (euid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: saved_user
         short_override: The saved user (suid).
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: real_user
         short_override: The real user (ruid). Identifies the real owner of the process.
-        beta: Reusing the `user` fields in this location is currently considered beta.
       - at: process
         as: attested_user
         short_override: The externally attested user based on an external source such as the Kube API.


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [8.5] Linux event model GA (#2082)