### PR TITLE
Add hint to RFC 5424 in `log.syslog.severity.name` and `log.syslog.severity.code`

### DIFF
--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -5894,7 +5894,7 @@ example: `12345`
 
 a| The Syslog numeric severity of the log event, if available.
 
-If the event source publishing via Syslog provides a different numeric severity value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.
+If the event source publishing via Syslog provides a different numeric severity value than defined in RFC 5424 (0-7), your source's numeric severity should go to `event.severity`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `event.severity`.
 
 type: long
 
@@ -5912,7 +5912,7 @@ example: `3`
 
 a| The Syslog numeric severity of the log event, if available.
 
-If the event source publishing via Syslog provides a different severity value (e.g. firewall, IDS), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.
+If the event source publishing via Syslog provides a different severity value than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice, Informational, Debug), your source's text severity should go to `log.level`. If the event source does not specify a distinct severity, you can optionally copy the Syslog severity to `log.level`.
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -3957,9 +3957,9 @@
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different numeric severity
-        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-        If the event source does not specify a distinct severity, you can optionally
-        copy the Syslog severity to `event.severity`.'
+        value than defined in RFC 5424 (0-7), your source''s numeric severity should
+        go to `event.severity`. If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `event.severity`.'
       example: 3
     - name: syslog.severity.name
       level: extended
@@ -3968,7 +3968,8 @@
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+        Informational, Debug), your source''s text severity should go to `log.level`.
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -6490,9 +6490,9 @@ log.syslog.severity.code:
   description: 'The Syslog numeric severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different numeric severity
-    value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-    If the event source does not specify a distinct severity, you can optionally copy
-    the Syslog severity to `event.severity`.'
+    value than defined in RFC 5424 (0-7), your source''s numeric severity should go
+    to `event.severity`. If the event source does not specify a distinct severity,
+    you can optionally copy the Syslog severity to `event.severity`.'
   example: 3
   flat_name: log.syslog.severity.code
   level: extended
@@ -6505,8 +6505,9 @@ log.syslog.severity.name:
   description: 'The Syslog numeric severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different severity value
-    (e.g. firewall, IDS), your source''s text severity should go to `log.level`. If
-    the event source does not specify a distinct severity, you can optionally copy
+    than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+    Informational, Debug), your source''s text severity should go to `log.level`.
+    If the event source does not specify a distinct severity, you can optionally copy
     the Syslog severity to `log.level`.'
   example: Error
   flat_name: log.syslog.severity.name

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -7978,9 +7978,9 @@ log:
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different numeric severity
-        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-        If the event source does not specify a distinct severity, you can optionally
-        copy the Syslog severity to `event.severity`.'
+        value than defined in RFC 5424 (0-7), your source''s numeric severity should
+        go to `event.severity`. If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `event.severity`.'
       example: 3
       flat_name: log.syslog.severity.code
       level: extended
@@ -7993,7 +7993,8 @@ log:
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+        Informational, Debug), your source''s text severity should go to `log.level`.
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -3907,9 +3907,9 @@
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different numeric severity
-        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-        If the event source does not specify a distinct severity, you can optionally
-        copy the Syslog severity to `event.severity`.'
+        value than defined in RFC 5424 (0-7), your source''s numeric severity should
+        go to `event.severity`. If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `event.severity`.'
       example: 3
     - name: syslog.severity.name
       level: extended
@@ -3918,7 +3918,8 @@
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+        Informational, Debug), your source''s text severity should go to `log.level`.
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -6421,9 +6421,9 @@ log.syslog.severity.code:
   description: 'The Syslog numeric severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different numeric severity
-    value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-    If the event source does not specify a distinct severity, you can optionally copy
-    the Syslog severity to `event.severity`.'
+    value than defined in RFC 5424 (0-7), your source''s numeric severity should go
+    to `event.severity`. If the event source does not specify a distinct severity,
+    you can optionally copy the Syslog severity to `event.severity`.'
   example: 3
   flat_name: log.syslog.severity.code
   level: extended
@@ -6436,8 +6436,9 @@ log.syslog.severity.name:
   description: 'The Syslog numeric severity of the log event, if available.
 
     If the event source publishing via Syslog provides a different severity value
-    (e.g. firewall, IDS), your source''s text severity should go to `log.level`. If
-    the event source does not specify a distinct severity, you can optionally copy
+    than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+    Informational, Debug), your source''s text severity should go to `log.level`.
+    If the event source does not specify a distinct severity, you can optionally copy
     the Syslog severity to `log.level`.'
   example: Error
   flat_name: log.syslog.severity.name

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -7898,9 +7898,9 @@ log:
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different numeric severity
-        value (e.g. firewall, IDS), your source''s numeric severity should go to `event.severity`.
-        If the event source does not specify a distinct severity, you can optionally
-        copy the Syslog severity to `event.severity`.'
+        value than defined in RFC 5424 (0-7), your source''s numeric severity should
+        go to `event.severity`. If the event source does not specify a distinct severity,
+        you can optionally copy the Syslog severity to `event.severity`.'
       example: 3
       flat_name: log.syslog.severity.code
       level: extended
@@ -7913,7 +7913,8 @@ log:
       description: 'The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity value
-        (e.g. firewall, IDS), your source''s text severity should go to `log.level`.
+        than defined in RFC 5424 (Emergency, Alert, Critical, Error, Warning, Notice,
+        Informational, Debug), your source''s text severity should go to `log.level`.
         If the event source does not specify a distinct severity, you can optionally
         copy the Syslog severity to `log.level`.'
       example: Error

--- a/schemas/log.yml
+++ b/schemas/log.yml
@@ -109,7 +109,8 @@
         The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different numeric severity
-        value (e.g. firewall, IDS), your source's numeric severity should go to `event.severity`.
+        value than defined in RFC 5424 (0-7), your source's numeric severity should
+        go to `event.severity`.
         If the event source does not specify a distinct severity,
         you can optionally copy the Syslog severity to `event.severity`.
 
@@ -122,7 +123,9 @@
         The Syslog numeric severity of the log event, if available.
 
         If the event source publishing via Syslog provides a different severity
-        value (e.g. firewall, IDS), your source's text severity should go to `log.level`.
+        value than defined in RFC 5424 (Emergency, Alert, Critical, Error,
+        Warning, Notice, Informational, Debug), your source's text severity
+        should go to `log.level`.
         If the event source does not specify a distinct severity,
         you can optionally copy the Syslog severity to `log.level`.
 


### PR DESCRIPTION
This PR updates the description of `log.syslog.severity.name` and `log.syslog.severity.code` to explicitly name the allowed values according to RFC 5424. 
<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? Yes
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? Yes
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? Yes
- If submitting code/script changes, have you verified all tests pass locally using `make test`? Yes
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? Yes
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. Yes
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? Yes
