### PR TITLE
[RFC] added new field: threat.indicator.id - resolves GH-2252

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `volume.*` as beta field set. #2269
+* Added `threat.indicator.id` [#2252](https://github.com/elastic/ecs/issues/2252)
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -10978,6 +10978,27 @@ example: `2020-11-05T17:25:47.000Z`
 // ===============================================================
 
 |
+[[field-threat-indicator-id]]
+<<field-threat-indicator-id, threat.indicator.id>>
+
+a| The id of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.
+
+While not required, a common approach is to use a STIX 2.x indicator id.
+
+type: keyword
+
+
+Note: this field should contain an array of values.
+
+
+
+example: `[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]`
+
+| extended
+
+// ===============================================================
+
+|
 [[field-threat-indicator-ip]]
 <<field-threat-indicator-ip, threat.indicator.ip>>
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -11645,6 +11645,17 @@
       description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
+    - name: indicator.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The id of the indicator used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator id."
+      example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+      default_field: false
     - name: indicator.ip
       level: extended
       type: ip

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -1500,6 +1500,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,threat,threat.indicator.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 8.12.0-dev+exp,true,threat,threat.indicator.geo.region_name,keyword,core,,Quebec,Region name.
 8.12.0-dev+exp,true,threat,threat.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+8.12.0-dev+exp,true,threat,threat.indicator.id,keyword,extended,array,[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37],ID of the indicator
 8.12.0-dev+exp,true,threat,threat.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.12.0-dev+exp,true,threat,threat.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
 8.12.0-dev+exp,true,threat,threat.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -18972,6 +18972,22 @@ threat.indicator.geo.timezone:
   original_fieldset: geo
   short: Time zone.
   type: keyword
+threat.indicator.id:
+  dashed_name: threat-indicator-id
+  description: "The id of the indicator used by this threat to conduct behavior commonly\
+    \ modeled using MITRE ATT&CK\xAE. This field can have multiple values to allow\
+    \ for the identification of the same indicator across systems that use different\
+    \ ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator\
+    \ id."
+  example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+  flat_name: threat.indicator.id
+  ignore_above: 1024
+  level: extended
+  name: indicator.id
+  normalize:
+  - array
+  short: ID of the indicator
+  type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
   description: Identifies a threat indicator as an IP address (irrespective of direction).

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -21644,6 +21644,22 @@ threat:
       original_fieldset: geo
       short: Time zone.
       type: keyword
+    threat.indicator.id:
+      dashed_name: threat-indicator-id
+      description: "The id of the indicator used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator id."
+      example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+      flat_name: threat.indicator.id
+      ignore_above: 1024
+      level: extended
+      name: indicator.id
+      normalize:
+      - array
+      short: ID of the indicator
+      type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
       description: Identifies a threat indicator as an IP address (irrespective of

--- a/experimental/generated/elasticsearch/composable/component/threat.json
+++ b/experimental/generated/elasticsearch/composable/component/threat.json
@@ -1522,6 +1522,10 @@
                     }
                   }
                 },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "ip": {
                   "type": "ip"
                 },

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -6727,6 +6727,10 @@
                   }
                 }
               },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "ip": {
                 "type": "ip"
               },

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -11595,6 +11595,17 @@
       description: The time zone of the location, such as IANA time zone name.
       example: America/Argentina/Buenos_Aires
       default_field: false
+    - name: indicator.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: "The id of the indicator used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator id."
+      example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+      default_field: false
     - name: indicator.ip
       level: extended
       type: ip

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -1493,6 +1493,7 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,threat,threat.indicator.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
 8.12.0-dev,true,threat,threat.indicator.geo.region_name,keyword,core,,Quebec,Region name.
 8.12.0-dev,true,threat,threat.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+8.12.0-dev,true,threat,threat.indicator.id,keyword,extended,array,[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37],ID of the indicator
 8.12.0-dev,true,threat,threat.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
 8.12.0-dev,true,threat,threat.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
 8.12.0-dev,true,threat,threat.indicator.marking.tlp,keyword,extended,,CLEAR,Indicator TLP marking

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -18903,6 +18903,22 @@ threat.indicator.geo.timezone:
   original_fieldset: geo
   short: Time zone.
   type: keyword
+threat.indicator.id:
+  dashed_name: threat-indicator-id
+  description: "The id of the indicator used by this threat to conduct behavior commonly\
+    \ modeled using MITRE ATT&CK\xAE. This field can have multiple values to allow\
+    \ for the identification of the same indicator across systems that use different\
+    \ ID formats.\nWhile not required, a common approach is to use a STIX 2.x indicator\
+    \ id."
+  example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+  flat_name: threat.indicator.id
+  ignore_above: 1024
+  level: extended
+  name: indicator.id
+  normalize:
+  - array
+  short: ID of the indicator
+  type: keyword
 threat.indicator.ip:
   dashed_name: threat-indicator-ip
   description: Identifies a threat indicator as an IP address (irrespective of direction).

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -21564,6 +21564,22 @@ threat:
       original_fieldset: geo
       short: Time zone.
       type: keyword
+    threat.indicator.id:
+      dashed_name: threat-indicator-id
+      description: "The id of the indicator used by this threat to conduct behavior\
+        \ commonly modeled using MITRE ATT&CK\xAE. This field can have multiple values\
+        \ to allow for the identification of the same indicator across systems that\
+        \ use different ID formats.\nWhile not required, a common approach is to use\
+        \ a STIX 2.x indicator id."
+      example: '[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]'
+      flat_name: threat.indicator.id
+      ignore_above: 1024
+      level: extended
+      name: indicator.id
+      normalize:
+      - array
+      short: ID of the indicator
+      type: keyword
     threat.indicator.ip:
       dashed_name: threat-indicator-ip
       description: Identifies a threat indicator as an IP address (irrespective of

--- a/generated/elasticsearch/composable/component/threat.json
+++ b/generated/elasticsearch/composable/component/threat.json
@@ -1522,6 +1522,10 @@
                     }
                   }
                 },
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
                 "ip": {
                   "type": "ip"
                 },

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -6685,6 +6685,10 @@
                   }
                 }
               },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "ip": {
                 "type": "ip"
               },

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -524,7 +524,7 @@
         that use different ID formats.
 
         While not required, a common approach is to use a STIX 2.x indicator id.
-      example: "indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37"
+      example: "[indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37]"
       normalize:
         - array
 

--- a/schemas/threat.yml
+++ b/schemas/threat.yml
@@ -514,6 +514,20 @@
         The name of the indicator's provider.
       example: lrz_urlhaus
 
+    - name: indicator.id
+      level: extended
+      type: keyword
+      short: ID of the indicator
+      description: >
+        The id of the indicator used by this threat to conduct behavior commonly modeled using MITRE ATT&CK®.
+        This field can have multiple values to allow for the identification of the same indicator across systems
+        that use different ID formats.
+
+        While not required, a common approach is to use a STIX 2.x indicator id.
+      example: "indicator--d7008e06-ab86-415a-9803-3c81ce2d3c37"
+      normalize:
+        - array
+
     - name: software.id
       level: extended
       type: keyword


### PR DESCRIPTION
Added `threat.indicator.id` field. Resolves #2252.

The new field `threat.indicator.id` will allow for security systems to append a threat.indicator.id. This field can have multiple values to allow for the identification of the same indicator across systems that use different ID formats.

Common serialization format you may expect to see here is a STIX 2.x indicator id. Here is an example of one being produced.

```json
{
            "type": "indicator",
            "spec_version": "2.1",
            "id": "indicator--8a8c60c4-00a8-43dd-ad76-8004ee718c39",
            "created": "2023-12-21T17:55:29.187214Z",
            "modified": "2023-12-21T17:55:29.187214Z",
            "name": "Malicious activity",
            "description": "Indicator for a known malicious IP address",
            "pattern": "[ipv4-addr:value = '192.168.1.1']",
            "pattern_type": "stix",
            "pattern_version": "2.1",
            "valid_from": "2023-01-01T12:00:00Z"
}
```