### PR TITLE
[Event] Clean up Event fields

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -3437,13 +3437,13 @@ example: `4648`
 [[field-event-created]]
 <<field-event-created, event.created>>
 
-a| event.created contains the date/time when the event was first read by an agent, or by your pipeline.
+a| `event.created` contains the date/time when the event was first read by an agent, or by your pipeline.
 
-This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event.
+This field is distinct from `@timestamp` in that `@timestamp` typically contain the time extracted from the original event.
 
 In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source.
 
-In case the two timestamps are identical, @timestamp should be used.
+In case the two timestamps are identical, `@timestamp` should be used.
 
 type: date
 
@@ -3481,7 +3481,7 @@ example: `apache.access`
 
 a| Duration of the event in nanoseconds.
 
-If event.start and event.end are known this value should be the difference between the end and start time.
+If `event.start` and `event.end` are known this value should be the difference between the end and start time.
 
 type: long
 
@@ -3497,7 +3497,7 @@ type: long
 [[field-event-end]]
 <<field-event-end, event.end>>
 
-a| event.end contains the date when the event ended or when the activity was last observed.
+a| `event.end` contains the date when the event ended or when the activity was last observed.
 
 type: date
 
@@ -3569,7 +3569,7 @@ a| This is one of four ECS Categorization Fields, and indicates the highest leve
 
 `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.
 
-The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.
+The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data is coming in at a regular interval or not.
 
 type: keyword
 
@@ -3785,7 +3785,7 @@ example: `7`
 [[field-event-start]]
 <<field-event-start, event.start>>
 
-a| event.start contains the date when the event started or when the activity was first observed.
+a| `event.start` contains the date when the event started or when the activity was first observed.
 
 type: date
 

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -35,7 +35,7 @@ This is one of four ECS Categorization Fields, and indicates the highest level i
 
 `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.
 
-The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.
+The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data is coming in at a regular interval or not.
 
 *Allowed Values*
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2424,10 +2424,10 @@
     - name: created
       level: core
       type: date
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -2435,7 +2435,7 @@
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
     - name: dataset
       level: core
@@ -2459,13 +2459,13 @@
       output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
     - name: end
       level: extended
       type: date
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
     - name: hash
       level: extended
       type: keyword
@@ -2505,7 +2505,7 @@
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
     - name: module
@@ -2628,8 +2628,8 @@
     - name: start
       level: extended
       type: date
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
     - name: timezone
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -246,7 +246,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev+exp,true,event,event.created,date,core,,2016-05-23T08:05:34.857Z,Time when the event was first read by an agent or by your pipeline.
 8.10.0-dev+exp,true,event,event.dataset,keyword,core,,apache.access,Name of the dataset.
 8.10.0-dev+exp,true,event,event.duration,long,core,,,Duration of the event in nanoseconds.
-8.10.0-dev+exp,true,event,event.end,date,extended,,,event.end contains the date when the event ended or when the activity was last observed.
+8.10.0-dev+exp,true,event,event.end,date,extended,,,`event.end` contains the date when the event ended or when the activity was last observed.
 8.10.0-dev+exp,true,event,event.hash,keyword,extended,,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
 8.10.0-dev+exp,true,event,event.id,keyword,core,,8a4f500d,Unique ID to describe the event.
 8.10.0-dev+exp,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
@@ -261,7 +261,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev+exp,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 8.10.0-dev+exp,true,event,event.sequence,long,extended,,,Sequence number of the event.
 8.10.0-dev+exp,true,event,event.severity,long,core,,7,Numeric severity of the event.
-8.10.0-dev+exp,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
+8.10.0-dev+exp,true,event,event.start,date,extended,,,`event.start` contains the date when the event started or when the activity was first observed.
 8.10.0-dev+exp,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.10.0-dev+exp,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.10.0-dev+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3199,18 +3199,18 @@ event.code:
   type: keyword
 event.created:
   dashed_name: event-created
-  description: 'event.created contains the date/time when the event was first read
+  description: '`event.created` contains the date/time when the event was first read
     by an agent, or by your pipeline.
 
-    This field is distinct from @timestamp in that @timestamp typically contain the
-    time extracted from the original event.
+    This field is distinct from `@timestamp` in that `@timestamp` typically contain
+    the time extracted from the original event.
 
     In most situations, these two timestamps will be slightly different. The difference
     can be used to calculate the delay between your source generating an event, and
     the time when your agent first processed it. This can be used to monitor your
     agent''s or pipeline''s ability to keep up with your event source.
 
-    In case the two timestamps are identical, @timestamp should be used.'
+    In case the two timestamps are identical, `@timestamp` should be used.'
   example: '2016-05-23T08:05:34.857Z'
   flat_name: event.created
   level: core
@@ -3239,8 +3239,8 @@ event.duration:
   dashed_name: event-duration
   description: 'Duration of the event in nanoseconds.
 
-    If event.start and event.end are known this value should be the difference between
-    the end and start time.'
+    If `event.start` and `event.end` are known this value should be the difference
+    between the end and start time.'
   flat_name: event.duration
   format: duration
   input_format: nanoseconds
@@ -3253,14 +3253,14 @@ event.duration:
   type: long
 event.end:
   dashed_name: event-end
-  description: event.end contains the date when the event ended or when the activity
-    was last observed.
+  description: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   flat_name: event.end
   level: extended
   name: end
   normalize: []
-  short: event.end contains the date when the event ended or when the activity was
-    last observed.
+  short: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   type: date
 event.hash:
   dashed_name: event-hash
@@ -3389,7 +3389,8 @@ event.kind:
 
     The value of this field can be used to inform how these kinds of events should
     be handled. They may warrant different retention, different access control, it
-    may also help understand whether the data coming in at a regular interval or not.'
+    may also help understand whether the data is coming in at a regular interval or
+    not.'
   example: alert
   flat_name: event.kind
   ignore_above: 1024
@@ -3580,14 +3581,14 @@ event.severity:
   type: long
 event.start:
   dashed_name: event-start
-  description: event.start contains the date when the event started or when the activity
-    was first observed.
+  description: '`event.start` contains the date when the event started or when the
+    activity was first observed.'
   flat_name: event.start
   level: extended
   name: start
   normalize: []
-  short: event.start contains the date when the event started or when the activity
-    was first observed.
+  short: '`event.start` contains the date when the event started or when the activity
+    was first observed.'
   type: date
 event.timezone:
   dashed_name: event-timezone

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4194,10 +4194,10 @@ event:
       type: keyword
     event.created:
       dashed_name: event-created
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -4205,7 +4205,7 @@ event:
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
       flat_name: event.created
       level: core
@@ -4235,7 +4235,7 @@ event:
       dashed_name: event-duration
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
       format: duration
@@ -4249,14 +4249,14 @@ event:
       type: long
     event.end:
       dashed_name: event-end
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
       flat_name: event.end
       level: extended
       name: end
       normalize: []
-      short: event.end contains the date when the event ended or when the activity
-        was last observed.
+      short: '`event.end` contains the date when the event ended or when the activity
+        was last observed.'
       type: date
     event.hash:
       dashed_name: event-hash
@@ -4386,7 +4386,7 @@ event:
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
       flat_name: event.kind
@@ -4582,14 +4582,14 @@ event:
       type: long
     event.start:
       dashed_name: event-start
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
       flat_name: event.start
       level: extended
       name: start
       normalize: []
-      short: event.start contains the date when the event started or when the activity
-        was first observed.
+      short: '`event.start` contains the date when the event started or when the activity
+        was first observed.'
       type: date
     event.timezone:
       dashed_name: event-timezone

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2374,10 +2374,10 @@
     - name: created
       level: core
       type: date
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -2385,7 +2385,7 @@
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
     - name: dataset
       level: core
@@ -2409,13 +2409,13 @@
       output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
     - name: end
       level: extended
       type: date
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
     - name: hash
       level: extended
       type: keyword
@@ -2455,7 +2455,7 @@
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
     - name: module
@@ -2578,8 +2578,8 @@
     - name: start
       level: extended
       type: date
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
     - name: timezone
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -239,7 +239,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev,true,event,event.created,date,core,,2016-05-23T08:05:34.857Z,Time when the event was first read by an agent or by your pipeline.
 8.10.0-dev,true,event,event.dataset,keyword,core,,apache.access,Name of the dataset.
 8.10.0-dev,true,event,event.duration,long,core,,,Duration of the event in nanoseconds.
-8.10.0-dev,true,event,event.end,date,extended,,,event.end contains the date when the event ended or when the activity was last observed.
+8.10.0-dev,true,event,event.end,date,extended,,,`event.end` contains the date when the event ended or when the activity was last observed.
 8.10.0-dev,true,event,event.hash,keyword,extended,,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
 8.10.0-dev,true,event,event.id,keyword,core,,8a4f500d,Unique ID to describe the event.
 8.10.0-dev,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
@@ -254,7 +254,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 8.10.0-dev,true,event,event.sequence,long,extended,,,Sequence number of the event.
 8.10.0-dev,true,event,event.severity,long,core,,7,Numeric severity of the event.
-8.10.0-dev,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
+8.10.0-dev,true,event,event.start,date,extended,,,`event.start` contains the date when the event started or when the activity was first observed.
 8.10.0-dev,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.10.0-dev,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.10.0-dev,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3130,18 +3130,18 @@ event.code:
   type: keyword
 event.created:
   dashed_name: event-created
-  description: 'event.created contains the date/time when the event was first read
+  description: '`event.created` contains the date/time when the event was first read
     by an agent, or by your pipeline.
 
-    This field is distinct from @timestamp in that @timestamp typically contain the
-    time extracted from the original event.
+    This field is distinct from `@timestamp` in that `@timestamp` typically contain
+    the time extracted from the original event.
 
     In most situations, these two timestamps will be slightly different. The difference
     can be used to calculate the delay between your source generating an event, and
     the time when your agent first processed it. This can be used to monitor your
     agent''s or pipeline''s ability to keep up with your event source.
 
-    In case the two timestamps are identical, @timestamp should be used.'
+    In case the two timestamps are identical, `@timestamp` should be used.'
   example: '2016-05-23T08:05:34.857Z'
   flat_name: event.created
   level: core
@@ -3170,8 +3170,8 @@ event.duration:
   dashed_name: event-duration
   description: 'Duration of the event in nanoseconds.
 
-    If event.start and event.end are known this value should be the difference between
-    the end and start time.'
+    If `event.start` and `event.end` are known this value should be the difference
+    between the end and start time.'
   flat_name: event.duration
   format: duration
   input_format: nanoseconds
@@ -3184,14 +3184,14 @@ event.duration:
   type: long
 event.end:
   dashed_name: event-end
-  description: event.end contains the date when the event ended or when the activity
-    was last observed.
+  description: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   flat_name: event.end
   level: extended
   name: end
   normalize: []
-  short: event.end contains the date when the event ended or when the activity was
-    last observed.
+  short: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   type: date
 event.hash:
   dashed_name: event-hash
@@ -3320,7 +3320,8 @@ event.kind:
 
     The value of this field can be used to inform how these kinds of events should
     be handled. They may warrant different retention, different access control, it
-    may also help understand whether the data coming in at a regular interval or not.'
+    may also help understand whether the data is coming in at a regular interval or
+    not.'
   example: alert
   flat_name: event.kind
   ignore_above: 1024
@@ -3511,14 +3512,14 @@ event.severity:
   type: long
 event.start:
   dashed_name: event-start
-  description: event.start contains the date when the event started or when the activity
-    was first observed.
+  description: '`event.start` contains the date when the event started or when the
+    activity was first observed.'
   flat_name: event.start
   level: extended
   name: start
   normalize: []
-  short: event.start contains the date when the event started or when the activity
-    was first observed.
+  short: '`event.start` contains the date when the event started or when the activity
+    was first observed.'
   type: date
 event.timezone:
   dashed_name: event-timezone

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4114,10 +4114,10 @@ event:
       type: keyword
     event.created:
       dashed_name: event-created
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -4125,7 +4125,7 @@ event:
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
       flat_name: event.created
       level: core
@@ -4155,7 +4155,7 @@ event:
       dashed_name: event-duration
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
       format: duration
@@ -4169,14 +4169,14 @@ event:
       type: long
     event.end:
       dashed_name: event-end
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
       flat_name: event.end
       level: extended
       name: end
       normalize: []
-      short: event.end contains the date when the event ended or when the activity
-        was last observed.
+      short: '`event.end` contains the date when the event ended or when the activity
+        was last observed.'
       type: date
     event.hash:
       dashed_name: event-hash
@@ -4306,7 +4306,7 @@ event:
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
       flat_name: event.kind
@@ -4502,14 +4502,14 @@ event:
       type: long
     event.start:
       dashed_name: event-start
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
       flat_name: event.start
       level: extended
       name: start
       normalize: []
-      short: event.start contains the date when the event started or when the activity
-        was first observed.
+      short: '`event.start` contains the date when the event started or when the activity
+        was first observed.'
       type: date
     event.timezone:
       dashed_name: event-timezone

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -70,7 +70,7 @@
 
         The value of this field can be used to inform how these kinds of events should be handled.
         They may warrant different retention, different access control, it may also
-        help understand whether the data coming in at a regular interval or not.
+        help understand whether the data is coming in at a regular interval or not.
       example: alert
       allowed_values:
         - name: alert
@@ -712,7 +712,7 @@
       description: >
         Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the
+        If `event.start` and `event.end` are known this value should be the
         difference between the end and start time.
 
     - name: sequence
@@ -744,10 +744,10 @@
       short: Time when the event was first read by an agent or by your pipeline.
       example: '2016-05-23T08:05:34.857Z'
       description: >
-        event.created contains the date/time when the event was first read by an
+        `event.created` contains the date/time when the event was first read by an
         agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different.
@@ -756,20 +756,20 @@
         This can be used to monitor your agent's or pipeline's ability to
         keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.
+        In case the two timestamps are identical, `@timestamp` should be used.
 
     - name: start
       level: extended
       type: date
       description: >
-        event.start contains the date when the event started or when the
+        `event.start` contains the date when the event started or when the
         activity was first observed.
 
     - name: end
       level: extended
       type: date
       description: >
-        event.end contains the date when the event ended or when the activity
+        `event.end` contains the date when the event ended or when the activity
         was last observed.
 
     - name: risk_score


### PR DESCRIPTION
New PR to properly generate docs by better following the contributing guide.

Added "is" to clear up a sentence and made more fields stick out using the ` characters which makes it more consistent with the rest of the documentation.

Cancels #2220 