### PR TITLE
Fix description of syslog.severity.name and syslog.severity.code

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5910,7 +5910,7 @@ example: `3`
 [[field-log-syslog-severity-name]]
 <<field-log-syslog-severity-name, log.syslog.severity.name>>
 
-a| The Syslog numeric severity of the log event, if available.
+a| The Syslog text-based severity of the log event, if available.
 
 If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3965,7 +3965,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The Syslog numeric severity of the log event, if available.
+      description: 'The Syslog text-based severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
         (e.g. firewall, IDS), your source''s text severity should go to `log.level`.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6502,7 +6502,7 @@ log.syslog.severity.code:
   type: long
 log.syslog.severity.name:
   dashed_name: log-syslog-severity-name
-  description: 'The Syslog numeric severity of the log event, if available.
+  description: 'The Syslog text-based severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different severity value
     (e.g. firewall, IDS), your source''s text severity should go to `log.level`. If

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7990,7 +7990,7 @@ log:
       type: long
     log.syslog.severity.name:
       dashed_name: log-syslog-severity-name
-      description: 'The Syslog numeric severity of the log event, if available.
+      description: 'The Syslog text-based severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
         (e.g. firewall, IDS), your source''s text severity should go to `log.level`.

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3915,7 +3915,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The Syslog numeric severity of the log event, if available.
+      description: 'The Syslog text-based severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
         (e.g. firewall, IDS), your source''s text severity should go to `log.level`.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6433,7 +6433,7 @@ log.syslog.severity.code:
   type: long
 log.syslog.severity.name:
   dashed_name: log-syslog-severity-name
-  description: 'The Syslog numeric severity of the log event, if available.
+  description: 'The Syslog text-based severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different severity value
     (e.g. firewall, IDS), your source''s text severity should go to `log.level`. If

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7910,7 +7910,7 @@ log:
       type: long
     log.syslog.severity.name:
       dashed_name: log-syslog-severity-name
-      description: 'The Syslog numeric severity of the log event, if available.
+      description: 'The Syslog text-based severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
         (e.g. firewall, IDS), your source''s text severity should go to `log.level`.

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -119,7 +119,7 @@
       example: Error
       short: Syslog text-based severity of the event.
       description: >
-        The Syslog numeric severity of the log event, if available.
+        The Syslog text-based severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity
         value (e.g. firewall, IDS), your source's text severity should go to `log.level`.


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? Yes
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? Yes
- If submitting code/script changes, have you verified all tests pass locally using `make test`? Yes
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? Yes
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. Yes
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? Yes

This PR corrects the wording of the `log.syslog.severity.name` description, to specify that this field should contain a text-based severity. This was already mentioned in the short description.

Closes #1948 