### PR TITLE
[vulnerability] Fix broken link for vulnerabilty.id

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -14,6 +14,8 @@ Thanks, you're awesome :-) -->
 
 #### Bugfixes
 
+* Fix broken link in docs for vulnerability.id. #2327
+
 #### Added
 
 * Added `volume.*` as beta field set. #2269

--- a/docs/fields/field-details.asciidoc
+++ b/docs/fields/field-details.asciidoc
@@ -13321,7 +13321,7 @@ example: `CVE`
 [[field-vulnerability-id]]
 <<field-vulnerability-id, vulnerability.id>>
 
-a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities and Exposure CVE ID]
+a| The identification (ID) is the number portion of a vulnerability entry. It includes a unique identification number for the vulnerability. For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
 
 type: keyword
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -13647,8 +13647,8 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-        and Exposure CVE ID]
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
+        and Exposure CVE ID])
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -22174,8 +22174,8 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-    and Exposure CVE ID]
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
+    Exposure CVE ID])
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -25158,8 +25158,8 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-        and Exposure CVE ID]
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
+        and Exposure CVE ID])
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -13597,8 +13597,8 @@
       ignore_above: 1024
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-        and Exposure CVE ID]
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
+        and Exposure CVE ID])
       example: CVE-2019-00001
       default_field: false
     - name: reference

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -22105,8 +22105,8 @@ vulnerability.id:
   dashed_name: vulnerability-id
   description: The identification (ID) is the number portion of a vulnerability entry.
     It includes a unique identification number for the vulnerability. For example
-    (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-    and Exposure CVE ID]
+    (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and
+    Exposure CVE ID])
   example: CVE-2019-00001
   flat_name: vulnerability.id
   ignore_above: 1024

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -25078,8 +25078,8 @@ vulnerability:
       dashed_name: vulnerability-id
       description: The identification (ID) is the number portion of a vulnerability
         entry. It includes a unique identification number for the vulnerability. For
-        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities
-        and Exposure CVE ID]
+        example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities
+        and Exposure CVE ID])
       example: CVE-2019-00001
       flat_name: vulnerability.id
       ignore_above: 1024

--- a/schemas/vulnerability.yml
+++ b/schemas/vulnerability.yml
@@ -147,7 +147,7 @@
       description: >
         The identification (ID) is the number portion of a vulnerability entry. It
         includes a unique identification number for the vulnerability.
-        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id)[Common Vulnerabilities and Exposure CVE ID]
+        For example (https://cve.mitre.org/about/faqs.html#what_is_cve_id[Common Vulnerabilities and Exposure CVE ID])
 
       example: CVE-2019-00001
 


### PR DESCRIPTION
The current link for vulnerability.id is: https://cve.mitre.org/about/faqs.html#what_is_cve_id) which is a broken link.
![image](https://github.com/elastic/ecs/assets/5582679/babcf3af-4f07-4244-98ca-1a21226e0e30)

This PR makes the link useable as: https://cve.mitre.org/about/faqs.html#what_is_cve_id

![image](https://github.com/elastic/ecs/assets/5582679/913bbd50-650f-44cc-a46a-04042bbb6005)
