### PR TITLE
[8.10] Bump gitpython from 3.1.34 to 3.1.35 in /scripts (#2265)

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -48,7 +48,7 @@ Thanks, you're awesome :-) -->
 
 #### Improvements
 * Improved documentation formatting to better follow the contributing guide. #2226
-* Bump `gitpython` dependency from 3.1.30 to 3.1.34 for security fixes. #2251, #2264
+* Bump `gitpython` dependency from 3.1.30 to 3.1.35 for security fixes. #2251, #2264, #2265
 
 <!-- All empty sections:
 

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0
 # License: BSD
-gitpython==3.1.34
+gitpython==3.1.35
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Bump gitpython from 3.1.34 to 3.1.35 in /scripts (#2265)](https://github.com/elastic/ecs/pull/2265)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)