### PR TITLE
Adding field vendor.name to Package ECS mapping

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,6 +15,7 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 #### Added
+* Add `vendor.name` as a field for package ECS fields
 
 #### Improvements
 

--- a/schemas/package.yml
+++ b/schemas/package.yml
@@ -21,9 +21,15 @@
   short: These fields contain information about an installed software package.
   description: >
     These fields contain information about an installed software package. It contains general information about a
-    package, such as name, version or size. It also contains installation details, such as time or location.
+    package, such as vendor, name, version or size. It also contains installation details, such as time or location.
   type: group
   fields:
+
+    - name: vendor
+      level: extended
+      type: keyword
+      description: Vendor name
+      example: Google
 
     - name: name
       level: extended


### PR DESCRIPTION
Pull request to add vendor name as an ECS field for the package ECS mappings to accompany the already existing fields such as package version and package name
