### PR TITLE
[8.10] Bump gitpython from 3.1.32 to 3.1.34 in /scripts (#2264)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -49,6 +49,12 @@ Thanks, you're awesome :-) -->
 #### Improvements
 * Improved documentation formatting to better follow the contributing guide. #2226
 
+### Tooling and Artifact Changes
+
+#### Improvements
+
+* Bump `gitpython` dependency from 3.1.30 to 3.1.34 for security fixes. #2251, #2264
+
 <!-- All empty sections:
 
 ## Unreleased

--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,11 +48,6 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 * Improved documentation formatting to better follow the contributing guide. #2226
-
-### Tooling and Artifact Changes
-
-#### Improvements
-
 * Bump `gitpython` dependency from 3.1.30 to 3.1.34 for security fixes. #2251, #2264
 
 <!-- All empty sections:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0
 # License: BSD
-gitpython==3.1.32
+gitpython==3.1.34
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Bump gitpython from 3.1.32 to 3.1.34 in /scripts (#2264)](https://github.com/elastic/ecs/pull/2264)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)