### PR TITLE
Tune container image fields to align with Otel SemConv

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -12,6 +12,8 @@ Thanks, you're awesome :-) -->
 
 #### Breaking changes
 
+* Tune container image fields to align with Otel SemConv #2282
+
 #### Bugfixes
 
 #### Added

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -1119,8 +1119,27 @@ type: keyword
 // ===============================================================
 
 |
-[[field-container-image-tag]]
-<<field-container-image-tag, container.image.tag>>
+[[field-container-image-repo-digests]]
+<<field-container-image-repo-digests, container.image.repo_digests>>
+
+a| [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238) report those under the `RepoDigests` field.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]`
+
+| extended
+
+// ===============================================================
+
+|
+[[field-container-image-tags]]
+<<field-container-image-tags, container.image.tags>>
 
 a| Container image tags.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -799,11 +799,21 @@
       type: keyword
       ignore_above: 1024
       description: Name of the image the container was built on.
-    - name: image.tag
+    - name: image.repo_digests
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+        and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+        report those under the `RepoDigests` field.'
+      example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+      default_field: false
+    - name: image.tags
       level: extended
       type: keyword
       ignore_above: 1024
       description: Container image tags.
+      default_field: false
     - name: labels
       level: extended
       type: object

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -93,7 +93,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0-dev+exp,true,container,container.id,keyword,core,,,Unique container id.
 8.11.0-dev+exp,true,container,container.image.hash.all,keyword,extended,array,[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26],An array of digests of the image the container was built on.
 8.11.0-dev+exp,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
-8.11.0-dev+exp,true,container,container.image.tag,keyword,extended,array,,Container image tags.
+8.11.0-dev+exp,true,container,container.image.repo_digests,keyword,extended,array,[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb],Repo digests of the container image as provided by the container runtime.
+8.11.0-dev+exp,true,container,container.image.tags,keyword,extended,array,,Container image tags.
 8.11.0-dev+exp,true,container,container.labels,object,extended,,,Image labels.
 8.11.0-dev+exp,true,container,container.memory.usage,scaled_float,extended,,,"Percent memory used, between 0 and 1."
 8.11.0-dev+exp,true,container,container.name,keyword,extended,,,Container name.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -1121,13 +1121,27 @@ container.image.name:
   normalize: []
   short: Name of the image the container was built on.
   type: keyword
-container.image.tag:
-  dashed_name: container-image-tag
-  description: Container image tags.
-  flat_name: container.image.tag
+container.image.repo_digests:
+  dashed_name: container-image-repo-digests
+  description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+    and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+    report those under the `RepoDigests` field.'
+  example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+  flat_name: container.image.repo_digests
   ignore_above: 1024
   level: extended
-  name: image.tag
+  name: image.repo_digests
+  normalize:
+  - array
+  short: Repo digests of the container image as provided by the container runtime.
+  type: keyword
+container.image.tags:
+  dashed_name: container-image-tags
+  description: Container image tags.
+  flat_name: container.image.tags
+  ignore_above: 1024
+  level: extended
+  name: image.tags
   normalize:
   - array
   short: Container image tags.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -1500,13 +1500,27 @@ container:
       normalize: []
       short: Name of the image the container was built on.
       type: keyword
-    container.image.tag:
-      dashed_name: container-image-tag
-      description: Container image tags.
-      flat_name: container.image.tag
+    container.image.repo_digests:
+      dashed_name: container-image-repo-digests
+      description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+        and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+        report those under the `RepoDigests` field.'
+      example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+      flat_name: container.image.repo_digests
       ignore_above: 1024
       level: extended
-      name: image.tag
+      name: image.repo_digests
+      normalize:
+      - array
+      short: Repo digests of the container image as provided by the container runtime.
+      type: keyword
+    container.image.tags:
+      dashed_name: container-image-tags
+      description: Container image tags.
+      flat_name: container.image.tags
+      ignore_above: 1024
+      level: extended
+      name: image.tags
       normalize:
       - array
       short: Container image tags.

--- a/experimental/generated/elasticsearch/composable/component/container.json
+++ b/experimental/generated/elasticsearch/composable/component/container.json
@@ -52,7 +52,11 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "tag": {
+                "repo_digests": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tags": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -521,7 +521,11 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "tag": {
+              "repo_digests": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "tags": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -749,11 +749,21 @@
       type: keyword
       ignore_above: 1024
       description: Name of the image the container was built on.
-    - name: image.tag
+    - name: image.repo_digests
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+        and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+        report those under the `RepoDigests` field.'
+      example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+      default_field: false
+    - name: image.tags
       level: extended
       type: keyword
       ignore_above: 1024
       description: Container image tags.
+      default_field: false
     - name: labels
       level: extended
       type: object

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -86,7 +86,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.11.0-dev,true,container,container.id,keyword,core,,,Unique container id.
 8.11.0-dev,true,container,container.image.hash.all,keyword,extended,array,[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26],An array of digests of the image the container was built on.
 8.11.0-dev,true,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
-8.11.0-dev,true,container,container.image.tag,keyword,extended,array,,Container image tags.
+8.11.0-dev,true,container,container.image.repo_digests,keyword,extended,array,[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb],Repo digests of the container image as provided by the container runtime.
+8.11.0-dev,true,container,container.image.tags,keyword,extended,array,,Container image tags.
 8.11.0-dev,true,container,container.labels,object,extended,,,Image labels.
 8.11.0-dev,true,container,container.memory.usage,scaled_float,extended,,,"Percent memory used, between 0 and 1."
 8.11.0-dev,true,container,container.name,keyword,extended,,,Container name.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -1052,13 +1052,27 @@ container.image.name:
   normalize: []
   short: Name of the image the container was built on.
   type: keyword
-container.image.tag:
-  dashed_name: container-image-tag
-  description: Container image tags.
-  flat_name: container.image.tag
+container.image.repo_digests:
+  dashed_name: container-image-repo-digests
+  description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+    and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+    report those under the `RepoDigests` field.'
+  example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+  flat_name: container.image.repo_digests
   ignore_above: 1024
   level: extended
-  name: image.tag
+  name: image.repo_digests
+  normalize:
+  - array
+  short: Repo digests of the container image as provided by the container runtime.
+  type: keyword
+container.image.tags:
+  dashed_name: container-image-tags
+  description: Container image tags.
+  flat_name: container.image.tags
+  ignore_above: 1024
+  level: extended
+  name: image.tags
   normalize:
   - array
   short: Container image tags.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -1420,13 +1420,27 @@ container:
       normalize: []
       short: Name of the image the container was built on.
       type: keyword
-    container.image.tag:
-      dashed_name: container-image-tag
-      description: Container image tags.
-      flat_name: container.image.tag
+    container.image.repo_digests:
+      dashed_name: container-image-repo-digests
+      description: '[Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect)
+        and [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+        report those under the `RepoDigests` field.'
+      example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
+      flat_name: container.image.repo_digests
       ignore_above: 1024
       level: extended
-      name: image.tag
+      name: image.repo_digests
+      normalize:
+      - array
+      short: Repo digests of the container image as provided by the container runtime.
+      type: keyword
+    container.image.tags:
+      dashed_name: container-image-tags
+      description: Container image tags.
+      flat_name: container.image.tags
+      ignore_above: 1024
+      level: extended
+      name: image.tags
       normalize:
       - array
       short: Container image tags.

--- a/generated/elasticsearch/composable/component/container.json
+++ b/generated/elasticsearch/composable/component/container.json
@@ -52,7 +52,11 @@
                   "ignore_above": 1024,
                   "type": "keyword"
                 },
-                "tag": {
+                "repo_digests": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "tags": {
                   "ignore_above": 1024,
                   "type": "keyword"
                 }

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -479,7 +479,11 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
-              "tag": {
+              "repo_digests": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "tags": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }

--- a/schemas/container.yml
+++ b/schemas/container.yml
@@ -64,7 +64,7 @@
       description: >
         Name of the image the container was built on.
 
-    - name: image.tag
+    - name: image.tags
       level: extended
       type: keyword
       description: >
@@ -81,6 +81,18 @@
         Each digest consists of the hash algorithm and value in this format: `algorithm:value`.
         Algorithm names should align with the field names in the ECS hash field set.
       example: '[sha256:f8fefc80e3273dc756f288a63945820d6476ad64883892c771b5e2ece6bf1b26]'
+      normalize:
+        - array
+
+    - name: image.repo_digests
+      level: extended
+      type: keyword
+      short: Repo digests of the container image as provided by the container runtime.
+      description: >
+        [Docker](https://docs.docker.com/engine/api/v1.43/#tag/Image/operation/ImageInspect) and
+        [CRI](https://github.com/kubernetes/cri-api/blob/c75ef5b473bbe2d0a4fc92f82235efd665ea8e9f/pkg/apis/runtime/v1/api.proto#L1237-L1238)
+        report those under the `RepoDigests` field.
+      example: '[example@sha256:afcc7f1ac1b49db317a7196c902e61c6c3c4607d63599ee1a82d702d249a0ccb]'
       normalize:
         - array
 


### PR DESCRIPTION
This PR tunes the `container.image.*` fields to align with Otel's SemConv. 
Specifically after https://github.com/open-telemetry/semantic-conventions/pull/159 have been merged, we need to adjust ECS to at least:

1) `container.image.tag` -> `container.image.tags`
2) `container.image.hash.all` -> `container.image.repo_digests`

For now I have added `container.image.repo_digests` as a new field and we can keep `container.image.hash.all` for backwards compatibility if we prefer.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->


__________________________________________________________________________________
- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? ✅ 
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)?
- If submitting code/script changes, have you verified all tests pass locally using `make test`?
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? ✅ 
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅ 
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? ✅ 
