### PR TITLE
Promote process.io and process.tty fields to GA

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -18,6 +18,7 @@ Thanks, you're awesome :-) -->
 
 * Added `volume.*` as beta field set. #2269
 * Advanced `process.env_vars` to GA. #2315
+* Advanced `process.io` and `process.tty` fields to GA. #2317
 
 #### Improvements
 

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -8182,9 +8182,7 @@ example: `True`
 [[field-process-io]]
 <<field-process-io, process.io>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-A chunk of input or output (IO) from a single process.
+a| A chunk of input or output (IO) from a single process.
 
 This field only appears on the top level process object, which is the process that wrote the output or read the input.
 
@@ -8202,9 +8200,7 @@ type: object
 [[field-process-io-bytes-skipped]]
 <<field-process-io-bytes-skipped, process.io.bytes_skipped>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-An array of byte offsets and lengths denoting where IO data has been skipped.
+a| An array of byte offsets and lengths denoting where IO data has been skipped.
 
 type: object
 
@@ -8223,9 +8219,7 @@ Note: this field should contain an array of values.
 [[field-process-io-bytes-skipped-length]]
 <<field-process-io-bytes-skipped-length, process.io.bytes_skipped.length>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The length of bytes skipped.
+a| The length of bytes skipped.
 
 type: long
 
@@ -8241,9 +8235,7 @@ type: long
 [[field-process-io-bytes-skipped-offset]]
 <<field-process-io-bytes-skipped-offset, process.io.bytes_skipped.offset>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
+a| The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
 type: long
 
@@ -8259,9 +8251,7 @@ type: long
 [[field-process-io-max-bytes-per-process-exceeded]]
 <<field-process-io-max-bytes-per-process-exceeded, process.io.max_bytes_per_process_exceeded>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting.
+a| If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting.
 
 type: boolean
 
@@ -8277,9 +8267,7 @@ type: boolean
 [[field-process-io-text]]
 <<field-process-io-text, process.io.text>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-A chunk of output or input sanitized to UTF-8.
+a| A chunk of output or input sanitized to UTF-8.
 
 Best efforts are made to ensure complete lines are captured in these events. Assumptions should NOT be made that multiple lines will appear in the same event. TTY output may contain terminal control codes such as for cursor movement, so some string queries may not match due to terminal codes inserted between characters of a word.
 
@@ -8297,9 +8285,7 @@ type: wildcard
 [[field-process-io-total-bytes-captured]]
 <<field-process-io-total-bytes-captured, process.io.total_bytes_captured>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The total number of bytes captured in this event.
+a| The total number of bytes captured in this event.
 
 type: long
 
@@ -8315,9 +8301,7 @@ type: long
 [[field-process-io-total-bytes-skipped]]
 <<field-process-io-total-bytes-skipped, process.io.total_bytes_skipped>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
+a| The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
 
 type: long
 
@@ -8333,9 +8317,7 @@ type: long
 [[field-process-io-type]]
 <<field-process-io-type, process.io.type>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The type of object on which the IO action (read or write) was taken.
+a| The type of object on which the IO action (read or write) was taken.
 
 Currently only 'tty' is supported. Other types may be added in the future for 'file' and 'socket' support.
 
@@ -8593,9 +8575,7 @@ example: `1`
 [[field-process-tty-columns]]
 <<field-process-tty-columns, process.tty.columns>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The number of character columns per line. e.g terminal width
+a| The number of character columns per line. e.g terminal width
 
 Terminal sizes can change, so this value reflects the maximum value for a given IO event. i.e. where event.action = 'text_output'
 
@@ -8613,9 +8593,7 @@ example: `80`
 [[field-process-tty-rows]]
 <<field-process-tty-rows, process.tty.rows>>
 
-a| beta:[ This field is beta and subject to change. ]
-
-The number of character rows in the terminal. e.g terminal height
+a| The number of character rows in the terminal. e.g terminal height
 
 Terminal sizes can change, so this value reflects the maximum value for a given IO event. i.e. where event.action = 'text_output'
 

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -9448,7 +9448,6 @@ process.interactive:
   short: Whether the process is connected to an interactive shell.
   type: boolean
 process.io:
-  beta: This field is beta and subject to change.
   dashed_name: process-io
   description: 'A chunk of input or output (IO) from a single process.
 
@@ -9461,7 +9460,6 @@ process.io:
   short: A chunk of input or output (IO) from a single process.
   type: object
 process.io.bytes_skipped:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped
   description: An array of byte offsets and lengths denoting where IO data has been
     skipped.
@@ -9473,7 +9471,6 @@ process.io.bytes_skipped:
   short: An array of byte offsets and lengths denoting where IO data has been skipped.
   type: object
 process.io.bytes_skipped.length:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-length
   description: The length of bytes skipped.
   flat_name: process.io.bytes_skipped.length
@@ -9483,7 +9480,6 @@ process.io.bytes_skipped.length:
   short: The length of bytes skipped.
   type: long
 process.io.bytes_skipped.offset:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
   description: The byte offset into this event's io.text (or io.bytes in the future)
     where length bytes were skipped.
@@ -9495,7 +9491,6 @@ process.io.bytes_skipped.offset:
     length bytes were skipped.
   type: long
 process.io.max_bytes_per_process_exceeded:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
   description: If true, the process producing the output has exceeded the max_kilobytes_per_process
     configuration setting.
@@ -9507,7 +9502,6 @@ process.io.max_bytes_per_process_exceeded:
     configuration setting.
   type: boolean
 process.io.text:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-text
   description: 'A chunk of output or input sanitized to UTF-8.
 
@@ -9522,7 +9516,6 @@ process.io.text:
   short: A chunk of output or input sanitized to UTF-8.
   type: wildcard
 process.io.total_bytes_captured:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
   flat_name: process.io.total_bytes_captured
@@ -9532,7 +9525,6 @@ process.io.total_bytes_captured:
   short: The total number of bytes captured in this event.
   type: long
 process.io.total_bytes_skipped:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
   description: The total number of bytes that were not captured due to implementation
     restrictions such as buffer size limits. Implementors should strive to ensure
@@ -9545,7 +9537,6 @@ process.io.total_bytes_skipped:
     such as buffer size limits.
   type: long
 process.io.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-type
   description: 'The type of object on which the IO action (read or write) was taken.
 
@@ -12602,7 +12593,6 @@ process.tty.char_device.minor:
   short: The TTY character device's minor number.
   type: long
 process.tty.columns:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-columns
   description: 'The number of character columns per line. e.g terminal width
 
@@ -12616,7 +12606,6 @@ process.tty.columns:
   short: The number of character columns per line. e.g terminal width
   type: long
 process.tty.rows:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-rows
   description: 'The number of character rows in the terminal. e.g terminal height
 

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -11658,7 +11658,6 @@ process:
       short: Whether the process is connected to an interactive shell.
       type: boolean
     process.io:
-      beta: This field is beta and subject to change.
       dashed_name: process-io
       description: 'A chunk of input or output (IO) from a single process.
 
@@ -11671,7 +11670,6 @@ process:
       short: A chunk of input or output (IO) from a single process.
       type: object
     process.io.bytes_skipped:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped
       description: An array of byte offsets and lengths denoting where IO data has
         been skipped.
@@ -11684,7 +11682,6 @@ process:
         skipped.
       type: object
     process.io.bytes_skipped.length:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-length
       description: The length of bytes skipped.
       flat_name: process.io.bytes_skipped.length
@@ -11694,7 +11691,6 @@ process:
       short: The length of bytes skipped.
       type: long
     process.io.bytes_skipped.offset:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
@@ -11706,7 +11702,6 @@ process:
         where length bytes were skipped.
       type: long
     process.io.max_bytes_per_process_exceeded:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
       description: If true, the process producing the output has exceeded the max_kilobytes_per_process
         configuration setting.
@@ -11718,7 +11713,6 @@ process:
         configuration setting.
       type: boolean
     process.io.text:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-text
       description: 'A chunk of output or input sanitized to UTF-8.
 
@@ -11734,7 +11728,6 @@ process:
       short: A chunk of output or input sanitized to UTF-8.
       type: wildcard
     process.io.total_bytes_captured:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-captured
       description: The total number of bytes captured in this event.
       flat_name: process.io.total_bytes_captured
@@ -11744,7 +11737,6 @@ process:
       short: The total number of bytes captured in this event.
       type: long
     process.io.total_bytes_skipped:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
@@ -11757,7 +11749,6 @@ process:
         restrictions such as buffer size limits.
       type: long
     process.io.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-type
       description: 'The type of object on which the IO action (read or write) was
         taken.
@@ -14820,7 +14811,6 @@ process:
       short: The TTY character device's minor number.
       type: long
     process.tty.columns:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-columns
       description: 'The number of character columns per line. e.g terminal width
 
@@ -14834,7 +14824,6 @@ process:
       short: The number of character columns per line. e.g terminal width
       type: long
     process.tty.rows:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-rows
       description: 'The number of character rows in the terminal. e.g terminal height
 

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -9379,7 +9379,6 @@ process.interactive:
   short: Whether the process is connected to an interactive shell.
   type: boolean
 process.io:
-  beta: This field is beta and subject to change.
   dashed_name: process-io
   description: 'A chunk of input or output (IO) from a single process.
 
@@ -9392,7 +9391,6 @@ process.io:
   short: A chunk of input or output (IO) from a single process.
   type: object
 process.io.bytes_skipped:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped
   description: An array of byte offsets and lengths denoting where IO data has been
     skipped.
@@ -9404,7 +9402,6 @@ process.io.bytes_skipped:
   short: An array of byte offsets and lengths denoting where IO data has been skipped.
   type: object
 process.io.bytes_skipped.length:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-length
   description: The length of bytes skipped.
   flat_name: process.io.bytes_skipped.length
@@ -9414,7 +9411,6 @@ process.io.bytes_skipped.length:
   short: The length of bytes skipped.
   type: long
 process.io.bytes_skipped.offset:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-bytes-skipped-offset
   description: The byte offset into this event's io.text (or io.bytes in the future)
     where length bytes were skipped.
@@ -9426,7 +9422,6 @@ process.io.bytes_skipped.offset:
     length bytes were skipped.
   type: long
 process.io.max_bytes_per_process_exceeded:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-max-bytes-per-process-exceeded
   description: If true, the process producing the output has exceeded the max_kilobytes_per_process
     configuration setting.
@@ -9438,7 +9433,6 @@ process.io.max_bytes_per_process_exceeded:
     configuration setting.
   type: boolean
 process.io.text:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-text
   description: 'A chunk of output or input sanitized to UTF-8.
 
@@ -9453,7 +9447,6 @@ process.io.text:
   short: A chunk of output or input sanitized to UTF-8.
   type: wildcard
 process.io.total_bytes_captured:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-captured
   description: The total number of bytes captured in this event.
   flat_name: process.io.total_bytes_captured
@@ -9463,7 +9456,6 @@ process.io.total_bytes_captured:
   short: The total number of bytes captured in this event.
   type: long
 process.io.total_bytes_skipped:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-total-bytes-skipped
   description: The total number of bytes that were not captured due to implementation
     restrictions such as buffer size limits. Implementors should strive to ensure
@@ -9476,7 +9468,6 @@ process.io.total_bytes_skipped:
     such as buffer size limits.
   type: long
 process.io.type:
-  beta: This field is beta and subject to change.
   dashed_name: process-io-type
   description: 'The type of object on which the IO action (read or write) was taken.
 
@@ -12533,7 +12524,6 @@ process.tty.char_device.minor:
   short: The TTY character device's minor number.
   type: long
 process.tty.columns:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-columns
   description: 'The number of character columns per line. e.g terminal width
 
@@ -12547,7 +12537,6 @@ process.tty.columns:
   short: The number of character columns per line. e.g terminal width
   type: long
 process.tty.rows:
-  beta: This field is beta and subject to change.
   dashed_name: process-tty-rows
   description: 'The number of character rows in the terminal. e.g terminal height
 

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -11578,7 +11578,6 @@ process:
       short: Whether the process is connected to an interactive shell.
       type: boolean
     process.io:
-      beta: This field is beta and subject to change.
       dashed_name: process-io
       description: 'A chunk of input or output (IO) from a single process.
 
@@ -11591,7 +11590,6 @@ process:
       short: A chunk of input or output (IO) from a single process.
       type: object
     process.io.bytes_skipped:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped
       description: An array of byte offsets and lengths denoting where IO data has
         been skipped.
@@ -11604,7 +11602,6 @@ process:
         skipped.
       type: object
     process.io.bytes_skipped.length:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-length
       description: The length of bytes skipped.
       flat_name: process.io.bytes_skipped.length
@@ -11614,7 +11611,6 @@ process:
       short: The length of bytes skipped.
       type: long
     process.io.bytes_skipped.offset:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-bytes-skipped-offset
       description: The byte offset into this event's io.text (or io.bytes in the future)
         where length bytes were skipped.
@@ -11626,7 +11622,6 @@ process:
         where length bytes were skipped.
       type: long
     process.io.max_bytes_per_process_exceeded:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-max-bytes-per-process-exceeded
       description: If true, the process producing the output has exceeded the max_kilobytes_per_process
         configuration setting.
@@ -11638,7 +11633,6 @@ process:
         configuration setting.
       type: boolean
     process.io.text:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-text
       description: 'A chunk of output or input sanitized to UTF-8.
 
@@ -11654,7 +11648,6 @@ process:
       short: A chunk of output or input sanitized to UTF-8.
       type: wildcard
     process.io.total_bytes_captured:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-captured
       description: The total number of bytes captured in this event.
       flat_name: process.io.total_bytes_captured
@@ -11664,7 +11657,6 @@ process:
       short: The total number of bytes captured in this event.
       type: long
     process.io.total_bytes_skipped:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-total-bytes-skipped
       description: The total number of bytes that were not captured due to implementation
         restrictions such as buffer size limits. Implementors should strive to ensure
@@ -11677,7 +11669,6 @@ process:
         restrictions such as buffer size limits.
       type: long
     process.io.type:
-      beta: This field is beta and subject to change.
       dashed_name: process-io-type
       description: 'The type of object on which the IO action (read or write) was
         taken.
@@ -14740,7 +14731,6 @@ process:
       short: The TTY character device's minor number.
       type: long
     process.tty.columns:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-columns
       description: 'The number of character columns per line. e.g terminal width
 
@@ -14754,7 +14744,6 @@ process:
       short: The number of character columns per line. e.g terminal width
       type: long
     process.tty.rows:
-      beta: This field is beta and subject to change.
       dashed_name: process-tty-rows
       description: 'The number of character rows in the terminal. e.g terminal height
 

--- a/schemas/process.yml
+++ b/schemas/process.yml
@@ -361,7 +361,6 @@
     - name: tty.rows
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The number of character rows in the terminal. e.g terminal height
       description: >
         The number of character rows in the terminal. e.g terminal height
@@ -372,7 +371,6 @@
     - name: tty.columns
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The number of character columns per line. e.g terminal width
       description: >
         The number of character columns per line. e.g terminal width
@@ -383,7 +381,6 @@
     - name: io
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       short: A chunk of input or output (IO) from a single process.
       description: >
         A chunk of input or output (IO) from a single process.
@@ -393,7 +390,6 @@
     - name: io.type
       level: extended
       type: keyword
-      beta: This field is beta and subject to change.
       short: The type of object on which the IO action (read or write) was taken.
       description: >
         The type of object on which the IO action (read or write) was taken.
@@ -403,7 +399,6 @@
     - name: io.text
       level: extended
       type: wildcard
-      beta: This field is beta and subject to change.
       short: A chunk of output or input sanitized to UTF-8.
       description: >
         A chunk of output or input sanitized to UTF-8.
@@ -413,14 +408,12 @@
     - name: io.total_bytes_captured
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       description: >
         The total number of bytes captured in this event.
 
     - name: io.total_bytes_skipped
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       short: The total number of bytes that were not captured due to implementation restrictions such as buffer size limits.
       description: >
         The total number of bytes that were not captured due to implementation restrictions such as buffer size limits. Implementors should strive to ensure this value is always zero
@@ -428,14 +421,12 @@
     - name: io.max_bytes_per_process_exceeded
       level: extended
       type: boolean
-      beta: This field is beta and subject to change.
       description: >
         If true, the process producing the output has exceeded the max_kilobytes_per_process configuration setting.
 
     - name: io.bytes_skipped
       level: extended
       type: object
-      beta: This field is beta and subject to change.
       description: >
         An array of byte offsets and lengths denoting where IO data has been skipped.
 
@@ -445,13 +436,11 @@
     - name: io.bytes_skipped.offset
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       description: >
         The byte offset into this event's io.text (or io.bytes in the future) where length bytes were skipped.
 
     - name: io.bytes_skipped.length
       level: extended
       type: long
-      beta: This field is beta and subject to change.
       description: >
         The length of bytes skipped.


### PR DESCRIPTION
Remove process.io and process.tty fields from beta, and promote to GA.

These fields have stabilized and are used in released features, so they can leave beta.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? ✅
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? ✅
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process] (https://github.com/elastic/ecs/blob/main/rfcs/README.md)? N/A
- If submitting code/script changes, have you verified all tests pass locally using `make test`? ✅
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? ✅
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. ✅
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? ✅
