### PR TITLE
[8.8] Clean up Event fields (#2226)

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -3421,13 +3421,13 @@ example: `4648`
 [[field-event-created]]
 <<field-event-created, event.created>>
 
-a| event.created contains the date/time when the event was first read by an agent, or by your pipeline.
+a| `event.created` contains the date/time when the event was first read by an agent, or by your pipeline.
 
-This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event.
+This field is distinct from `@timestamp` in that `@timestamp` typically contain the time extracted from the original event.
 
 In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source.
 
-In case the two timestamps are identical, @timestamp should be used.
+In case the two timestamps are identical, `@timestamp` should be used.
 
 type: date
 
@@ -3465,7 +3465,7 @@ example: `apache.access`
 
 a| Duration of the event in nanoseconds.
 
-If event.start and event.end are known this value should be the difference between the end and start time.
+If `event.start` and `event.end` are known this value should be the difference between the end and start time.
 
 type: long
 
@@ -3481,7 +3481,7 @@ type: long
 [[field-event-end]]
 <<field-event-end, event.end>>
 
-a| event.end contains the date when the event ended or when the activity was last observed.
+a| `event.end` contains the date when the event ended or when the activity was last observed.
 
 type: date
 
@@ -3553,7 +3553,7 @@ a| This is one of four ECS Categorization Fields, and indicates the highest leve
 
 `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.
 
-The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.
+The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data is coming in at a regular interval or not.
 
 type: keyword
 
@@ -3769,7 +3769,7 @@ example: `7`
 [[field-event-start]]
 <<field-event-start, event.start>>
 
-a| event.start contains the date when the event started or when the activity was first observed.
+a| `event.start` contains the date when the event started or when the activity was first observed.
 
 type: date
 

--- a/docs/fields/field-values.asciidoc
+++ b/docs/fields/field-values.asciidoc
@@ -35,7 +35,7 @@ This is one of four ECS Categorization Fields, and indicates the highest level i
 
 `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events.
 
-The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not.
+The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data is coming in at a regular interval or not.
 
 *Allowed Values*
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -2419,10 +2419,10 @@
     - name: created
       level: core
       type: date
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -2430,7 +2430,7 @@
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
     - name: dataset
       level: core
@@ -2454,13 +2454,13 @@
       output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
     - name: end
       level: extended
       type: date
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
     - name: hash
       level: extended
       type: keyword
@@ -2500,7 +2500,7 @@
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
     - name: module
@@ -2623,8 +2623,8 @@
     - name: start
       level: extended
       type: date
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
     - name: timezone
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -245,7 +245,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.8.0+exp,true,event,event.created,date,core,,2016-05-23T08:05:34.857Z,Time when the event was first read by an agent or by your pipeline.
 8.8.0+exp,true,event,event.dataset,keyword,core,,apache.access,Name of the dataset.
 8.8.0+exp,true,event,event.duration,long,core,,,Duration of the event in nanoseconds.
-8.8.0+exp,true,event,event.end,date,extended,,,event.end contains the date when the event ended or when the activity was last observed.
+8.8.0+exp,true,event,event.end,date,extended,,,`event.end` contains the date when the event ended or when the activity was last observed.
 8.8.0+exp,true,event,event.hash,keyword,extended,,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
 8.8.0+exp,true,event,event.id,keyword,core,,8a4f500d,Unique ID to describe the event.
 8.8.0+exp,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
@@ -260,7 +260,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.8.0+exp,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 8.8.0+exp,true,event,event.sequence,long,extended,,,Sequence number of the event.
 8.8.0+exp,true,event,event.severity,long,core,,7,Numeric severity of the event.
-8.8.0+exp,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
+8.8.0+exp,true,event,event.start,date,extended,,,`event.start` contains the date when the event started or when the activity was first observed.
 8.8.0+exp,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.8.0+exp,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.8.0+exp,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -3190,18 +3190,18 @@ event.code:
   type: keyword
 event.created:
   dashed_name: event-created
-  description: 'event.created contains the date/time when the event was first read
+  description: '`event.created` contains the date/time when the event was first read
     by an agent, or by your pipeline.
 
-    This field is distinct from @timestamp in that @timestamp typically contain the
-    time extracted from the original event.
+    This field is distinct from `@timestamp` in that `@timestamp` typically contain
+    the time extracted from the original event.
 
     In most situations, these two timestamps will be slightly different. The difference
     can be used to calculate the delay between your source generating an event, and
     the time when your agent first processed it. This can be used to monitor your
     agent''s or pipeline''s ability to keep up with your event source.
 
-    In case the two timestamps are identical, @timestamp should be used.'
+    In case the two timestamps are identical, `@timestamp` should be used.'
   example: '2016-05-23T08:05:34.857Z'
   flat_name: event.created
   level: core
@@ -3230,8 +3230,8 @@ event.duration:
   dashed_name: event-duration
   description: 'Duration of the event in nanoseconds.
 
-    If event.start and event.end are known this value should be the difference between
-    the end and start time.'
+    If `event.start` and `event.end` are known this value should be the difference
+    between the end and start time.'
   flat_name: event.duration
   format: duration
   input_format: nanoseconds
@@ -3244,14 +3244,14 @@ event.duration:
   type: long
 event.end:
   dashed_name: event-end
-  description: event.end contains the date when the event ended or when the activity
-    was last observed.
+  description: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   flat_name: event.end
   level: extended
   name: end
   normalize: []
-  short: event.end contains the date when the event ended or when the activity was
-    last observed.
+  short: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   type: date
 event.hash:
   dashed_name: event-hash
@@ -3380,7 +3380,8 @@ event.kind:
 
     The value of this field can be used to inform how these kinds of events should
     be handled. They may warrant different retention, different access control, it
-    may also help understand whether the data coming in at a regular interval or not.'
+    may also help understand whether the data is coming in at a regular interval or
+    not.'
   example: alert
   flat_name: event.kind
   ignore_above: 1024
@@ -3571,14 +3572,14 @@ event.severity:
   type: long
 event.start:
   dashed_name: event-start
-  description: event.start contains the date when the event started or when the activity
-    was first observed.
+  description: '`event.start` contains the date when the event started or when the
+    activity was first observed.'
   flat_name: event.start
   level: extended
   name: start
   normalize: []
-  short: event.start contains the date when the event started or when the activity
-    was first observed.
+  short: '`event.start` contains the date when the event started or when the activity
+    was first observed.'
   type: date
 event.timezone:
   dashed_name: event-timezone

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -4185,10 +4185,10 @@ event:
       type: keyword
     event.created:
       dashed_name: event-created
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -4196,7 +4196,7 @@ event:
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
       flat_name: event.created
       level: core
@@ -4226,7 +4226,7 @@ event:
       dashed_name: event-duration
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
       format: duration
@@ -4240,14 +4240,14 @@ event:
       type: long
     event.end:
       dashed_name: event-end
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
       flat_name: event.end
       level: extended
       name: end
       normalize: []
-      short: event.end contains the date when the event ended or when the activity
-        was last observed.
+      short: '`event.end` contains the date when the event ended or when the activity
+        was last observed.'
       type: date
     event.hash:
       dashed_name: event-hash
@@ -4377,7 +4377,7 @@ event:
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
       flat_name: event.kind
@@ -4573,14 +4573,14 @@ event:
       type: long
     event.start:
       dashed_name: event-start
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
       flat_name: event.start
       level: extended
       name: start
       normalize: []
-      short: event.start contains the date when the event started or when the activity
-        was first observed.
+      short: '`event.start` contains the date when the event started or when the activity
+        was first observed.'
       type: date
     event.timezone:
       dashed_name: event-timezone

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -2369,10 +2369,10 @@
     - name: created
       level: core
       type: date
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -2380,7 +2380,7 @@
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
     - name: dataset
       level: core
@@ -2404,13 +2404,13 @@
       output_precision: 1
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
     - name: end
       level: extended
       type: date
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
     - name: hash
       level: extended
       type: keyword
@@ -2450,7 +2450,7 @@
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
     - name: module
@@ -2573,8 +2573,8 @@
     - name: start
       level: extended
       type: date
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
     - name: timezone
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -238,7 +238,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.8.0,true,event,event.created,date,core,,2016-05-23T08:05:34.857Z,Time when the event was first read by an agent or by your pipeline.
 8.8.0,true,event,event.dataset,keyword,core,,apache.access,Name of the dataset.
 8.8.0,true,event,event.duration,long,core,,,Duration of the event in nanoseconds.
-8.8.0,true,event,event.end,date,extended,,,event.end contains the date when the event ended or when the activity was last observed.
+8.8.0,true,event,event.end,date,extended,,,`event.end` contains the date when the event ended or when the activity was last observed.
 8.8.0,true,event,event.hash,keyword,extended,,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
 8.8.0,true,event,event.id,keyword,core,,8a4f500d,Unique ID to describe the event.
 8.8.0,true,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
@@ -253,7 +253,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.8.0,true,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
 8.8.0,true,event,event.sequence,long,extended,,,Sequence number of the event.
 8.8.0,true,event,event.severity,long,core,,7,Numeric severity of the event.
-8.8.0,true,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
+8.8.0,true,event,event.start,date,extended,,,`event.start` contains the date when the event started or when the activity was first observed.
 8.8.0,true,event,event.timezone,keyword,extended,,,Event time zone.
 8.8.0,true,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
 8.8.0,true,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -3121,18 +3121,18 @@ event.code:
   type: keyword
 event.created:
   dashed_name: event-created
-  description: 'event.created contains the date/time when the event was first read
+  description: '`event.created` contains the date/time when the event was first read
     by an agent, or by your pipeline.
 
-    This field is distinct from @timestamp in that @timestamp typically contain the
-    time extracted from the original event.
+    This field is distinct from `@timestamp` in that `@timestamp` typically contain
+    the time extracted from the original event.
 
     In most situations, these two timestamps will be slightly different. The difference
     can be used to calculate the delay between your source generating an event, and
     the time when your agent first processed it. This can be used to monitor your
     agent''s or pipeline''s ability to keep up with your event source.
 
-    In case the two timestamps are identical, @timestamp should be used.'
+    In case the two timestamps are identical, `@timestamp` should be used.'
   example: '2016-05-23T08:05:34.857Z'
   flat_name: event.created
   level: core
@@ -3161,8 +3161,8 @@ event.duration:
   dashed_name: event-duration
   description: 'Duration of the event in nanoseconds.
 
-    If event.start and event.end are known this value should be the difference between
-    the end and start time.'
+    If `event.start` and `event.end` are known this value should be the difference
+    between the end and start time.'
   flat_name: event.duration
   format: duration
   input_format: nanoseconds
@@ -3175,14 +3175,14 @@ event.duration:
   type: long
 event.end:
   dashed_name: event-end
-  description: event.end contains the date when the event ended or when the activity
-    was last observed.
+  description: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   flat_name: event.end
   level: extended
   name: end
   normalize: []
-  short: event.end contains the date when the event ended or when the activity was
-    last observed.
+  short: '`event.end` contains the date when the event ended or when the activity
+    was last observed.'
   type: date
 event.hash:
   dashed_name: event-hash
@@ -3311,7 +3311,8 @@ event.kind:
 
     The value of this field can be used to inform how these kinds of events should
     be handled. They may warrant different retention, different access control, it
-    may also help understand whether the data coming in at a regular interval or not.'
+    may also help understand whether the data is coming in at a regular interval or
+    not.'
   example: alert
   flat_name: event.kind
   ignore_above: 1024
@@ -3502,14 +3503,14 @@ event.severity:
   type: long
 event.start:
   dashed_name: event-start
-  description: event.start contains the date when the event started or when the activity
-    was first observed.
+  description: '`event.start` contains the date when the event started or when the
+    activity was first observed.'
   flat_name: event.start
   level: extended
   name: start
   normalize: []
-  short: event.start contains the date when the event started or when the activity
-    was first observed.
+  short: '`event.start` contains the date when the event started or when the activity
+    was first observed.'
   type: date
 event.timezone:
   dashed_name: event-timezone

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -4105,10 +4105,10 @@ event:
       type: keyword
     event.created:
       dashed_name: event-created
-      description: 'event.created contains the date/time when the event was first
+      description: '`event.created` contains the date/time when the event was first
         read by an agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different. The difference
@@ -4116,7 +4116,7 @@ event:
         and the time when your agent first processed it. This can be used to monitor
         your agent''s or pipeline''s ability to keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.'
+        In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
       flat_name: event.created
       level: core
@@ -4146,7 +4146,7 @@ event:
       dashed_name: event-duration
       description: 'Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the difference
+        If `event.start` and `event.end` are known this value should be the difference
         between the end and start time.'
       flat_name: event.duration
       format: duration
@@ -4160,14 +4160,14 @@ event:
       type: long
     event.end:
       dashed_name: event-end
-      description: event.end contains the date when the event ended or when the activity
-        was last observed.
+      description: '`event.end` contains the date when the event ended or when the
+        activity was last observed.'
       flat_name: event.end
       level: extended
       name: end
       normalize: []
-      short: event.end contains the date when the event ended or when the activity
-        was last observed.
+      short: '`event.end` contains the date when the event ended or when the activity
+        was last observed.'
       type: date
     event.hash:
       dashed_name: event-hash
@@ -4297,7 +4297,7 @@ event:
 
         The value of this field can be used to inform how these kinds of events should
         be handled. They may warrant different retention, different access control,
-        it may also help understand whether the data coming in at a regular interval
+        it may also help understand whether the data is coming in at a regular interval
         or not.'
       example: alert
       flat_name: event.kind
@@ -4493,14 +4493,14 @@ event:
       type: long
     event.start:
       dashed_name: event-start
-      description: event.start contains the date when the event started or when the
-        activity was first observed.
+      description: '`event.start` contains the date when the event started or when
+        the activity was first observed.'
       flat_name: event.start
       level: extended
       name: start
       normalize: []
-      short: event.start contains the date when the event started or when the activity
-        was first observed.
+      short: '`event.start` contains the date when the event started or when the activity
+        was first observed.'
       type: date
     event.timezone:
       dashed_name: event-timezone

--- a/schemas/event.yml
+++ b/schemas/event.yml
@@ -70,7 +70,7 @@
 
         The value of this field can be used to inform how these kinds of events should be handled.
         They may warrant different retention, different access control, it may also
-        help understand whether the data coming in at a regular interval or not.
+        help understand whether the data is coming in at a regular interval or not.
       example: alert
       allowed_values:
         - name: alert
@@ -712,7 +712,7 @@
       description: >
         Duration of the event in nanoseconds.
 
-        If event.start and event.end are known this value should be the
+        If `event.start` and `event.end` are known this value should be the
         difference between the end and start time.
 
     - name: sequence
@@ -744,10 +744,10 @@
       short: Time when the event was first read by an agent or by your pipeline.
       example: '2016-05-23T08:05:34.857Z'
       description: >
-        event.created contains the date/time when the event was first read by an
+        `event.created` contains the date/time when the event was first read by an
         agent, or by your pipeline.
 
-        This field is distinct from @timestamp in that @timestamp typically contain
+        This field is distinct from `@timestamp` in that `@timestamp` typically contain
         the time extracted from the original event.
 
         In most situations, these two timestamps will be slightly different.
@@ -756,20 +756,20 @@
         This can be used to monitor your agent's or pipeline's ability to
         keep up with your event source.
 
-        In case the two timestamps are identical, @timestamp should be used.
+        In case the two timestamps are identical, `@timestamp` should be used.
 
     - name: start
       level: extended
       type: date
       description: >
-        event.start contains the date when the event started or when the
+        `event.start` contains the date when the event started or when the
         activity was first observed.
 
     - name: end
       level: extended
       type: date
       description: >
-        event.end contains the date when the event ended or when the activity
+        `event.end` contains the date when the event ended or when the activity
         was last observed.
 
     - name: risk_score


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [Clean up Event fields (#2226)](https://github.com/elastic/ecs/pull/2226)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)