### PR TITLE
[main] [elastic/ecs] Cutting 8.6 changelog for HFF (#2114)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -32,17 +32,13 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-## 8.6.0 (Soft Feature Freeze)
+## 8.6.0 (Hard Feature Freeze)
 
 ### Schema Changes
 
-#### Breaking changes
-
-#### Bugfixes
-
 #### Added
 
-* Adding `vulnerability` option for `event.catgeory`. #2029
+* Adding `vulnerability` option for `event.category`. #2029
 * Added `device.*` field set as beta. #2030
 * Added `tlp.version` to threat #2074
 * Added fields for executable object format metadata for ELF, Mach-O and PE #2083
@@ -50,47 +46,6 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Added `CLEAR` and `AMBER+STRICT` as valid values for `threat.indicator.marking.tlp` and `enrichments.indicator.marking.tlp` to accept new [TLP 2.0](https://www.first.org/tlp/) markings #2022, #2074
-
-#### Deprecated
-
-### Tooling and Artifact Changes
-
-#### Breaking changes
-
-#### Bugfixes
-
-#### Added
-
-#### Improvements
-
-#### Deprecated
-
-## 8.5.0 (Hard Feature Freeze)
-
-### Schema Changes
-
-* Fields added to process, user and group fieldsets in RFC 0030 (Linux event model) are now GA. Beta removed.
-
-#### Added
-
-* Adding `risk.*` fields as experimental. #1994, #2010
-* Adding `process.io.*` as beta fields. #1956, #2031
-* Adding `process.tty.rows` and `process.tty.columns` as beta fields. #2031
-* Changed `process.env_vars` field type to be an array of keywords. #2038
-* `process.attested_user` and `process.attested_groups` as beta fields. #2050
-* Added `risk.*` fieldset to beta. #2051, #2058
-
-#### Improvements
-
-* Advances `threat.enrichments.indicator` to GA. #1928
-* Added `ios` and `android` as valid values for `os.type` #1999
-
-### Tooling and Artifact Changes
-
-#### Bugfixes
-
-* Added Deprecation Warning for `misspell` task #1993
-* Fix typo in client schema #2014
 
 <!-- All empty sections:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.6` to `main`:
 - [[elastic/ecs] Cutting 8.6 changelog for HFF (#2114)](https://github.com/elastic/ecs/pull/2114)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)