### PR TITLE
Remove `expected_values` from *.indicator.name field defs

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Remove `expected_values` from `threat.*.indicator.name` fields. #2281
+
 #### Added
 
 #### Improvements

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -10526,19 +10526,7 @@ example: `2020-11-05T17:25:47.000Z`
 
 a| The display name indicator in an UI friendly format
 
-Expected values for this field:
-
-* `5.2.75.227`
-* `2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6`
-* `https://example.com/some/path`
-* `example.com`
-* `373d34874d7bc89fd4cefa6272ee80bf`
-* `b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7`
-* `email@example.com`
-* `HKLM\\SOFTWARE\\Microsoft\\Active`
-* `13335`
-* `00:00:5e:00:53:af`
-* `8008`
+URL, IP address, email address, registry key, port number, hash value, or other relevant name can serve as the display name.
 
 type: keyword
 
@@ -11084,19 +11072,7 @@ example: `2020-11-05T17:25:47.000Z`
 
 a| The display name indicator in an UI friendly format
 
-Expected values for this field:
-
-* `5.2.75.227`
-* `2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6`
-* `https://example.com/some/path`
-* `example.com`
-* `373d34874d7bc89fd4cefa6272ee80bf`
-* `b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7`
-* `email@example.com`
-* `HKLM\\SOFTWARE\\Microsoft\\Active`
-* `13335`
-* `00:00:5e:00:53:af`
-* `8008`
+URL, IP address, email address, registry key, port number, hash value, or other relevant name can serve as the display name.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -10077,7 +10077,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
       default_field: false
     - name: enrichments.indicator.port
@@ -11681,7 +11684,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
       default_field: false
     - name: indicator.port

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -16325,20 +16325,11 @@ threat.enrichments.indicator.modified_at:
   type: date
 threat.enrichments.indicator.name:
   dashed_name: threat-enrichments-indicator-name
-  description: The display name indicator in an UI friendly format
+  description: 'The display name indicator in an UI friendly format
+
+    URL, IP address, email address, registry key, port number, hash value, or other
+    relevant name can serve as the display name.'
   example: 5.2.75.227
-  expected_values:
-  - 5.2.75.227
-  - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-  - https://example.com/some/path
-  - example.com
-  - 373d34874d7bc89fd4cefa6272ee80bf
-  - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-  - email@example.com
-  - HKLM\\SOFTWARE\\Microsoft\\Active
-  - 13335
-  - 00:00:5e:00:53:af
-  - 8008
   flat_name: threat.enrichments.indicator.name
   ignore_above: 1024
   level: extended
@@ -19044,20 +19035,11 @@ threat.indicator.modified_at:
   type: date
 threat.indicator.name:
   dashed_name: threat-indicator-name
-  description: The display name indicator in an UI friendly format
+  description: 'The display name indicator in an UI friendly format
+
+    URL, IP address, email address, registry key, port number, hash value, or other
+    relevant name can serve as the display name.'
   example: 5.2.75.227
-  expected_values:
-  - 5.2.75.227
-  - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-  - https://example.com/some/path
-  - example.com
-  - 373d34874d7bc89fd4cefa6272ee80bf
-  - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-  - email@example.com
-  - HKLM\\SOFTWARE\\Microsoft\\Active
-  - 13335
-  - 00:00:5e:00:53:af
-  - 8008
   flat_name: threat.indicator.name
   ignore_above: 1024
   level: extended

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -18992,20 +18992,11 @@ threat:
       type: date
     threat.enrichments.indicator.name:
       dashed_name: threat-enrichments-indicator-name
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
-      expected_values:
-      - 5.2.75.227
-      - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-      - https://example.com/some/path
-      - example.com
-      - 373d34874d7bc89fd4cefa6272ee80bf
-      - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-      - email@example.com
-      - HKLM\\SOFTWARE\\Microsoft\\Active
-      - 13335
-      - 00:00:5e:00:53:af
-      - 8008
       flat_name: threat.enrichments.indicator.name
       ignore_above: 1024
       level: extended
@@ -21717,20 +21708,11 @@ threat:
       type: date
     threat.indicator.name:
       dashed_name: threat-indicator-name
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
-      expected_values:
-      - 5.2.75.227
-      - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-      - https://example.com/some/path
-      - example.com
-      - 373d34874d7bc89fd4cefa6272ee80bf
-      - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-      - email@example.com
-      - HKLM\\SOFTWARE\\Microsoft\\Active
-      - 13335
-      - 00:00:5e:00:53:af
-      - 8008
       flat_name: threat.indicator.name
       ignore_above: 1024
       level: extended

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -10027,7 +10027,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
       default_field: false
     - name: enrichments.indicator.port
@@ -11631,7 +11634,10 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
       default_field: false
     - name: indicator.port

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -16256,20 +16256,11 @@ threat.enrichments.indicator.modified_at:
   type: date
 threat.enrichments.indicator.name:
   dashed_name: threat-enrichments-indicator-name
-  description: The display name indicator in an UI friendly format
+  description: 'The display name indicator in an UI friendly format
+
+    URL, IP address, email address, registry key, port number, hash value, or other
+    relevant name can serve as the display name.'
   example: 5.2.75.227
-  expected_values:
-  - 5.2.75.227
-  - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-  - https://example.com/some/path
-  - example.com
-  - 373d34874d7bc89fd4cefa6272ee80bf
-  - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-  - email@example.com
-  - HKLM\\SOFTWARE\\Microsoft\\Active
-  - 13335
-  - 00:00:5e:00:53:af
-  - 8008
   flat_name: threat.enrichments.indicator.name
   ignore_above: 1024
   level: extended
@@ -18975,20 +18966,11 @@ threat.indicator.modified_at:
   type: date
 threat.indicator.name:
   dashed_name: threat-indicator-name
-  description: The display name indicator in an UI friendly format
+  description: 'The display name indicator in an UI friendly format
+
+    URL, IP address, email address, registry key, port number, hash value, or other
+    relevant name can serve as the display name.'
   example: 5.2.75.227
-  expected_values:
-  - 5.2.75.227
-  - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-  - https://example.com/some/path
-  - example.com
-  - 373d34874d7bc89fd4cefa6272ee80bf
-  - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-  - email@example.com
-  - HKLM\\SOFTWARE\\Microsoft\\Active
-  - 13335
-  - 00:00:5e:00:53:af
-  - 8008
   flat_name: threat.indicator.name
   ignore_above: 1024
   level: extended

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -18912,20 +18912,11 @@ threat:
       type: date
     threat.enrichments.indicator.name:
       dashed_name: threat-enrichments-indicator-name
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
-      expected_values:
-      - 5.2.75.227
-      - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-      - https://example.com/some/path
-      - example.com
-      - 373d34874d7bc89fd4cefa6272ee80bf
-      - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-      - email@example.com
-      - HKLM\\SOFTWARE\\Microsoft\\Active
-      - 13335
-      - 00:00:5e:00:53:af
-      - 8008
       flat_name: threat.enrichments.indicator.name
       ignore_above: 1024
       level: extended
@@ -21637,20 +21628,11 @@ threat:
       type: date
     threat.indicator.name:
       dashed_name: threat-indicator-name
-      description: The display name indicator in an UI friendly format
+      description: 'The display name indicator in an UI friendly format
+
+        URL, IP address, email address, registry key, port number, hash value, or
+        other relevant name can serve as the display name.'
       example: 5.2.75.227
-      expected_values:
-      - 5.2.75.227
-      - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-      - https://example.com/some/path
-      - example.com
-      - 373d34874d7bc89fd4cefa6272ee80bf
-      - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-      - email@example.com
-      - HKLM\\SOFTWARE\\Microsoft\\Active
-      - 13335
-      - 00:00:5e:00:53:af
-      - 8008
       flat_name: threat.indicator.name
       ignore_above: 1024
       level: extended

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -111,18 +111,9 @@
       short: Indicator display name
       description: >
         The display name indicator in an UI friendly format
-      expected_values:
-        - 5.2.75.227
-        - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-        - https://example.com/some/path
-        - example.com
-        - 373d34874d7bc89fd4cefa6272ee80bf
-        - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-        - email@example.com
-        - HKLM\\SOFTWARE\\Microsoft\\Active
-        - 13335
-        - 00:00:5e:00:53:af
-        - 8008
+
+        URL, IP address, email address, registry key, port number, hash value,
+        or other relevant name can serve as the display name.
       example: 5.2.75.227
 
     - name: enrichments.indicator.description
@@ -419,18 +410,9 @@
       short: Indicator display name
       description: >
         The display name indicator in an UI friendly format
-      expected_values:
-        - 5.2.75.227
-        - 2a02:cf40:add:4002:91f2:a9b2:e09a:6fc6
-        - https://example.com/some/path
-        - example.com
-        - 373d34874d7bc89fd4cefa6272ee80bf
-        - b0e914d1bbe19433cc9df64ea1ca07fe77f7b150b511b786e46e007941a62bd7
-        - email@example.com
-        - HKLM\\SOFTWARE\\Microsoft\\Active
-        - 13335
-        - 00:00:5e:00:53:af
-        - 8008
+
+        URL, IP address, email address, registry key, port number, hash value,
+        or other relevant name can serve as the display name.
       example: 5.2.75.227
 
     - name: indicator.description


### PR DESCRIPTION
The `threat.indicator.name` and `threat.enrichments.indicator.name` are misusing the `expected_value` parameter in their field definitions. This change removes `expected_value`.

I propose the removal is a bug fix vs. a breaking change since the current `expected_values` on these fields is not useful for real-world applications.