### PR TITLE
[8.11] Bump gitpython from 3.1.35 to 3.1.37 in /scripts (#2292)

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0
 # License: BSD
-gitpython==3.1.35
+gitpython==3.1.37
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Bump gitpython from 3.1.35 to 3.1.37 in /scripts (#2292)](https://github.com/elastic/ecs/pull/2292)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)