### PR TITLE
Adding package.vendor to ECS package mapping

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -15,7 +15,7 @@ Thanks, you're awesome :-) -->
 #### Bugfixes
 
 #### Added
-
+* Added `package.vendor` since we already had package version and package name. 
 #### Improvements
 
 #### Deprecated

--- a/schemas/package.yml
+++ b/schemas/package.yml
@@ -25,6 +25,12 @@
   type: group
   fields:
 
+    - name: vendor
+      level: extended
+      type: keyword
+      description: Vendor name
+      example: Google
+
     - name: name
       level: extended
       type: keyword


### PR DESCRIPTION
Adding an ECS mapping for package that maps to package.vendor to accompany other fields such as package.name and package.version