### PR TITLE
[8.7] Bump gitpython from 3.1.27 to 3.1.30 in /scripts (#2139)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -45,6 +45,7 @@ Thanks, you're awesome :-) -->
 #### Improvements
 
 * Updated usage docs to include `threat.indicator.url.domain` and changed `indicator.marking.tlp` and `indicator.enrichments.marking.tlp` from "WHITE" to "CLEAR" to align with TLP 2.0. #2124
+* Bump `gitpython` from `3.1.27` to `3.1.30` in `/scripts`. #2139
 
 
 <!-- All empty sections:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0
 # License: BSD
-gitpython==3.1.27
+gitpython==3.1.30
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Bump gitpython from 3.1.27 to 3.1.30 in /scripts (#2139)](https://github.com/elastic/ecs/pull/2139)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)