### PR TITLE
[8.10] Bump gitpython from 3.1.30 to 3.1.32 in /scripts (#2251)

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0
 # License: BSD
-gitpython==3.1.30
+gitpython==3.1.32
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Bump gitpython from 3.1.30 to 3.1.32 in /scripts (#2251)](https://github.com/elastic/ecs/pull/2251)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)