### PR TITLE
Update docs-preview link

### DIFF
--- a/.github/workflows/docs-preview-comment.yml
+++ b/.github/workflows/docs-preview-comment.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const comment = `Documentation changes preview: https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff`;
+            const comment = `Documentation changes preview: https://${context.repo.repo}_bk_${pr.number}.docs-preview.app.elstc.co/diff`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,


### PR DESCRIPTION
Following the migration from Jenkins to Buildkite, docs previews are now available at <repo>_bk_<PR>.

More context in https://github.com/elastic/docs/pull/2898

Note - a shared GH action can also be found here: https://github.com/elastic/docs/tree/master/.github/actions/docs-preview

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)?
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)?
- If submitting code/script changes, have you verified all tests pass locally using `make test`?
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)?
