### PR TITLE
Fix type of normalize for process.io.bytes_skipped

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -65,6 +65,20 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
+## [8.5.1](https://github.com/elastic/ecs/compare/v8.5.0...v8.5.1)
+
+### Schema Changes
+
+#### Added
+
+#### Improvements
+
+### Tooling and Artifact Changes
+
+#### Bugfixes
+
+* Fix type of `normalize` in `process.io.bytes_skipped`. #2094
+
 ## 8.5.0 (Hard Feature Freeze)
 
 ### Schema Changes

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -729,7 +729,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev+exp,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.7.0-dev+exp,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
-8.7.0-dev+exp,true,process,process.io.bytes_skipped,object,extended,"a, r, r, a, y",,An array of byte offsets and lengths denoting where IO data has been skipped.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
 8.7.0-dev+exp,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
 8.7.0-dev+exp,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.7.0-dev+exp,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -9337,7 +9337,8 @@ process.io.bytes_skipped:
   flat_name: process.io.bytes_skipped
   level: extended
   name: io.bytes_skipped
-  normalize: array
+  normalize:
+  - array
   short: An array of byte offsets and lengths denoting where IO data has been skipped.
   type: object
 process.io.bytes_skipped.length:

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -11549,7 +11549,8 @@ process:
       flat_name: process.io.bytes_skipped
       level: extended
       name: io.bytes_skipped
-      normalize: array
+      normalize:
+      - array
       short: An array of byte offsets and lengths denoting where IO data has been
         skipped.
       type: object

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -722,7 +722,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.hash.tlsh,keyword,extended,,,TLSH hash.
 8.7.0-dev,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.7.0-dev,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
-8.7.0-dev,true,process,process.io.bytes_skipped,object,extended,"a, r, r, a, y",,An array of byte offsets and lengths denoting where IO data has been skipped.
+8.7.0-dev,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
 8.7.0-dev,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
 8.7.0-dev,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.7.0-dev,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -9268,7 +9268,8 @@ process.io.bytes_skipped:
   flat_name: process.io.bytes_skipped
   level: extended
   name: io.bytes_skipped
-  normalize: array
+  normalize:
+  - array
   short: An array of byte offsets and lengths denoting where IO data has been skipped.
   type: object
 process.io.bytes_skipped.length:

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -11469,7 +11469,8 @@ process:
       flat_name: process.io.bytes_skipped
       level: extended
       name: io.bytes_skipped
-      normalize: array
+      normalize:
+      - array
       short: An array of byte offsets and lengths denoting where IO data has been
         skipped.
       type: object

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -403,7 +403,8 @@
       description: >
         An array of byte offsets and lengths denoting where IO data has been skipped.
 
-      normalize: array
+      normalize:
+        - array
 
     - name: io.bytes_skipped.offset
       level: extended

--- a/scripts/tests/test_ecs_spec.py
+++ b/scripts/tests/test_ecs_spec.py
@@ -126,6 +126,10 @@ class TestEcsSpec(unittest.TestCase):
             self.assertIn('array', field['normalize'],
                           "All fields under `related.*` should be arrays")
 
+    def test_normalize_always_array(self):
+        for (field_name, field) in self.ecs_fields.items():
+            self.assertIsInstance(field.get('normalize'), list, field_name)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes an incorrectly typed `normalize` in `process.io.bytes_skipped` and adds a regression test to prevent this from happening in the future.

Please take a look.