### PR TITLE
Fix Untrusted search path under some conditions on Windows allows arbitrary code execution

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,6 +2,6 @@ pip
 # License: MIT
 PyYAML==6.0.1
 # License: BSD
-gitpython==3.1.37
+gitpython==3.1.41
 # License: BSD
 Jinja2==3.0.3


### PR DESCRIPTION

Although GitPython often avoids executing programs found in an untrusted search path since 3.1.33, two situations remain where this still occurs. Either can allow arbitrary code execution under some circumstances.

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)?
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)?
- If submitting code/script changes, have you verified all tests pass locally using `make test`?
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes?
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)?
