### PR TITLE
[8.7 forward port] Move 8.7.0 entries from CHANGELOG.next.md to CHANGELOG.md (#2184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 # CHANGELOG
 All notable changes to this project will be documented in this file based on the [Keep a Changelog](http://keepachangelog.com/) Standard. This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [8.7.0](https://github.com/elastic/ecs/compare/v8.6.1...v8.7.0)
+
+### Schema Changes
+
+#### Bugfixes
+
+* remove duplicated `client.domain` definition #2120
+
+#### Added
+
+* adding `name` field to `threat.indicator` #2121
+* adding `api` option to `event.category` #2147
+* adding `library` option to `event.category` #2154
+
+#### Improvements
+
+* description for `host.name` definition updated to encourage use of FDQN #2122
+
+### Tooling and Artifact Changes
+
+#### Improvements
+
+* Updated usage docs to include `threat.indicator.url.domain` and changed `indicator.marking.tlp` and `indicator.enrichments.marking.tlp` from "WHITE" to "CLEAR" to align with TLP 2.0. #2124
+* Bump `gitpython` from `3.1.27` to `3.1.30` in `/scripts`. #2139
+
 ## [8.6.1](https://github.com/elastic/ecs/compare/v8.6.0...v8.6.1)
 
 ### Schema Changes

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -38,31 +38,6 @@ Thanks, you're awesome :-) -->
 
 #### Deprecated
 
-## 8.7.0 (Hard Feature Freeze)
-
-### Schema Changes
-
-#### Bugfixes
-
-* remove duplicated `client.domain` definition #2120
-
-#### Added
-
-* adding `name` field to `threat.indicator` #2121
-* adding `api` option to `event.category` #2147
-* adding `library` option to `event.category` #2154
-
-#### Improvements
-
-* description for `host.name` definition updated to encourage use of FDQN #2122
-
-### Tooling and Artifact Changes
-
-#### Improvements
-
-* Updated usage docs to include `threat.indicator.url.domain` and changed `indicator.marking.tlp` and `indicator.enrichments.marking.tlp` from "WHITE" to "CLEAR" to align with TLP 2.0. #2124
-* Bump `gitpython` from `3.1.27` to `3.1.30` in `/scripts`. #2139
-
 <!-- All empty sections:
 
 ## Unreleased


### PR DESCRIPTION
Forward port for https://github.com/elastic/ecs/pull/2184