### PR TITLE
Permit `event.type: access` for `event.category: file` events

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 
+* Add `access` as an allowed type for `event.type: file`. #2174
+
 #### Improvements
 
 #### Deprecated

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -240,7 +240,7 @@ Relating to a set of information that has been created on, or has existed on a f
 
 *Expected event types for category file:*
 
-change, creation, deletion, info
+access, change, creation, deletion, info
 
 
 [float]

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3022,6 +3022,7 @@ event.category:
       from both host-based and network-based sources. An example source of a network-based
       detection of a file transfer would be the Zeek file.log.
     expected_event_types:
+    - access
     - change
     - creation
     - deletion

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4014,6 +4014,7 @@ event:
           can come from both host-based and network-based sources. An example source
           of a network-based detection of a file transfer would be the Zeek file.log.
         expected_event_types:
+        - access
         - change
         - creation
         - deletion

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -2953,6 +2953,7 @@ event.category:
       from both host-based and network-based sources. An example source of a network-based
       detection of a file transfer would be the Zeek file.log.
     expected_event_types:
+    - access
     - change
     - creation
     - deletion

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -3934,6 +3934,7 @@ event:
           can come from both host-based and network-based sources. An example source
           of a network-based detection of a file transfer would be the Zeek file.log.
         expected_event_types:
+        - access
         - change
         - creation
         - deletion

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -239,6 +239,7 @@
             from both host-based and network-based sources. An example source of a network-based
             detection of a file transfer would be the Zeek file.log.
           expected_event_types:
+            - access
             - change
             - creation
             - deletion


### PR DESCRIPTION
Currently, events categorized as `event.category: file` do not list `access` as an expected event type.

I believe this is likely an oversight when the ECS categorization fields were originally defined. This PR proposes adding `access` as one of the allowed types for `file`.
