### PR TITLE
Respect `ignore_above` if set for a `flattened` type field

### DIFF
--- a/scripts/generators/es_template.py
+++ b/scripts/generators/es_template.py
@@ -191,7 +191,7 @@ def entry_for(field: Field) -> Dict:
         elif 'index' in field and not field['index']:
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['index', 'doc_values'])
 
-        if field['type'] == 'keyword':
+        if field['type'] == 'keyword' or field['type'] == 'flattened':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['ignore_above'])
         elif field['type'] == 'constant_keyword':
             ecs_helpers.dict_copy_existing_keys(field, field_entry, ['value'])

--- a/scripts/tests/test_es_template.py
+++ b/scripts/tests/test_es_template.py
@@ -174,6 +174,44 @@ class TestGeneratorsEsTemplate(unittest.TestCase):
         exp = {'type': 'constant_keyword'}
         self.assertEqual(es_template.entry_for(test_map), exp)
 
+    def test_keyword_pass_ignore_above(self):
+        test_map = {
+            'name': 'field_with_ignore_above_set',
+            'type': 'keyword',
+            'ignore_above': 1024
+        }
+
+        exp = {
+            'type': 'keyword',
+            'ignore_above': 1024
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+    def test_flattened_pass_ignore_above(self):
+        test_map = {
+            'name': 'field_with_ignore_above_set',
+            'type': 'flattened',
+            'ignore_above': 1024
+        }
+
+        exp = {
+            'type': 'flattened',
+            'ignore_above': 1024
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
+    def test_other_types_not_pass_ignore_above(self):
+        test_map = {
+            'name': 'field_should_not_have_ignore_above_set',
+            'type': 'text',
+            'ignore_above': 1024
+        }
+
+        exp = {
+            'type': 'text'
+        }
+        self.assertEqual(es_template.entry_for(test_map), exp)
+
     def test_parameters(self):
         test_map = {
             'name': 'field_with_parameters',


### PR DESCRIPTION
If a field explicitly sets the `ignore_above` parameter on a `flattened` field, permit the setting on the final field in the generated ES index templates.

This change does _not_ set `ignore_above` by default on a `flattened` field. This topic is a separate discussion: https://github.com/elastic/ecs/issues/2247.

Closes #2237  
