### PR TITLE
Fixes invalid 'number' type on 4 process.io subfields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.5.2](https://github.com/elastic/ecs/compare/v8.5.1...v8.5.2)
+
+### Schema Changes
+
+#### Bugfixes
+
+* Fixes invalid `number` type on 4 `process.io` subfields. #2105
+
 ## [8.5.1](https://github.com/elastic/ecs/compare/v8.5.0...v8.5.1)
 
 ### Tooling and Artifact Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8191,7 +8191,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The length of bytes skipped.
 
-type: number
+type: long
 
 
 
@@ -8209,7 +8209,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
-type: number
+type: long
 
 
 
@@ -8265,7 +8265,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The total number of bytes captured in this event.
 
-type: number
+type: long
 
 
 
@@ -8283,7 +8283,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
 
-type: number
+type: long
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -6674,12 +6674,12 @@
       default_field: false
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       description: The length of bytes skipped.
       default_field: false
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
       default_field: false
@@ -6702,12 +6702,12 @@
       default_field: false
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       description: The total number of bytes captured in this event.
       default_field: false
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
         this value is always zero

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -730,12 +730,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev+exp,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.7.0-dev+exp,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
 8.7.0-dev+exp,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
-8.7.0-dev+exp,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
-8.7.0-dev+exp,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
+8.7.0-dev+exp,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.7.0-dev+exp,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
 8.7.0-dev+exp,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
-8.7.0-dev+exp,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
-8.7.0-dev+exp,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.7.0-dev+exp,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
+8.7.0-dev+exp,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.7.0-dev+exp,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.7.0-dev+exp,true,process,process.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in a Mach-O file.
 8.7.0-dev+exp,true,process,process.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -9350,7 +9350,7 @@ process.io.bytes_skipped.length:
   name: io.bytes_skipped.length
   normalize: []
   short: The length of bytes skipped.
-  type: number
+  type: long
 process.io.bytes_skipped.offset:
   beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
@@ -9362,7 +9362,7 @@ process.io.bytes_skipped.offset:
   normalize: []
   short: The byte offset into this event's io.text (or io.bytes in the future) where
     length bytes were skipped.
-  type: number
+  type: long
 process.io.max_bytes_per_process_exceeded:
   beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
@@ -9399,7 +9399,7 @@ process.io.total_bytes_captured:
   name: io.total_bytes_captured
   normalize: []
   short: The total number of bytes captured in this event.
-  type: number
+  type: long
 process.io.total_bytes_skipped:
   beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
@@ -9412,7 +9412,7 @@ process.io.total_bytes_skipped:
   normalize: []
   short: The total number of bytes that were not captured due to implementation restrictions
     such as buffer size limits.
-  type: number
+  type: long
 process.io.type:
   beta: This field is beta and subject to change.
   dashed_name: process-io-type

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -11563,7 +11563,7 @@ process:
       name: io.bytes_skipped.length
       normalize: []
       short: The length of bytes skipped.
-      type: number
+      type: long
     process.io.bytes_skipped.offset:
       beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
@@ -11575,7 +11575,7 @@ process:
       normalize: []
       short: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
-      type: number
+      type: long
     process.io.max_bytes_per_process_exceeded:
       beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
@@ -11613,7 +11613,7 @@ process:
       name: io.total_bytes_captured
       normalize: []
       short: The total number of bytes captured in this event.
-      type: number
+      type: long
     process.io.total_bytes_skipped:
       beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
@@ -11626,7 +11626,7 @@ process:
       normalize: []
       short: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits.
-      type: number
+      type: long
     process.io.type:
       beta: This field is beta and subject to change.
       dashed_name: process-io-type

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -688,10 +688,10 @@
                 "bytes_skipped": {
                   "properties": {
                     "length": {
-                      "type": "number"
+                      "type": "long"
                     },
                     "offset": {
-                      "type": "number"
+                      "type": "long"
                     }
                   },
                   "type": "object"
@@ -703,10 +703,10 @@
                   "type": "wildcard"
                 },
                 "total_bytes_captured": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "total_bytes_skipped": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -3395,10 +3395,10 @@
               "bytes_skipped": {
                 "properties": {
                   "length": {
-                    "type": "number"
+                    "type": "long"
                   },
                   "offset": {
-                    "type": "number"
+                    "type": "long"
                   }
                 },
                 "type": "object"
@@ -3410,10 +3410,10 @@
                 "type": "wildcard"
               },
               "total_bytes_captured": {
-                "type": "number"
+                "type": "long"
               },
               "total_bytes_skipped": {
-                "type": "number"
+                "type": "long"
               },
               "type": {
                 "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -6624,12 +6624,12 @@
       default_field: false
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       description: The length of bytes skipped.
       default_field: false
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
       default_field: false
@@ -6652,12 +6652,12 @@
       default_field: false
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       description: The total number of bytes captured in this event.
       default_field: false
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
         this value is always zero

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -723,12 +723,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.7.0-dev,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.7.0-dev,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
 8.7.0-dev,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
-8.7.0-dev,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
-8.7.0-dev,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.7.0-dev,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
+8.7.0-dev,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.7.0-dev,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
 8.7.0-dev,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
-8.7.0-dev,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
-8.7.0-dev,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.7.0-dev,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
+8.7.0-dev,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.7.0-dev,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.7.0-dev,true,process,process.macho.go_import_hash,keyword,extended,,10bddcb4cee42080f76c88d9ff964491,A hash of the Go language imports in a Mach-O file.
 8.7.0-dev,true,process,process.macho.go_imports,flattened,extended,,,List of imported Go language element names and types.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -9281,7 +9281,7 @@ process.io.bytes_skipped.length:
   name: io.bytes_skipped.length
   normalize: []
   short: The length of bytes skipped.
-  type: number
+  type: long
 process.io.bytes_skipped.offset:
   beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
@@ -9293,7 +9293,7 @@ process.io.bytes_skipped.offset:
   normalize: []
   short: The byte offset into this event's io.text (or io.bytes in the future) where
     length bytes were skipped.
-  type: number
+  type: long
 process.io.max_bytes_per_process_exceeded:
   beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
@@ -9330,7 +9330,7 @@ process.io.total_bytes_captured:
   name: io.total_bytes_captured
   normalize: []
   short: The total number of bytes captured in this event.
-  type: number
+  type: long
 process.io.total_bytes_skipped:
   beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
@@ -9343,7 +9343,7 @@ process.io.total_bytes_skipped:
   normalize: []
   short: The total number of bytes that were not captured due to implementation restrictions
     such as buffer size limits.
-  type: number
+  type: long
 process.io.type:
   beta: This field is beta and subject to change.
   dashed_name: process-io-type

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -11483,7 +11483,7 @@ process:
       name: io.bytes_skipped.length
       normalize: []
       short: The length of bytes skipped.
-      type: number
+      type: long
     process.io.bytes_skipped.offset:
       beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
@@ -11495,7 +11495,7 @@ process:
       normalize: []
       short: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
-      type: number
+      type: long
     process.io.max_bytes_per_process_exceeded:
       beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
@@ -11533,7 +11533,7 @@ process:
       name: io.total_bytes_captured
       normalize: []
       short: The total number of bytes captured in this event.
-      type: number
+      type: long
     process.io.total_bytes_skipped:
       beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
@@ -11546,7 +11546,7 @@ process:
       normalize: []
       short: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits.
-      type: number
+      type: long
     process.io.type:
       beta: This field is beta and subject to change.
       dashed_name: process-io-type

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -688,10 +688,10 @@
                 "bytes_skipped": {
                   "properties": {
                     "length": {
-                      "type": "number"
+                      "type": "long"
                     },
                     "offset": {
-                      "type": "number"
+                      "type": "long"
                     }
                   },
                   "type": "object"
@@ -703,10 +703,10 @@
                   "type": "wildcard"
                 },
                 "total_bytes_captured": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "total_bytes_skipped": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -3353,10 +3353,10 @@
               "bytes_skipped": {
                 "properties": {
                   "length": {
-                    "type": "number"
+                    "type": "long"
                   },
                   "offset": {
-                    "type": "number"
+                    "type": "long"
                   }
                 },
                 "type": "object"
@@ -3368,10 +3368,10 @@
                 "type": "wildcard"
               },
               "total_bytes_captured": {
-                "type": "number"
+                "type": "long"
               },
               "total_bytes_skipped": {
-                "type": "number"
+                "type": "long"
               },
               "type": {
                 "ignore_above": 1024,

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -376,14 +376,14 @@
 
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The total number of bytes captured in this event.
 
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       short: The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
       description: >
@@ -408,14 +408,14 @@
 
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The length of bytes skipped.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? y
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? y
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? n
