### PR TITLE
Add process.thread.capabilities

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -16,6 +16,8 @@ Thanks, you're awesome :-) -->
 
 #### Added
 * Added `container.security_context.privileged` to indicated whether a container was started in privileged mode. #2219, #2225
+* Added `process.thread.capabilities.permitted` to contain the current thread's possible capabilities. #2245
+* Added `process.thread.capabilities.effective` to contain the current thread's effective capabilities. #2245
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8450,6 +8450,44 @@ example: `2016-05-23T08:05:34.853Z`
 // ===============================================================
 
 |
+[[field-process-thread-capabilities-effective]]
+<<field-process-thread-capabilities-effective, process.thread.capabilities.effective>>
+
+a| This is the set of capabilities used by the kernel to perform permission checks for the thread.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `["CAP_BPF", "CAP_SYS_ADMIN"]`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-process-thread-capabilities-permitted]]
+<<field-process-thread-capabilities-permitted, process.thread.capabilities.permitted>>
+
+a| This is a limiting superset for the effective capabilities that the thread may assume.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `["CAP_BPF", "CAP_SYS_ADMIN"]`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-process-thread-id]]
 <<field-process-thread-id, process.thread.id>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -7799,6 +7799,24 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: parent.thread.capabilities.effective
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
+    - name: parent.thread.capabilities.permitted
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
     - name: parent.thread.id
       level: extended
       type: long

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -8524,6 +8524,24 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: thread.capabilities.effective
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
+    - name: thread.capabilities.permitted
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -887,6 +887,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev+exp,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.10.0-dev+exp,true,process,process.parent.supplemental_groups.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.10.0-dev+exp,true,process,process.parent.supplemental_groups.name,keyword,extended,,,Name of the group.
+8.10.0-dev+exp,true,process,process.parent.thread.capabilities.effective,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities used for permission checks.
+8.10.0-dev+exp,true,process,process.parent.thread.capabilities.permitted,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities a thread could assume.
 8.10.0-dev+exp,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.10.0-dev+exp,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 8.10.0-dev+exp,true,process,process.parent.title,keyword,extended,,,Process title.

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -987,6 +987,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev+exp,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.10.0-dev+exp,true,process,process.supplemental_groups.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.10.0-dev+exp,true,process,process.supplemental_groups.name,keyword,extended,,,Name of the group.
+8.10.0-dev+exp,true,process,process.thread.capabilities.effective,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities used for permission checks.
+8.10.0-dev+exp,true,process,process.thread.capabilities.permitted,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities a thread could assume.
 8.10.0-dev+exp,true,process,process.thread.id,long,extended,,4242,Thread ID.
 8.10.0-dev+exp,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 8.10.0-dev+exp,true,process,process.title,keyword,extended,,,Process title.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -11290,6 +11290,36 @@ process.parent.supplemental_groups.name:
   original_fieldset: group
   short: Name of the group.
   type: keyword
+process.parent.thread.capabilities.effective:
+  dashed_name: process-parent-thread-capabilities-effective
+  description: This is the set of capabilities used by the kernel to perform permission
+    checks for the thread.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.parent.thread.capabilities.effective
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.effective
+  normalize:
+  - array
+  original_fieldset: process
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities used for permission checks.
+  type: keyword
+process.parent.thread.capabilities.permitted:
+  dashed_name: process-parent-thread-capabilities-permitted
+  description: This is a limiting superset for the effective capabilities that the
+    thread may assume.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.parent.thread.capabilities.permitted
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.permitted
+  normalize:
+  - array
+  original_fieldset: process
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities a thread could assume.
+  type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
   description: Thread ID.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -12469,6 +12469,34 @@ process.supplemental_groups.name:
   original_fieldset: group
   short: Name of the group.
   type: keyword
+process.thread.capabilities.effective:
+  dashed_name: process-thread-capabilities-effective
+  description: This is the set of capabilities used by the kernel to perform permission
+    checks for the thread.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.thread.capabilities.effective
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.effective
+  normalize:
+  - array
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities used for permission checks.
+  type: keyword
+process.thread.capabilities.permitted:
+  dashed_name: process-thread-capabilities-permitted
+  description: This is a limiting superset for the effective capabilities that the
+    thread may assume.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.thread.capabilities.permitted
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.permitted
+  normalize:
+  - array
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities a thread could assume.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -14687,6 +14687,34 @@ process:
       original_fieldset: group
       short: Name of the group.
       type: keyword
+    process.thread.capabilities.effective:
+      dashed_name: process-thread-capabilities-effective
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.thread.capabilities.effective
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.effective
+      normalize:
+      - array
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities used for permission checks.
+      type: keyword
+    process.thread.capabilities.permitted:
+      dashed_name: process-thread-capabilities-permitted
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.thread.capabilities.permitted
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.permitted
+      normalize:
+      - array
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities a thread could assume.
+      type: keyword
     process.thread.id:
       dashed_name: process-thread-id
       description: Thread ID.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -13507,6 +13507,36 @@ process:
       original_fieldset: group
       short: Name of the group.
       type: keyword
+    process.parent.thread.capabilities.effective:
+      dashed_name: process-parent-thread-capabilities-effective
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.parent.thread.capabilities.effective
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.effective
+      normalize:
+      - array
+      original_fieldset: process
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities used for permission checks.
+      type: keyword
+    process.parent.thread.capabilities.permitted:
+      dashed_name: process-parent-thread-capabilities-permitted
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.parent.thread.capabilities.permitted
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.permitted
+      normalize:
+      - array
+      original_fieldset: process
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities a thread could assume.
+      type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
       description: Thread ID.

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -1310,6 +1310,18 @@
                 },
                 "thread": {
                   "properties": {
+                    "capabilities": {
+                      "properties": {
+                        "effective": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "permitted": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
                     "id": {
                       "type": "long"
                     },

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -1777,6 +1777,18 @@
             },
             "thread": {
               "properties": {
+                "capabilities": {
+                  "properties": {
+                    "effective": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "permitted": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "id": {
                   "type": "long"
                 },

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -4031,6 +4031,18 @@
               },
               "thread": {
                 "properties": {
+                  "capabilities": {
+                    "properties": {
+                      "effective": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "permitted": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
                   "id": {
                     "type": "long"
                   },

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -4498,6 +4498,18 @@
           },
           "thread": {
             "properties": {
+              "capabilities": {
+                "properties": {
+                  "effective": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "permitted": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "id": {
                 "type": "long"
               },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -7749,6 +7749,24 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: parent.thread.capabilities.effective
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
+    - name: parent.thread.capabilities.permitted
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
     - name: parent.thread.id
       level: extended
       type: long

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -8474,6 +8474,24 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: thread.capabilities.effective
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
+    - name: thread.capabilities.permitted
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -880,6 +880,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev,true,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.10.0-dev,true,process,process.parent.supplemental_groups.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.10.0-dev,true,process,process.parent.supplemental_groups.name,keyword,extended,,,Name of the group.
+8.10.0-dev,true,process,process.parent.thread.capabilities.effective,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities used for permission checks.
+8.10.0-dev,true,process,process.parent.thread.capabilities.permitted,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities a thread could assume.
 8.10.0-dev,true,process,process.parent.thread.id,long,extended,,4242,Thread ID.
 8.10.0-dev,true,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
 8.10.0-dev,true,process,process.parent.title,keyword,extended,,,Process title.

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -980,6 +980,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.10.0-dev,true,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
 8.10.0-dev,true,process,process.supplemental_groups.id,keyword,extended,,,Unique identifier for the group on the system/platform.
 8.10.0-dev,true,process,process.supplemental_groups.name,keyword,extended,,,Name of the group.
+8.10.0-dev,true,process,process.thread.capabilities.effective,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities used for permission checks.
+8.10.0-dev,true,process,process.thread.capabilities.permitted,keyword,extended,array,"[""CAP_BPF"", ""CAP_SYS_ADMIN""]",Array of capabilities a thread could assume.
 8.10.0-dev,true,process,process.thread.id,long,extended,,4242,Thread ID.
 8.10.0-dev,true,process,process.thread.name,keyword,extended,,thread-0,Thread name.
 8.10.0-dev,true,process,process.title,keyword,extended,,,Process title.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -11221,6 +11221,36 @@ process.parent.supplemental_groups.name:
   original_fieldset: group
   short: Name of the group.
   type: keyword
+process.parent.thread.capabilities.effective:
+  dashed_name: process-parent-thread-capabilities-effective
+  description: This is the set of capabilities used by the kernel to perform permission
+    checks for the thread.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.parent.thread.capabilities.effective
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.effective
+  normalize:
+  - array
+  original_fieldset: process
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities used for permission checks.
+  type: keyword
+process.parent.thread.capabilities.permitted:
+  dashed_name: process-parent-thread-capabilities-permitted
+  description: This is a limiting superset for the effective capabilities that the
+    thread may assume.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.parent.thread.capabilities.permitted
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.permitted
+  normalize:
+  - array
+  original_fieldset: process
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities a thread could assume.
+  type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
   description: Thread ID.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -12400,6 +12400,34 @@ process.supplemental_groups.name:
   original_fieldset: group
   short: Name of the group.
   type: keyword
+process.thread.capabilities.effective:
+  dashed_name: process-thread-capabilities-effective
+  description: This is the set of capabilities used by the kernel to perform permission
+    checks for the thread.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.thread.capabilities.effective
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.effective
+  normalize:
+  - array
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities used for permission checks.
+  type: keyword
+process.thread.capabilities.permitted:
+  dashed_name: process-thread-capabilities-permitted
+  description: This is a limiting superset for the effective capabilities that the
+    thread may assume.
+  example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+  flat_name: process.thread.capabilities.permitted
+  ignore_above: 1024
+  level: extended
+  name: thread.capabilities.permitted
+  normalize:
+  - array
+  pattern: ^(CAP_[A-Z_]+|\d+)$
+  short: Array of capabilities a thread could assume.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -14607,6 +14607,34 @@ process:
       original_fieldset: group
       short: Name of the group.
       type: keyword
+    process.thread.capabilities.effective:
+      dashed_name: process-thread-capabilities-effective
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.thread.capabilities.effective
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.effective
+      normalize:
+      - array
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities used for permission checks.
+      type: keyword
+    process.thread.capabilities.permitted:
+      dashed_name: process-thread-capabilities-permitted
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.thread.capabilities.permitted
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.permitted
+      normalize:
+      - array
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities a thread could assume.
+      type: keyword
     process.thread.id:
       dashed_name: process-thread-id
       description: Thread ID.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -13427,6 +13427,36 @@ process:
       original_fieldset: group
       short: Name of the group.
       type: keyword
+    process.parent.thread.capabilities.effective:
+      dashed_name: process-parent-thread-capabilities-effective
+      description: This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.parent.thread.capabilities.effective
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.effective
+      normalize:
+      - array
+      original_fieldset: process
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities used for permission checks.
+      type: keyword
+    process.parent.thread.capabilities.permitted:
+      dashed_name: process-parent-thread-capabilities-permitted
+      description: This is a limiting superset for the effective capabilities that
+        the thread may assume.
+      example: '["CAP_BPF", "CAP_SYS_ADMIN"]'
+      flat_name: process.parent.thread.capabilities.permitted
+      ignore_above: 1024
+      level: extended
+      name: thread.capabilities.permitted
+      normalize:
+      - array
+      original_fieldset: process
+      pattern: ^(CAP_[A-Z_]+|\d+)$
+      short: Array of capabilities a thread could assume.
+      type: keyword
     process.parent.thread.id:
       dashed_name: process-parent-thread-id
       description: Thread ID.

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -1310,6 +1310,18 @@
                 },
                 "thread": {
                   "properties": {
+                    "capabilities": {
+                      "properties": {
+                        "effective": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        },
+                        "permitted": {
+                          "ignore_above": 1024,
+                          "type": "keyword"
+                        }
+                      }
+                    },
                     "id": {
                       "type": "long"
                     },

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -1777,6 +1777,18 @@
             },
             "thread": {
               "properties": {
+                "capabilities": {
+                  "properties": {
+                    "effective": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "permitted": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
                 "id": {
                   "type": "long"
                 },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -3989,6 +3989,18 @@
               },
               "thread": {
                 "properties": {
+                  "capabilities": {
+                    "properties": {
+                      "effective": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "permitted": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    }
+                  },
                   "id": {
                     "type": "long"
                   },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -4456,6 +4456,18 @@
           },
           "thread": {
             "properties": {
+              "capabilities": {
+                "properties": {
+                  "effective": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "permitted": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "id": {
                 "type": "long"
               },

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -206,6 +206,7 @@
       level: extended
       type: keyword
       short: Array of capabilities a thread could assume.
+      pattern: ^(CAP_[A-Z_]+|\d+)$
       description: >
         This is a limiting superset for the effective capabilities that the
         thread may assume.
@@ -217,6 +218,7 @@
       level: extended
       type: keyword
       short: Array of capabilities used for permission checks.
+      pattern: ^(CAP_[A-Z_]+|\d+)$
       description: >
         This is the set of capabilities used by the kernel to perform permission
         checks for the thread.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -202,6 +202,28 @@
       description: >
         Thread name.
 
+    - name: thread.capabilities.permitted
+      level: extended
+      type: keyword
+      short: Array of capabilities a thread could assume.
+      description: >
+        This is a limiting superset for the effective capabilities that the
+        thread may assume.
+      example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
+      normalize:
+        - array
+
+    - name: thread.capabilities.effective
+      level: extended
+      type: keyword
+      short: Array of capabilities used for permission checks.
+      description: >
+        This is the set of capabilities used by the kernel to perform permission
+        checks for the thread.
+      example: "[\"CAP_BPF\", \"CAP_SYS_ADMIN\"]"
+      normalize:
+        - array
+
     - name: start
       level: extended
       type: date

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -443,6 +443,10 @@ fields:
         fields:
           id: {}
           name: {}
+          capabilities:
+            fields:
+              effective: {}
+              permitted: {}
       title: {}
       tty:
         fields: "*"

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -309,6 +309,10 @@ fields:
             fields:
               id: {}
               name: {}
+              capabilities:
+                fields:
+                  effective: {}
+                  permitted: {}
           title: {}
           tty:
             fields:


### PR DESCRIPTION
Being able to gather and track Linux capabilities for a process (thread) could allow us to detect and prevent various activities such as container escapes, privilege escalation and exploitation.
