### PR TITLE
Add `process.group` fields to generated schemas

### DIFF
--- a/CHANGELOG.next.md
+++ b/CHANGELOG.next.md
@@ -21,6 +21,7 @@ Thanks, you're awesome :-) -->
 * Advanced `process.env_vars` to GA. #2315
 * Advanced `process.io` and `process.tty` fields to GA. #2317
 * Added `threat.indicator.id`. #2324
+* Added `process.group` to generated schemas. #2335
 
 #### Improvements
 

--- a/experimental/generated/beats/fields.ecs.yml
+++ b/experimental/generated/beats/fields.ecs.yml
@@ -5496,6 +5496,18 @@
         start).'
       example: 137
       default_field: false
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
     - name: group_leader.args
       level: extended
       type: keyword

--- a/experimental/generated/csv/fields.csv
+++ b/experimental/generated/csv/fields.csv
@@ -690,6 +690,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev+exp,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev+exp,true,process,process.exit_code,long,extended,,137,The exit code of the process.
+8.12.0-dev+exp,true,process,process.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+8.12.0-dev+exp,true,process,process.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev+exp,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev+exp,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev+exp,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.

--- a/experimental/generated/ecs/ecs_flat.yml
+++ b/experimental/generated/ecs/ecs_flat.yml
@@ -8930,6 +8930,28 @@ process.exit_code:
   normalize: []
   short: The exit code of the process.
   type: long
+process.group.id:
+  dashed_name: process-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: process.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+process.group.name:
+  dashed_name: process-group-name
+  description: Name of the group.
+  flat_name: process.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
 process.group_leader.args:
   dashed_name: process-group-leader-args
   description: 'Array of process arguments, starting with the absolute path to the

--- a/experimental/generated/ecs/ecs_nested.yml
+++ b/experimental/generated/ecs/ecs_nested.yml
@@ -11140,6 +11140,28 @@ process:
       normalize: []
       short: The exit code of the process.
       type: long
+    process.group.id:
+      dashed_name: process-group-id
+      description: Unique identifier for the group on the system/platform.
+      flat_name: process.group.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      original_fieldset: group
+      short: Unique identifier for the group on the system/platform.
+      type: keyword
+    process.group.name:
+      dashed_name: process-group-name
+      description: Name of the group.
+      flat_name: process.group.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
     process.group_leader.args:
       dashed_name: process-group-leader-args
       description: 'Array of process arguments, starting with the absolute path to

--- a/experimental/generated/elasticsearch/composable/component/process.json
+++ b/experimental/generated/elasticsearch/composable/component/process.json
@@ -481,6 +481,18 @@
             "exit_code": {
               "type": "long"
             },
+            "group": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "group_leader": {
               "properties": {
                 "args": {

--- a/experimental/generated/elasticsearch/legacy/template.json
+++ b/experimental/generated/elasticsearch/legacy/template.json
@@ -3202,6 +3202,18 @@
           "exit_code": {
             "type": "long"
           },
+          "group": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "group_leader": {
             "properties": {
               "args": {

--- a/generated/beats/fields.ecs.yml
+++ b/generated/beats/fields.ecs.yml
@@ -5446,6 +5446,18 @@
         start).'
       example: 137
       default_field: false
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
     - name: group_leader.args
       level: extended
       type: keyword

--- a/generated/csv/fields.csv
+++ b/generated/csv/fields.csv
@@ -683,6 +683,8 @@ ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
 8.12.0-dev,true,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.executable.text,match_only_text,extended,,/usr/bin/ssh,Absolute path to the process executable.
 8.12.0-dev,true,process,process.exit_code,long,extended,,137,The exit code of the process.
+8.12.0-dev,true,process,process.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+8.12.0-dev,true,process,process.group.name,keyword,extended,,,Name of the group.
 8.12.0-dev,true,process,process.group_leader.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
 8.12.0-dev,true,process,process.group_leader.args_count,long,extended,,4,Length of the process.args array.
 8.12.0-dev,true,process,process.group_leader.command_line,wildcard,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.

--- a/generated/ecs/ecs_flat.yml
+++ b/generated/ecs/ecs_flat.yml
@@ -8861,6 +8861,28 @@ process.exit_code:
   normalize: []
   short: The exit code of the process.
   type: long
+process.group.id:
+  dashed_name: process-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: process.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+process.group.name:
+  dashed_name: process-group-name
+  description: Name of the group.
+  flat_name: process.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
 process.group_leader.args:
   dashed_name: process-group-leader-args
   description: 'Array of process arguments, starting with the absolute path to the

--- a/generated/ecs/ecs_nested.yml
+++ b/generated/ecs/ecs_nested.yml
@@ -11060,6 +11060,28 @@ process:
       normalize: []
       short: The exit code of the process.
       type: long
+    process.group.id:
+      dashed_name: process-group-id
+      description: Unique identifier for the group on the system/platform.
+      flat_name: process.group.id
+      ignore_above: 1024
+      level: extended
+      name: id
+      normalize: []
+      original_fieldset: group
+      short: Unique identifier for the group on the system/platform.
+      type: keyword
+    process.group.name:
+      dashed_name: process-group-name
+      description: Name of the group.
+      flat_name: process.group.name
+      ignore_above: 1024
+      level: extended
+      name: name
+      normalize: []
+      original_fieldset: group
+      short: Name of the group.
+      type: keyword
     process.group_leader.args:
       dashed_name: process-group-leader-args
       description: 'Array of process arguments, starting with the absolute path to

--- a/generated/elasticsearch/composable/component/process.json
+++ b/generated/elasticsearch/composable/component/process.json
@@ -481,6 +481,18 @@
             "exit_code": {
               "type": "long"
             },
+            "group": {
+              "properties": {
+                "id": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
             "group_leader": {
               "properties": {
                 "args": {

--- a/generated/elasticsearch/legacy/template.json
+++ b/generated/elasticsearch/legacy/template.json
@@ -3160,6 +3160,18 @@
           "exit_code": {
             "type": "long"
           },
+          "group": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "group_leader": {
             "properties": {
               "args": {

--- a/schemas/subsets/main.yml
+++ b/schemas/subsets/main.yml
@@ -360,6 +360,10 @@ fields:
           args: {}
           args_count: {}
           executable: {}
+      group:
+        fields:
+          id: {}
+          name: {}
       real_group:
         fields:
           id: {}


### PR DESCRIPTION

<!--
Thank you for your interest in and contributing to ECS! There are a
few simple things to check before submitting your pull request that
can help with the review process. You should delete these items from
our submission, but they are here to help bring them to your attention.
-->

Add `process.group` fields as the effective group for the process schema. `process.group` was (probably mistakenly) being excluded from the schema, as it wasn't part of `schemas/subsets/main.yml`. The other related process group fields are already included in the schema (real_group, saved_group), and `process.group` is defined with field re-use in [group.yml](https://github.com/elastic/ecs/blob/main/schemas/group.yml#L32-L34).

---

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? y
- Have you followed the [contributor guidelines](https://github.com/elastic/ecs/blob/main/CONTRIBUTING.md)? y
- For proposing substantial changes or additions to the schema, have you reviewed the [RFC process](https://github.com/elastic/ecs/blob/main/rfcs/README.md)? n/a
- If submitting code/script changes, have you verified all tests pass locally using `make test`? y
- If submitting schema/fields updates, have you generated new artifacts by running `make` and committed those changes? y
- Is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. y
- Have you added an entry to the [CHANGELOG.next.md](https://github.com/elastic/ecs/blob/main/CHANGELOG.next.md)? y
