### PR TITLE
[8.5] Fixes invalid 'number' type on 4 process.io subfields. (#2105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.5.2](https://github.com/elastic/ecs/compare/v8.5.1...v8.5.2)
+
+### Schema Changes
+
+#### Bugfixes
+
+* Fixes invalid `number` type on 4 `process.io` subfields. #2105
+
 ## [8.5.1](https://github.com/elastic/ecs/compare/v8.5.0...v8.5.1)
 
 ### Schema Changes

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -7394,7 +7394,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The length of bytes skipped.
 
-type: number
+type: long
 
 
 
@@ -7412,7 +7412,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
-type: number
+type: long
 
 
 
@@ -7468,7 +7468,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The total number of bytes captured in this event.
 
-type: number
+type: long
 
 
 
@@ -7486,7 +7486,7 @@ a| beta:[ This field is beta and subject to change. ]
 
 The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
 
-type: number
+type: long
 
 
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5877,12 +5877,12 @@
       default_field: false
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       description: The length of bytes skipped.
       default_field: false
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
       default_field: false
@@ -5905,12 +5905,12 @@
       default_field: false
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       description: The total number of bytes captured in this event.
       default_field: false
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
         this value is always zero

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -662,12 +662,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.1+exp,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.5.1+exp,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
 8.5.1+exp,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
-8.5.1+exp,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
-8.5.1+exp,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.5.1+exp,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
+8.5.1+exp,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.5.1+exp,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
 8.5.1+exp,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
-8.5.1+exp,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
-8.5.1+exp,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.5.1+exp,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
+8.5.1+exp,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.5.1+exp,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.5.1+exp,true,process,process.name,keyword,extended,,ssh,Process name.
 8.5.1+exp,true,process,process.name.text,match_only_text,extended,,ssh,Process name.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8506,7 +8506,7 @@ process.io.bytes_skipped.length:
   name: io.bytes_skipped.length
   normalize: []
   short: The length of bytes skipped.
-  type: number
+  type: long
 process.io.bytes_skipped.offset:
   beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
@@ -8518,7 +8518,7 @@ process.io.bytes_skipped.offset:
   normalize: []
   short: The byte offset into this event's io.text (or io.bytes in the future) where
     length bytes were skipped.
-  type: number
+  type: long
 process.io.max_bytes_per_process_exceeded:
   beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
@@ -8555,7 +8555,7 @@ process.io.total_bytes_captured:
   name: io.total_bytes_captured
   normalize: []
   short: The total number of bytes captured in this event.
-  type: number
+  type: long
 process.io.total_bytes_skipped:
   beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
@@ -8568,7 +8568,7 @@ process.io.total_bytes_skipped:
   normalize: []
   short: The total number of bytes that were not captured due to implementation restrictions
     such as buffer size limits.
-  type: number
+  type: long
 process.io.type:
   beta: This field is beta and subject to change.
   dashed_name: process-io-type

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -10215,7 +10215,7 @@ process:
       name: io.bytes_skipped.length
       normalize: []
       short: The length of bytes skipped.
-      type: number
+      type: long
     process.io.bytes_skipped.offset:
       beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
@@ -10227,7 +10227,7 @@ process:
       normalize: []
       short: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
-      type: number
+      type: long
     process.io.max_bytes_per_process_exceeded:
       beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
@@ -10265,7 +10265,7 @@ process:
       name: io.total_bytes_captured
       normalize: []
       short: The total number of bytes captured in this event.
-      type: number
+      type: long
     process.io.total_bytes_skipped:
       beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
@@ -10278,7 +10278,7 @@ process:
       normalize: []
       short: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits.
-      type: number
+      type: long
     process.io.type:
       beta: This field is beta and subject to change.
       dashed_name: process-io-type

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -659,10 +659,10 @@
                 "bytes_skipped": {
                   "properties": {
                     "length": {
-                      "type": "number"
+                      "type": "long"
                     },
                     "offset": {
-                      "type": "number"
+                      "type": "long"
                     }
                   },
                   "type": "object"
@@ -674,10 +674,10 @@
                   "type": "wildcard"
                 },
                 "total_bytes_captured": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "total_bytes_skipped": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -3155,10 +3155,10 @@
               "bytes_skipped": {
                 "properties": {
                   "length": {
-                    "type": "number"
+                    "type": "long"
                   },
                   "offset": {
-                    "type": "number"
+                    "type": "long"
                   }
                 },
                 "type": "object"
@@ -3170,10 +3170,10 @@
                 "type": "wildcard"
               },
               "total_bytes_captured": {
-                "type": "number"
+                "type": "long"
               },
               "total_bytes_skipped": {
-                "type": "number"
+                "type": "long"
               },
               "type": {
                 "ignore_above": 1024,

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5827,12 +5827,12 @@
       default_field: false
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       description: The length of bytes skipped.
       default_field: false
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
       default_field: false
@@ -5855,12 +5855,12 @@
       default_field: false
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       description: The total number of bytes captured in this event.
       default_field: false
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
         this value is always zero

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -655,12 +655,12 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.5.1,true,process,process.interactive,boolean,extended,,True,Whether the process is connected to an interactive shell.
 8.5.1,true,process,process.io,object,extended,,,A chunk of input or output (IO) from a single process.
 8.5.1,true,process,process.io.bytes_skipped,object,extended,array,,An array of byte offsets and lengths denoting where IO data has been skipped.
-8.5.1,true,process,process.io.bytes_skipped.length,number,extended,,,The length of bytes skipped.
-8.5.1,true,process,process.io.bytes_skipped.offset,number,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+8.5.1,true,process,process.io.bytes_skipped.length,long,extended,,,The length of bytes skipped.
+8.5.1,true,process,process.io.bytes_skipped.offset,long,extended,,,The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 8.5.1,true,process,process.io.max_bytes_per_process_exceeded,boolean,extended,,,"If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting."
 8.5.1,true,process,process.io.text,wildcard,extended,,,A chunk of output or input sanitized to UTF-8.
-8.5.1,true,process,process.io.total_bytes_captured,number,extended,,,The total number of bytes captured in this event.
-8.5.1,true,process,process.io.total_bytes_skipped,number,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
+8.5.1,true,process,process.io.total_bytes_captured,long,extended,,,The total number of bytes captured in this event.
+8.5.1,true,process,process.io.total_bytes_skipped,long,extended,,,The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
 8.5.1,true,process,process.io.type,keyword,extended,,,The type of object on which the IO action (read or write) was taken.
 8.5.1,true,process,process.name,keyword,extended,,ssh,Process name.
 8.5.1,true,process,process.name.text,match_only_text,extended,,ssh,Process name.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8437,7 +8437,7 @@ process.io.bytes_skipped.length:
   name: io.bytes_skipped.length
   normalize: []
   short: The length of bytes skipped.
-  type: number
+  type: long
 process.io.bytes_skipped.offset:
   beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
@@ -8449,7 +8449,7 @@ process.io.bytes_skipped.offset:
   normalize: []
   short: The byte offset into this event's io.text (or io.bytes in the future) where
     length bytes were skipped.
-  type: number
+  type: long
 process.io.max_bytes_per_process_exceeded:
   beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
@@ -8486,7 +8486,7 @@ process.io.total_bytes_captured:
   name: io.total_bytes_captured
   normalize: []
   short: The total number of bytes captured in this event.
-  type: number
+  type: long
 process.io.total_bytes_skipped:
   beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
@@ -8499,7 +8499,7 @@ process.io.total_bytes_skipped:
   normalize: []
   short: The total number of bytes that were not captured due to implementation restrictions
     such as buffer size limits.
-  type: number
+  type: long
 process.io.type:
   beta: This field is beta and subject to change.
   dashed_name: process-io-type

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -10135,7 +10135,7 @@ process:
       name: io.bytes_skipped.length
       normalize: []
       short: The length of bytes skipped.
-      type: number
+      type: long
     process.io.bytes_skipped.offset:
       beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
@@ -10147,7 +10147,7 @@ process:
       normalize: []
       short: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
-      type: number
+      type: long
     process.io.max_bytes_per_process_exceeded:
       beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
@@ -10185,7 +10185,7 @@ process:
       name: io.total_bytes_captured
       normalize: []
       short: The total number of bytes captured in this event.
-      type: number
+      type: long
     process.io.total_bytes_skipped:
       beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
@@ -10198,7 +10198,7 @@ process:
       normalize: []
       short: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits.
-      type: number
+      type: long
     process.io.type:
       beta: This field is beta and subject to change.
       dashed_name: process-io-type

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -659,10 +659,10 @@
                 "bytes_skipped": {
                   "properties": {
                     "length": {
-                      "type": "number"
+                      "type": "long"
                     },
                     "offset": {
-                      "type": "number"
+                      "type": "long"
                     }
                   },
                   "type": "object"
@@ -674,10 +674,10 @@
                   "type": "wildcard"
                 },
                 "total_bytes_captured": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "total_bytes_skipped": {
-                  "type": "number"
+                  "type": "long"
                 },
                 "type": {
                   "ignore_above": 1024,

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -3113,10 +3113,10 @@
               "bytes_skipped": {
                 "properties": {
                   "length": {
-                    "type": "number"
+                    "type": "long"
                   },
                   "offset": {
-                    "type": "number"
+                    "type": "long"
                   }
                 },
                 "type": "object"
@@ -3128,10 +3128,10 @@
                 "type": "wildcard"
               },
               "total_bytes_captured": {
-                "type": "number"
+                "type": "long"
               },
               "total_bytes_skipped": {
-                "type": "number"
+                "type": "long"
               },
               "type": {
                 "ignore_above": 1024,

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -376,14 +376,14 @@
 
     - name: io.total_bytes_captured
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The total number of bytes captured in this event.
 
     - name: io.total_bytes_skipped
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       short: The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
       description: >
@@ -408,14 +408,14 @@
 
     - name: io.bytes_skipped.offset
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
     - name: io.bytes_skipped.length
       level: extended
-      type: number
+      type: long
       beta: This field is beta and subject to change.
       description: >
         The length of bytes skipped.


### PR DESCRIPTION
Backports the following commits to 8.5:
 - Fixes invalid 'number' type on 4 process.io subfields. (#2105)