### PR TITLE
Clean up duplicated headers in `CHANGELOG.next`

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,11 +48,6 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 * Improved documentation formatting to better follow the contributing guide. #2226
-
-### Tooling and Artifact Changes
-
-#### Improvements
-
 * Bump `gitpython` dependency from 3.1.30 to 3.1.34 for security fixes. #2251, #2264
 
 <!-- All empty sections:


### PR DESCRIPTION
Fix dupe'd changelog headers I introduced in #2264 