### PR TITLE
Tlp patch

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -32,6 +32,14 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
+## 8.6.1
+
+### Schema Changes
+
+#### Bugfixes
+
+* Fixing `tlp_version` and `tlp` field for threat. #2156
+
 <!-- All empty sections:
 
 ## Unreleased

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -9654,8 +9654,33 @@ example: `2020-11-05T17:25:47.000Z`
 // ===============================================================
 
 |
+[[field-threat-enrichments-indicator-marking-tlp]]
+<<field-threat-enrichments-indicator-marking-tlp, threat.enrichments.indicator.marking.tlp>>
+
+a| Traffic Light Protocol sharing markings.
+
+Expected values for this field:
+
+* `WHITE`
+* `CLEAR`
+* `GREEN`
+* `AMBER`
+* `AMBER+STRICT`
+* `RED`
+
+type: keyword
+
+
+
+example: `CLEAR`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-threat-enrichments-indicator-marking-tlp-version]]
-<<field-threat-enrichments-indicator-marking-tlp-version, threat.enrichments.indicator.marking.tlp.version>>
+<<field-threat-enrichments-indicator-marking-tlp-version, threat.enrichments.indicator.marking.tlp_version>>
 
 a| Traffic Light Protocol version.
 
@@ -10630,7 +10655,7 @@ example: `https://attack.mitre.org/techniques/T1059/001/`
 
 |
 [[field-threat-threat-indicator-marking-tlp-version]]
-<<field-threat-threat-indicator-marking-tlp-version, threat.threat.indicator.marking.tlp.version>>
+<<field-threat-threat-indicator-marking-tlp-version, threat.threat.indicator.marking.tlp_version>>
 
 a| Traffic Light Protocol version.
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -10207,6 +10207,22 @@ example: `CLEAR`
 // ===============================================================
 
 |
+[[field-threat-indicator-marking-tlp-version]]
+<<field-threat-indicator-marking-tlp-version, threat.indicator.marking.tlp_version>>
+
+a| Traffic Light Protocol version.
+
+type: keyword
+
+
+
+example: `2.0`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-threat-indicator-modified-at]]
 <<field-threat-indicator-modified-at, threat.indicator.modified_at>>
 
@@ -10648,22 +10664,6 @@ Note: this field should contain an array of values.
 
 
 example: `https://attack.mitre.org/techniques/T1059/001/`
-
-| extended
-
-// ===============================================================
-
-|
-[[field-threat-threat-indicator-marking-tlp-version]]
-<<field-threat-threat-indicator-marking-tlp-version, threat.threat.indicator.marking.tlp_version>>
-
-a| Traffic Light Protocol version.
-
-type: keyword
-
-
-
-example: `2.0`
 
 | extended
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -10855,6 +10855,13 @@
       description: Traffic Light Protocol sharing markings.
       example: CLEAR
       default_field: false
+    - name: indicator.marking.tlp_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Traffic Light Protocol version.
+      example: 2.0
+      default_field: false
     - name: indicator.modified_at
       level: extended
       type: date
@@ -11409,13 +11416,6 @@
       description: "The reference url of subtechnique used by this threat. You can\
         \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
-      default_field: false
-    - name: threat.indicator.marking.tlp_version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Traffic Light Protocol version.
-      example: 2.0
       default_field: false
   - name: tls
     title: TLS

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -9422,7 +9422,14 @@
         this indicator.
       example: '2020-11-05T17:25:47.000Z'
       default_field: false
-    - name: enrichments.indicator.marking.tlp.version
+    - name: enrichments.indicator.marking.tlp
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Traffic Light Protocol sharing markings.
+      example: CLEAR
+      default_field: false
+    - name: enrichments.indicator.marking.tlp_version
       level: extended
       type: keyword
       ignore_above: 1024
@@ -11403,7 +11410,7 @@
         \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       default_field: false
-    - name: threat.indicator.marking.tlp.version
+    - name: threat.indicator.marking.tlp_version
       level: extended
       type: keyword
       ignore_above: 1024

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1110,7 +1110,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0+exp,true,threat,threat.enrichments.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 8.6.0+exp,true,threat,threat.enrichments.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.6.0+exp,true,threat,threat.enrichments.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
-8.6.0+exp,true,threat,threat.enrichments.indicator.marking.tlp.version,keyword,extended,,2.0,Indicator TLP version
+8.6.0+exp,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking
+8.6.0+exp,true,threat,threat.enrichments.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0+exp,true,threat,threat.enrichments.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.6.0+exp,true,threat,threat.enrichments.indicator.port,long,extended,,443,Indicator port
 8.6.0+exp,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
@@ -1373,7 +1374,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0+exp,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
 8.6.0+exp,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.6.0+exp,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
-8.6.0+exp,true,threat,threat.threat.indicator.marking.tlp.version,keyword,extended,,2.0,Indicator TLP version
+8.6.0+exp,true,threat,threat.threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0+exp,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.6.0+exp,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
 8.6.0+exp,true,tls,tls.client.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the client.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1303,6 +1303,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0+exp,true,threat,threat.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.6.0+exp,true,threat,threat.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
 8.6.0+exp,true,threat,threat.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking
+8.6.0+exp,true,threat,threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0+exp,true,threat,threat.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.6.0+exp,true,threat,threat.indicator.port,long,extended,,443,Indicator port
 8.6.0+exp,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
@@ -1374,7 +1375,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0+exp,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
 8.6.0+exp,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.6.0+exp,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
-8.6.0+exp,true,threat,threat.threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0+exp,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.6.0+exp,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
 8.6.0+exp,true,tls,tls.client.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the client.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -16461,6 +16461,17 @@ threat.indicator.marking.tlp:
   normalize: []
   short: Indicator TLP marking
   type: keyword
+threat.indicator.marking.tlp_version:
+  dashed_name: threat-indicator-marking-tlp-version
+  description: Traffic Light Protocol version.
+  example: 2.0
+  flat_name: threat.indicator.marking.tlp_version
+  ignore_above: 1024
+  level: extended
+  name: indicator.marking.tlp_version
+  normalize: []
+  short: Indicator TLP version
+  type: keyword
 threat.indicator.modified_at:
   dashed_name: threat-indicator-modified-at
   description: The date and time when intelligence source last modified information
@@ -17392,17 +17403,6 @@ threat.technique.subtechnique.reference:
   normalize:
   - array
   short: Threat subtechnique URL reference.
-  type: keyword
-threat.threat.indicator.marking.tlp_version:
-  dashed_name: threat-threat-indicator-marking-tlp-version
-  description: Traffic Light Protocol version.
-  example: 2.0
-  flat_name: threat.threat.indicator.marking.tlp_version
-  ignore_above: 1024
-  level: extended
-  name: threat.indicator.marking.tlp_version
-  normalize: []
-  short: Indicator TLP version
   type: keyword
 tls.cipher:
   dashed_name: tls-cipher

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -14042,14 +14042,32 @@ threat.enrichments.indicator.last_seen:
   normalize: []
   short: Date/time indicator was last reported.
   type: date
-threat.enrichments.indicator.marking.tlp.version:
+threat.enrichments.indicator.marking.tlp:
+  dashed_name: threat-enrichments-indicator-marking-tlp
+  description: Traffic Light Protocol sharing markings.
+  example: CLEAR
+  expected_values:
+  - WHITE
+  - CLEAR
+  - GREEN
+  - AMBER
+  - AMBER+STRICT
+  - RED
+  flat_name: threat.enrichments.indicator.marking.tlp
+  ignore_above: 1024
+  level: extended
+  name: enrichments.indicator.marking.tlp
+  normalize: []
+  short: Indicator TLP marking
+  type: keyword
+threat.enrichments.indicator.marking.tlp_version:
   dashed_name: threat-enrichments-indicator-marking-tlp-version
   description: Traffic Light Protocol version.
   example: 2.0
-  flat_name: threat.enrichments.indicator.marking.tlp.version
+  flat_name: threat.enrichments.indicator.marking.tlp_version
   ignore_above: 1024
   level: extended
-  name: enrichments.indicator.marking.tlp.version
+  name: enrichments.indicator.marking.tlp_version
   normalize: []
   short: Indicator TLP version
   type: keyword
@@ -17375,14 +17393,14 @@ threat.technique.subtechnique.reference:
   - array
   short: Threat subtechnique URL reference.
   type: keyword
-threat.threat.indicator.marking.tlp.version:
+threat.threat.indicator.marking.tlp_version:
   dashed_name: threat-threat-indicator-marking-tlp-version
   description: Traffic Light Protocol version.
   example: 2.0
-  flat_name: threat.threat.indicator.marking.tlp.version
+  flat_name: threat.threat.indicator.marking.tlp_version
   ignore_above: 1024
   level: extended
-  name: threat.indicator.marking.tlp.version
+  name: threat.indicator.marking.tlp_version
   normalize: []
   short: Indicator TLP version
   type: keyword

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -16212,14 +16212,32 @@ threat:
       normalize: []
       short: Date/time indicator was last reported.
       type: date
-    threat.enrichments.indicator.marking.tlp.version:
+    threat.enrichments.indicator.marking.tlp:
+      dashed_name: threat-enrichments-indicator-marking-tlp
+      description: Traffic Light Protocol sharing markings.
+      example: CLEAR
+      expected_values:
+      - WHITE
+      - CLEAR
+      - GREEN
+      - AMBER
+      - AMBER+STRICT
+      - RED
+      flat_name: threat.enrichments.indicator.marking.tlp
+      ignore_above: 1024
+      level: extended
+      name: enrichments.indicator.marking.tlp
+      normalize: []
+      short: Indicator TLP marking
+      type: keyword
+    threat.enrichments.indicator.marking.tlp_version:
       dashed_name: threat-enrichments-indicator-marking-tlp-version
       description: Traffic Light Protocol version.
       example: 2.0
-      flat_name: threat.enrichments.indicator.marking.tlp.version
+      flat_name: threat.enrichments.indicator.marking.tlp_version
       ignore_above: 1024
       level: extended
-      name: enrichments.indicator.marking.tlp.version
+      name: enrichments.indicator.marking.tlp_version
       normalize: []
       short: Indicator TLP version
       type: keyword
@@ -19552,14 +19570,14 @@ threat:
       - array
       short: Threat subtechnique URL reference.
       type: keyword
-    threat.threat.indicator.marking.tlp.version:
+    threat.threat.indicator.marking.tlp_version:
       dashed_name: threat-threat-indicator-marking-tlp-version
       description: Traffic Light Protocol version.
       example: 2.0
-      flat_name: threat.threat.indicator.marking.tlp.version
+      flat_name: threat.threat.indicator.marking.tlp_version
       ignore_above: 1024
       level: extended
-      name: threat.indicator.marking.tlp.version
+      name: threat.indicator.marking.tlp_version
       normalize: []
       short: Indicator TLP version
       type: keyword

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -18635,6 +18635,17 @@ threat:
       normalize: []
       short: Indicator TLP marking
       type: keyword
+    threat.indicator.marking.tlp_version:
+      dashed_name: threat-indicator-marking-tlp-version
+      description: Traffic Light Protocol version.
+      example: 2.0
+      flat_name: threat.indicator.marking.tlp_version
+      ignore_above: 1024
+      level: extended
+      name: indicator.marking.tlp_version
+      normalize: []
+      short: Indicator TLP version
+      type: keyword
     threat.indicator.modified_at:
       dashed_name: threat-indicator-modified-at
       description: The date and time when intelligence source last modified information
@@ -19569,17 +19580,6 @@ threat:
       normalize:
       - array
       short: Threat subtechnique URL reference.
-      type: keyword
-    threat.threat.indicator.marking.tlp_version:
-      dashed_name: threat-threat-indicator-marking-tlp-version
-      description: Traffic Light Protocol version.
-      example: 2.0
-      flat_name: threat.threat.indicator.marking.tlp_version
-      ignore_above: 1024
-      level: extended
-      name: threat.indicator.marking.tlp_version
-      normalize: []
-      short: Indicator TLP version
       type: keyword
   group: 2
   name: threat

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -531,12 +531,12 @@
                     "marking": {
                       "properties": {
                         "tlp": {
-                          "properties": {
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },
@@ -1699,13 +1699,9 @@
                   "properties": {
                     "marking": {
                       "properties": {
-                        "tlp": {
-                          "properties": {
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     }

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -1371,6 +1371,10 @@
                     "tlp": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "tlp_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
@@ -1688,22 +1692,6 @@
                     "reference": {
                       "ignore_above": 1024,
                       "type": "keyword"
-                    }
-                  }
-                }
-              }
-            },
-            "threat": {
-              "properties": {
-                "indicator": {
-                  "properties": {
-                    "marking": {
-                      "properties": {
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
                     }
                   }
                 }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -5207,12 +5207,12 @@
                   "marking": {
                     "properties": {
                       "tlp": {
-                        "properties": {
-                          "version": {
-                            "ignore_above": 1024,
-                            "type": "keyword"
-                          }
-                        }
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "tlp_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       }
                     }
                   },
@@ -6375,13 +6375,9 @@
                 "properties": {
                   "marking": {
                     "properties": {
-                      "tlp": {
-                        "properties": {
-                          "version": {
-                            "ignore_above": 1024,
-                            "type": "keyword"
-                          }
-                        }
+                      "tlp_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       }
                     }
                   }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -6047,6 +6047,10 @@
                   "tlp": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "tlp_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               },
@@ -6364,22 +6368,6 @@
                   "reference": {
                     "ignore_above": 1024,
                     "type": "keyword"
-                  }
-                }
-              }
-            }
-          },
-          "threat": {
-            "properties": {
-              "indicator": {
-                "properties": {
-                  "marking": {
-                    "properties": {
-                      "tlp_version": {
-                        "ignore_above": 1024,
-                        "type": "keyword"
-                      }
-                    }
                   }
                 }
               }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -9372,7 +9372,14 @@
         this indicator.
       example: '2020-11-05T17:25:47.000Z'
       default_field: false
-    - name: enrichments.indicator.marking.tlp.version
+    - name: enrichments.indicator.marking.tlp
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Traffic Light Protocol sharing markings.
+      example: CLEAR
+      default_field: false
+    - name: enrichments.indicator.marking.tlp_version
       level: extended
       type: keyword
       ignore_above: 1024
@@ -11353,7 +11360,7 @@
         \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
       default_field: false
-    - name: threat.indicator.marking.tlp.version
+    - name: threat.indicator.marking.tlp_version
       level: extended
       type: keyword
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -10805,6 +10805,13 @@
       description: Traffic Light Protocol sharing markings.
       example: CLEAR
       default_field: false
+    - name: indicator.marking.tlp_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Traffic Light Protocol version.
+      example: 2.0
+      default_field: false
     - name: indicator.modified_at
       level: extended
       type: date
@@ -11359,13 +11366,6 @@
       description: "The reference url of subtechnique used by this threat. You can\
         \ use a MITRE ATT&CK\xAE subtechnique, for example. (ex. https://attack.mitre.org/techniques/T1059/001/)"
       example: https://attack.mitre.org/techniques/T1059/001/
-      default_field: false
-    - name: threat.indicator.marking.tlp_version
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Traffic Light Protocol version.
-      example: 2.0
       default_field: false
   - name: tls
     title: TLS

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1103,7 +1103,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0,true,threat,threat.enrichments.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
 8.6.0,true,threat,threat.enrichments.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.6.0,true,threat,threat.enrichments.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
-8.6.0,true,threat,threat.enrichments.indicator.marking.tlp.version,keyword,extended,,2.0,Indicator TLP version
+8.6.0,true,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking
+8.6.0,true,threat,threat.enrichments.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0,true,threat,threat.enrichments.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.6.0,true,threat,threat.enrichments.indicator.port,long,extended,,443,Indicator port
 8.6.0,true,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
@@ -1366,7 +1367,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
 8.6.0,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.6.0,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
-8.6.0,true,threat,threat.threat.indicator.marking.tlp.version,keyword,extended,,2.0,Indicator TLP version
+8.6.0,true,threat,threat.threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.6.0,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
 8.6.0,true,tls,tls.client.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the client.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1296,6 +1296,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0,true,threat,threat.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.6.0,true,threat,threat.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
 8.6.0,true,threat,threat.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking
+8.6.0,true,threat,threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0,true,threat,threat.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
 8.6.0,true,threat,threat.indicator.port,long,extended,,443,Indicator port
 8.6.0,true,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
@@ -1367,7 +1368,6 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.6.0,true,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
 8.6.0,true,threat,threat.technique.subtechnique.name.text,match_only_text,extended,,PowerShell,Threat subtechnique name.
 8.6.0,true,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
-8.6.0,true,threat,threat.threat.indicator.marking.tlp_version,keyword,extended,,2.0,Indicator TLP version
 8.6.0,true,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
 8.6.0,true,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
 8.6.0,true,tls,tls.client.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the client.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -16392,6 +16392,17 @@ threat.indicator.marking.tlp:
   normalize: []
   short: Indicator TLP marking
   type: keyword
+threat.indicator.marking.tlp_version:
+  dashed_name: threat-indicator-marking-tlp-version
+  description: Traffic Light Protocol version.
+  example: 2.0
+  flat_name: threat.indicator.marking.tlp_version
+  ignore_above: 1024
+  level: extended
+  name: indicator.marking.tlp_version
+  normalize: []
+  short: Indicator TLP version
+  type: keyword
 threat.indicator.modified_at:
   dashed_name: threat-indicator-modified-at
   description: The date and time when intelligence source last modified information
@@ -17323,17 +17334,6 @@ threat.technique.subtechnique.reference:
   normalize:
   - array
   short: Threat subtechnique URL reference.
-  type: keyword
-threat.threat.indicator.marking.tlp_version:
-  dashed_name: threat-threat-indicator-marking-tlp-version
-  description: Traffic Light Protocol version.
-  example: 2.0
-  flat_name: threat.threat.indicator.marking.tlp_version
-  ignore_above: 1024
-  level: extended
-  name: threat.indicator.marking.tlp_version
-  normalize: []
-  short: Indicator TLP version
   type: keyword
 tls.cipher:
   dashed_name: tls-cipher

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -13973,14 +13973,32 @@ threat.enrichments.indicator.last_seen:
   normalize: []
   short: Date/time indicator was last reported.
   type: date
-threat.enrichments.indicator.marking.tlp.version:
+threat.enrichments.indicator.marking.tlp:
+  dashed_name: threat-enrichments-indicator-marking-tlp
+  description: Traffic Light Protocol sharing markings.
+  example: CLEAR
+  expected_values:
+  - WHITE
+  - CLEAR
+  - GREEN
+  - AMBER
+  - AMBER+STRICT
+  - RED
+  flat_name: threat.enrichments.indicator.marking.tlp
+  ignore_above: 1024
+  level: extended
+  name: enrichments.indicator.marking.tlp
+  normalize: []
+  short: Indicator TLP marking
+  type: keyword
+threat.enrichments.indicator.marking.tlp_version:
   dashed_name: threat-enrichments-indicator-marking-tlp-version
   description: Traffic Light Protocol version.
   example: 2.0
-  flat_name: threat.enrichments.indicator.marking.tlp.version
+  flat_name: threat.enrichments.indicator.marking.tlp_version
   ignore_above: 1024
   level: extended
-  name: enrichments.indicator.marking.tlp.version
+  name: enrichments.indicator.marking.tlp_version
   normalize: []
   short: Indicator TLP version
   type: keyword
@@ -17306,14 +17324,14 @@ threat.technique.subtechnique.reference:
   - array
   short: Threat subtechnique URL reference.
   type: keyword
-threat.threat.indicator.marking.tlp.version:
+threat.threat.indicator.marking.tlp_version:
   dashed_name: threat-threat-indicator-marking-tlp-version
   description: Traffic Light Protocol version.
   example: 2.0
-  flat_name: threat.threat.indicator.marking.tlp.version
+  flat_name: threat.threat.indicator.marking.tlp_version
   ignore_above: 1024
   level: extended
-  name: threat.indicator.marking.tlp.version
+  name: threat.indicator.marking.tlp_version
   normalize: []
   short: Indicator TLP version
   type: keyword

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -18555,6 +18555,17 @@ threat:
       normalize: []
       short: Indicator TLP marking
       type: keyword
+    threat.indicator.marking.tlp_version:
+      dashed_name: threat-indicator-marking-tlp-version
+      description: Traffic Light Protocol version.
+      example: 2.0
+      flat_name: threat.indicator.marking.tlp_version
+      ignore_above: 1024
+      level: extended
+      name: indicator.marking.tlp_version
+      normalize: []
+      short: Indicator TLP version
+      type: keyword
     threat.indicator.modified_at:
       dashed_name: threat-indicator-modified-at
       description: The date and time when intelligence source last modified information
@@ -19489,17 +19500,6 @@ threat:
       normalize:
       - array
       short: Threat subtechnique URL reference.
-      type: keyword
-    threat.threat.indicator.marking.tlp_version:
-      dashed_name: threat-threat-indicator-marking-tlp-version
-      description: Traffic Light Protocol version.
-      example: 2.0
-      flat_name: threat.threat.indicator.marking.tlp_version
-      ignore_above: 1024
-      level: extended
-      name: threat.indicator.marking.tlp_version
-      normalize: []
-      short: Indicator TLP version
       type: keyword
   group: 2
   name: threat

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -16132,14 +16132,32 @@ threat:
       normalize: []
       short: Date/time indicator was last reported.
       type: date
-    threat.enrichments.indicator.marking.tlp.version:
+    threat.enrichments.indicator.marking.tlp:
+      dashed_name: threat-enrichments-indicator-marking-tlp
+      description: Traffic Light Protocol sharing markings.
+      example: CLEAR
+      expected_values:
+      - WHITE
+      - CLEAR
+      - GREEN
+      - AMBER
+      - AMBER+STRICT
+      - RED
+      flat_name: threat.enrichments.indicator.marking.tlp
+      ignore_above: 1024
+      level: extended
+      name: enrichments.indicator.marking.tlp
+      normalize: []
+      short: Indicator TLP marking
+      type: keyword
+    threat.enrichments.indicator.marking.tlp_version:
       dashed_name: threat-enrichments-indicator-marking-tlp-version
       description: Traffic Light Protocol version.
       example: 2.0
-      flat_name: threat.enrichments.indicator.marking.tlp.version
+      flat_name: threat.enrichments.indicator.marking.tlp_version
       ignore_above: 1024
       level: extended
-      name: enrichments.indicator.marking.tlp.version
+      name: enrichments.indicator.marking.tlp_version
       normalize: []
       short: Indicator TLP version
       type: keyword
@@ -19472,14 +19490,14 @@ threat:
       - array
       short: Threat subtechnique URL reference.
       type: keyword
-    threat.threat.indicator.marking.tlp.version:
+    threat.threat.indicator.marking.tlp_version:
       dashed_name: threat-threat-indicator-marking-tlp-version
       description: Traffic Light Protocol version.
       example: 2.0
-      flat_name: threat.threat.indicator.marking.tlp.version
+      flat_name: threat.threat.indicator.marking.tlp_version
       ignore_above: 1024
       level: extended
-      name: threat.indicator.marking.tlp.version
+      name: threat.indicator.marking.tlp_version
       normalize: []
       short: Indicator TLP version
       type: keyword

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -531,12 +531,12 @@
                     "marking": {
                       "properties": {
                         "tlp": {
-                          "properties": {
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     },
@@ -1699,13 +1699,9 @@
                   "properties": {
                     "marking": {
                       "properties": {
-                        "tlp": {
-                          "properties": {
-                            "version": {
-                              "ignore_above": 1024,
-                              "type": "keyword"
-                            }
-                          }
+                        "tlp_version": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
                         }
                       }
                     }

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -1371,6 +1371,10 @@
                     "tlp": {
                       "ignore_above": 1024,
                       "type": "keyword"
+                    },
+                    "tlp_version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
                     }
                   }
                 },
@@ -1688,22 +1692,6 @@
                     "reference": {
                       "ignore_above": 1024,
                       "type": "keyword"
-                    }
-                  }
-                }
-              }
-            },
-            "threat": {
-              "properties": {
-                "indicator": {
-                  "properties": {
-                    "marking": {
-                      "properties": {
-                        "tlp_version": {
-                          "ignore_above": 1024,
-                          "type": "keyword"
-                        }
-                      }
                     }
                   }
                 }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -5165,12 +5165,12 @@
                   "marking": {
                     "properties": {
                       "tlp": {
-                        "properties": {
-                          "version": {
-                            "ignore_above": 1024,
-                            "type": "keyword"
-                          }
-                        }
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "tlp_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       }
                     }
                   },
@@ -6333,13 +6333,9 @@
                 "properties": {
                   "marking": {
                     "properties": {
-                      "tlp": {
-                        "properties": {
-                          "version": {
-                            "ignore_above": 1024,
-                            "type": "keyword"
-                          }
-                        }
+                      "tlp_version": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       }
                     }
                   }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -6005,6 +6005,10 @@
                   "tlp": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "tlp_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 }
               },
@@ -6322,22 +6326,6 @@
                   "reference": {
                     "ignore_above": 1024,
                     "type": "keyword"
-                  }
-                }
-              }
-            }
-          },
-          "threat": {
-            "properties": {
-              "indicator": {
-                "properties": {
-                  "marking": {
-                    "properties": {
-                      "tlp_version": {
-                        "ignore_above": 1024,
-                        "type": "keyword"
-                      }
-                    }
                   }
                 }
               }

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -175,7 +175,7 @@
         - RED
       example: CLEAR
 
-    - name: enrichments.indicator.marking.tlp.version
+    - name: enrichments.indicator.marking.tlp_version
       level: extended
       type: keyword
       short: Indicator TLP version
@@ -468,7 +468,7 @@
         - RED
       example: CLEAR
 
-    - name: threat.indicator.marking.tlp.version
+    - name: threat.indicator.marking.tlp_version
       level: extended
       type: keyword
       short: Indicator TLP version

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -468,7 +468,7 @@
         - RED
       example: CLEAR
 
-    - name: threat.indicator.marking.tlp_version
+    - name: indicator.marking.tlp_version
       level: extended
       type: keyword
       short: Indicator TLP version


### PR DESCRIPTION
In https://github.com/elastic/ecs/pull/2074 , with the addition of `indicator.marking.tlp.version` we inadvertently removed `indicator.marking.tlp` since a field cannot be both it's own leaf field and a parent of another object.

In this PR, we move from `tlp.version` to `.tlp_version`

Relates [to](https://github.com/elastic/ecs/issues/2073) 