### PR TITLE
Promote process.env_vars to GA

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -17,6 +17,7 @@ Thanks, you're awesome :-) -->
 #### Added
 
 * Added `volume.*` as beta field set. #2269
+* Advanced `process.env_vars` to GA. #2315
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8101,9 +8101,7 @@ type: keyword
 [[field-process-env-vars]]
 <<field-process-env-vars, process.env_vars>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-Array of environment variable bindings. Captured from a snapshot of the environment at the time of execution.
+a| Array of environment variable bindings. Captured from a snapshot of the environment at the time of execution.
 
 May be filtered to protect sensitive information.
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8888,7 +8888,6 @@ process.entry_leader.working_directory:
   short: The working directory of the process.
   type: keyword
 process.env_vars:
-  beta: This field is beta and subject to change.
   dashed_name: process-env-vars
   description: 'Array of environment variable bindings. Captured from a snapshot of
     the environment at the time of execution.

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -11098,7 +11098,6 @@ process:
       short: The working directory of the process.
       type: keyword
     process.env_vars:
-      beta: This field is beta and subject to change.
       dashed_name: process-env-vars
       description: 'Array of environment variable bindings. Captured from a snapshot
         of the environment at the time of execution.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8819,7 +8819,6 @@ process.entry_leader.working_directory:
   short: The working directory of the process.
   type: keyword
 process.env_vars:
-  beta: This field is beta and subject to change.
   dashed_name: process-env-vars
   description: 'Array of environment variable bindings. Captured from a snapshot of
     the environment at the time of execution.

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -11018,7 +11018,6 @@ process:
       short: The working directory of the process.
       type: keyword
     process.env_vars:
-      beta: This field is beta and subject to change.
       dashed_name: process-env-vars
       description: 'Array of environment variable bindings. Captured from a snapshot
         of the environment at the time of execution.

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -307,7 +307,6 @@
     - name: env_vars
       level: extended
       type: keyword
-      beta: This field is beta and subject to change.
       short: Array of environment variable bindings.
       description: >
         Array of environment variable bindings.


### PR DESCRIPTION
Promote process.env_vars to GA. This field has been stabilized and in use for some time now, so it should be promoted to GA status.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?  ✅
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? ✅
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? N/A
- If submitting code/script changes, have you verified all tests pass locally using `make test`? ✅
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? ✅
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? ✅
