### PR TITLE
[main] Release notes for 8.5.2 

### DIFF
--- a/docs/release-notes/8.5.2.asciidoc
+++ b/docs/release-notes/8.5.2.asciidoc
@@ -1,0 +1,12 @@
+[[ecs-release-notes-8.5.2]]
+=== 8.5.2
+
+[[schema-changes-8.5.2]]
+[float]
+==== Schema changes
+
+[[schema-bugfixes-8.5.2]]
+[float]
+===== Bugfixes
+
+* Fixes invalid `number` type on 4 `process.io` subfields. {ecs_pull}2105[#2105]

--- a/docs/release-notes/index.asciidoc
+++ b/docs/release-notes/index.asciidoc
@@ -4,6 +4,7 @@
 This section summarizes the changes in each release.
 
 * <<ecs-release-notes-8.6.0, {ecs} version 8.6.0>>
+* <<ecs-release-notes-8.5.2, {ecs} version 8.5.2>>
 * <<ecs-release-notes-8.5.1, {ecs} version 8.5.1>>
 * <<ecs-release-notes-8.5.0, {ecs} version 8.5.0>>
 * <<ecs-release-notes-8.4.0, {ecs} version 8.4.0>>
@@ -21,6 +22,7 @@ This section summarizes the changes in each release.
 :pull: https://github.com/elastic/ecs/pull/
 
 include::8.6.asciidoc[]
+include::8.5.2.asciidoc[]
 include::8.5.1.asciidoc[]
 include::8.5.asciidoc[]
 include::8.4.asciidoc[]


### PR DESCRIPTION
main forward-port of https://github.com/elastic/ecs/pull/2110