### PR TITLE
[8.11] Removing entry for volume field set addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ All notable changes to this project will be documented in this file based on the
 
 * Remove `expected_values` from `threat.*.indicator.name` fields. #2281
 
-#### Added
-
-* Added `volume.*` as beta field set. #2269
-
 ### Tooling and Artifact Changes
 
 #### Bugfixes


### PR DESCRIPTION
Correcting erroneous entry for PR https://github.com/elastic/ecs/pull/2269 in the 8.11 changelog (& moved to 8.12)