### PR TITLE
[elastic/ecs] Cutting 8.6 changelog for HFF

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -47,7 +47,38 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 
-* Added `CLEAR` and `AMBER+STRICT` as valid values for `threat.indicator.marking.tlp` to accept new [TLP 2.0](https://www.first.org/tlp/) markings - [#2022](https://github.com/elastic/ecs/issues/2022)
+#### Deprecated
+
+### Tooling and Artifact Changes
+
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
+#### Improvements
+
+#### Deprecated
+
+## 8.6.0 (Soft Feature Freeze)
+
+### Schema Changes
+
+#### Breaking changes
+
+#### Bugfixes
+
+#### Added
+
+* Adding `vulnerability` option for `event.catgeory`. #2029
+* Added `device.*` field set as beta. #2030
+* Added `tlp.version` to threat #2074
+* Added fields for executable object format metadata for ELF, Mach-O and PE #2083
+
+#### Improvements
+
+* Added `CLEAR` and `AMBER+STRICT` as valid values for `threat.indicator.marking.tlp` and `enrichments.indicator.marking.tlp` to accept new [TLP 2.0](https://www.first.org/tlp/) markings #2022, #2074
 
 #### Deprecated
 
@@ -63,13 +94,11 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-## 8.5.0 (Soft Feature Freeze)
+## 8.5.0 (Hard Feature Freeze)
 
 ### Schema Changes
 
-#### Breaking changes
-
-#### Bugfixes
+* Fields added to process, user and group fieldsets in RFC 0030 (Linux event model) are now GA. Beta removed.
 
 #### Added
 
@@ -85,21 +114,12 @@ Thanks, you're awesome :-) -->
 * Advances `threat.enrichments.indicator` to GA. #1928
 * Added `ios` and `android` as valid values for `os.type` #1999
 
-#### Deprecated
-
 ### Tooling and Artifact Changes
-
-#### Breaking changes
 
 #### Bugfixes
 
 * Added Deprecation Warning for `misspell` task #1993
-
-#### Added
-
-#### Improvements
-
-#### Deprecated
+* Fix typo in client schema #2014
 
 <!-- All empty sections:
 

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -32,43 +32,9 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-## 8.6.0 (Soft Feature Freeze)
+## 8.6.0 (Hard Feature Freeze)
 
 ### Schema Changes
-
-#### Breaking changes
-
-#### Bugfixes
-
-#### Added
-
-* Adding `vulnerability` option for `event.catgeory`. #2029
-* Added `device.*` field set as beta. #2030
-* Added `tlp.version` to threat #2074
-
-#### Improvements
-
-#### Deprecated
-
-### Tooling and Artifact Changes
-
-#### Breaking changes
-
-#### Bugfixes
-
-#### Added
-
-#### Improvements
-
-#### Deprecated
-
-## 8.6.0 (Soft Feature Freeze)
-
-### Schema Changes
-
-#### Breaking changes
-
-#### Bugfixes
 
 #### Added
 
@@ -80,48 +46,6 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Added `CLEAR` and `AMBER+STRICT` as valid values for `threat.indicator.marking.tlp` and `enrichments.indicator.marking.tlp` to accept new [TLP 2.0](https://www.first.org/tlp/) markings #2022, #2074
-
-#### Deprecated
-
-### Tooling and Artifact Changes
-
-#### Breaking changes
-
-#### Bugfixes
-
-#### Added
-
-#### Improvements
-
-#### Deprecated
-
-## 8.5.0 (Hard Feature Freeze)
-
-### Schema Changes
-
-* Fields added to process, user and group fieldsets in RFC 0030 (Linux event model) are now GA. Beta removed.
-
-#### Added
-
-* Adding `risk.*` fields as experimental. #1994, #2010
-* Adding `process.io.*` as beta fields. #1956, #2031
-* Adding `process.tty.rows` and `process.tty.columns` as beta fields. #2031
-* Changed `process.env_vars` field type to be an array of keywords. #2038
-* `process.attested_user` and `process.attested_groups` as beta fields. #2050
-* Added `risk.*` fieldset to beta. #2051, #2058
-
-#### Improvements
-
-* Advances `threat.enrichments.indicator` to GA. #1928
-* Added `ios` and `android` as valid values for `os.type` #1999
-* Advances linux event model fields and fieldsets under process, user and group to GA. #2082
-
-### Tooling and Artifact Changes
-
-#### Bugfixes
-
-* Added Deprecation Warning for `misspell` task #1993
-* Fix typo in client schema #2014
 
 <!-- All empty sections:
 


### PR DESCRIPTION
Cut the changelog in the HFF branch:
Change the title of the feature frozen release section from "8.x.0 (Soft Feature Freeze)" to indicate that the version is in hard feature freeze. Example: "8.1.0 (Hard Feature Freeze)"
Sort entries by PR ID within their sections.
Remove empty sections
Compare the changelog entries with the commits of the main branch,
to ensure no changelog is missing
Submit a PR with only the HFF changelog, to facilitate forward porting
