### PR TITLE
Trigger elastic/ecs-typescript workflow after ecs-release is published

### DIFF
--- a/.github/workflows/build_ecs_typescript.yml
+++ b/.github/workflows/build_ecs_typescript.yml
@@ -14,7 +14,7 @@ jobs:
           curl -L \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.ACTIONS_KEY }}" \
+          -H "Authorization: Bearer ${{ secrets.ECS_TYPESCRIPT_REPO_TRIGGER_KEY }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/elastic/ecs-typescript/actions/workflows/generate.yml/dispatches \
           -d '{"ref":"main","inputs":{"ecsRef":"${{ env.RELEASE_VERSION }}"}}'

--- a/.github/workflows/build_ecs_typescript.yml
+++ b/.github/workflows/build_ecs_typescript.yml
@@ -1,0 +1,20 @@
+name: Build ecs-typescript and create updated definitions PR
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Trigger workflow on ecs-typescript
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.ACTIONS_KEY }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/elastic/ecs-typescript/actions/workflows/generate.yml/dispatches \
+          -d '{"ref":"main","inputs":{"ecsRef":"${{ env.RELEASE_VERSION }}"}}'


### PR DESCRIPTION
This PR will add another workflow here, triggered after ECS release is published.

It starts another workflow, here: https://github.com/elastic/ecs-typescript/blob/main/.github/workflows/generate.yml

The goal is to have automated PRs whenever there is a new ECS release, which - after manual review - will be merged.
