### PR TITLE
[main] adding release notes for ecs 8.8 (#2209)

### DIFF
--- a/docs/release-notes/8.8.asciidoc
+++ b/docs/release-notes/8.8.asciidoc
@@ -1,0 +1,25 @@
+[[ecs-release-notes-8.8.0]]
+=== 8.8.0
+
+[[schema-changes-8.8.0]]
+[float]
+==== Schema changes
+
+[[schema-added-8.8.0]]
+[float]
+===== Added
+
+* Add `access` as an allowed type for `event.type: file`. {ecs_pull}2174[#2174]
+* Add `orchestrator.resource.annotation` and `orchestrator.resource.label`. {ecs_pull}2181[#2181]
+* Add `event.kind: asset` as a beta category. {ecs_pull}2191[#2191]
+
+
+[[tooling-changes-8.8.0]]
+[float]
+==== Tooling and artifact changes
+
+[[tooling-added-8.8.0]]
+[float]
+===== Added
+
+* Add `parameters` property for field definitions, to provide any mapping parameter. {ecs_pull}2084[#2084]

--- a/docs/release-notes/index.asciidoc
+++ b/docs/release-notes/index.asciidoc
@@ -3,6 +3,7 @@
 
 This section summarizes the changes in each release.
 
+* <<ecs-release-notes-8.8.0, {ecs} version 8.8.0>>
 * <<ecs-release-notes-8.7.0, {ecs} version 8.7.0>>
 * <<ecs-release-notes-8.6.1, {ecs} version 8.6.1>>
 * <<ecs-release-notes-8.6.0, {ecs} version 8.6.0>>
@@ -23,6 +24,7 @@ This section summarizes the changes in each release.
 :issue: https://github.com/elastic/ecs/issues/
 :pull: https://github.com/elastic/ecs/pull/
 
+include::8.8.asciidoc[]
 include::8.7.asciidoc[]
 include::8.6.1.asciidoc[]
 include::8.6.asciidoc[]


### PR DESCRIPTION
forward port of https://github.com/elastic/ecs/pull/2209