### PR TITLE
Add the `api` value to `event.category`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,7 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* adding `api` option to `event.category` #XXXX
 * adding `name` field to `threat.indicator` #2121
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -3389,7 +3389,7 @@ Note: this field should contain an array of values.
 
 *Important*: The field value must be one of the following:
 
-authentication, configuration, database, driver, email, file, host, iam, intrusion_detection, malware, network, package, process, registry, session, threat, vulnerability, web
+api, authentication, configuration, database, driver, email, file, host, iam, intrusion_detection, malware, network, package, process, registry, session, threat, vulnerability, web
 
 To learn more about when to use which value, visit the page
 <<ecs-allowed-values-event-category,allowed values for event.category>>

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -156,12 +156,12 @@ This field is an array. This will allow proper categorization of some events tha
 [[ecs-event-category-api]]
 ==== api
 
-Events in this category correspond to API events propagated directly from the Operating System (Windows, Linux, etc.), from either the native API function or system call, or a managed source of events (such as ETW, syslog).
+Events in this category annotate API calls that occured on a system. Typical sources for those events could be from the Operating System level through the native libraries (for example Windows Win32, Linux libc, etc.), or managed sources of events (such as ETW, syslog), but can also include network protocols (such as SOAP, RPC, Websocket, REST, etc.)
 
 
 *Expected event types for category api:*
 
-access, admin, allowed, denied, end, start, user
+access, admin, allowed, change, creation, deletion, denied, end, info, start, user
 
 
 [float]

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -132,6 +132,7 @@ This field is an array. This will allow proper categorization of some events tha
 
 *Allowed Values*
 
+* <<ecs-event-category-api,api>>
 * <<ecs-event-category-authentication,authentication>>
 * <<ecs-event-category-configuration,configuration>>
 * <<ecs-event-category-database,database>>
@@ -150,6 +151,18 @@ This field is an array. This will allow proper categorization of some events tha
 * <<ecs-event-category-threat,threat>>
 * <<ecs-event-category-vulnerability,vulnerability>>
 * <<ecs-event-category-web,web>>
+
+[float]
+[[ecs-event-category-api]]
+==== api
+
+Events in this category correspond to API events propagated directly from the Operating System (Windows, Linux, etc.), from either the native API function or system call, or a managed source of events (such as ETW, syslog).
+
+
+*Expected event types for category api:*
+
+access, admin, allowed, denied, end, start, user
+
 
 [float]
 [[ecs-event-category-authentication]]

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2944,6 +2944,18 @@ event.agent_id_status:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category correspond to API events propagated directly
+      from the Operating System (Windows, Linux, etc.), from either the native API
+      function or system call, or a managed source of events (such as ETW, syslog).
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - denied
+    - end
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -2944,15 +2944,21 @@ event.agent_id_status:
   type: keyword
 event.category:
   allowed_values:
-  - description: Events in this category correspond to API events propagated directly
-      from the Operating System (Windows, Linux, etc.), from either the native API
-      function or system call, or a managed source of events (such as ETW, syslog).
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
     expected_event_types:
     - access
     - admin
     - allowed
+    - change
+    - creation
+    - deletion
     - denied
     - end
+    - info
     - start
     - user
     name: api

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3936,16 +3936,21 @@ event:
       type: keyword
     event.category:
       allowed_values:
-      - description: Events in this category correspond to API events propagated directly
-          from the Operating System (Windows, Linux, etc.), from either the native
-          API function or system call, or a managed source of events (such as ETW,
-          syslog).
+      - description: Events in this category annotate API calls that occured on a
+          system. Typical sources for those events could be from the Operating System
+          level through the native libraries (for example Windows Win32, Linux libc,
+          etc.), or managed sources of events (such as ETW, syslog), but can also
+          include network protocols (such as SOAP, RPC, Websocket, REST, etc.)
         expected_event_types:
         - access
         - admin
         - allowed
+        - change
+        - creation
+        - deletion
         - denied
         - end
+        - info
         - start
         - user
         name: api

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -3936,6 +3936,19 @@ event:
       type: keyword
     event.category:
       allowed_values:
+      - description: Events in this category correspond to API events propagated directly
+          from the Operating System (Windows, Linux, etc.), from either the native
+          API function or system call, or a managed source of events (such as ETW,
+          syslog).
+        expected_event_types:
+        - access
+        - admin
+        - allowed
+        - denied
+        - end
+        - start
+        - user
+        name: api
       - description: Events in this category are related to the challenge and response
           process in which credentials are supplied and verified to allow the creation
           of a session. Common sources for these logs are Windows event logs and ssh

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2875,15 +2875,21 @@ event.agent_id_status:
   type: keyword
 event.category:
   allowed_values:
-  - description: Events in this category correspond to API events propagated directly
-      from the Operating System (Windows, Linux, etc.), from either the native API
-      function or system call, or a managed source of events (such as ETW, syslog).
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
     expected_event_types:
     - access
     - admin
     - allowed
+    - change
+    - creation
+    - deletion
     - denied
     - end
+    - info
     - start
     - user
     name: api

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2875,6 +2875,18 @@ event.agent_id_status:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category correspond to API events propagated directly
+      from the Operating System (Windows, Linux, etc.), from either the native API
+      function or system call, or a managed source of events (such as ETW, syslog).
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - denied
+    - end
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3856,6 +3856,19 @@ event:
       type: keyword
     event.category:
       allowed_values:
+      - description: Events in this category correspond to API events propagated directly
+          from the Operating System (Windows, Linux, etc.), from either the native
+          API function or system call, or a managed source of events (such as ETW,
+          syslog).
+        expected_event_types:
+        - access
+        - admin
+        - allowed
+        - denied
+        - end
+        - start
+        - user
+        name: api
       - description: Events in this category are related to the challenge and response
           process in which credentials are supplied and verified to allow the creation
           of a session. Common sources for these logs are Windows event logs and ssh

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3856,16 +3856,21 @@ event:
       type: keyword
     event.category:
       allowed_values:
-      - description: Events in this category correspond to API events propagated directly
-          from the Operating System (Windows, Linux, etc.), from either the native
-          API function or system call, or a managed source of events (such as ETW,
-          syslog).
+      - description: Events in this category annotate API calls that occured on a
+          system. Typical sources for those events could be from the Operating System
+          level through the native libraries (for example Windows Win32, Linux libc,
+          etc.), or managed sources of events (such as ETW, syslog), but can also
+          include network protocols (such as SOAP, RPC, Websocket, REST, etc.)
         expected_event_types:
         - access
         - admin
         - allowed
+        - change
+        - creation
+        - deletion
         - denied
         - end
+        - info
         - start
         - user
         name: api

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -156,6 +156,19 @@
       normalize:
         - array
       allowed_values:
+        - name: api
+          description: >
+            Events in this category correspond to API events propagated directly
+            from the Operating System (Windows, Linux, etc.), from either the native
+            API function or system call, or a managed source of events (such as ETW, syslog).
+          expected_event_types:
+            - access
+            - admin
+            - allowed
+            - denied
+            - end
+            - start
+            - user
         - name: authentication
           description: >
             Events in this category are related to the challenge and response process

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -158,15 +158,20 @@
       allowed_values:
         - name: api
           description: >
-            Events in this category correspond to API events propagated directly
-            from the Operating System (Windows, Linux, etc.), from either the native
-            API function or system call, or a managed source of events (such as ETW, syslog).
+            Events in this category annotate API calls that occured on a system. Typical sources
+            for those events could be from the Operating System level through the native libraries
+            (for example Windows Win32, Linux libc, etc.), or managed sources of events (such as ETW,
+            syslog), but can also include network protocols (such as SOAP, RPC, Websocket, REST, etc.)
           expected_event_types:
             - access
             - admin
             - allowed
+            - change
+            - creation
+            - deletion
             - denied
             - end
+            - info
             - start
             - user
         - name: authentication


### PR DESCRIPTION
This Pull Request adds a new value for the `event.category` : `api`. Events in this category correspond to API events propagated directly from the Operating System from either the native API function (for instance, OS callbacks from Windows or Linux), system calls, or also managed source of events (such as ETW for instance).

Resolves #2138 

